### PR TITLE
Enable zero-violation ruff families (LOG, G, ICN, INP, ISC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,12 @@ select = [
   "F", # pyflakes
   "FLY", # flynt: convert string formatting to f-strings
   "FURB", # refurb
+  "G", # flake8-logging-format — flag % / .format / f-string in logger calls
   "I", # isort
+  "ICN", # flake8-import-conventions — pin canonical import aliases
+  "INP", # flake8-no-pep420 — flag implicit namespace packages (missing __init__.py)
+  "ISC", # flake8-implicit-str-concat — flag accidental ``"a" "b"`` adjacent-string concat
+  "LOG", # flake8-logging — catch ``logging.warn`` / wrong exception handling on the logger
   "N", # pep8-naming
   "PERF", # performance
   "PL", # pylint
@@ -188,7 +193,9 @@ select = [
 # module importable for unit tests without PyGithub installed, and the temp
 # file path is a runner-controlled location not user input. SLF001 is also
 # waived so action unit tests can call into helper-private methods directly.
-".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001", "SLF001"]
+# INP001 (implicit namespace package) is waived because action directories
+# are standalone scripts, not part of the Python package tree.
+".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001", "SLF001", "INP001"]
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"


### PR DESCRIPTION
# What does this implement/fix?

Five additional ruff rule families that fire zero violations on
the current tree, locked in now as forward-protection in the
same spirit as #822's SLF001 enable.

## Families enabled

| Code | Family | Catches |
|---|---|---|
| `LOG` | flake8-logging | `logging.warn` (deprecated), wrong `exc_info` usage on the logger |
| `G` | flake8-logging-format | `_LOGGER.info("x=" + str(x))` / .format / f-string in logger calls — preserves lazy-format performance and structured-log compatibility |
| `ICN` | flake8-import-conventions | Pins canonical aliases (`import numpy as np` etc.) |
| `INP` | flake8-no-pep420 | Implicit namespace packages (a Python tree missing `__init__.py`) |
| `ISC` | flake8-implicit-str-concat | Accidental adjacent-string concat in list literals (`["foo" "bar"]`) |

Zero new violations on `esphome_device_builder/`, `tests/`,
`script/`, or `.github/actions/**`. Pre-commit clean; full
3395-test suite passes.

## One per-file-ignore added

INP001 fires on `.github/actions/generate-release-notes/test_generate_notes.py`
because that action directory is a standalone script tree, not
part of the Python package. Already exempted via the existing
`.github/actions/**` per-file-ignore line (added INP001 to the
existing list there alongside SLF001).

## Out of scope

Three further families with non-zero violation counts each
warrant their own audit PR — adding them here would conflate
the safe-enable from the audit-and-fix work:

- `ASYNC` (flake8-async, 46 violations) — blocking calls in
  async functions; valuable for an asyncio-heavy codebase but
  each site needs human triage (some are intentional sync
  calls).
- `BLE` (flake8-blind-except, 22 violations) — broad
  `except Exception:` clauses; some are legitimate defensive
  arms.
- `TRY` (tryceratops, 120 violations) — exception handling
  antipatterns; many sites have intentional shape.

`TCH` (flake8-type-checking) was on my original audit
shortlist but a count-script bug made it look like zero —
actually 324 violations. Out of scope here too.

**Related issue or feature (if applicable):**

- Companion to the SLF001 enable in #822.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
