### PR TITLE
Split ReceiverController: extract peer-CRUD WS commands

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_crud.py
+++ b/esphome_device_builder/controllers/remote_build/peer_crud.py
@@ -1,0 +1,98 @@
+"""Receiver-side ``approve_peer`` / ``remove_peer`` WS commands."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import ErrorCode, RemoteBuildSettingsView
+from ._validators import validate_dashboard_id
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+
+# Debounce window for the receiver-side peers-store write so a
+# burst of approvals collapses to one disk write.
+_PEERS_SAVE_DELAY_SECONDS = 1.0
+
+
+async def approve_peer(
+    controller: ReceiverController, *, dashboard_id: str
+) -> RemoteBuildSettingsView:
+    """
+    Promote a PENDING peer to APPROVED.
+
+    Pops the in-memory PENDING entry, inserts it into the
+    RAM-canonical ``state.approved_peers`` dict, schedules a
+    debounced write to the receiver-peers store, and fires
+    :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` with
+    ``{dashboard_id, status: "approved"}``. The offloader's
+    pair-status listener observes the flip via the bus event +
+    re-snapshot path. ``NOT_FOUND`` if no PENDING entry
+    matches; ``INVALID_ARGS`` if the dashboard_id already
+    corresponds to an APPROVED row (duplicate Accept click,
+    almost always a UI race; refuse rather than silently
+    re-fire the event).
+    """
+    clean_id = validate_dashboard_id(dashboard_id)
+
+    pending = controller.state.pending_peers.pop(clean_id, None)
+    if pending is None:
+        # Differentiate "already approved" from "never existed"
+        # so the frontend can decide whether to refresh or
+        # surface an error. Both reads short-circuit through
+        # RAM — no disk I/O.
+        if clean_id in controller.state.approved_peers:
+            msg = f"peer is already approved: {clean_id}"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        msg = f"no pending peer with dashboard_id: {clean_id}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+
+    controller.state.approved_peers[clean_id] = pending
+    controller._peers_store.async_delay_save(
+        controller._serialize_peers, delay=_PEERS_SAVE_DELAY_SECONDS
+    )
+    controller._fire_pair_status_changed(clean_id, "approved")
+    return await controller._current_settings_view()
+
+
+async def remove_peer(
+    controller: ReceiverController, *, dashboard_id: str
+) -> RemoteBuildSettingsView:
+    """
+    Delete a peer row (works on both PENDING and APPROVED).
+
+    Two semantically distinct outcomes share the same WS command:
+
+    * Removing a PENDING entry from the in-memory dict is
+      *rejection* — the row never represented established
+      trust, so this is inbox cleanup. Fires the
+      ``status="removed"`` event so any offloader currently
+      long-polling pair_status sees the cancellation and
+      drops its local state.
+    * Removing an APPROVED row from ``state.approved_peers``
+      (RAM-canonical, debounced to disk) is *revocation* —
+      fires the same
+      :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED`
+      ``status="removed"`` event so the offloader can
+      surface a ``peer_revoked`` UI alert.
+
+    ``NOT_FOUND`` if neither dict has a row.
+    """
+    clean_id = validate_dashboard_id(dashboard_id)
+
+    # PENDING: in-memory, no disk write needed (PENDING never
+    # reaches the peers store).
+    if controller.state.pending_peers.pop(clean_id, None) is not None:
+        controller._fire_pair_status_changed(clean_id, "removed")
+        return await controller._current_settings_view()
+
+    if controller.state.approved_peers.pop(clean_id, None) is None:
+        msg = f"no peer with dashboard_id: {clean_id}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    controller._peers_store.async_delay_save(
+        controller._serialize_peers, delay=_PEERS_SAVE_DELAY_SECONDS
+    )
+    controller._fire_pair_status_changed(clean_id, "removed")
+    return await controller._current_settings_view()

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -47,7 +47,13 @@ from ...models import (
 from ..config import (
     load_remote_build_settings,
 )
-from . import cleanup_loop, identity_commands, peer_link_sessions, settings_receiver
+from . import (
+    cleanup_loop,
+    identity_commands,
+    peer_crud,
+    peer_link_sessions,
+    settings_receiver,
+)
 from ._receiver_state import ReceiverState
 from ._shared import _RemoteBuildBase, drain_tasks
 from ._storage_codecs import (
@@ -56,9 +62,6 @@ from ._storage_codecs import (
     encode_peers,
 )
 from ._summaries import peer_summary
-from ._validators import (
-    validate_dashboard_id,
-)
 from .artifacts_download import ArtifactsDownloadSender
 from .job_fanout import JobFanout
 from .peer_link import PeerLinkSession, TerminateReason
@@ -73,10 +76,6 @@ _LOGGER = logging.getLogger(__name__)
 # Pairing-window lifetime. Auto-closes after this much idle;
 # the frontend extends on each activity tick.
 _PAIRING_WINDOW_DURATION_SECONDS = 300.0
-
-# Debounce window for the receiver-side peers-store write so a
-# burst of approvals collapses to one disk write.
-_PEERS_SAVE_DELAY_SECONDS = 1.0
 
 
 class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
@@ -286,76 +285,13 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
 
     @api_command("remote_build/approve_peer")
     async def approve_peer(self, *, dashboard_id: str, **kwargs: Any) -> RemoteBuildSettingsView:
-        """
-        Promote a PENDING peer to APPROVED.
-
-        Pops the in-memory PENDING entry, inserts it into the
-        RAM-canonical ``state.approved_peers`` dict, schedules a
-        debounced write to the receiver-peers store, and fires
-        :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` with
-        ``{dashboard_id, status: "approved"}``. The offloader's
-        pair-status listener observes the flip via the bus event +
-        re-snapshot path. ``NOT_FOUND`` if no PENDING entry
-        matches; ``INVALID_ARGS`` if the dashboard_id already
-        corresponds to an APPROVED row (duplicate Accept click,
-        almost always a UI race; refuse rather than silently
-        re-fire the event).
-        """
-        clean_id = validate_dashboard_id(dashboard_id)
-
-        pending = self.state.pending_peers.pop(clean_id, None)
-        if pending is None:
-            # Differentiate "already approved" from "never existed"
-            # so the frontend can decide whether to refresh or
-            # surface an error. Both reads short-circuit through
-            # RAM — no disk I/O.
-            if clean_id in self.state.approved_peers:
-                msg = f"peer is already approved: {clean_id}"
-                raise CommandError(ErrorCode.INVALID_ARGS, msg)
-            msg = f"no pending peer with dashboard_id: {clean_id}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-
-        self.state.approved_peers[clean_id] = pending
-        self._peers_store.async_delay_save(self._serialize_peers, delay=_PEERS_SAVE_DELAY_SECONDS)
-        self._fire_pair_status_changed(clean_id, "approved")
-        return await self._current_settings_view()
+        """Promote a PENDING peer to APPROVED."""
+        return await peer_crud.approve_peer(self, dashboard_id=dashboard_id)
 
     @api_command("remote_build/remove_peer")
     async def remove_peer(self, *, dashboard_id: str, **kwargs: Any) -> RemoteBuildSettingsView:
-        """
-        Delete a peer row (works on both PENDING and APPROVED).
-
-        Two semantically distinct outcomes share the same WS command:
-
-        * Removing a PENDING entry from the in-memory dict is
-          *rejection* — the row never represented established
-          trust, so this is inbox cleanup. Fires the
-          ``status="removed"`` event so any offloader currently
-          long-polling pair_status sees the cancellation and
-          drops its local state.
-        * Removing an APPROVED row from ``state.approved_peers``
-          (RAM-canonical, debounced to disk) is *revocation* —
-          fires the same
-          :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED`
-          ``status="removed"`` event so the offloader can
-          surface a ``peer_revoked`` UI alert.
-
-        ``NOT_FOUND`` if neither dict has a row.
-        """
-        clean_id = validate_dashboard_id(dashboard_id)
-
-        # PENDING: in-memory, no disk write needed (PENDING never
-        # reaches the peers store).
-        if self.state.pending_peers.pop(clean_id, None) is not None:
-            self._fire_pair_status_changed(clean_id, "removed")
-            return await self._current_settings_view()
-
-        if self.state.approved_peers.pop(clean_id, None) is None:
-            msg = f"no peer with dashboard_id: {clean_id}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        self._peers_store.async_delay_save(self._serialize_peers, delay=_PEERS_SAVE_DELAY_SECONDS)
-        self._fire_pair_status_changed(clean_id, "removed")
-        return await self._current_settings_view()
+        """Delete a peer row (works on both PENDING and APPROVED)."""
+        return await peer_crud.remove_peer(self, dashboard_id=dashboard_id)
 
     def _serialize_peers(self) -> ReceiverPeers:
         """Build the on-disk peers shape from the in-RAM ``state.approved_peers`` dict."""


### PR DESCRIPTION
# What does this implement/fix?

Fifth in the receiver-split arc (after #809 cleanup loop, #815 peer-link sessions, #821 identity commands, #826 settings commands). Extracts the receiver-UI peer-CRUD WS commands into a new sibling module `controllers/remote_build/peer_crud.py`:

- `approve_peer` — promotes a PENDING peer to APPROVED, schedules the debounced disk write, fires `REMOTE_BUILD_PAIR_STATUS_CHANGED`.
- `remove_peer` — deletes a peer row (PENDING rejection or APPROVED revocation), same status-changed event in both branches.

Both stay as bound-method delegates on the controller for `@api_command` WS dispatch. Bodies take `ReceiverController` as the first arg.

## What stays on the controller

The peer-summary projection helpers stay on the controller:
- `_peer_summaries` — used by `settings_receiver.to_view` + `peers_snapshot`.
- `approved_peer_label` — used by pair-flow `record_pair_request`.
- `peers_snapshot` — `subscribe_events` initial_state seed.
- `_serialize_peers` — `peers_store.async_delay_save` target.
- `_fire_pair_status_changed` — used by `peer_crud` + pair-flow `record_pair_request`.

## Imports

Moved out of `receiver.py`: `validate_dashboard_id`, the `_PEERS_SAVE_DELAY_SECONDS` constant.

## Test impact

Zero test changes — the `@api_command` surface is unchanged and tests instance-call through the bound delegates.

`receiver.py`: **713 → 649 lines** (-64). Combined with #809 + #815 + #821 + #826: 1083 → 649 (-434, **-40%**). All 3418 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the ReceiverController split arc. Remaining concern groups: pair flow / lookup, pairing window.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
