### PR TITLE
Split ReceiverController: extract settings commands

### DIFF
--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -28,8 +28,6 @@ from ...helpers.api import CommandError, api_command
 from ...helpers.event_bus import Event
 from ...helpers.storage import Store
 from ...models import (
-    MAX_CLEANUP_TTL_SECONDS,
-    MIN_CLEANUP_TTL_SECONDS,
     TERMINAL_JOB_EVENTS,
     ErrorCode,
     EventType,
@@ -48,9 +46,8 @@ from ...models import (
 )
 from ..config import (
     load_remote_build_settings,
-    remote_build_settings_transaction,
 )
-from . import cleanup_loop, identity_commands, peer_link_sessions
+from . import cleanup_loop, identity_commands, peer_link_sessions, settings_receiver
 from ._receiver_state import ReceiverState
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
@@ -215,23 +212,11 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
     @api_command("remote_build/get_settings")
     async def get_settings(self, **kwargs: Any) -> RemoteBuildSettingsView:
         """Return the receiver-side remote-build settings (wire view)."""
-        return self._to_view(await self._load_settings_async())
+        return await settings_receiver.get_settings(self)
 
     def _to_view(self, settings: RemoteBuildSettings) -> RemoteBuildSettingsView:
-        """Project receiver settings to wire view, merging in-memory peers.
-
-        The peer list is RAM-canonical: PENDING entries live in
-        ``self.state.pending_peers`` for the active pairing window's
-        lifetime (never hit disk) and APPROVED entries live in
-        ``self.state.approved_peers`` / its per-file ``Store``.
-        ``settings`` is consulted for the master ``enabled``
-        toggle.
-        """
-        return RemoteBuildSettingsView(
-            enabled=settings.enabled,
-            cleanup_ttl_seconds=settings.cleanup_ttl_seconds,
-            peers=self._peer_summaries(),
-        )
+        """Project receiver settings to wire view, merging in-memory peers."""
+        return settings_receiver.to_view(self, settings)
 
     def _peer_summaries(self) -> list[PeerSummary]:
         """Merge PENDING + APPROVED into a single ``PeerSummary`` list.
@@ -262,33 +247,8 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
     async def _modify_settings(
         self, mutator: Callable[[RemoteBuildSettings], None]
     ) -> RemoteBuildSettingsView:
-        """
-        Run ``mutator`` against the current settings and persist the result.
-
-        Wraps :func:`remote_build_settings_transaction` so the
-        whole read-modify-write happens under the metadata lock,
-        so two concurrent callers can't both read the same starting
-        value and have the second save wipe the first's change.
-        Runs in the default executor since the transaction does
-        blocking JSON I/O. Returns the wire view so the response
-        leaving this method can never carry ``secret_sha256``.
-
-        ``mutator`` is invoked with the freshly-loaded settings
-        and is expected to mutate it in place. A
-        :class:`CommandError` raised inside the mutator (e.g.
-        duplicate-detection on add) propagates out and discards
-        the pending write; same exception-on-discard contract as
-        :func:`metadata_transaction`.
-        """
-
-        def _txn() -> RemoteBuildSettings:
-            with remote_build_settings_transaction(self._db.settings.config_dir) as settings:
-                mutator(settings)
-                return settings
-
-        loop = asyncio.get_running_loop()
-        settings = await loop.run_in_executor(None, _txn)
-        return self._to_view(settings)
+        """Run *mutator* against the current settings and persist the result."""
+        return await settings_receiver.modify_settings(self, mutator)
 
     @api_command("remote_build/set_settings")
     async def set_settings(
@@ -298,46 +258,10 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         cleanup_ttl_seconds: int | None = None,
         **kwargs: Any,
     ) -> RemoteBuildSettingsView:
-        """
-        Persist the receiver-side ``enabled`` master switch.
-
-        Read-modify-write so peers / other fields stay intact.
-        Strict-bool validation defeats truthiness coercion on
-        this security-sensitive toggle.
-
-        Optional ``cleanup_ttl_seconds`` updates the cleanup
-        sweep threshold, range-checked against
-        :data:`MIN_CLEANUP_TTL_SECONDS` /
-        :data:`MAX_CLEANUP_TTL_SECONDS`. Omit to keep current.
-
-        Live-rebinds the peer-link listener: True runs the
-        startup bind path, False tears down + clears the mDNS
-        pin/port advertise. Fail-soft on bind error.
-        """
-        if not isinstance(enabled, bool):
-            msg = "remote_build/set_settings: 'enabled' must be a boolean"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-        if cleanup_ttl_seconds is not None:
-            # bool subclasses int, so reject ``True`` first to
-            # avoid a misleading OUT_OF_RANGE on a type error.
-            if isinstance(cleanup_ttl_seconds, bool) or not isinstance(cleanup_ttl_seconds, int):
-                msg = "remote_build/set_settings: 'cleanup_ttl_seconds' must be an integer"
-                raise CommandError(ErrorCode.INVALID_ARGS, msg)
-            if not MIN_CLEANUP_TTL_SECONDS <= cleanup_ttl_seconds <= MAX_CLEANUP_TTL_SECONDS:
-                msg = (
-                    f"remote_build/set_settings: 'cleanup_ttl_seconds' must be between "
-                    f"{MIN_CLEANUP_TTL_SECONDS} and {MAX_CLEANUP_TTL_SECONDS}"
-                )
-                raise CommandError(ErrorCode.INVALID_ARGS, msg)
-
-        def _set(settings: RemoteBuildSettings) -> None:
-            settings.enabled = enabled
-            if cleanup_ttl_seconds is not None:
-                settings.cleanup_ttl_seconds = cleanup_ttl_seconds
-
-        view = await self._modify_settings(_set)
-        await self._db.apply_remote_build_enabled()
-        return view
+        """Persist the receiver-side ``enabled`` master switch."""
+        return await settings_receiver.set_settings(
+            self, enabled=enabled, cleanup_ttl_seconds=cleanup_ttl_seconds
+        )
 
     # ------------------------------------------------------------------
     # Offloader-side settings: master toggle + per-pairing enable.
@@ -439,7 +363,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
     async def _current_settings_view(self) -> RemoteBuildSettingsView:
         """Load settings from disk and project to the wire view (post-mutation response)."""
-        return self._to_view(await self._load_settings_async())
+        return await settings_receiver.current_settings_view(self)
 
     # ------------------------------------------------------------------
     # Peer-link Noise WS dispatch helpers — called by the post-handshake

--- a/esphome_device_builder/controllers/remote_build/settings_receiver.py
+++ b/esphome_device_builder/controllers/remote_build/settings_receiver.py
@@ -1,0 +1,132 @@
+"""Receiver-side ``get_settings`` / ``set_settings`` WS commands."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import (
+    MAX_CLEANUP_TTL_SECONDS,
+    MIN_CLEANUP_TTL_SECONDS,
+    ErrorCode,
+    RemoteBuildSettings,
+    RemoteBuildSettingsView,
+)
+from ..config import remote_build_settings_transaction
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+
+async def get_settings(controller: ReceiverController) -> RemoteBuildSettingsView:
+    """Return the receiver-side remote-build settings (wire view)."""
+    return to_view(controller, await controller._load_settings_async())
+
+
+def to_view(
+    controller: ReceiverController, settings: RemoteBuildSettings
+) -> RemoteBuildSettingsView:
+    """Project receiver settings to wire view, merging in-memory peers.
+
+    The peer list is RAM-canonical: PENDING entries live in
+    ``state.pending_peers`` for the active pairing window's
+    lifetime (never hit disk) and APPROVED entries live in
+    ``state.approved_peers`` / its per-file ``Store``.
+    ``settings`` is consulted for the master ``enabled``
+    toggle.
+    """
+    return RemoteBuildSettingsView(
+        enabled=settings.enabled,
+        cleanup_ttl_seconds=settings.cleanup_ttl_seconds,
+        peers=controller._peer_summaries(),
+    )
+
+
+async def modify_settings(
+    controller: ReceiverController,
+    mutator: Callable[[RemoteBuildSettings], None],
+) -> RemoteBuildSettingsView:
+    """
+    Run ``mutator`` against the current settings and persist the result.
+
+    Wraps :func:`remote_build_settings_transaction` so the
+    whole read-modify-write happens under the metadata lock,
+    so two concurrent callers can't both read the same starting
+    value and have the second save wipe the first's change.
+    Runs in the default executor since the transaction does
+    blocking JSON I/O. Returns the wire view so the response
+    leaving this method can never carry ``secret_sha256``.
+
+    ``mutator`` is invoked with the freshly-loaded settings
+    and is expected to mutate it in place. A
+    :class:`CommandError` raised inside the mutator (e.g.
+    duplicate-detection on add) propagates out and discards
+    the pending write; same exception-on-discard contract as
+    :func:`metadata_transaction`.
+    """
+
+    def _txn() -> RemoteBuildSettings:
+        with remote_build_settings_transaction(controller._db.settings.config_dir) as settings:
+            mutator(settings)
+            return settings
+
+    loop = asyncio.get_running_loop()
+    settings = await loop.run_in_executor(None, _txn)
+    return to_view(controller, settings)
+
+
+async def set_settings(
+    controller: ReceiverController,
+    *,
+    enabled: bool,
+    cleanup_ttl_seconds: int | None = None,
+) -> RemoteBuildSettingsView:
+    """
+    Persist the receiver-side ``enabled`` master switch.
+
+    Read-modify-write so peers / other fields stay intact.
+    Strict-bool validation defeats truthiness coercion on
+    this security-sensitive toggle.
+
+    Optional ``cleanup_ttl_seconds`` updates the cleanup
+    sweep threshold, range-checked against
+    :data:`MIN_CLEANUP_TTL_SECONDS` /
+    :data:`MAX_CLEANUP_TTL_SECONDS`. Omit to keep current.
+
+    Live-rebinds the peer-link listener: True runs the
+    startup bind path, False tears down + clears the mDNS
+    pin/port advertise. Fail-soft on bind error.
+    """
+    if not isinstance(enabled, bool):
+        msg = "remote_build/set_settings: 'enabled' must be a boolean"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if cleanup_ttl_seconds is not None:
+        # bool subclasses int, so reject ``True`` first to
+        # avoid a misleading OUT_OF_RANGE on a type error.
+        if isinstance(cleanup_ttl_seconds, bool) or not isinstance(cleanup_ttl_seconds, int):
+            msg = "remote_build/set_settings: 'cleanup_ttl_seconds' must be an integer"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        if not MIN_CLEANUP_TTL_SECONDS <= cleanup_ttl_seconds <= MAX_CLEANUP_TTL_SECONDS:
+            msg = (
+                f"remote_build/set_settings: 'cleanup_ttl_seconds' must be between "
+                f"{MIN_CLEANUP_TTL_SECONDS} and {MAX_CLEANUP_TTL_SECONDS}"
+            )
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
+    def _set(settings: RemoteBuildSettings) -> None:
+        settings.enabled = enabled
+        if cleanup_ttl_seconds is not None:
+            settings.cleanup_ttl_seconds = cleanup_ttl_seconds
+
+    view = await modify_settings(controller, _set)
+    await controller._db.apply_remote_build_enabled()
+    return view
+
+
+async def current_settings_view(
+    controller: ReceiverController,
+) -> RemoteBuildSettingsView:
+    """Load settings from disk and project to the wire view (post-mutation response)."""
+    return to_view(controller, await controller._load_settings_async())


