### PR TITLE
Split ReceiverController: extract identity commands

### DIFF
--- a/esphome_device_builder/controllers/remote_build/identity_commands.py
+++ b/esphome_device_builder/controllers/remote_build/identity_commands.py
@@ -1,0 +1,80 @@
+"""Receiver-side ``get_identity`` / ``rotate_identity`` WS commands."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ...helpers import dashboard_identity as _dashboard_identity_helper
+from ...helpers.api import CommandError
+from ...helpers.dashboard_identity import get_or_create_identity
+from ...models import (
+    ErrorCode,
+    EventType,
+    IdentityView,
+    RemoteBuildIdentityRotatedData,
+)
+from ._summaries import identity_view
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+
+async def get_identity(controller: ReceiverController) -> IdentityView:
+    """Return this dashboard's stable identity (id + pin + versions + bind state).
+
+    The X25519 private key is never returned; only
+    ``pin_sha256`` (the fingerprint mDNS broadcasts and
+    offloaders pin against).
+    """
+    loop = asyncio.get_running_loop()
+    identity = await loop.run_in_executor(
+        None, get_or_create_identity, controller._db.settings.config_dir
+    )
+    return identity_view(identity, listener_bound=controller._db.is_remote_build_listener_bound)
+
+
+async def rotate_identity(controller: ReceiverController) -> IdentityView:
+    """
+    Mint a fresh X25519 peer-link keypair, replacing whatever's on disk.
+
+    Forces every paired offloader to re-pair — peers pinned
+    on the old ``pin_sha256`` see a fingerprint mismatch on
+    the next handshake. ``dashboard_id`` is preserved.
+
+    Side effects when remote-build is currently bound:
+    listener torn down + rebuilt with the fresh key,
+    ``pin_sha256`` re-advertised in mDNS, rebuild fail-softs
+    (``listener_bound=False`` in the response).
+    :attr:`EventType.REMOTE_BUILD_IDENTITY_ROTATED` fires
+    regardless of bind state so subscribers can refresh
+    cached pins without polling.
+
+    Concurrent calls return ``ALREADY_EXISTS`` — two
+    rotations racing would each tear down + rebuild the
+    listener; back-to-back is almost always an accidental
+    double-click.
+    """
+    # Check+set is atomic on the single asyncio loop.
+    if controller.state.rotation_in_flight:
+        msg = "remote_build: an identity rotation is already in progress"
+        raise CommandError(ErrorCode.ALREADY_EXISTS, msg)
+    controller.state.rotation_in_flight = True
+    try:
+        loop = asyncio.get_running_loop()
+        identity = await loop.run_in_executor(
+            None, _dashboard_identity_helper.rotate_identity, controller._db.settings.config_dir
+        )
+        listener_bound = await controller._db.reload_remote_build_identity(
+            pin_sha256=identity.pin_sha256,
+        )
+        controller._db.bus.fire(
+            EventType.REMOTE_BUILD_IDENTITY_ROTATED,
+            RemoteBuildIdentityRotatedData(
+                dashboard_id=identity.dashboard_id,
+                pin_sha256=identity.pin_sha256,
+            ),
+        )
+        return identity_view(identity, listener_bound=listener_bound)
+    finally:
+        controller.state.rotation_in_flight = False

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -24,9 +24,7 @@ import time
 from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Any, Literal
 
-from ...helpers import dashboard_identity as _dashboard_identity_helper
 from ...helpers.api import CommandError, api_command
-from ...helpers.dashboard_identity import get_or_create_identity
 from ...helpers.event_bus import Event
 from ...helpers.storage import Store
 from ...models import (
@@ -41,7 +39,6 @@ from ...models import (
     PeerStatus,
     PeerSummary,
     ReceiverPeers,
-    RemoteBuildIdentityRotatedData,
     RemoteBuildPairingWindowChangedData,
     RemoteBuildPairRequestReceivedData,
     RemoteBuildPairStatusChangedData,
@@ -53,7 +50,7 @@ from ..config import (
     load_remote_build_settings,
     remote_build_settings_transaction,
 )
-from . import cleanup_loop, peer_link_sessions
+from . import cleanup_loop, identity_commands, peer_link_sessions
 from ._receiver_state import ReceiverState
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
@@ -61,7 +58,7 @@ from ._storage_codecs import (
     decode_peers,
     encode_peers,
 )
-from ._summaries import identity_view, peer_summary
+from ._summaries import peer_summary
 from ._validators import (
     validate_dashboard_id,
 )
@@ -349,63 +346,13 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
     @api_command("remote_build/get_identity")
     async def get_identity(self, **kwargs: Any) -> IdentityView:
-        """Return this dashboard's stable identity (id + pin + versions + bind state).
-
-        The X25519 private key is never returned; only
-        ``pin_sha256`` (the fingerprint mDNS broadcasts and
-        offloaders pin against).
-        """
-        loop = asyncio.get_running_loop()
-        identity = await loop.run_in_executor(
-            None, get_or_create_identity, self._db.settings.config_dir
-        )
-        return identity_view(identity, listener_bound=self._db.is_remote_build_listener_bound)
+        """Return this dashboard's stable identity (id + pin + versions + bind state)."""
+        return await identity_commands.get_identity(self)
 
     @api_command("remote_build/rotate_identity")
     async def rotate_identity(self, **kwargs: Any) -> IdentityView:
