### PR TITLE
Add unit coverage for FirmwareController.find_remote_peer_job / remote_peer_job_ids

### DIFF
--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -293,3 +293,119 @@ def test_active_remote_peer_jobs_empty_when_no_remote_jobs(
     )
 
     assert list(controller.active_remote_peer_jobs()) == []
+
+
+# ---------------------------------------------------------------------------
+# find_remote_peer_job / remote_peer_job_ids
+# ---------------------------------------------------------------------------
+
+
+def _remote_job(
+    job_id: str,
+    *,
+    remote_peer: str,
+    remote_job_id: str,
+    status: JobStatus = JobStatus.QUEUED,
+) -> FirmwareJob:
+    return FirmwareJob(
+        job_id=job_id,
+        configuration=f".esphome/.remote_builds/{remote_peer}/{job_id}/{job_id}.yaml",
+        job_type=JobType.COMPILE,
+        status=status,
+        remote_peer=remote_peer,
+        remote_job_id=remote_job_id,
+    )
+
+
+def test_find_remote_peer_job_returns_matching_job(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Matching (remote_peer, remote_job_id) → the FirmwareJob instance.
+
+    The receiver's artifacts-download path uses this as the
+    single lookup that gates "is this offloader allowed to
+    fetch artifacts for this job?". Pin the positive match
+    against a peer/id pair that also has a sibling job under
+    the same peer (different id) so a regression that returned
+    the first peer match wouldn't pass.
+    """
+    target = _remote_job("target", remote_peer="alpha", remote_job_id="r-1")
+    sibling = _remote_job("sibling", remote_peer="alpha", remote_job_id="r-2")
+    controller = firmware_controller_factory(target, sibling, with_settings=False)
+
+    result = controller.find_remote_peer_job(remote_peer="alpha", remote_job_id="r-1")
+
+    assert result is target
+
+
+def test_find_remote_peer_job_returns_none_when_remote_job_id_mismatches(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Right peer, wrong remote_job_id → None.
+
+    Both fields must match — the receiver path uses this to
+    reject artifacts requests for an id the peer never
+    submitted, so the per-field check has to be AND, not OR.
+    """
+    job = _remote_job("present", remote_peer="alpha", remote_job_id="r-1")
+    controller = firmware_controller_factory(job, with_settings=False)
+
+    result = controller.find_remote_peer_job(remote_peer="alpha", remote_job_id="r-ghost")
+
+    assert result is None
+
+
+def test_find_remote_peer_job_returns_none_when_state_is_empty(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Empty state.jobs → None, no raise.
+
+    Cold-start contract: the receiver may query before any job
+    has landed. Linear scan over an empty dict returns None
+    cleanly.
+    """
+    controller = firmware_controller_factory(with_settings=False)
+
+    assert controller.find_remote_peer_job(remote_peer="alpha", remote_job_id="r-1") is None
+
+
+def test_remote_peer_job_ids_returns_remote_job_ids_for_peer(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Every job under *remote_peer* contributes its ``remote_job_id``.
+
+    The artifacts-download reject log uses this list to surface
+    "available ids" when a requested one doesn't match. Pin a
+    two-id case so a regression that returned only the first
+    match would show up here.
+    """
+    a = _remote_job("alpha-a", remote_peer="alpha", remote_job_id="r-a")
+    b = _remote_job("alpha-b", remote_peer="alpha", remote_job_id="r-b")
+    controller = firmware_controller_factory(a, b, with_settings=False)
+
+    assert sorted(controller.remote_peer_job_ids(remote_peer="alpha")) == ["r-a", "r-b"]
+
+
+def test_remote_peer_job_ids_excludes_jobs_from_other_peers(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Jobs whose ``remote_peer`` doesn't match are filtered out.
+
+    Receivers serve multiple offloaders simultaneously; the
+    reject log mustn't leak ids from a different peer's
+    queue.
+    """
+    mine = _remote_job("mine", remote_peer="alpha", remote_job_id="r-mine")
+    theirs = _remote_job("theirs", remote_peer="beta", remote_job_id="r-theirs")
+    controller = firmware_controller_factory(mine, theirs, with_settings=False)
+
+    assert controller.remote_peer_job_ids(remote_peer="alpha") == ["r-mine"]
+
+
+def test_remote_peer_job_ids_returns_empty_list_when_state_is_empty(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Empty state.jobs → empty list, not None or a raise."""
+    controller = firmware_controller_factory(with_settings=False)
+
+    assert controller.remote_peer_job_ids(remote_peer="alpha") == []


### PR DESCRIPTION
# What does this implement/fix?

PR #819 extracted `FirmwareState` and added two thin public accessors on `FirmwareController` to keep cross-package callers out of the State dataclass:

- `find_remote_peer_job(remote_peer, remote_job_id) -> FirmwareJob | None`
- `remote_peer_job_ids(remote_peer) -> list[str]`

Codecov flagged the production implementations in `esphome_device_builder/controllers/firmware/jobs.py` as uncovered:

```
controllers/firmware/jobs.py    61      5    92%   71-74, 85
```

The end-to-end test paths (`tests/test_remote_build_artifacts_download.py`, `tests/e2e/test_download_artifacts.py`, `tests/e2e/test_install_round_trip.py`) all use a `MagicMock` firmware controller wired through `wire_firmware_remote_peer_api_mocks` in `tests/conftest.py` — that helper installs `side_effect` lambdas that mirror the linear-scan semantics, so the real `jobs.py` functions never run.

**Fix.** Six direct unit tests against the public accessors, pinning each branch:

- `find_remote_peer_job` — matching pair → job; right peer + wrong `remote_job_id` → None; empty state → None.
- `remote_peer_job_ids` — ids of matching peer's jobs; excludes other peers; empty state → empty list.

Tests sit alongside the existing `active_remote_peer_jobs` coverage in `tests/controllers/firmware/test_get_jobs.py` and use the `firmware_controller_factory` fixture from `tests/controllers/firmware/conftest.py` to seed `state.jobs` at known `remote_peer` / `remote_job_id` pairings.

No production-code changes. The mock helper's docstring in `tests/conftest.py` is already accurate and doesn't grow new branches.

**Related issue or feature (if applicable):**

- fixes #823

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