### PR DESCRIPTION
# What does this implement/fix?

Fourth in the receiver-split arc (after #809 cleanup loop, #815 peer-link sessions, #821 identity commands). Extracts the receiver-side settings WS commands plus the shared read-modify-write helpers into a new sibling module `controllers/remote_build/settings_receiver.py`:

- `get_settings` — returns the wire view of receiver-side settings (master enabled toggle + cleanup TTL + peers).
- `set_settings` — persists the master enabled toggle + optional `cleanup_ttl_seconds` with strict-bool validation and live-rebind of the peer-link listener.
- `to_view` — shared projection helper used by both commands and by the post-mutation response on peer-CRUD WS commands.
- `modify_settings` — read-modify-write under the metadata lock, returns the wire view.
- `current_settings_view` — convenience wrapper that loads + projects (used by `approve_peer` / `remove_peer` / `set_settings`).

The two `@api_command`-decorated WS methods stay as bound delegates on the controller (WS dispatch needs them on the class). The three private helpers (`_to_view`, `_modify_settings`, `_current_settings_view`) also stay as bound delegates because the still-on-controller peer-CRUD methods (`approve_peer`, `remove_peer`) and pair-flow methods (`record_pair_request`, `_lookup_peer_response`) call them.

## Module name

`settings_receiver` rather than `settings_commands` to disambiguate from the existing `settings_commands.py` which holds the offloader-side settings WS commands.

## Imports

Moved out of `receiver.py`: `collections.abc.Callable`, `remote_build_settings_transaction`, `MAX_CLEANUP_TTL_SECONDS`, `MIN_CLEANUP_TTL_SECONDS`.

## Test impact

Zero test changes — the `@api_command` surface and bound delegates resolve unchanged.

`receiver.py`: **789 → 713 lines** (-76). Combined with #809 + #815 + #821: 1083 → 713 (-370, **-34%**). All 3417 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the ReceiverController split arc. Remaining concern groups: peer CRUD WS commands, pair flow / lookup, pairing window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
