### PR TITLE
Enable DTZ (flake8-datetimez) and fix lock-file timestamp display

### DIFF
--- a/esphome_device_builder/helpers/single_instance.py
+++ b/esphome_device_builder/helpers/single_instance.py
@@ -49,7 +49,7 @@ import sys
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from io import TextIOWrapper
 from pathlib import Path
 
@@ -130,7 +130,11 @@ def _report_existing_instance(lock_file_path: Path, config_dir: Path) -> None:
         content = lock_file_path.read_text(encoding="utf-8").strip()
         if content:
             existing = json.loads(content)
-            start_dt = datetime.fromtimestamp(existing["start_ts"])
+            # ``start_ts`` is a Unix timestamp (UTC by definition);
+            # convert to a tz-aware local datetime so the operator
+            # sees the start time in their wall clock with the
+            # platform's locale abbreviation below.
+            start_dt = datetime.fromtimestamp(existing["start_ts"], tz=UTC).astimezone()
             # Locale's tz abbrev when the platform supports it
             # (most Unixen do); falls back to the unannotated
             # local-time stamp on bare-metal platforms whose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ select = [
   "B", # flake8-bugbear
   "C4", # flake8-comprehensions
   "D", # pydocstyle
+  "DTZ", # flake8-datetimez — flag naive datetime construction; force explicit tz
   "E", # pycodestyle errors
   "F", # pyflakes
   "FLY", # flynt: convert string formatting to f-strings

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -255,12 +255,17 @@ def test_report_existing_instance_local_time_fallback(
     # exercise the fallback branch on a runner that would
     # normally return a tz string. Real datetime for everything
     # else so the YYYY-MM-DD HH:MM:SS portion still formats.
+    # ``astimezone`` is a no-op here — the production code chains
+    # it after ``fromtimestamp`` for tz-aware local conversion,
+    # but for the fallback-branch test we only need ``strftime``
+    # to land on the fake.
     fake_dt = MagicMock()
     fake_dt.strftime.side_effect = lambda fmt: "" if fmt == "%Z" else "2023-11-14 22:13:20"
+    fake_dt.astimezone.return_value = fake_dt
     monkeypatch.setattr(
         single_instance,
         "datetime",
-        MagicMock(fromtimestamp=lambda _ts: fake_dt),
+        MagicMock(fromtimestamp=lambda *args, **kwargs: fake_dt),
     )
 
     _report_existing_instance(lock_path, tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Enables `flake8-datetimez` (DTZ) and fixes the single
existing violation. Naive datetime construction is a real
source of dashboard bugs in fleet-style systems (DST flips,
mixed-timezone receivers), and locking the rule in now keeps
it that way.

Followup to #822 (SLF001), #824 (LOG / G / ICN / INP / ISC),
and #829 (PTH).

## The one fix

`helpers/single_instance.py:133` (lock-file error display):

```python
# before
start_dt = datetime.fromtimestamp(existing["start_ts"])
# after
start_dt = datetime.fromtimestamp(existing["start_ts"], tz=UTC).astimezone()
```

`fromtimestamp` without a `tz` argument interprets the Unix
timestamp via the host's local timezone and returns a *naive*
datetime. The display path then `strftime`s it with `%Z` for
the platform locale's tz abbreviation. The intent is right
("show the operator a local-time start"), but the naive shape
is fragile: `%Z` returns empty on platforms where the host
has no resolvable timezone, and a naive datetime can't be
compared against tz-aware values elsewhere.

The replacement is the documented "UTC timestamp → local
tz-aware display" pattern: `fromtimestamp(..., tz=UTC)`
returns a tz-aware UTC datetime (unambiguous — Unix
timestamps are UTC by definition); `.astimezone()` then
converts to the host-local tz so the existing `strftime`
chain still surfaces local wall-clock time with the
platform's locale abbreviation.

## Test update

`test_report_existing_instance_local_time_fallback`
monkeypatched `datetime.fromtimestamp` with a single-arg
lambda; the new call signature passes `tz=UTC` as a kwarg.
Widened the lambda to `*args, **kwargs` and stubbed
`fake_dt.astimezone` to no-op (return the same fake) so the
fallback-branch shape still exercises through.

All 3396 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Companion to #822 / #824 / #829 (ruff-family enables).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
