### PR TITLE
Refactor FirmwareController: extract FirmwareState dataclass

### DIFF
--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -1,0 +1,47 @@
+"""Mutable domain state for :class:`FirmwareController`."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from ...models import FirmwareJob
+
+
+@dataclass
+class FirmwareState:
+    """Mutable state for :class:`FirmwareController`."""
+
+    # ``esphome`` CLI invocation discovered at ``start()`` —
+    # ``[sys.executable, "-m", "esphome"]`` or the on-PATH
+    # ``esphome`` binary, whichever ``_find_esphome_cmd``
+    # picks first. ``cli`` reads it to build the subprocess argv.
+    esphome_cmd: list[str] = field(default_factory=list)
+
+    # Persistent single-job queue. Producer is ``_enqueue``;
+    # consumer is the runner loop. Survives restarts via the
+    # on-disk persistence layer.
+    queue: asyncio.Queue[FirmwareJob] = field(default_factory=asyncio.Queue)
+
+    # Active + recent jobs keyed by ``job_id``. ``persistence``
+    # reads / writes on every state transition; ``clean``,
+    # ``follow``, ``jobs``, ``factories``, and ``lifecycle`` read
+    # for lookup. Trimmed to history limits by
+    # ``persistence._prune_history``.
+    jobs: dict[str, FirmwareJob] = field(default_factory=dict)
+
+    # Single-job runner slot — ``None`` when idle. ``runner``
+    # reads / writes as the job lifecycle transitions through
+    # the queue.
+    current_job: FirmwareJob | None = None
+    current_process: asyncio.subprocess.Process | None = None
+
+    # Job ids the user asked to cancel; the runner consults this
+    # on subprocess exit to mark CANCELLED instead of FAILED.
+    cancel_requested: set[str] = field(default_factory=set)
+
+    # Per-job wake event for the remote runner — set by the
+    # cancel handler so a remote job waiting on its terminal
+    # frame unblocks instantly. The local subprocess path uses
+    # SIGTERM instead and doesn't register here.
+    cancel_events: dict[str, asyncio.Event] = field(default_factory=dict)

--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -90,7 +90,7 @@ async def _fan_out_clean_to_connected_peers(
 
 def _active_build_for(controller: FirmwareController, configuration: str) -> FirmwareJob | None:
     """Return any in-flight build-producing job on *configuration*, else None."""
-    for active in controller._jobs.values():
+    for active in controller.state.jobs.values():
         if active.configuration != configuration:
             continue
         if active.status not in _ACTIVE_JOB_STATUSES:

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -30,6 +30,7 @@ from ...models import (
 from . import bulk, cli, factories, follow, jobs, lifecycle, persistence, runner
 from . import clean as clean_mod
 from . import download as download_mod
+from ._state import FirmwareState
 from .helpers import (
     _find_esphome_cmd,
     _validate_port,
@@ -54,20 +55,8 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
-        self._queue: asyncio.Queue[FirmwareJob] = asyncio.Queue()
-        self._jobs: dict[str, FirmwareJob] = {}
-        self._current_job: FirmwareJob | None = None
-        self._current_process: asyncio.subprocess.Process | None = None
+        self.state = FirmwareState()
         self._runner_task: asyncio.Task | None = None
-        self._esphome_cmd: list[str] = []
-        # Job ids the user asked to cancel; the runner consults this
-        # on subprocess exit to mark CANCELLED instead of FAILED.
-        self._cancel_requested: set[str] = set()
-        # Per-job wake event for the remote runner — set by the
-        # cancel handler so a remote job waiting on its terminal
-        # frame unblocks instantly. The local subprocess path uses
-        # SIGTERM instead and doesn't register here.
-        self._cancel_events: dict[str, asyncio.Event] = {}
 
     @property
     def bus(self) -> EventBus:
@@ -87,20 +76,20 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         scheduler reading only ``running`` would misclassify a
         fully-loaded receiver as accepting more work.
         """
-        running = self._current_job is not None
-        queue_depth = self._queue.qsize()
+        running = self.state.current_job is not None
+        queue_depth = self.state.queue.qsize()
         idle = not running and queue_depth == 0
         return idle, running, queue_depth
 
     async def start(self) -> None:
         """Start the queue processor and restore persisted jobs."""
-        self._esphome_cmd = _find_esphome_cmd()
+        self.state.esphome_cmd = _find_esphome_cmd()
         _LOGGER.info(
             "ESPHome command: %s (interpreter: %s)",
-            " ".join(self._esphome_cmd),
+            " ".join(self.state.esphome_cmd),
             sys.executable,
         )
-        ok, detail = await _verify_esphome_importable(self._esphome_cmd)
+        ok, detail = await _verify_esphome_importable(self.state.esphome_cmd)
         if ok:
             _LOGGER.info("ESPHome CLI sanity check OK — %s", detail)
         else:
@@ -282,6 +271,14 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     def active_remote_peer_jobs(self) -> Iterator[FirmwareJob]:
         return jobs.active_remote_peer_jobs(self)
 
+    def find_remote_peer_job(self, *, remote_peer: str, remote_job_id: str) -> FirmwareJob | None:
+        """Return the FirmwareJob matching (*remote_peer*, *remote_job_id*), or None."""
+        return jobs.find_remote_peer_job(self, remote_peer=remote_peer, remote_job_id=remote_job_id)
+
+    def remote_peer_job_ids(self, *, remote_peer: str) -> list[str]:
+        """Return the ``remote_job_id`` of every job submitted by *remote_peer*."""
+        return jobs.remote_peer_job_ids(self, remote_peer=remote_peer)
+
     @api_command("firmware/follow_job")
     async def follow_job(
         self, *, job_id: str, client: Any = None, message_id: str = "", **kwargs: Any
@@ -373,7 +370,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         new_name: str = "",
     ) -> list[str]:
         return cli.build_command(
-            self._esphome_cmd, job_type, config_path, port, cache_args, new_name
+            self.state.esphome_cmd, job_type, config_path, port, cache_args, new_name
         )
 
     def _build_cache_args(self, job: FirmwareJob) -> list[str]:

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -63,7 +63,7 @@ def create_job(
         device_name=device_name,
         device_friendly_name=device_friendly_name,
     )
-    controller._jobs[job.job_id] = job
+    controller.state.jobs[job.job_id] = job
     return job
 
 
