### PR TITLE
Gate _emit_field list-of-dicts branch on all-elements-are-dicts

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -280,7 +280,7 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
         for sub_key, sub_value in value.items():
             lines.extend(_emit_field(sub_key, sub_value, indent + ESPHOME_YAML_INDENT))
         return lines
-    if isinstance(value, list) and value and isinstance(value[0], dict):
+    if isinstance(value, list) and value and all(isinstance(item, dict) for item in value):
         lines = [f"{indent}{key}:"]
         for item in value:
             first = True

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1107,6 +1107,24 @@ def test_generate_component_yaml_recurses_through_nested_dict_indent() -> None:
     assert "      leaf: v" in out
 
 
+def test_generate_component_yaml_handles_mixed_dict_and_scalar_list_without_raising() -> None:
+    """
+    A list with a leading dict but a non-dict later element falls through.
+
+    The list-of-dicts branch is gated on every element being a dict;
+    a mixed list takes the flow-style fallback instead. Without
+    the all-dict gate the second-iteration ``item.items()`` call
+    would raise ``AttributeError`` and surface as a generic
+    internal error to the user. Pin both the no-raise contract
+    and the flow-style fallback shape (valid YAML by accident —
+    the dict renders as a flow mapping via ``str(dict)`` and the
+    scalar renders bare).
+    """
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"items": [{"a": 1}, "loose"]})
+    assert "items: [{'a': 1}, loose]" in out
+
+
 def test_generate_component_yaml_emits_list_of_dicts_as_block_sequence() -> None:
     """A list of dicts renders as ``- mapping`` block-sequence items.
 


### PR DESCRIPTION
# What does this implement/fix?

`_emit_field`'s list-of-dicts branch was gated on `isinstance(value[0], dict)` — only the first element checked. The inner loop assumed every item was a dict (`item.items()`), so a list with a leading dict and a later scalar element raised `AttributeError: 'str' object has no attribute 'items'`:

```python
from esphome_device_builder.helpers.yaml.component import _emit_field
_emit_field("items", [{"a": 1}, "loose"], "  ")
# AttributeError: 'str' object has no attribute 'items'
```

In production this surfaces as a generic "internal error" from the WS handler rather than a typed `CommandError(INVALID_ARGS, …)`.

Pre-existing — predates the helpers/yaml split arc (#796 / #813) and the scalar-list flow-style fix (#817), all of which carried this gate byte-for-byte. Copilot flagged the precondition gap during #817's review and the fix was deferred per the project's strict split-then-clean cadence.

**Fix.** Tighten the gate to `all(isinstance(item, dict) for item in value)`. Mixed lists now fall through to the scalar-list flow-style branch (#817), which routes each element through `_format_flow_yaml_value` and emits a flow list where the dict elements render via `str(dict)` (a Python-repr accident that happens to produce valid YAML flow-mapping syntax for simple values) and the scalars render bare. No exception, valid-by-accident YAML output for the unlikely mixed-input case.

**Test.** One pinning test added to `tests/test_yaml_helpers.py` right before the existing list-of-dicts test, driven end-to-end through `generate_component_yaml` (same shape as the other `_emit_field` branch tests).

**Related issue or feature (if applicable):**

- fixes #820

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
