### PR TITLE
Enable SLF001 ruff rule to enforce State boundary at cross-package edges

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -364,7 +364,10 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
                 except Exception:
                     await client.send_error("", ErrorCode.INVALID_MESSAGE, "Invalid JSON")
                     continue
-                client.create_task(client._handle_command(raw))
+                # Same-module call: the WS dispatch loop lives next to
+                # ``WebSocketClient`` and reaches its command handler
+                # directly. SLF001 can't see the module boundary.
+                client.create_task(client._handle_command(raw))  # noqa: SLF001
     finally:
         await client.cleanup()
         _LOGGER.debug("WebSocket client disconnected")

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1138,7 +1138,11 @@ class DeviceBuilder:
         # tells the OS to pick an ephemeral port; the bound port
         # lives on the started server socket.
         port = configured_port
-        if configured_port == 0 and site._server is not None:
+        # ``site._server`` is genuinely aiohttp-private — there's no
+        # public way to get the bound port off a ``TCPSite`` after an
+        # ephemeral-port (configured_port=0) bind. We reach in; if
+        # aiohttp ever renames it the cast below crashes loudly.
+        if configured_port == 0 and site._server is not None:  # noqa: SLF001
             # typeshed's ``asyncio.AbstractServer`` doesn't expose
             # ``sockets`` even though the concrete ``base_events.Server``
             # does — the asyncio docs list it as part of the public
@@ -1146,7 +1150,7 @@ class DeviceBuilder:
             # access boundary; the alternative (``getattr`` + None
             # checks) would obscure what's actually a stable
             # documented attribute.
-            sockets = cast("asyncio.base_events.Server", site._server).sockets
+            sockets = cast("asyncio.base_events.Server", site._server).sockets  # noqa: SLF001
             if sockets:
                 port = sockets[0].getsockname()[1]
         return runner, identity, port