-        """
-        Mint a fresh X25519 peer-link keypair, replacing whatever's on disk.
-
-        Forces every paired offloader to re-pair — peers pinned
-        on the old ``pin_sha256`` see a fingerprint mismatch on
-        the next handshake. ``dashboard_id`` is preserved.
-
-        Side effects when remote-build is currently bound:
-        listener torn down + rebuilt with the fresh key,
-        ``pin_sha256`` re-advertised in mDNS, rebuild fail-softs
-        (``listener_bound=False`` in the response).
-        :attr:`EventType.REMOTE_BUILD_IDENTITY_ROTATED` fires
-        regardless of bind state so subscribers can refresh
-        cached pins without polling.
-
-        Concurrent calls return ``ALREADY_EXISTS`` — two
-        rotations racing would each tear down + rebuild the
-        listener; back-to-back is almost always an accidental
-        double-click.
-        """
-        # Check+set is atomic on the single asyncio loop.
-        if self.state.rotation_in_flight:
-            msg = "remote_build: an identity rotation is already in progress"
-            raise CommandError(ErrorCode.ALREADY_EXISTS, msg)
-        self.state.rotation_in_flight = True
-        try:
-            loop = asyncio.get_running_loop()
-            identity = await loop.run_in_executor(
-                None, _dashboard_identity_helper.rotate_identity, self._db.settings.config_dir
-            )
-            listener_bound = await self._db.reload_remote_build_identity(
-                pin_sha256=identity.pin_sha256,
-            )
-            self._db.bus.fire(
-                EventType.REMOTE_BUILD_IDENTITY_ROTATED,
-                RemoteBuildIdentityRotatedData(
-                    dashboard_id=identity.dashboard_id,
-                    pin_sha256=identity.pin_sha256,
-                ),
-            )
-            return identity_view(identity, listener_bound=listener_bound)
-        finally:
-            self.state.rotation_in_flight = False
+        """Mint a fresh X25519 peer-link keypair, replacing whatever's on disk."""
+        return await identity_commands.rotate_identity(self)
 
     # ------------------------------------------------------------------
     # Peer CRUD — receiver-UI surface for the Pairing requests inbox.


### PR DESCRIPTION
# What does this implement/fix?

Third in the receiver-split arc (after #809 cleanup loop and #815 peer-link sessions). Extracts the two identity WS commands into a new sibling module `controllers/remote_build/identity_commands.py`:

- `get_identity` — returns the dashboard's stable identity (id + pin + versions + bind state).
- `rotate_identity` — mints a fresh X25519 peer-link keypair; forces every paired offloader to re-pair on the next handshake.

Both stay as bound-method delegates on the controller (the `@api_command` decorator binds them to the WS dispatch). Bodies take `ReceiverController` as the first arg.

## Imports

Moved out of `receiver.py`: `dashboard_identity` helper module, `get_or_create_identity`, `IdentityView`, `RemoteBuildIdentityRotatedData`, the `identity_view` summary.

## Test impact

Zero test changes — the `@api_command` surface is unchanged and tests instance-call through the bound delegates.

`receiver.py`: **842 → 789 lines** (-53). Combined with #809 + #815: 1083 → 789 (-294, **-27%**). All 3413 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the ReceiverController split arc. Remaining concern groups: pairing window, pair flow / lookup, peer CRUD WS commands, settings WS commands.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
