### PR TITLE
Enable PTH (flake8-use-pathlib) and convert 9 os/os.path call sites

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -356,7 +356,7 @@ def _load_metadata(config_dir: Path) -> dict[str, Any]:
 
 def _save_metadata(config_dir: Path, data: dict[str, Any]) -> None:
     path = config_dir / _METADATA_FILE
-    # tempfile + os.replace so lock-free readers never observe a partial write.
+    # tempfile + Path.replace so lock-free readers never observe a partial write.
     fd, tmp_name = tempfile.mkstemp(prefix=f"{_METADATA_FILE}.", suffix=".tmp", dir=str(config_dir))
     tmp_path = Path(tmp_name)
     try:
@@ -364,7 +364,7 @@ def _save_metadata(config_dir: Path, data: dict[str, Any]) -> None:
         # binary mode. The on-disk file stays readable / diffable.
         with os.fdopen(fd, "wb") as fh:
             fh.write(dumps_indent(data))
-        os.replace(tmp_path, path)
+        tmp_path.replace(path)
     except Exception:
         with suppress(OSError):
             tmp_path.unlink()
@@ -1198,9 +1198,9 @@ def _read_descriptor_file(path: str) -> str | None:
 
 
 def _unlink_quietly(path: str) -> None:
-    """``os.unlink(path)`` swallowing ``OSError``."""
+    """``Path(path).unlink()`` swallowing ``OSError``."""
     with suppress(OSError):