--- a/esphome_device_builder/helpers/api.py
+++ b/esphome_device_builder/helpers/api.py
@@ -54,7 +54,10 @@ def api_command(command: str) -> Callable[[_F], _F]:
     """
 
     def decorator(func: _F) -> _F:
-        func._api_command = command  # type: ignore[attr-defined]
+        # Framework metadata stamped on the decorated function; the
+        # leading underscore is the "not for callers" convention,
+        # not class-private state, so SLF001 doesn't apply.
+        func._api_command = command  # type: ignore[attr-defined]  # noqa: SLF001
         return func
 
     return decorator
@@ -71,5 +74,5 @@ def collect_api_commands(obj: object) -> dict[str, CommandHandler]:
             continue
         method = getattr(obj, name, None)
         if callable(method) and hasattr(method, "_api_command"):
-            handlers[method._api_command] = method
+            handlers[method._api_command] = method  # noqa: SLF001 — see ``api_command``
     return handlers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,9 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 # CLI scripts: noisy print is fine, late imports gate optional esphome introspection
 # behind try/except ImportError, and several subprocess invocations are inherent.
-"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415"]
+# SLF001 is also waived here so smoke-test scripts (``check_catalog.py``) can
+# inspect catalog internals (``_by_id``, ``_components``) without per-line noqa.
+"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001"]
 # Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
 "esphome_device_builder/discover.py" = ["T20"]
 # Tests need free access to controller privates for setup / assertion;
@@ -184,8 +186,9 @@ select = [
 "esphome_device_builder/controllers/**/*.py" = ["SLF001"]
 # GitHub Action helpers: prints are CI-log diagnostics, lazy imports keep the
 # module importable for unit tests without PyGithub installed, and the temp
-# file path is a runner-controlled location not user input.
-".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001"]
+# file path is a runner-controlled location not user input. SLF001 is also
+# waived so action unit tests can call into helper-private methods directly.
+".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001", "SLF001"]
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,9 @@ select = [
   "RUF", # ruff-specific
   "S", # flake8-bandit
   "SIM", # flake8-simplify
+  "SLF", # flake8-self — flag cross-class private member access so the State
+  # dataclass boundary stays load-bearing; sibling-module access within a
+  # controller package is exempted via per-file-ignores below.
   "T20", # flake8-print
   "UP", # pyupgrade
   "W", # pycodestyle warnings
@@ -163,10 +166,22 @@ select = [
 "script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415"]
 # Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
 "esphome_device_builder/discover.py" = ["T20"]
-"tests/*" = ["S105", "S106"] # hardcoded test credentials
+# Tests need free access to controller privates for setup / assertion;
+# enforcing SLF001 here would mean a noqa on nearly every fixture and
+# would obscure the cases where the protection actually matters.
+"tests/*" = ["S105", "S106", "SLF001"] # hardcoded test credentials
 # Manual scripts: print is the UX, late imports gate optional setup,
 # subprocess + tempdir paths are part of the CLI contract.
 "tests/manual/*" = ["T20", "S108", "PLC0415"]
+# Controller-package siblings (``controllers/X/runner.py`` etc.) are
+# delegate modules that share state with ``controllers/X/controller.py``.
+# CLAUDE.md's State convention scopes cross-module *data* through
+# ``controller.state.X`` but leaves base infrastructure (``_db``,
+# ``_listeners``, ``_tasks``) and private helper methods underscored —
+# siblings reach those by design. The protection SLF001 buys us lives
+# at the cross-*package* boundary (and at the top-level files outside
+# this glob), which this exemption preserves.
+"esphome_device_builder/controllers/**/*.py" = ["SLF001"]
 # GitHub Action helpers: prints are CI-log diagnostics, lazy imports keep the
 # module importable for unit tests without PyGithub installed, and the temp
 # file path is a runner-controlled location not user input.


### PR DESCRIPTION
# What does this implement/fix?

`flake8-self`'s `SLF001` flags private-member access from
outside the owning class. Enabling it across the codebase
locks in the State dataclass convention (#795 / #797 / #801 /
#819) — a future cross-package reach into another controller's
`_jobs` / `_queue` / etc. now lights up at lint time rather
than slipping through review.

## Per-file-ignores

Two exemptions keep the rule's signal-to-noise ratio sane:

- **`tests/*`** — tests legitimately reach into controller
  privates to set up fixtures and assert internal state. The
  test files have 1670+ such reaches today; enforcing here
  would generate a sea of noqa annotations with no real
  protection (a stray `firmware._jobs` in a test is at worst
  a coupling smell, not a design escape).

- **`esphome_device_builder/controllers/**/*.py`** — per
  CLAUDE.md's State convention, sibling modules inside a
  controller package reach into `controller._db` /
  `_listeners` / `_tasks` / private helper methods by design.
  The State pattern enforces cross-module *data* access through
  `controller.state.X`; base infrastructure (`_db`) and private
  helper methods stay underscored. SLF001 doesn't model
  package boundaries, so we exempt the inside of each
  controller package wholesale. The protection that survives
  this exemption is exactly the one we wanted: top-level files
  (`api/ws.py`, `device_builder.py`, `helpers/api.py`) and any
  future non-controller modules can't silently reach into a
  controller's privates without a deliberate noqa.

## Five outliers at the edges

Each carries a `# noqa: SLF001` with an explanatory comment so
future review knows why the lint was bypassed:

- `api/ws.py`: the WS dispatch loop calls
  `client._handle_command` from a module-level function next
  to `WebSocketClient`. Same-module access (not a true class
  boundary), but SLF001 can't see the module level.
- `device_builder.py`: `site._server` is genuinely aiohttp-
  private. We reach in because there's no public way to read
  the bound port off a `TCPSite` after an ephemeral-port
  (`configured_port=0`) bind. If aiohttp ever renames it the
  cast crashes loudly.
- `helpers/api.py`: `func._api_command` is the canonical
  decorator-stamp metadata pattern — the leading underscore is
  "framework metadata" naming, not class-private state.

## What this does NOT do

This is the *enable + grandfather* step. The follow-up that
adds the missing test coverage from PR #819 (Codecov flagged
two uncovered branches in `firmware/jobs.py`) is a separate
PR.

**Related issue or feature (if applicable):**

- Companion to the State dataclass arc: #795 / #797 / #801 / #819.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