@@ -110,7 +110,7 @@ async def enqueue(
     RENAME has *job*'s configuration locked.
     """
     controller._check_rename_lock(job)
-    await controller._queue.put(job)
+    await controller.state.queue.put(job)
     queued_payload: JobLifecycleData = {"job": job}
     controller._db.bus.fire(EventType.JOB_QUEUED, queued_payload)
     if supersede and job.configuration:
@@ -131,7 +131,7 @@ def check_rename_lock(controller: FirmwareController, job: FirmwareJob) -> None:
     new_touches = _names_touched_by_job(job)
     if not new_touches:
         return
-    for active in controller._jobs.values():
+    for active in controller.state.jobs.values():
         if active.job_type != JobType.RENAME:
             continue
         if active.status not in _ACTIVE_JOB_STATUSES:
@@ -158,7 +158,7 @@ async def supersede_active_jobs(
     """Cancel queued/running jobs for ``configuration``."""
     to_cancel = [
         j.job_id
-        for j in controller._jobs.values()
+        for j in controller.state.jobs.values()
         if j.job_id != exclude_job_id
         and j.configuration == configuration
         and j.status in _ACTIVE_JOB_STATUSES

--- a/esphome_device_builder/controllers/firmware/follow.py
+++ b/esphome_device_builder/controllers/firmware/follow.py
@@ -37,7 +37,7 @@ async def follow_job(
     every line appended during replay, and the gap widened
     forever after the first in-flight ``_trim_job_output`` reassign.
     """
-    job = controller._jobs.get(job_id)
+    job = controller.state.jobs.get(job_id)
     if not job:
         msg = f"Job not found: {job_id}"
         raise ValueError(msg)
@@ -136,7 +136,10 @@ async def follow_jobs(
     # both the snapshot AND the listener, so the client sees the
     # same line twice.
     snapshot_payloads = (
-        [job.to_dict() for job in sorted(controller._jobs.values(), key=attrgetter("created_at"))]
+        [
+            job.to_dict()
+            for job in sorted(controller.state.jobs.values(), key=attrgetter("created_at"))
+        ]
         if snapshot
         else []
     )

--- a/esphome_device_builder/controllers/firmware/jobs.py
+++ b/esphome_device_builder/controllers/firmware/jobs.py
@@ -29,7 +29,7 @@ async def get_jobs(
     configuration: str | None = None,
 ) -> list[FirmwareJob]:
     """List jobs, optionally filtered by status or configuration."""
-    jobs = list(controller._jobs.values())
+    jobs = list(controller.state.jobs.values())
     if status:
         jobs = [j for j in jobs if j.status == status]
     if configuration:
@@ -39,7 +39,7 @@ async def get_jobs(
 
 async def get_job(controller: FirmwareController, *, job_id: str) -> FirmwareJob | None:
     """Get a specific job with full output."""
-    return controller._jobs.get(job_id)
+    return controller.state.jobs.get(job_id)
 
 
 def active_remote_peer_jobs(controller: FirmwareController) -> Iterator[FirmwareJob]:
@@ -47,14 +47,42 @@ def active_remote_peer_jobs(controller: FirmwareController) -> Iterator[Firmware
 
     ``remote_peer`` is empty on locally-submitted jobs so they're
     filtered out; the public accessor exists so callers don't
-    reach into ``_jobs`` directly.
+    reach into ``state.jobs`` directly.
     """
-    for job in controller._jobs.values():
+    for job in controller.state.jobs.values():
         if job.status not in _ACTIVE_JOB_STATUSES:
             continue
         if not job.remote_peer:
             continue
         yield job
+
+
+def find_remote_peer_job(
+    controller: FirmwareController, *, remote_peer: str, remote_job_id: str
+) -> FirmwareJob | None:
+    """Return the FirmwareJob matching (*remote_peer*, *remote_job_id*), or None.
+
+    Linear scan over ``state.jobs.values()``; cardinality is
+    bounded by the firmware queue's retention so the scan is
+    cheap. Public accessor so cross-package callers (the
+    receiver's artifacts-download path) don't reach into
+    ``state.jobs`` directly.
+    """
+    for job in controller.state.jobs.values():
+        if job.remote_peer == remote_peer and job.remote_job_id == remote_job_id:
+            return job
+    return None
+
+
+def remote_peer_job_ids(controller: FirmwareController, *, remote_peer: str) -> list[str]:
+    """Return the ``remote_job_id`` of every job in the queue submitted by *remote_peer*.
+
+    Used by the artifacts-download reject-log to surface the
+    available ids when a requested one doesn't match. Public
+    accessor so the cross-package caller doesn't reach into
+    ``state.jobs`` directly.
+    """
+    return [j.remote_job_id for j in controller.state.jobs.values() if j.remote_peer == remote_peer]
 
 
 async def cancel(controller: FirmwareController, *, job_id: str) -> None:
@@ -72,7 +100,7 @@ async def cancel(controller: FirmwareController, *, job_id: str) -> None:
     status. State-out-of-sync stays as ``RuntimeError`` (server
     bug, not user input).
     """
-    job = controller._jobs.get(job_id)
+    job = controller.state.jobs.get(job_id)
     if not job:
         msg = f"Job not found: {job_id}"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
@@ -90,14 +118,14 @@ async def cancel(controller: FirmwareController, *, job_id: str) -> None:
         return
 
     if job.status == JobStatus.RUNNING:
-        if controller._current_job is None or controller._current_job.job_id != job_id:
+        if controller.state.current_job is None or controller.state.current_job.job_id != job_id:
             msg = "Running job is not the active subprocess (state out of sync)"
             raise RuntimeError(msg)
-        controller._cancel_requested.add(job_id)
+        controller.state.cancel_requested.add(job_id)
         # Wake any runner parked on its cancel event — only the
         # remote runner registers one; the local subprocess path's
         # wake signal is SIGTERM on the spawned process.
-        cancel_event = controller._cancel_events.get(job_id)
+        cancel_event = controller.state.cancel_events.get(job_id)
         if cancel_event is not None:
             cancel_event.set()
         await controller._terminate_current_process()
@@ -112,9 +140,9 @@ async def clear(controller: FirmwareController, *, status: JobStatus | str | Non
     terminal = TERMINAL_JOB_STATUSES
     to_remove = [
         jid
-        for jid, job in controller._jobs.items()
+        for jid, job in controller.state.jobs.items()
         if (status and job.status == status) or (not status and job.status in terminal)
     ]
     for jid in to_remove:
-        del controller._jobs[jid]
+        del controller.state.jobs[jid]
     await controller._persist_jobs()

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -37,9 +37,9 @@ def finalize_terminal(controller: FirmwareController, job: FirmwareJob, status: 
     must set it on the job before calling.
     """
     _mark_job_terminal(job, status)
-    if controller._current_job is job:
-        controller._current_job = None
-        controller._current_process = None
+    if controller.state.current_job is job:
+        controller.state.current_job = None
+        controller.state.current_process = None
     payload: JobLifecycleData = {"job": job}
     controller._db.bus.fire(_STATUS_TO_TERMINAL_EVENT[status], payload)
 
@@ -51,7 +51,7 @@ def finalize_cancelled(controller: FirmwareController, job: FirmwareJob) -> None
     :meth:`FirmwareController.cancel` runs (``_prune_history`` +
     ``_persist_jobs``); the runner has already seen the job.
     """
-    controller._cancel_requested.discard(job.job_id)
+    controller.state.cancel_requested.discard(job.job_id)
     # Route through the bound-method delegate so test patches on
     # ``controller._finalize_terminal`` intercept this path too.
     controller._finalize_terminal(job, JobStatus.CANCELLED)
@@ -64,7 +64,7 @@ def raise_if_cancelled(controller: FirmwareController, job: FirmwareJob, phase: 
     cancel-aware ``except Exception`` branch keys off to finalise
     as CANCELLED instead of FAILED.
     """
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         msg = f"Cancelled during {phase}"
         raise ValueError(msg)
 
@@ -78,10 +78,12 @@ async def terminate_current_process(controller: FirmwareController) -> None:
     /T`` on Windows. The runner loop is what actually finalises
     the job on exit — this helper only nudges the process.
     """
-    proc = controller._current_process
+    proc = controller.state.current_process
     if proc is None:
         return
     await terminate_subtree_with_grace(
         proc,
-        job_label=f"job {controller._current_job.job_id}" if controller._current_job else "job ?",
+        job_label=f"job {controller.state.current_job.job_id}"
+        if controller.state.current_job
+        else "job ?",
     )

--- a/esphome_device_builder/controllers/firmware/persistence.py
+++ b/esphome_device_builder/controllers/firmware/persistence.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def prune_history(controller: FirmwareController) -> None:
     """
-    Trim ``controller._jobs`` to the configured history limits.
+    Trim ``controller.state.jobs`` to the configured history limits.
 
     Active (queued / running) jobs are always kept. Terminal
     compile / upload / install jobs collapse to one entry per
@@ -39,7 +39,7 @@ def prune_history(controller: FirmwareController) -> None:
     active: list[FirmwareJob] = []
     primary: list[FirmwareJob] = []
     aux: list[FirmwareJob] = []
-    for job in controller._jobs.values():
+    for job in controller.state.jobs.values():
         if job.status not in terminal_states:
             active.append(job)
         elif job.job_type in _PRIMARY_JOB_TYPES:
@@ -63,7 +63,7 @@ def prune_history(controller: FirmwareController) -> None:
     aux.sort(key=attrgetter("created_at"), reverse=True)
     aux = aux[:_MAX_AUX_TERMINAL_JOBS]
 
-    controller._jobs = {j.job_id: j for j in (*active, *deduped_primary, *aux)}
+    controller.state.jobs = {j.job_id: j for j in (*active, *deduped_primary, *aux)}
 
 
 async def load_jobs(controller: FirmwareController) -> None:
@@ -80,12 +80,12 @@ async def load_jobs(controller: FirmwareController) -> None:
     for job_data in data.get(_JOBS_KEY, []):
         try:
             job = FirmwareJob.from_dict(job_data)
-            controller._jobs[job.job_id] = job
+            controller.state.jobs[job.job_id] = job
             if job.status in _ACTIVE_JOB_STATUSES:
                 if job.status == JobStatus.RUNNING:
                     job.reset()
                 job.status = JobStatus.QUEUED
-                await controller._queue.put(job)
+                await controller.state.queue.put(job)
         except Exception:
             # ``job_data`` is normally a dict, but a corrupt
             # persistence file could contain a primitive
@@ -109,6 +109,6 @@ async def persist_jobs(controller: FirmwareController) -> None:
 
     def _save() -> None:
         with metadata_transaction(config_dir) as data:
-            data[_JOBS_KEY] = [j.to_dict() for j in controller._jobs.values()]
+            data[_JOBS_KEY] = [j.to_dict() for j in controller.state.jobs.values()]
 
     await loop.run_in_executor(None, _save)

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -151,7 +151,7 @@ async def run_remote_job(
     # ``asyncio.wait({terminal, session_lost, cancel_event_task})``
     # and wakes on whichever fires first.
     cancel_event = asyncio.Event()
-    controller._cancel_events[job.job_id] = cancel_event
+    controller.state.cancel_events[job.job_id] = cancel_event
     # A cancel that landed during ``_execute_job``'s pre-runner
     # phase (``_current_job = job`` is set before the persist
     # await, so the cancel handler accepts the request and
@@ -160,7 +160,7 @@ async def run_remote_job(
     # ``_cancel_events.get(job_id)`` returns ``None`` and the
     # ``set()`` is skipped). Replay the late wake here so the
     # runner doesn't park on an event that will never fire.
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         cancel_event.set()
 
     def _is_ours(data: OffloaderJobOutputData | OffloaderJobStateChangedData) -> bool:
@@ -215,7 +215,7 @@ async def run_remote_job(
         # Clean up the registration so a future job reusing the
         # id (theoretical — uuid4 collision aside) doesn't
         # signal a stale event.
-        controller._cancel_events.pop(job.job_id, None)
+        controller.state.cancel_events.pop(job.job_id, None)
 
 
 async def _dispatch_and_drive(
@@ -474,7 +474,7 @@ async def _await_terminal(
             cancel_wait.cancel()
 
     data = terminal.result()
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         # User cancel beat the receiver's terminal frame to the
         # loop (receiver completed / failed while our cancel was
         # in flight). Mirror the local subprocess path: user
@@ -546,7 +546,7 @@ async def _fetch_and_materialise(
 
     # Honour a cancel that arrived between the receiver's
     # completed frame and us getting here.
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         controller._finalize_cancelled(job)
         return False
     return True
@@ -569,7 +569,7 @@ async def _fetch_and_run_local_upload(
     # Cancel that landed after ``_fetch_and_materialise``'s
     # own check returned True — same race window the old
     # one-shot helper covered.
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         controller._finalize_cancelled(job)
         return
 
@@ -596,7 +596,7 @@ async def _fetch_and_run_local_upload(
 
     cache_args = controller._build_cache_args(job)
     cmd = [
-        *controller._esphome_cmd,
+        *controller.state.esphome_cmd,
         "--dashboard",
         *cache_args,
         "upload",
@@ -651,7 +651,7 @@ async def _run_upload_subprocess(
     (``_ingest_output_line``) so the firmware-tasks UI sees
     one event stream regardless of which CPU produced the
     bytes. ``_tracked_subprocess`` registers the spawn with
-    ``controller._current_process`` so a concurrent
+    ``controller.state.current_process`` so a concurrent
     ``firmware/cancel`` lands SIGTERM on the upload chain
     just like it does for the local-only path.
     """
@@ -669,7 +669,7 @@ async def _run_upload_subprocess(
         # ``download_artifacts`` await and the spawn — without
         # this check, the subprocess gets started for a job
         # the user already aborted.
-        if job.job_id in controller._cancel_requested:
+        if job.job_id in controller.state.cancel_requested:
             await controller._terminate_current_process()
 
         assert proc.stdout is not None  # type narrowing
@@ -678,7 +678,7 @@ async def _run_upload_subprocess(
 
         exit_code = await proc.wait()
 
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         controller._finalize_cancelled(job)
         return None
     job.exit_code = exit_code
@@ -777,7 +777,7 @@ def _fail_locally(
     subprocess path's contract.
     """
     error = f"{_REMOTE_BUILD_ERROR_PREFIX}{reason}"
-    if job.job_id in controller._cancel_requested:
+    if job.job_id in controller.state.cancel_requested:
         controller._finalize_cancelled(job)
         _LOGGER.info("Remote job %s cancelled (failure path: %s)", job.job_id, error)
         return

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -36,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 async def run_queue(controller: FirmwareController) -> None:
     """Background loop: process one job at a time."""
     while True:
-        job = await controller._queue.get()
+        job = await controller.state.queue.get()
         if job.status == JobStatus.CANCELLED:
             continue
         await controller._execute_job(job)
@@ -48,7 +48,7 @@ async def execute_job(  # noqa: PLR0912, PLR0915
     """Execute a single firmware job."""
     job.status = JobStatus.RUNNING
     job.started_at = datetime.now(UTC).isoformat()
-    controller._current_job = job
+    controller.state.current_job = job
     _LOGGER.info(
         "Starting job %s: %s %s",
         job.job_id,
@@ -132,7 +132,7 @@ async def execute_job(  # noqa: PLR0912, PLR0915
             # the brief async window where ``_current_process`` was
             # ``None`` lets the install run to completion before the
             # post-``proc.wait()`` cancel check sees the flag.
-            if job.job_id in controller._cancel_requested:
+            if job.job_id in controller.state.cancel_requested:
                 await controller._terminate_current_process()
 
             assert proc.stdout is not None  # type narrowing
@@ -169,7 +169,7 @@ async def execute_job(  # noqa: PLR0912, PLR0915
         # If the user cancelled this job mid-run, the subprocess
         # exits non-zero (terminated by signal). Honour that
         # intent rather than reporting it as a generic failure.
-        if job.job_id in controller._cancel_requested:
+        if job.job_id in controller.state.cancel_requested:
             controller._finalize_cancelled(job)
             _LOGGER.info("Job %s cancelled mid-run (exit %s)", job.job_id, exit_code)
         else:
@@ -213,7 +213,7 @@ async def execute_job(  # noqa: PLR0912, PLR0915
         # to short-circuit the install — without this branch
         # that error would be reported as a generic failure
         # rather than the user-driven cancel it actually is.
-        if job.job_id in controller._cancel_requested:
+        if job.job_id in controller.state.cancel_requested:
             controller._finalize_cancelled(job)
             _LOGGER.info("Job %s cancelled before subprocess wait: %s", job.job_id, exc)
         else:
@@ -221,8 +221,8 @@ async def execute_job(  # noqa: PLR0912, PLR0915
             controller._finalize_terminal(job, JobStatus.FAILED)
             _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
     finally:
-        controller._current_job = None
-        controller._current_process = None
+        controller.state.current_job = None
+        controller.state.current_process = None
         if job.status in (
             JobStatus.COMPLETED,
             JobStatus.FAILED,
@@ -317,8 +317,8 @@ async def tracked_subprocess(
     between this subprocess and the next one.
     """
     proc = await create_subprocess_exec(*args, **kwargs)
-    prev = controller._current_process
-    controller._current_process = proc
+    prev = controller.state.current_process
+    controller.state.current_process = proc
     try:
         yield proc
     except asyncio.CancelledError:
@@ -335,4 +335,4 @@ async def tracked_subprocess(
         await controller._terminate_current_process()
         raise
     finally:
-        controller._current_process = prev
+        controller.state.current_process = prev

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -207,18 +207,16 @@ class ArtifactsDownloadSender:
             await self._send_reject(session, job_id, _REASON_DUPLICATE_DOWNLOAD)
             return
 
-        firmware_job = self._find_remote_job(session.dashboard_id, job_id)
+        firmware_job = self._firmware.find_remote_peer_job(
+            remote_peer=session.dashboard_id, remote_job_id=job_id
+        )
         if firmware_job is None:
             _LOGGER.warning(
                 "download_artifacts from %s: no matching firmware job for "
                 "remote_job_id=%s (peer's submitted jobs: %s)",
                 session.dashboard_id,
                 job_id,
-                [
-                    j.remote_job_id
-                    for j in self._firmware._jobs.values()
-                    if j.remote_peer == session.dashboard_id
-                ],
+                self._firmware.remote_peer_job_ids(remote_peer=session.dashboard_id),
             )
             await self._send_reject(session, job_id, _REASON_UNKNOWN_JOB)
             return
@@ -279,23 +277,6 @@ class ArtifactsDownloadSender:
             await self._send_stream(session, job_id, packed)
         finally:
             self._inflight.pop(session.dashboard_id, None)
-
-    def _find_remote_job(self, remote_peer: str, remote_job_id: str) -> Any:
-        """Linear scan over ``FirmwareController._jobs`` for a matching remote job.
-
-        Same shape as :meth:`JobFanout.resolve_firmware_job_id`
-        but unconditional on terminal status — the download
-        path needs to find COMPLETED jobs (which JobFanout
-        evicts on terminal events). Walks ``_jobs`` directly;
-        cardinality is bounded by the firmware queue's
-        retention so the linear scan is cheap.
-
-        Returns the :class:`FirmwareJob` or ``None`` on miss.
-        """
-        for job in self._firmware._jobs.values():
-            if job.remote_peer == remote_peer and job.remote_job_id == remote_job_id:
-                return job
-        return None
 
     async def _send_reject(self, session: PeerLinkSession, job_id: str, reason: str) -> None:
         """Send a single ``artifacts_end{accepted: false, reason}`` and return."""

--- a/esphome_device_builder/controllers/remote_build/job_fanout.py
+++ b/esphome_device_builder/controllers/remote_build/job_fanout.py
@@ -104,8 +104,9 @@ class JobFanout:
         # remote-peer job. Populated on JOB_QUEUED (the first
         # event for any job) so :meth:`_on_output`'s hot-path
         # lookup is a sync dict access against state we own,
-        # not a private reach into ``firmware._jobs``. Dropped
-        # on terminal events so a never-emitted JOB_OUTPUT for
+        # not a linear scan through ``firmware.find_remote_peer_job``
+        # on every output line. Dropped on terminal events so a
+        # never-emitted JOB_OUTPUT for
         # a long-finished job doesn't keep the entry around
         # forever (the firmware controller retains job rows
         # for post-mortem inspection).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -291,6 +291,30 @@ def make_remote_build_controller(
     )
 
 
+def wire_firmware_remote_peer_api_mocks(firmware: Any, jobs_by_id: dict[str, Any]) -> None:
+    """Wire a MagicMock firmware controller's remote-peer lookup API against *jobs_by_id*.
+
+    Assigns ``firmware.state.jobs = jobs_by_id`` and installs
+    ``side_effect`` callables on ``find_remote_peer_job`` and
+    ``remote_peer_job_ids`` so they return what the real
+    :class:`FirmwareController` would. Single source of truth
+    so the e2e harness and unit tests share the same stub
+    semantics.
+    """
+    firmware.state.jobs = jobs_by_id
+    firmware.find_remote_peer_job.side_effect = lambda *, remote_peer, remote_job_id: next(
+        (
+            j
+            for j in jobs_by_id.values()
+            if j.remote_peer == remote_peer and j.remote_job_id == remote_job_id
+        ),
+        None,
+    )
+    firmware.remote_peer_job_ids.side_effect = lambda *, remote_peer: [
+        j.remote_job_id for j in jobs_by_id.values() if j.remote_peer == remote_peer
+    ]
+
+
 async def cancel_and_drain(task: asyncio.Task[Any]) -> None:
     """Cancel *task* and await its termination, swallowing the resulting CancelledError.
 

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -33,6 +33,7 @@ import pytest
 
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.models import EventType, FirmwareJob
 
@@ -144,7 +145,8 @@ def firmware_controller_factory(
         with_real_bus: bool = False,
     ) -> FirmwareController:
         controller = FirmwareController.__new__(FirmwareController)
-        controller._jobs = {j.job_id: j for j in jobs}
+        controller.state = FirmwareState()
+        controller.state.jobs = {j.job_id: j for j in jobs}
         if not with_real_persistence:
             controller._persist_jobs = AsyncMock()
 
@@ -182,15 +184,15 @@ def firmware_controller_factory(
         # don't drive the runner. Without this, cancel-queued /
         # supersede tests that fire JOB_CANCELLED through the
         # helper crash on ``AttributeError``.
-        controller._current_job = None
-        controller._current_process = None
+        controller.state.current_job = None
+        controller.state.current_process = None
 
         if with_queue:
-            controller._queue = AsyncMock()
+            controller.state.queue = AsyncMock()
 
         if with_terminate:
-            controller._cancel_requested = set()
-            controller._cancel_events = {}
+            controller.state.cancel_requested = set()
+            controller.state.cancel_events = {}
             controller._terminate_current_process = AsyncMock()
 
         return controller
@@ -240,7 +242,7 @@ def capture_firmware_events() -> Iterator[CaptureEventsFactory]:
 def capture_enqueue_order() -> Iterator[CaptureEnqueueOrderFactory]:
     """Yield a factory that traces ``_queue.put`` + ``bus.fire`` into one ordered log.
 
-    Each ``await self._queue.put(job)`` appends ``(EnqueueStep.PUT, job)``
+    Each ``await self.state.queue.put(job)`` appends ``(EnqueueStep.PUT, job)``
     and each broadcast for a subscribed ``EventType`` appends
     ``(EnqueueStep.FIRE, Event)``. Tests assert the put-then-fire
     ordering by index in the returned list — the previous shape
@@ -275,13 +277,13 @@ def capture_enqueue_order() -> Iterator[CaptureEnqueueOrderFactory]:
         for event_type in event_types:
             bus.add_listener(event_type, lambda event: log.append((EnqueueStep.FIRE, event)))
 
-        swaps.append((controller, controller._queue, controller._db.bus))
-        controller._queue = queue_proxy
+        swaps.append((controller, controller.state.queue, controller._db.bus))
+        controller.state.queue = queue_proxy
         controller._db.bus = bus
         return log
 
     yield _factory
 
     for controller, original_queue, original_bus in swaps:
-        controller._queue = original_queue
+        controller.state.queue = original_queue
         controller._db.bus = original_bus

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -271,7 +271,7 @@ def _firmware_controller_with(devices_controller: Any) -> FirmwareController:
     db = MagicMock()
     db.devices = devices_controller
     controller = FirmwareController(db)
-    controller._esphome_cmd = ["esphome"]
+    controller.state.esphome_cmd = ["esphome"]
     return controller
 
 

--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -33,6 +33,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import (
     ErrorCode,
@@ -147,12 +148,12 @@ async def test_follow_jobs_returns_immediately_when_client_is_none(
     The WS dispatcher passes ``client=None`` for in-process
     callers (e.g. the WS test harness driving the handler
     without a live socket). Without the early return, the
-    handler would later iterate ``self._jobs`` and call
+    handler would later iterate ``self.state.jobs`` and call
     ``client.send_event`` on ``None`` — an attribute error,
     not a clean shape mismatch.
     """
     controller = firmware_controller_factory()
-    controller._jobs = {
+    controller.state.jobs = {
         "j1": _job("j1", "kitchen.yaml", JobType.COMPILE, status=JobStatus.COMPLETED),
     }
 
@@ -180,9 +181,9 @@ async def test_run_queue_skips_cancelled_jobs_without_spawning(
     spawn a real subprocess for a job the user already gave up on.
     """
     controller = firmware_controller_factory()
-    controller._queue = asyncio.Queue()
+    controller.state.queue = asyncio.Queue()
     cancelled = _job("j1", "kitchen.yaml", JobType.COMPILE, status=JobStatus.CANCELLED)
-    await controller._queue.put(cancelled)
+    await controller.state.queue.put(cancelled)
 
     spawned = False
 
@@ -196,7 +197,7 @@ async def test_run_queue_skips_cancelled_jobs_without_spawning(
     # Give the runner a chance to dequeue + skip + return for next get.
     for _ in range(20):
         await asyncio.sleep(0)
-        if controller._queue.empty():
+        if controller.state.queue.empty():
             break
     runner.cancel()
     with contextlib.suppress(asyncio.CancelledError):
@@ -219,8 +220,8 @@ async def test_terminate_current_process_no_op_when_no_process(
     against ``None`` would surface as a hard error here.
     """
     controller = firmware_controller_factory()
-    controller._current_process = None
-    controller._current_job = None
+    controller.state.current_process = None
+    controller.state.current_job = None
 
     # Should return without raising; no process to terminate.
     await controller._terminate_current_process()
@@ -240,7 +241,8 @@ def test_build_command_for_rename_appends_new_name_positional() -> None:
     "rename failed" with no actionable hint. Pin the arg order.
     """
     controller = FirmwareController.__new__(FirmwareController)
-    controller._esphome_cmd = ["esphome"]
+    controller.state = FirmwareState()
+    controller.state.esphome_cmd = ["esphome"]
     controller._db = MagicMock()
     controller._db.devices = None
 
@@ -291,5 +293,5 @@ def test_prune_history_collapses_primary_jobs_to_newest_per_configuration(
 
     controller._prune_history()
 
-    surviving_ids = set(controller._jobs.keys())
+    surviving_ids = set(controller.state.jobs.keys())
     assert surviving_ids == {"new"}

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -153,7 +153,7 @@ async def test_cancel_queued_does_not_touch_terminate_current_process(
     """The QUEUED branch never reaches the subprocess terminator.
 
     Belt-and-braces: ``_terminate_current_process`` walks
-    ``self._current_process`` and signals it. For a queued job
+    ``self.state.current_process`` and signals it. For a queued job
     there is no subprocess (and ``_current_process`` is ``None``),
     so calling it here is at best a no-op; at worst a future
     refactor of the terminator that doesn't gracefully handle the
@@ -187,11 +187,11 @@ async def test_cancel_running_job_records_intent_and_terminates(
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
-    controller._current_job = job
+    controller.state.current_job = job
 
     await controller.cancel(job_id="j-r")
 
-    assert "j-r" in controller._cancel_requested
+    assert "j-r" in controller.state.cancel_requested
     controller._terminate_current_process.assert_awaited_once()
 
 
@@ -210,7 +210,7 @@ async def test_cancel_running_job_does_not_fire_event_directly(
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
-    controller._current_job = job
+    controller.state.current_job = job
     captured = capture_firmware_events(controller, EventType.JOB_CANCELLED)
 
     await controller.cancel(job_id="j-r")
@@ -254,7 +254,7 @@ async def test_cancel_running_job_with_mismatched_current_job_raises(
     job = _job("j-r", status=JobStatus.RUNNING)
     other = _job("j-other", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, other, with_settings=False, with_terminate=True)
-    controller._current_job = other  # somebody else is running
+    controller.state.current_job = other  # somebody else is running
 
     with pytest.raises(RuntimeError, match="state out of sync"):
         await controller.cancel(job_id="j-r")

--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -268,7 +268,7 @@ async def test_clean_supersedes_other_active_clean_on_same_configuration(
     controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     first = await controller.clean(configuration="kitchen.yaml")
     first.status = JobStatus.RUNNING
-    controller._current_job = first
+    controller.state.current_job = first
 
     second = await controller.clean(configuration="kitchen.yaml")
 
@@ -341,7 +341,7 @@ async def test_clean_fans_out_to_connected_approved_peers(
     # Assert on status, not just existence, so a regression that
     # re-introduced supersede shows up here rather than as silent
     # cancellation of every clean but the last one in production.
-    clean_jobs = [j for j in controller._jobs.values() if j.job_type is JobType.CLEAN]
+    clean_jobs = [j for j in controller.state.jobs.values() if j.job_type is JobType.CLEAN]
     assert len(clean_jobs) == 3  # 1 local + 2 remote
     assert all(j.status is JobStatus.QUEUED for j in clean_jobs), (
         "every fan-out job must stay QUEUED; if any are CANCELLED the "
@@ -402,7 +402,7 @@ async def test_clean_fan_out_does_not_supersede_sibling_jobs(
 
     statuses = {
         (j.source.value, j.source_pin_sha256[:1] or "-"): j.status
-        for j in controller._jobs.values()
+        for j in controller.state.jobs.values()
         if j.job_type is JobType.CLEAN
     }
     assert statuses == {
@@ -444,7 +444,7 @@ async def test_repeat_clean_supersedes_entire_prior_fan_out_batch(
     first_local = await controller.clean(configuration="kitchen.yaml")
     first_remotes = [
         j
-        for j in controller._jobs.values()
+        for j in controller.state.jobs.values()
         if j.source is JobSource.REMOTE
         and j.job_type is JobType.CLEAN
         and j.job_id != first_local.job_id
@@ -462,14 +462,14 @@ async def test_repeat_clean_supersedes_entire_prior_fan_out_batch(
     # the second local + its two new remotes are active.
     active = [
         j
-        for j in controller._jobs.values()
+        for j in controller.state.jobs.values()
         if j.job_type is JobType.CLEAN and j.status is JobStatus.QUEUED
     ]
     assert {j.job_id for j in active} == {
         second_local.job_id,
         *(
             j.job_id
-            for j in controller._jobs.values()
+            for j in controller.state.jobs.values()
             if j.source is JobSource.REMOTE and j.status is JobStatus.QUEUED
         ),
     }
@@ -510,7 +510,7 @@ async def test_clean_skips_disconnected_or_pending_peers(
 
     remote_pins = {
         j.source_pin_sha256
-        for j in controller._jobs.values()
+        for j in controller.state.jobs.values()
         if j.source is JobSource.REMOTE and j.job_type is JobType.CLEAN
     }
     assert remote_pins == {"c".ljust(64, "0")}
@@ -538,4 +538,4 @@ async def test_clean_with_no_remote_build_controller_skips_fan_out(
 
     assert returned.source is JobSource.LOCAL
     # No REMOTE jobs queued.
-    assert not any(j.source is JobSource.REMOTE for j in controller._jobs.values())
+    assert not any(j.source is JobSource.REMOTE for j in controller.state.jobs.values())

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -70,7 +70,7 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
     something the caller wants to know about, not have masked
     by partial success. Pin both halves: the validator raises
     ``CommandError(INVALID_ARGS)``, AND no jobs land in
-    ``self._jobs`` (the validator runs *before* the per-entry
+    ``self.state.jobs`` (the validator runs *before* the per-entry
     enqueue loop, so a single bad entry must keep every other
     entry's job from being created too).
     """

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -61,34 +61,34 @@ if TYPE_CHECKING:
 def _wire_real_queue(controller: FirmwareController) -> None:
     """Swap the conftest's ``AsyncMock`` queue for a real ``asyncio.Queue``.
 
-    The runner does ``await self._queue.get()``; an ``AsyncMock``
+    The runner does ``await self.state.queue.get()``; an ``AsyncMock``
     returns its default sentinel immediately and the runner would
     spin instead of waiting for a real submission. Pair the queue
     swap with the supersede stub (passthrough) and the
     cancel-tracking surface ``_execute_job`` reads.
     """
-    controller._queue = asyncio.Queue()
+    controller.state.queue = asyncio.Queue()
 
     async def _supersede(_configuration: str, *, exclude_job_id: str) -> None:
         return
 
     controller._supersede_active_jobs = _supersede  # type: ignore[assignment]
-    controller._current_job = None
-    controller._current_process = None
-    controller._cancel_requested = set()
-    controller._cancel_events = {}
+    controller.state.current_job = None
+    controller.state.current_process = None
+    controller.state.cancel_requested = set()
+    controller.state.cancel_events = {}
 
 
 def _fake_esphome(controller: FirmwareController, script: str) -> None:
     """Point ``_esphome_cmd`` at an inline Python script.
 
-    ``_build_command`` produces ``[*self._esphome_cmd, '--dashboard',
+    ``_build_command`` produces ``[*self.state.esphome_cmd, '--dashboard',
     *cache_args, '<subcommand>', '<config_path>', ...]`` — so the
     script will see ``sys.argv == [<script>, '--dashboard', 'compile',
     '<path>']``. Scripts ignore the args and just emit the output
     shape the test wants to exercise.
     """
-    controller._esphome_cmd = [sys.executable, "-c", script]
+    controller.state.esphome_cmd = [sys.executable, "-c", script]
 
 
 def _seed_yaml(tmp_path: Path, name: str = "kitchen.yaml") -> None:
@@ -312,7 +312,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
 
     The user-cancelled path: the runner subprocess gets terminated
     (or completes with a non-zero exit because we sent SIGTERM),
-    and the runner consults ``self._cancel_requested`` to
+    and the runner consults ``self.state.cancel_requested`` to
     distinguish "user pulled the plug" from "the build genuinely
     failed". Without this branch every cancel would render as a
     red FAILED row in the dashboard's job table, confusing the
@@ -356,7 +356,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         captured.append({"type": event_type, "data": data})
         # First JOB_OUTPUT line means the subprocess is up,
         # streaming through ``iter_lines_with_progress``, and
-        # ``self._current_process`` has been assigned.
+        # ``self.state.current_process`` has been assigned.
         if event_type == EventType.JOB_OUTPUT:
             proc_alive.set()
         elif event_type == EventType.JOB_CANCELLED:
@@ -372,9 +372,9 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         # Mark cancel + terminate the process — the runner picks
         # up the cancel flag when it loops back to read the next
         # line and sees EOF.
-        controller._cancel_requested.add(job.job_id)
-        assert controller._current_process is not None
-        controller._current_process.terminate()
+        controller.state.cancel_requested.add(job.job_id)
+        assert controller.state.current_process is not None
+        controller.state.current_process.terminate()
 
         # Wait for the cancel event from the runner's natural
         # post-``proc.wait()`` path, NOT from ``runner_task.cancel()``
@@ -397,7 +397,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
     assert any(c["type"] == EventType.JOB_CANCELLED for c in captured)
     assert not any(c["type"] == EventType.JOB_FAILED for c in captured)
     # Cancel id is consumed so a re-queue with the same id wouldn't auto-cancel.
-    assert job.job_id not in controller._cancel_requested
+    assert job.job_id not in controller.state.cancel_requested
 
 
 @pytest.mark.asyncio
@@ -454,8 +454,8 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     runner_task = asyncio.create_task(controller._run_queue())
     try:
         await asyncio.wait_for(proc_alive.wait(), timeout=10.0)
-        assert controller._current_process is not None
-        proc = controller._current_process
+        assert controller.state.current_process is not None
+        proc = controller.state.current_process
 
         # Cancel the runner task itself — this is the shutdown shape,
         # not the user-cancel one. Nothing is added to
@@ -480,7 +480,7 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     assert proc.returncode is not None, "runner-shutdown branch should have terminated the proc"
     # The discard is unconditional — it's a no-op when the id wasn't
     # in the set, which is exactly the shutdown case.
-    assert job.job_id not in controller._cancel_requested
+    assert job.job_id not in controller.state.cancel_requested
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -34,7 +34,7 @@ def _make_controller_with_job(
 ) -> FirmwareController:
     """Build a controller shell that ``follow_job`` can drive end-to-end.
 
-    ``follow_job`` reads ``self._jobs`` and ``self._db.bus`` only —
+    ``follow_job`` reads ``self.state.jobs`` and ``self._db.bus`` only —
     everything else is unused for this path. ``with_real_bus=True``
     swaps in the real ``EventBus`` so the listener-attach + fire
     semantics match production; ``with_settings=False`` skips the

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -27,7 +27,7 @@ def _make_controller(
 ) -> FirmwareController:
     """Build a ``follow_jobs``-shaped controller via the shared factory.
 
-    ``follow_jobs`` reads ``self._jobs`` and ``self._db.bus`` only;
+    ``follow_jobs`` reads ``self.state.jobs`` and ``self._db.bus`` only;
     ``with_real_bus=True`` swaps in the real ``EventBus`` so the
     listener-attach + fire semantics match production, and
     ``with_settings=False`` skips the config-dir wiring this path

--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -1,6 +1,6 @@
 """Coverage for the read-only firmware-job inspectors.
 
-Two handlers, both pure read-throughs against ``self._jobs``:
+Two handlers, both pure read-throughs against ``self.state.jobs``:
 
 - ``firmware/get_jobs`` — filtered + sorted listing. Filters by
   ``status`` and ``configuration``; sorts newest-first by

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -173,7 +173,7 @@ async def test_install_enqueues_before_firing_job_queued(
     the first ``JOB_OUTPUT`` line arrives (sometimes a few seconds
     later for cold-start compiles).
 
-    Ordering matters: ``_enqueue`` calls ``await self._queue.put``
+    Ordering matters: ``_enqueue`` calls ``await self.state.queue.put``
     *before* firing the bus event. A frontend that receives
     ``JOB_QUEUED`` and immediately calls ``firmware/follow_job``
     races the runner — if the event broadcast preceded the queue

--- a/tests/controllers/firmware/test_install_to_specific_address.py
+++ b/tests/controllers/firmware/test_install_to_specific_address.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.controllers.firmware.helpers import (
     PortType,
     _validate_port,
@@ -34,13 +35,14 @@ from esphome_device_builder.models import ErrorCode, FirmwareJob, JobType
 def _controller() -> FirmwareController:
     """Build a controller skeleton with just the surface ``_build_command`` needs.
 
-    ``_build_command`` only reads ``self._esphome_cmd``; the rest of
+    ``_build_command`` only reads ``self.state.esphome_cmd``; the rest of
     the controller (queue, scanner, bus) isn't relevant for these
     tests. ``__new__`` skips ``__init__`` so we don't have to seed a
     full ``DeviceBuilder``.
     """
     controller = FirmwareController.__new__(FirmwareController)
-    controller._esphome_cmd = ["esphome"]
+    controller.state = FirmwareState()
+    controller.state.esphome_cmd = ["esphome"]
     controller._db = MagicMock()
     controller._db.devices = None  # cache args become a no-op
     return controller

--- a/tests/controllers/firmware/test_persistence.py
+++ b/tests/controllers/firmware/test_persistence.py
@@ -6,7 +6,7 @@ implementation rewrite (separate ``jobs.json`` file, sqlite,
 whatever) keeps the tests passing as long as the user-visible
 behaviour is preserved. Two acknowledged seams remain:
 
-- The ``RUNNING``-carryover test mutates ``writer._jobs[id]``
+- The ``RUNNING``-carryover test mutates ``writer.state.jobs[id]``
   directly to simulate "the runner was mid-build when the
   dashboard died". There's no public API for putting a job
   into ``RUNNING`` status without spawning a real ``esphome``
@@ -22,7 +22,7 @@ behaviour is preserved. Two acknowledged seams remain:
 Some tests also assert on ``_queue.put`` (which the conftest
 factory installs as ``AsyncMock``) to confirm the load path
 actually exchanged the job onto the queue — ``get_jobs()``
-alone reads ``self._jobs`` and would pass even if the runner
+alone reads ``self.state.jobs`` and would pass even if the runner
 never saw the job. That's a defence-in-depth check on the
 ``"will run after restart"`` half of the policy.
 
@@ -145,11 +145,11 @@ async def test_queued_job_survives_dashboard_restart(
     assert after_restart[0].status == JobStatus.QUEUED
     assert after_restart[0].configuration == "kitchen.yaml"
     # Confirm the load path actually put the job back on the queue,
-    # not just into ``self._jobs``. ``get_jobs`` reads the in-memory
+    # not just into ``self.state.jobs``. ``get_jobs`` reads the in-memory
     # map, which would still pass if ``_load_jobs`` forgot to
-    # ``await self._queue.put(...)``.
-    reader._queue.put.assert_awaited_once()
-    queued_arg = reader._queue.put.await_args.args[0]
+    # ``await self.state.queue.put(...)``.
+    reader.state.queue.put.assert_awaited_once()
+    queued_arg = reader.state.queue.put.await_args.args[0]
     assert queued_arg.job_id == queued.job_id
 
 
@@ -179,7 +179,7 @@ async def test_running_job_re_queues_with_clean_state_after_restart(
     problem; without it the rebuild's lines would silently
     concatenate onto whatever the crash left behind.
 
-    Phase 1 has to mutate ``self._jobs[...].status`` directly to
+    Phase 1 has to mutate ``self.state.jobs[...].status`` directly to
     simulate the runner having picked up the job before the
     dashboard went down — there's no public API for "make the
     runner mid-build" without spawning a real ``esphome``.
@@ -193,7 +193,7 @@ async def test_running_job_re_queues_with_clean_state_after_restart(
     # the status flip + per-run state are what the real runner
     # would have set on its own. Persistence happens implicitly
     # via the next ``compile`` submission's enqueue path.
-    in_flight = writer._jobs[queued.job_id]
+    in_flight = writer.state.jobs[queued.job_id]
     in_flight.status = JobStatus.RUNNING
     in_flight.output = ["compile in progress …\n", "src/main.cpp\n"]
     in_flight.progress = 47
@@ -225,8 +225,8 @@ async def test_running_job_re_queues_with_clean_state_after_restart(
     # The load path put both jobs (the running carryover + the
     # follow-up queued sibling) onto the queue — confirms the
     # carryover will actually run, not just sit ``QUEUED`` in
-    # ``self._jobs`` forever.
-    queued_ids = {call.args[0].job_id for call in reader._queue.put.await_args_list}
+    # ``self.state.jobs`` forever.
+    queued_ids = {call.args[0].job_id for call in reader.state.queue.put.await_args_list}
     assert queued.job_id in queued_ids
 
 
@@ -255,7 +255,7 @@ async def test_resumed_running_job_completes_on_next_run(
     (tmp_path / "kitchen.yaml").write_text("")
     writer = _persistent_controller(firmware_controller_factory)
     queued = await writer.compile(configuration="kitchen.yaml")
-    in_flight = writer._jobs[queued.job_id]
+    in_flight = writer.state.jobs[queued.job_id]
     in_flight.status = JobStatus.RUNNING
     in_flight.output = ["compile in progress …\n"]
     in_flight.progress = 47
@@ -269,7 +269,7 @@ async def test_resumed_running_job_completes_on_next_run(
     # that just assert on calls, but the runner needs a real
     # ``asyncio.Queue`` so ``_load_jobs``'s ``put`` and
     # ``_run_queue``'s ``get`` actually exchange jobs.
-    reader._queue = asyncio.Queue()
+    reader.state.queue = asyncio.Queue()
 
     # Replace _execute_job with a fast COMPLETED transition so we
     # don't actually spawn ``esphome``. The runner's loop calls
@@ -348,7 +348,7 @@ async def test_cancelled_job_survives_restart_without_being_requeued(
     # job at status ``CANCELLED`` would pass even if the loader
     # accidentally put it on the queue too — assert the queue
     # interaction explicitly.
-    reader._queue.put.assert_not_awaited()
+    reader.state.queue.put.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/firmware/test_prune_history.py
+++ b/tests/controllers/firmware/test_prune_history.py
@@ -1,7 +1,7 @@
 """End-to-end coverage for ``FirmwareController._prune_history``.
 
 The prune helper runs after every terminal-state transition (and
-on cancel / clear) to keep ``self._jobs`` from growing unbounded.
+on cancel / clear) to keep ``self.state.jobs`` from growing unbounded.
 The classification logic is a three-way fork — active / primary
 terminal / aux terminal — and the aux branch
 (``aux.append(job)``) was uncovered: the existing end-to-end
@@ -58,7 +58,7 @@ async def test_cancelling_aux_jobs_below_cap_keeps_them_all(
 
     await _cancel_all(controller, job_ids)
 
-    surviving = [j for j in controller._jobs.values() if j.job_type == JobType.CLEAN]
+    surviving = [j for j in controller.state.jobs.values() if j.job_type == JobType.CLEAN]
     assert len(surviving) == under_cap
     assert all(j.status == JobStatus.CANCELLED for j in surviving)
 
@@ -70,7 +70,7 @@ async def test_cancelling_aux_jobs_over_cap_drops_oldest(
 
     Pins the ``aux.append(job)`` + ``aux[:_MAX_AUX_TERMINAL_JOBS]``
     chain end-to-end. Without the cap, a user spamming
-    ``firmware/clean`` could grow ``self._jobs`` unbounded —
+    ``firmware/clean`` could grow ``self.state.jobs`` unbounded —
     clean jobs don't get the per-configuration dedup the primary
     pool uses, so a separate cap is the only thing keeping the
     pool bounded.
@@ -82,7 +82,7 @@ async def test_cancelling_aux_jobs_over_cap_drops_oldest(
 
     await _cancel_all(controller, job_ids)
 
-    surviving_ids = set(controller._jobs.keys())
+    surviving_ids = set(controller.state.jobs.keys())
     assert len(surviving_ids) == _MAX_AUX_TERMINAL_JOBS
     # Newest-first ordering: the most-recently submitted ids
     # survive, the oldest ``overflow`` are evicted.
@@ -111,9 +111,9 @@ async def test_aux_overflow_does_not_evict_compile_jobs(
     await _cancel_all(controller, clean_ids)
 
     # The compile (primary) survived the aux flood.
-    assert compile_job.job_id in controller._jobs
+    assert compile_job.job_id in controller.state.jobs
     # Aux pool got capped.
-    aux_kept = [j for j in controller._jobs.values() if j.job_type == JobType.CLEAN]
+    aux_kept = [j for j in controller.state.jobs.values() if j.job_type == JobType.CLEAN]
     assert len(aux_kept) == _MAX_AUX_TERMINAL_JOBS
 
 
@@ -139,12 +139,12 @@ async def test_active_aux_job_survives_aux_overflow(
     await _cancel_all(controller, overflow_ids)
 
     # Queued job is still in _jobs.
-    assert queued_job.job_id in controller._jobs
-    assert controller._jobs[queued_job.job_id].status == JobStatus.QUEUED
+    assert queued_job.job_id in controller.state.jobs
+    assert controller.state.jobs[queued_job.job_id].status == JobStatus.QUEUED
     # Terminal aux pool capped (queued job doesn't count toward the cap).
     terminal_cleans = [
         j
-        for j in controller._jobs.values()
+        for j in controller.state.jobs.values()
         if j.job_type == JobType.CLEAN and j.status != JobStatus.QUEUED
     ]
     assert len(terminal_cleans) == _MAX_AUX_TERMINAL_JOBS
@@ -178,6 +178,6 @@ async def test_aux_pool_keeps_repeated_cleans_against_same_configuration(
     # All three survived — supersede cancelled the first two (now
     # in the aux pool) and the third is still QUEUED. None were
     # collapsed by configuration.
-    assert set(job_ids).issubset(controller._jobs.keys())
-    statuses = {controller._jobs[jid].status for jid in job_ids}
+    assert set(job_ids).issubset(controller.state.jobs.keys())
+    statuses = {controller.state.jobs[jid].status for jid in job_ids}
     assert statuses == {JobStatus.CANCELLED, JobStatus.QUEUED}

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController, remote_runner
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import (
     EventType,
@@ -57,7 +58,7 @@ def test_queue_status_snapshot_idle() -> None:
 def test_queue_status_snapshot_running_only() -> None:
     """Runner busy with no backlog: idle=False, running=True, depth=0."""
     controller = _make_controller()
-    controller._current_job = _job()
+    controller.state.current_job = _job()
     idle, running, queue_depth = controller.queue_status_snapshot()
     assert idle is False
     assert running is True
@@ -75,8 +76,8 @@ def test_queue_status_snapshot_queued_but_not_running() -> None:
     up the next item.
     """
     controller = _make_controller()
-    controller._queue.put_nowait(_job("a"))
-    controller._queue.put_nowait(_job("b"))
+    controller.state.queue.put_nowait(_job("a"))
+    controller.state.queue.put_nowait(_job("b"))
     idle, running, queue_depth = controller.queue_status_snapshot()
     assert idle is False
     assert running is False
@@ -86,8 +87,8 @@ def test_queue_status_snapshot_queued_but_not_running() -> None:
 def test_queue_status_snapshot_running_and_queued() -> None:
     """Runner busy AND backlog: idle=False, running=True, depth>0."""
     controller = _make_controller()
-    controller._current_job = _job("active")
-    controller._queue.put_nowait(_job("waiting"))
+    controller.state.current_job = _job("active")
+    controller.state.queue.put_nowait(_job("waiting"))
     idle, running, queue_depth = controller.queue_status_snapshot()
     assert idle is False
     assert running is True
@@ -114,13 +115,14 @@ def _make_controller_with_real_bus() -> FirmwareController:
     db = MagicMock()
     db.bus = EventBus()
     controller = FirmwareController.__new__(FirmwareController)
+    controller.state = FirmwareState()
     controller._db = db
-    controller._jobs = {}
-    controller._queue = asyncio.Queue()
-    controller._current_job = None
-    controller._current_process = None
-    controller._cancel_requested = set()
-    controller._cancel_events = {}
+    controller.state.jobs = {}
+    controller.state.queue = asyncio.Queue()
+    controller.state.current_job = None
+    controller.state.current_process = None
+    controller.state.cancel_requested = set()
+    controller.state.cancel_events = {}
     return controller
 
 
@@ -165,16 +167,16 @@ def test_finalize_terminal_releases_slot_before_listener_fires(
     every subsequent install to LOCAL.
     """
     controller = _make_controller_with_real_bus()
-    controller._current_job = _job()
-    controller._current_process = MagicMock()
+    controller.state.current_job = _job()
+    controller.state.current_process = MagicMock()
     captured = _capture_snapshot_in_listener(controller, event_type)
 
-    controller._finalize_terminal(controller._current_job, status)
+    controller._finalize_terminal(controller.state.current_job, status)
 
     assert captured == [(True, False, 0)]
     # And the slot stays released after the fire returns.
-    assert controller._current_job is None
-    assert controller._current_process is None
+    assert controller.state.current_job is None
+    assert controller.state.current_process is None
 
 
 def test_finalize_terminal_skips_release_when_job_not_current() -> None:
@@ -190,13 +192,13 @@ def test_finalize_terminal_skips_release_when_job_not_current() -> None:
     controller = _make_controller_with_real_bus()
     running = _job("running")
     other = _job("other")
-    controller._current_job = running
+    controller.state.current_job = running
     captured = _capture_snapshot_in_listener(controller, EventType.JOB_FAILED)
 
     controller._finalize_terminal(other, JobStatus.FAILED)
 
     assert captured == [(False, True, 0)]
-    assert controller._current_job is running
+    assert controller.state.current_job is running
 
 
 def test_finalize_terminal_rejects_non_terminal_status() -> None:
@@ -209,12 +211,12 @@ def test_finalize_terminal_rejects_non_terminal_status() -> None:
     would crash later with a less-actionable ``KeyError``).
     """
     controller = _make_controller_with_real_bus()
-    controller._current_job = _job()
+    controller.state.current_job = _job()
 
     with pytest.raises(ValueError, match="non-terminal status"):
-        controller._finalize_terminal(controller._current_job, JobStatus.RUNNING)
+        controller._finalize_terminal(controller.state.current_job, JobStatus.RUNNING)
     # Slot intact — we raised before the release.
-    assert controller._current_job is not None
+    assert controller.state.current_job is not None
 
 
 @pytest.mark.parametrize(
@@ -242,8 +244,8 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
     # to inspect the same FirmwareJob instance the helpers
     # operated on.
     job = _job()
-    controller._current_job = job
-    controller._current_process = MagicMock()
+    controller.state.current_job = job
+    controller.state.current_process = MagicMock()
     captured = _capture_snapshot_in_listener(controller, event_type)
 
     if fn_name == "_finalize_success":
@@ -252,8 +254,8 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
         remote_runner._fail_locally(controller, job, reason="boom")
 
     assert captured == [(True, False, 0)]
-    assert controller._current_job is None
-    assert controller._current_process is None
+    assert controller.state.current_job is None
+    assert controller.state.current_process is None
     assert job.status is status
     if status is JobStatus.FAILED:
         # ``_fail_locally`` stamps ``job.error`` before

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -244,8 +244,8 @@ def _request_remote_cancel(controller: Any, job: FirmwareJob) -> None:
     ``_terminate_current_process`` branches that don't apply
     on the remote path.
     """
-    controller._cancel_requested.add(job.job_id)
-    event = controller._cancel_events.get(job.job_id)
+    controller.state.cancel_requested.add(job.job_id)
+    event = controller.state.cancel_events.get(job.job_id)
     if event is not None:
         event.set()
 
@@ -735,7 +735,7 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.CANCELLED
-    assert job.job_id not in controller._cancel_requested
+    assert job.job_id not in controller.state.cancel_requested
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
@@ -1093,7 +1093,7 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.CANCELLED
-    assert job.job_id not in controller._cancel_requested
+    assert job.job_id not in controller.state.cancel_requested
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
@@ -1309,7 +1309,7 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     # ``_cancel_requested`` carries the flag, but no entry
     # exists in ``_cancel_events`` yet (the runner hasn't
     # been called).
-    controller._cancel_requested.add(job.job_id)
+    controller.state.cancel_requested.add(job.job_id)
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     # The runner's bundle build + submit will still complete
@@ -1337,7 +1337,7 @@ async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
 
     Pins the wiring on the controller side: the cancel
     handler must look up
-    ``self._cancel_events[job_id]`` and call ``set()`` so a
+    ``self.state.cancel_events[job_id]`` and call ``set()`` so a
     runner parked on
     ``asyncio.wait({..., cancel_wait})`` wakes immediately.
     Without that signal the runner would deadlock until the
@@ -1357,9 +1357,9 @@ async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     # The WS cancel handler refuses non-existent jobs and the
     # ``_current_job`` mismatch is a hard error — wire both so
     # the handler's ``RUNNING`` branch runs.
-    controller._jobs[job.job_id] = job
+    controller.state.jobs[job.job_id] = job
     job.status = JobStatus.RUNNING
-    controller._current_job = job
+    controller.state.current_job = job
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1414,7 +1414,7 @@ async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_loca
 
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1
-    assert job.job_id not in controller._cancel_requested
+    assert job.job_id not in controller.state.cancel_requested
 
 
 # ---------------------------------------------------------------------------
@@ -1442,7 +1442,7 @@ def _wire_upload_subprocess(
 ) -> None:
     """Point the controller's runner at a python-one-liner ``esphome upload``.
 
-    The runner builds the cmd as ``[*controller._esphome_cmd,
+    The runner builds the cmd as ``[*controller.state.esphome_cmd,
     '--dashboard', ..., 'upload', <yaml>, '--device', <port>,
     '--file', <staged_firmware>]``. Pointing
     ``_esphome_cmd`` at ``python -c <script>`` lets the test
@@ -1460,7 +1460,7 @@ def _wire_upload_subprocess(
     script = (
         f"import sys; sys.stdout.write({quoted_stdout}); sys.stdout.flush(); sys.exit({exit_code})"
     )
-    controller._esphome_cmd = [sys.executable, "-c", script]
+    controller.state.esphome_cmd = [sys.executable, "-c", script]
     controller._build_cache_args = lambda _job: []
 
 
@@ -1682,7 +1682,7 @@ async def test_fetch_and_run_local_upload_pre_spawn_cancel_finalises_locally(
     captured = _capture_local_events(controller)
     client = _make_client()
     job = _make_remote_install_job()
-    controller._cancel_requested.add(job.job_id)
+    controller.state.cancel_requested.add(job.job_id)
     controller._tracked_subprocess = MagicMock(  # type: ignore[method-assign]
         side_effect=AssertionError("subprocess should not have spawned")
     )
@@ -1703,7 +1703,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     User Stop during the ``esphome upload`` subprocess finalises as CANCELLED.
 
     The runner's ``_tracked_subprocess`` registers the
-    upload spawn with ``controller._current_process``, and
+    upload spawn with ``controller.state.current_process``, and
     ``FirmwareController.cancel``'s
     ``_terminate_current_process`` lands SIGTERM on the
     spawned tree. The subprocess exits non-zero (terminated
@@ -1727,7 +1727,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     )
     # Replace the script with one that actually sleeps, so the
     # subprocess is parked when we cancel.
-    controller._esphome_cmd = [
+    controller.state.esphome_cmd = [
         sys.executable,
         "-c",
         "import sys, time; sys.stdout.write('starting upload\\n'); "
@@ -1735,8 +1735,8 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     ]
 
     async def _terminate() -> None:
-        assert controller._current_process is not None  # type narrowing
-        controller._current_process.terminate()
+        assert controller.state.current_process is not None  # type narrowing
+        controller.state.current_process.terminate()
 
     controller._terminate_current_process = _terminate  # type: ignore[method-assign]
     job = _make_remote_install_job()
@@ -1746,7 +1746,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     _fire_state(controller, job_id=job.job_id, status="completed")
 
     # Wait until the subprocess is up.
-    while controller._current_process is None:
+    while controller.state.current_process is None:
         await asyncio.sleep(0.01)
 
     _request_remote_cancel(controller, job)
@@ -1806,7 +1806,7 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     # subprocess spawn. The in-context-manager check fires
     # post-spawn.
     def _build_cache_args_then_cancel(_job: object) -> list[str]:
-        controller._cancel_requested.add(job.job_id)
+        controller.state.cancel_requested.add(job.job_id)
         return []
 
     controller._build_cache_args = _build_cache_args_then_cancel  # type: ignore[method-assign]
@@ -1838,7 +1838,7 @@ async def test_fetch_and_materialise_cancel_post_staging_finalises_locally(
     captured = _capture_local_events(controller)
     client = _make_client()
     job = _make_remote_install_job()
-    controller._cancel_requested.add(job.job_id)
+    controller.state.cancel_requested.add(job.job_id)
 
     proceed = await remote_runner._fetch_and_materialise(
         controller=controller, job=job, client=client

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -161,7 +161,7 @@ async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
         status=JobStatus.RUNNING,
     )
     controller = firmware_controller_factory(rename, with_settings=False)
-    controller._queue = AsyncMock()
+    controller.state.queue = AsyncMock()
     controller._db = type(
         "DB",
         (),

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -34,6 +34,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.models import EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
     CaptureEnqueueOrderFactory,
@@ -173,7 +174,8 @@ def test_build_command_for_reset_build_env_uses_clean_all_with_config_dir(
     device.
     """
     controller = FirmwareController.__new__(FirmwareController)
-    controller._esphome_cmd = ["esphome"]
+    controller.state = FirmwareState()
+    controller.state.esphome_cmd = ["esphome"]
     controller._db = MagicMock()
     controller._db.devices = None
 
@@ -205,7 +207,8 @@ def test_build_command_for_reset_build_env_ignores_port_and_cache_args(
     invocation could still pass them).
     """
     controller = FirmwareController.__new__(FirmwareController)
-    controller._esphome_cmd = ["esphome"]
+    controller.state = FirmwareState()
+    controller.state.esphome_cmd = ["esphome"]
     controller._db = MagicMock()
     controller._db.devices = None
 

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -26,6 +26,7 @@ import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import lifecycle as _firmware_lifecycle_mod
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers import process as _process_mod
 from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
@@ -145,8 +146,9 @@ def test_signal_process_group_returns_false_on_permission_error(
 def controller() -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
     ctrl = FirmwareController.__new__(FirmwareController)
-    ctrl._current_process = None  # type: ignore[attr-defined]
-    ctrl._current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
+    ctrl.state = FirmwareState()
+    ctrl.state.current_process = None  # type: ignore[attr-defined]
+    ctrl.state.current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
     return ctrl
 
 
@@ -198,7 +200,7 @@ async def test_terminate_kills_grandchild_via_process_group(
         stderr=asyncio.subprocess.STDOUT,
         start_new_session=True,
     )
-    controller._current_process = proc  # type: ignore[attr-defined]
+    controller.state.current_process = proc  # type: ignore[attr-defined]
 
     try:
         # Read the two pid lines from stdout so we know what to verify.

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
+from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers import process as process_module
 from esphome_device_builder.helpers.process import _terminate_subtree_windows
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
@@ -36,8 +37,9 @@ windows_only = pytest.mark.skipif(
 def controller() -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
     ctrl = FirmwareController.__new__(FirmwareController)
-    ctrl._current_process = None  # type: ignore[attr-defined]
-    ctrl._current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
+    ctrl.state = FirmwareState()
+    ctrl.state.current_process = None  # type: ignore[attr-defined]
+    ctrl.state.current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
     return ctrl
 
 
@@ -53,7 +55,7 @@ async def test_terminate_kills_subprocess_via_taskkill(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
-    controller._current_process = proc  # type: ignore[attr-defined]
+    controller.state.current_process = proc  # type: ignore[attr-defined]
 
     try:
         await controller._terminate_current_process()

--- a/tests/controllers/firmware/test_supersede.py
+++ b/tests/controllers/firmware/test_supersede.py
@@ -16,7 +16,7 @@ the user-visible contract is:
   fires).
 - The ``exclude_job_id`` guard keeps the new submission from
   cancelling itself — without it, ``_supersede_active_jobs``
-  would iterate ``self._jobs.values()``, find the new
+  would iterate ``self.state.jobs.values()``, find the new
   ``QUEUED`` entry, and immediately cancel it.
 
 Drives through public API only — submit via ``compile`` /
@@ -89,7 +89,7 @@ async def test_resubmit_does_not_cancel_itself(
     """The new submission's own ``QUEUED`` entry is excluded from supersede.
 
     Without the ``exclude_job_id`` guard,
-    ``_supersede_active_jobs`` would iterate ``self._jobs.values()``,
+    ``_supersede_active_jobs`` would iterate ``self.state.jobs.values()``,
     find the new submission's own entry (already in
     ``_jobs`` by the time supersede runs), and cancel it
     along with the predecessor — leaving the user with no
@@ -134,7 +134,7 @@ async def test_resubmit_cancels_running_predecessor(
     # justified seam as ``test_persistence.py``'s RUNNING-carryover
     # test).
     first.status = JobStatus.RUNNING
-    controller._current_job = first
+    controller.state.current_job = first
 
     second = await controller.compile(configuration="kitchen.yaml")
 
@@ -142,7 +142,7 @@ async def test_resubmit_cancels_running_predecessor(
     # ``finally`` would convert this into terminal CANCELLED on
     # the next turn (not exercised here; ``_terminate_current_process``
     # is the AsyncMock from ``with_terminate=True``).
-    assert first.job_id in controller._cancel_requested
+    assert first.job_id in controller.state.cancel_requested
     controller._terminate_current_process.assert_awaited()
     # Second submission queued normally.
     jobs = {j.job_id: j for j in await controller.get_jobs()}

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -83,16 +83,16 @@ if TYPE_CHECKING:
 
 
 def _wire_real_queue(controller: FirmwareController) -> None:
-    controller._queue = asyncio.Queue()
+    controller.state.queue = asyncio.Queue()
 
     async def _supersede(_configuration: str, *, exclude_job_id: str) -> None:
         return
 
     controller._supersede_active_jobs = _supersede  # type: ignore[assignment]
-    controller._current_job = None
-    controller._current_process = None
-    controller._cancel_requested = set()
-    controller._cancel_events = {}
+    controller.state.current_job = None
+    controller.state.current_process = None
+    controller.state.cancel_requested = set()
+    controller.state.cancel_events = {}
 
 
 def _seed_yaml(tmp_path: Path, name: str = "kitchen.yaml") -> None:
@@ -256,7 +256,7 @@ def _set_esphome_cmd(controller: FirmwareController) -> None:
     to be a list with at least one element so ``_build_command``
     has something to splat.
     """
-    controller._esphome_cmd = [sys.executable, "-c", "pass"]
+    controller.state.esphome_cmd = [sys.executable, "-c", "pass"]
 
 
 # ---------------------------------------------------------------------------
@@ -616,7 +616,7 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
         # ``_terminate_current_process`` no-ops). The poll proves the
         # registration happens BEFORE the runner waits on the proc,
         # which is the contract that makes mid-verify cancel work.
-        while controller._current_process is None:
+        while controller.state.current_process is None:
             await asyncio.sleep(0.01)
         await controller.cancel(job_id=job.job_id)
 
@@ -669,8 +669,8 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
             # before the verify subprocess returns. The fake exits
             # quickly (no real hang) so the runner reaches the post-
             # wait cancel check inside ``_verify_chip`` and raises.
-            if controller._current_job is not None:
-                controller._cancel_requested.add(controller._current_job.job_id)
+            if controller.state.current_job is not None:
+                controller.state.cancel_requested.add(controller.state.current_job.job_id)
                 cancel_armed = True
             return await real(
                 sys.executable,
@@ -696,7 +696,7 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
     # The cancel flag is consumed by the except-branch finalisation —
     # not strictly required (no other path reads it after) but pin it
     # so a future refactor that forgets the discard surfaces here.
-    assert job.job_id not in controller._cancel_requested
+    assert job.job_id not in controller.state.cancel_requested
 
 
 # ---------------------------------------------------------------------------
@@ -732,7 +732,7 @@ async def test_tracked_subprocess_registers_and_clears_current_process(
     # is unused by this test (we never trip the CancelledError or
     # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    assert controller._current_process is None
+    assert controller.state.current_process is None
 
     async with controller._tracked_subprocess(
         sys.executable,
@@ -741,11 +741,11 @@ async def test_tracked_subprocess_registers_and_clears_current_process(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller._current_process is proc
+        assert controller.state.current_process is proc
         await proc.wait()
 
     # Restored on exit.
-    assert controller._current_process is None
+    assert controller.state.current_process is None
 
 
 @pytest.mark.asyncio
@@ -768,7 +768,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exit(
     # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
     sentinel = object()
-    controller._current_process = sentinel  # type: ignore[assignment]
+    controller.state.current_process = sentinel  # type: ignore[assignment]
 
     async with controller._tracked_subprocess(
         sys.executable,
@@ -777,10 +777,10 @@ async def test_tracked_subprocess_restores_prior_value_on_exit(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller._current_process is proc  # registered for the duration
+        assert controller.state.current_process is proc  # registered for the duration
         await proc.wait()
 
-    assert controller._current_process is sentinel  # restored
+    assert controller.state.current_process is sentinel  # restored
 
 
 @pytest.mark.asyncio
@@ -802,7 +802,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
     # is unused by this test (we never trip the CancelledError or
     # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    assert controller._current_process is None
+    assert controller.state.current_process is None
 
     with pytest.raises(RuntimeError, match="boom"):
         async with controller._tracked_subprocess(
@@ -822,7 +822,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
             msg = "boom"
             raise RuntimeError(msg)
 
-    assert controller._current_process is None
+    assert controller.state.current_process is None
 
 
 @pytest.mark.asyncio
@@ -840,7 +840,7 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     ``_cancel_requested`` but ``_terminate_current_process`` walked
     a ``None`` field and no-op'd. Without the post-spawn flag check
     inside ``_execute_job`` (the ``if job.job_id in
-    self._cancel_requested: await self._terminate_current_process()``
+    self.state.cancel_requested: await self._terminate_current_process()``
     branch right after the main spawn), the install would run to
     completion before the post-``proc.wait()`` cancel handler saw
     the flag — the issue-#136 symptom for the "cancel arrived
@@ -875,7 +875,7 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     real_terminate = controller._terminate_current_process
 
     async def _spy_terminate() -> None:
-        terminate_calls.append(controller._current_process)
+        terminate_calls.append(controller.state.current_process)
         await real_terminate()
 
     monkeypatch.setattr(controller, "_terminate_current_process", _spy_terminate)
@@ -887,8 +887,8 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
         # returning the proc — this is the "cancel arrived in
         # the verify→main-spawn gap" scenario the post-spawn
         # check guards.
-        if controller._current_job is not None:
-            controller._cancel_requested.add(controller._current_job.job_id)
+        if controller.state.current_job is not None:
+            controller.state.cancel_requested.add(controller.state.current_job.job_id)
         return await real(sys.executable, "-c", _BUILD_SCRIPT_OK, **kwargs)
 
     monkeypatch.setattr(runner_module, "create_subprocess_exec", _wrapper)

--- a/tests/e2e/test_download_artifacts.py
+++ b/tests/e2e/test_download_artifacts.py
@@ -23,7 +23,7 @@ The chain (happy path):
                           receive loop
                        →  ``ArtifactsDownloadSender.handle_download_artifacts``
                           resolves ``(remote_peer, remote_job_id)``
-                          via linear scan over ``firmware._jobs``,
+                          via linear scan over ``firmware.state.jobs``,
                           calls real :func:`_pack_build_artifacts`
                           (StorageJSON sidecar + ``idedata.json``
                           + per-image bytes read off the autouse
@@ -46,7 +46,7 @@ pins ``CORE.data_dir`` to). Soft-reject tests don't need the
 packer to run; they short-circuit on the receiver's
 ``_find_remote_job`` / status gate.
 
-The receiver's ``db.firmware._jobs`` map is seeded with a
+The receiver's ``db.firmware.state.jobs`` map is seeded with a
 synthetic :class:`FirmwareJob` whose
 ``(remote_peer, remote_job_id)`` matches the dialogue —
 ``ArtifactsDownloadSender._find_remote_job`` walks that map
@@ -72,6 +72,7 @@ from esphome_device_builder.models import (
 )
 
 from .._storage_fixtures import write_storage_json
+from ..conftest import wire_firmware_remote_peer_api_mocks
 from .conftest import PairedInstances
 
 
@@ -86,7 +87,7 @@ def _seed_firmware_job(
     """Put a remote-peer :class:`FirmwareJob` on the receiver's firmware map.
 
     :meth:`ArtifactsDownloadSender._find_remote_job` linear-
-    scans ``firmware._jobs`` for a matching
+    scans ``firmware.state.jobs`` for a matching
     ``(remote_peer, remote_job_id)``; seeding here lets the
     e2e flow proceed past the ``unknown_job`` soft-reject
     without standing up a real firmware queue. The same
@@ -103,7 +104,7 @@ def _seed_firmware_job(
         remote_peer=instances.offloader_dashboard_id,
         remote_job_id=remote_job_id,
     )
-    instances.receiver._db.firmware._jobs = {job_id: job}
+    wire_firmware_remote_peer_api_mocks(instances.receiver._db.firmware, {job_id: job})
     return job
 
 
@@ -256,7 +257,7 @@ async def test_download_artifacts_unknown_job_surfaces_not_found(
     ``duplicate_download`` / ``pack_failed``). The receiver-
     side :meth:`_find_remote_job` returns ``None`` when the
     ``(remote_peer, remote_job_id)`` correlation isn't in
-    ``firmware._jobs``; the sender replies with a single
+    ``firmware.state.jobs``; the sender replies with a single
     ``artifacts_end{accepted: false, reason: "unknown_job"}``
     frame (no preceding ``artifacts_start``); the offloader-
     side WS layer maps that reason to
@@ -266,7 +267,7 @@ async def test_download_artifacts_unknown_job_surfaces_not_found(
     await paired_instances.wait_until_session_opened()
     # Deliberately don't seed the firmware map; the linear
     # scan finds nothing and the sender's first branch trips.
-    paired_instances.receiver._db.firmware._jobs = {}
+    wire_firmware_remote_peer_api_mocks(paired_instances.receiver._db.firmware, {})
 
     with pytest.raises(CommandError) as exc_info:
         await paired_instances.offloader.download_artifacts(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -26,7 +26,7 @@ fan-out, then download_artifacts, all keyed on the same
 ``(offloader dashboard_id, offloader-side job_id)`` correlation
 through to the receiver's
 ``ArtifactsDownloadSender._find_remote_job`` linear scan over
-``firmware._jobs``. A regression that breaks the correlation
+``firmware.state.jobs``. A regression that breaks the correlation
 between the submit-side and download-side reads, or one that
 fails to keep the session healthy across two application-
 message types, would slip past the per-flow tests but surface
@@ -86,7 +86,7 @@ from esphome_device_builder.models import (
 )
 
 from .._storage_fixtures import write_storage_json
-from ..conftest import capture_events
+from ..conftest import capture_events, wire_firmware_remote_peer_api_mocks
 from .conftest import PairedInstances
 
 
@@ -129,8 +129,8 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
     ``QUEUED`` → ``COMPLETED`` after firing the lifecycle events
     so the download-side ``_find_remote_job`` accepts it.
 
-    ``firmware._jobs`` is a real dict (not a mock) so the
-    receiver-side download path's ``firmware._jobs.values()``
+    ``firmware.state.jobs`` is a real dict (not a mock) so the
+    receiver-side download path's ``firmware.state.jobs.values()``
     iteration finds the recorded job. Production has the real
     queue populating this dict; here we populate it from
     ``_create_job``.
@@ -161,7 +161,7 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
     firmware = instances.receiver._db.firmware
     firmware._create_job = MagicMock(side_effect=_create_job)
     firmware._enqueue = AsyncMock(side_effect=lambda job: job)
-    firmware._jobs = receiver_jobs
+    wire_firmware_remote_peer_api_mocks(firmware, receiver_jobs)
     # ``_on_firmware_queue_transition`` (registered on every
     # JOB_QUEUED / JOB_STARTED / terminal event) reads
     # ``queue_status_snapshot()`` and tuple-unpacks the result.

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -79,7 +79,7 @@ def _make_firmware_with_job(
     status: JobStatus = JobStatus.COMPLETED,
     configuration: str = "kitchen.yaml",
 ) -> Any:
-    """Stub ``FirmwareController`` with a single matching FirmwareJob in ``_jobs``."""
+    """Stub ``FirmwareController`` exposing one matching job via the public API."""
     job = MagicMock()
     job.remote_peer = remote_peer
     job.remote_job_id = remote_job_id
@@ -87,7 +87,16 @@ def _make_firmware_with_job(
     job.configuration = configuration
 
     firmware = MagicMock()
-    firmware._jobs = {"local-1": job}
+
+    def _find(*, remote_peer: str, remote_job_id: str) -> Any:
+        if job.remote_peer == remote_peer and job.remote_job_id == remote_job_id:
+            return job
+        return None
+
+    firmware.find_remote_peer_job.side_effect = _find
+    firmware.remote_peer_job_ids.side_effect = lambda *, remote_peer: (
+        [job.remote_job_id] if job.remote_peer == remote_peer else []
+    )
     return firmware
 
 


### PR DESCRIPTION
# What does this implement/fix?

Same pattern as #795 (`OffloaderState`), #797 (`DevicesState`),
and #801 (`ReceiverState`), now applied to the firmware
controller. Firmware was already split into a sibling-module
package (`runner` / `persistence` / `clean` / `follow` / `jobs`
/ `factories` / `lifecycle` / `remote_runner` / `cli` / `bulk`
/ `download`), but kept the legacy `controller._foo` private-
attr shape — 49 cross-sibling reads across 8 files. Per
CLAUDE.md's State dataclass convention, that's the
"post-split cleanup arc" the rule explicitly warns about:

> When splitting a controller into a package, design with
> `XxxState` from PR 1 — adding it later forces a post-split
> cleanup arc (#795, #797).

## FirmwareState (in `controllers/firmware/_state.py`)

Mutable domain state:

- `esphome_cmd`
- `queue`
- `jobs`
- `current_job`
- `current_process`
- `cancel_requested`
- `cancel_events`

## What stays on the controller

- `_db`, base infrastructure
- `_runner_task` — controller-internal, no sibling reads it

## Public API to keep cross-package callers out of state

`ArtifactsDownloadSender` (in `controllers/remote_build/`) was
reaching into `firmware.state.jobs.values()` in two places to
find a job by `(remote_peer, remote_job_id)`. Cross-package
reaches into a sibling controller's State are a smell — the
state is internal to the owner's package. Added two thin public
methods on the firmware controller so cross-package callers
go through the API instead:

- `find_remote_peer_job(remote_peer, remote_job_id)` — the
  lookup primitive (replaces the old
  `ArtifactsDownloadSender._find_remote_job` private method,
  which has been removed)
- `remote_peer_job_ids(remote_peer)` — for the reject-log
  list of available ids

Same shape as the existing `active_remote_peer_jobs` public
accessor that already lives on the controller for the same
reason.

## Test impact

Mechanical attribute renames across 26 test files (every
firmware-package sibling test plus three non-firmware test
files that seeded `firmware.state.jobs` directly).

The e2e cases that previously just set
`firmware.state.jobs = {...}` on a `MagicMock` firmware
controller now go through `wire_firmware_remote_peer_api_mocks`
in `tests/conftest.py` — a single source of truth that
installs `state.jobs` plus the matching `find_remote_peer_job`
/ `remote_peer_job_ids` side-effects so the stub mirrors the
real controller's API.

All 3390 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Closes the state-dataclass arc started in #795 / #797 / #801.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