-        os.unlink(path)
+        Path(path).unlink()
 
 
 async def _read_app_descriptor_board_id(port: str) -> str | None:

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -129,7 +129,7 @@ async def clone_device(
     carry_board_id = source_meta.get("board_id") if source_meta else None
 
     def _commit() -> None:
-        with open(new_path, "x", encoding="utf-8") as f:
+        with new_path.open("x", encoding="utf-8") as f:
             f.write(new_content)
         if carry_board_id:
             set_device_metadata(config_dir, new_filename, board_id=carry_board_id)

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -114,7 +114,7 @@ async def create_device(  # noqa: PLR0915
         # Exclusive-create so a concurrent ``devices/create`` (or
         # any other writer) can't slip between a preflight check
         # and the write and silently clobber an in-flight config.
-        with open(config_path, "x", encoding="utf-8") as f:
+        with config_path.open("x", encoding="utf-8") as f:
             f.write(yaml_content)
 
     try:

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -46,9 +46,9 @@ def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
             raise
         with fh:
             if mode is not None:
-                os.chmod(tmp_path, mode)
+                tmp_path.chmod(mode)
             fh.write(data)
-        os.replace(tmp_path, path)
+        tmp_path.replace(path)
     except Exception:
         # Suppress all OSError on cleanup so the original write
         # failure isn't masked by a secondary unlink permission

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -23,10 +23,10 @@ def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
     """
     Write *data* to *path* atomically.
 
-    Stages bytes in a sibling tempfile, then ``os.replace``s into
+    Stages bytes in a sibling tempfile, then ``Path.replace``s into
     place. Readers see either the old or new bytes, never a
     truncated file. ``mode`` is applied to the staging file before
-    the rename; ``os.replace`` carries that mode to the destination.
+    the rename; ``Path.replace`` carries that mode to the destination.
     """
     fd, tmp_str = tempfile.mkstemp(
         prefix=path.name + ".",

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 import hashlib
 import logging
-import os
 import secrets
 import time
 from collections import deque
@@ -183,8 +182,8 @@ class SessionStore:
         data = {"sessions": [asdict(s) for s in self._sessions.values()]}
         tmp = self._path.with_suffix(self._path.suffix + ".tmp")
         tmp.write_bytes(dumps(data))
-        os.chmod(tmp, 0o600)
-        os.replace(tmp, self._path)
+        tmp.chmod(0o600)
+        tmp.replace(self._path)
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -254,9 +254,10 @@ def compute_build_dir_size(build_dir: Path) -> int:
     # permission denied at root). Per-file errors are caught
     # below.
     for dirpath, _dirnames, filenames in os.walk(build_dir, onerror=lambda _e: None):
+        dir_path = Path(dirpath)
         for filename in filenames:
             try:
-                total += os.path.getsize(os.path.join(dirpath, filename))
+                total += (dir_path / filename).stat().st_size
             except OSError:
                 continue
     return total

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -408,7 +408,7 @@ def _stage_offloader_validated_yaml(
     finally:
         os.close(fd)
     if sys.platform != "win32":
-        os.chmod(path, 0o600)
+        path.chmod(0o600)
     now = time.time()
     os.utime(path, (now, now))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ select = [
   "N", # pep8-naming
   "PERF", # performance
   "PL", # pylint
+  "PTH", # flake8-use-pathlib — prefer pathlib over os.path/os primitives
   "PLR0904", # too-many-public-methods (preview) — cap new god-classes at 20
   "RET", # flake8-return
   "RUF", # ruff-specific
@@ -194,8 +195,10 @@ select = [
 # file path is a runner-controlled location not user input. SLF001 is also
 # waived so action unit tests can call into helper-private methods directly.
 # INP001 (implicit namespace package) is waived because action directories
-# are standalone scripts, not part of the Python package tree.
-".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001", "SLF001", "INP001"]
+# are standalone scripts, not part of the Python package tree. PTH123
+# (use Path.open) is waived for the same reason — action scripts open
+# files via plain ``open()`` for legibility, no pathlib churn warranted.
+".github/actions/**" = ["T20", "S108", "PLC0415", "BLE001", "SLF001", "INP001", "PTH123"]
 
 [tool.codespell]
 skip = "*.json,*/definitions/*"

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -508,24 +508,18 @@ async def test_clone_device_handles_filesystem_race_on_target_filename(
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
 
-    # Patch the executor's ``_commit`` body via the underlying
-    # ``open`` call. The clone command's commit closure does
-    # ``with open(new_path, "x", ...)`` — flipping that to raise
-    # ``FileExistsError`` simulates the race without needing real
-    # cross-process scheduling.
-    real_open = open
+    # Patch ``Path.open`` so the clone command's
+    # ``with new_path.open("x", ...)`` raises ``FileExistsError``
+    # without needing real cross-process scheduling.
+    real_open = Path.open
 
-    def _raising_open(path, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
-        if "x" in mode and str(path).endswith("bedroom-bulb.yaml"):
-            raise FileExistsError(str(path))
-        return real_open(path, mode, *args, **kwargs)
+    def _raising_open(self, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        if "x" in mode and str(self).endswith("bedroom-bulb.yaml"):
+            raise FileExistsError(str(self))
+        return real_open(self, mode, *args, **kwargs)
 
     with (
-        patch(
-            "esphome_device_builder.controllers.devices.mutations_clone.open",
-            _raising_open,
-            create=True,
-        ),
+        patch.object(Path, "open", _raising_open),
         pytest.raises(CommandError) as excinfo,
     ):
         await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")

--- a/tests/test_build_size.py
+++ b/tests/test_build_size.py
@@ -18,7 +18,6 @@ that pins the post-CLEAN refresh hand-off).
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -82,22 +81,22 @@ def test_compute_build_dir_size_swallows_per_entry_errors(tmp_path: Path) -> Non
     """A vanishing file mid-walk doesn't fail the whole operation.
 
     Concurrent compile cleanup can yank entries between
-    ``os.walk`` returning the filename and ``os.path.getsize``
-    stat'ing it. Returning the partial total is better than
-    crashing the dashboard.
+    ``os.walk`` returning the filename and ``Path.stat()`` reading
+    its size. Returning the partial total is better than crashing
+    the dashboard.
     """
     (tmp_path / "good.bin").write_bytes(b"x" * 100)
-    bad_path = str(tmp_path / "vanished.bin")
-    (tmp_path / "vanished.bin").write_bytes(b"y" * 200)
+    bad_path = tmp_path / "vanished.bin"
+    bad_path.write_bytes(b"y" * 200)
 
-    real_getsize = os.path.getsize
+    real_stat = Path.stat
 
-    def fake_getsize(path: str) -> int:
-        if path == bad_path:
+    def fake_stat(self: Path, *args: object, **kwargs: object) -> object:
+        if self == bad_path:
             raise OSError("file disappeared")
-        return real_getsize(path)
+        return real_stat(self, *args, **kwargs)
 
-    with patch("esphome_device_builder.helpers.build_size.os.path.getsize", fake_getsize):
+    with patch.object(Path, "stat", fake_stat):
         # 100 from good.bin; the bad one is skipped.
         assert compute_build_dir_size(tmp_path) == 100
 


### PR DESCRIPTION
# What does this implement/fix?

Enables `flake8-use-pathlib` (PTH) and converts the 9 call
sites that fired violations. Pure stylistic — prefers
`Path.X()` over `os.X(path)` / `os.path.X(path)` so the path
API stays internally consistent with the rest of the codebase
that already lives on `pathlib.Path`.

Followup to #822 (SLF001) and #824 (LOG / G / ICN / INP / ISC).

## Production-code conversions

- `controllers/config.py` — `os.replace` / `os.unlink` →
  `Path.replace` / `Path.unlink`.
- `controllers/devices/mutations_clone.py` and `mutations_create.py`
  — `open(p, "x", ...)` → `p.open("x", ...)` (the path
  variables are already `Path` from `settings.rel_path`, so
  the change is a method-call swap, not a wrap).
- `helpers/atomic_io.py`, `helpers/auth.py` — `os.chmod` +
  `os.replace` on the temp-then-rename atomic-write helpers
  switched to the `Path` methods. `auth.py` drops the
  now-unused `import os`.
- `helpers/build_size.py` —
  `os.path.getsize(os.path.join(dirpath, filename))` collapses
  to `(dir_path / filename).stat().st_size`; `Path(dirpath)`
  is hoisted out of the inner loop to avoid per-file
  construction during the directory walk.
- `helpers/remote_artifacts_materialise.py` —
  `os.chmod(path, ...)` → `path.chmod(...)` (`path` is already
  a `Path` from `resolve_compiled_config_path`).

## .github/actions per-file-ignore

PTH123 (`open()` → `Path.open()`) is waived for action
scripts; they use plain `open()` for legibility and don't
otherwise work with `Path` objects. Added alongside the
existing `SLF001` / `INP001` waivers on the same line.

## Test updates

Two tests monkeypatched `open` / `os.path.getsize` on the
production module and would have broken once the call sites
moved to `Path.open` / `Path.stat`. Switched both to
`patch.object(Path, ...)`, which targets the actual call
surface and is robust to future similar refactors:

- `test_clone_device_handles_filesystem_race_on_target_filename`
- `test_compute_build_dir_size_swallows_per_entry_errors`

All 3396 tests pass, pre-commit clean.

**Related issue or feature (if applicable):**

- Companion to #822 (SLF001) and #824 (LOG / G / ICN / INP / ISC).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
