### PR TITLE
Split ReceiverController: extract pair-flow

### DIFF
--- a/esphome_device_builder/controllers/remote_build/pair_flow.py
+++ b/esphome_device_builder/controllers/remote_build/pair_flow.py
@@ -1,0 +1,227 @@
+"""Receiver-side peer-link Noise WS dispatch helpers (pair flow)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Literal
+
+from ...helpers.event_bus import Event
+from ...models import (
+    EventType,
+    IntentResponse,
+    RemoteBuildPairRequestReceivedData,
+    RemoteBuildPairStatusChangedData,
+    StoredPeer,
+)
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def record_pair_request(
+    controller: ReceiverController,
+    *,
+    dashboard_id: str,
+    pin_sha256: str,
+    static_x25519_pub: bytes,
+    label: str,
+    peer_ip: str,
+) -> IntentResponse:
+    """
+    Process an ``intent="pair_request"`` Noise session.
+
+    Returns:
+    * ``APPROVED`` — row exists for ``dashboard_id`` with
+      APPROVED status and matching pin. Re-pair against
+      existing trust bypasses the pairing window so an
+      offloader hiccup doesn't force a re-approve.
+    * ``PENDING`` — new ``StoredPeer`` created or existing
+      PENDING row refreshed. Only reachable inside an open
+      pairing window; fires
+      :attr:`EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED`
+      so the receiver UI surfaces the inbox row.
+    * ``REJECTED`` — APPROVED row exists but pin doesn't
+      match: offloader rotated identity, or someone is
+      claiming a stranger's ``dashboard_id``. Refused
+      regardless of window state.
+    * ``NO_PAIRING_WINDOW`` — closed window for a request
+      that would create/refresh a PENDING row.
+    """
+    # Already-APPROVED row: re-pair against existing trust
+    # bypasses the window. Pin mismatch is refused regardless
+    # (rotation or impersonation).
+    approved_peer = controller.state.approved_peers.get(dashboard_id)
+    if approved_peer is not None:
+        if approved_peer.pin_sha256 != pin_sha256:
+            return IntentResponse.REJECTED
+        return IntentResponse.APPROVED
+
+    if not controller.is_pairing_window_open():
+        return IntentResponse.NO_PAIRING_WINDOW
+
+    # Refuse to overwrite a PENDING entry's pubkey — defense
+    # in depth against a LAN attacker injecting a rival key
+    # under the same scraped dashboard_id (the OOB fingerprint
+    # check at approve-time is the load-bearing gate, but
+    # silent overwrite enables a DoS). Same-pubkey retries
+    # refresh label / peer_ip / paired_at via the path below.
+    existing = controller.state.pending_peers.get(dashboard_id)
+    if existing is not None and existing.static_x25519_pub != static_x25519_pub:
+        _LOGGER.warning(
+            "pair_request from %s claims dashboard_id=%s but presented "
+            "a different X25519 pubkey than the existing PENDING entry "
+            "from %s; refusing the overwrite",
+            peer_ip,
+            dashboard_id,
+            existing.peer_ip,
+        )
+        return IntentResponse.REJECTED
+
+    paired_at = time.time()
+    controller.state.pending_peers[dashboard_id] = StoredPeer(
+        dashboard_id=dashboard_id,
+        pin_sha256=pin_sha256,
+        static_x25519_pub=static_x25519_pub,
+        label=label,
+        paired_at=paired_at,
+        peer_ip=peer_ip,
+    )
+    payload: RemoteBuildPairRequestReceivedData = {
+        "dashboard_id": dashboard_id,
+        "pin_sha256": pin_sha256,
+        "label": label,
+        "peer_ip": peer_ip,
+        "paired_at": paired_at,
+    }
+    controller._db.bus.fire(EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED, payload)
+    return IntentResponse.PENDING
+
+
+async def lookup_peer_for_session(
+    controller: ReceiverController,
+    *,
+    dashboard_id: str,
+    pin_sha256: str,
+) -> IntentResponse:
+    """
+    Resolve an ``intent="peer_link"`` request.
+
+    Returns ``OK`` if APPROVED + pin matches, ``PENDING`` if
+    the row's still in the pending dict (admin hasn't clicked
+    Accept), ``REJECTED`` for no row or pin drift. The
+    offloader treats REJECTED as "send a fresh pair_request".
+    """
+    return await _lookup_peer_response(
+        controller,
+        dashboard_id=dashboard_id,
+        pin_sha256=pin_sha256,
+        approved_response=IntentResponse.OK,
+    )
+
+
+async def lookup_peer_for_status(
+    controller: ReceiverController,
+    *,
+    dashboard_id: str,
+    pin_sha256: str,
+) -> IntentResponse:
+    """
+    Resolve an ``intent="pair_status"`` query, long-polling on PENDING.
+
+    Returns :attr:`IntentResponse.APPROVED` or ``REJECTED``.
+    REJECTED is reached four ways: never paired, admin
+    clicked Reject, offloader's peer-link identity rotated,
+    or window-close cleared the pending dict mid-wait. The
+    offloader treats all of them as peer-revoked.
+
+    Long-poll: with snapshot=PENDING, await
+    :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` for
+    the matching ``dashboard_id``. No timeout — WS hangs
+    until the offloader cancels or the dict mutates.
+
+    Listener-attach-before-snapshot ordering is
+    load-bearing: an ``approve_peer`` firing between
+    snapshot and wait must not slip past. Window-gating is
+    implicit — closed window = empty pending dict = REJECTED
+    on snapshot, long-poll never starts.
+
+    Differs from :func:`lookup_peer_for_session` only in
+    returning ``APPROVED`` vs ``OK`` — pair_status is
+    informational, peer_link is connection-establishing.
+    """
+    flip_event = asyncio.Event()
+
+    def _on_pair_status(event: Event[RemoteBuildPairStatusChangedData]) -> None:
+        if event.data["dashboard_id"] == dashboard_id:
+            flip_event.set()
+
+    with controller._db.bus.listening(
+        [EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED], _on_pair_status
+    ):
+        snapshot = await _lookup_peer_response(
+            controller,
+            dashboard_id=dashboard_id,
+            pin_sha256=pin_sha256,
+            approved_response=IntentResponse.APPROVED,
+        )
+        if snapshot is not IntentResponse.PENDING:
+            return snapshot
+        await flip_event.wait()
+        return await _lookup_peer_response(
+            controller,
+            dashboard_id=dashboard_id,
+            pin_sha256=pin_sha256,
+            approved_response=IntentResponse.APPROVED,
+        )
+
+
+def fire_pair_status_changed(
+    controller: ReceiverController,
+    dashboard_id: str,
+    status: Literal["approved", "removed"],
+) -> None:
+    """Fire ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` for a peer transition."""
+    payload: RemoteBuildPairStatusChangedData = {
+        "dashboard_id": dashboard_id,
+        "status": status,
+    }
+    controller._db.bus.fire(EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED, payload)
+
+
+async def _lookup_peer_response(
+    controller: ReceiverController,
+    *,
+    dashboard_id: str,
+    pin_sha256: str,
+    approved_response: IntentResponse,
+) -> IntentResponse:
+    """
+    Shared lookup core for the peer_link / pair_status WS dispatch paths.
+
+    Walks the in-memory PENDING dict first, then the persisted
+    APPROVED list. Both intents need the same pin-match check
+    on either store; only the APPROVED return value differs
+    (caller passes :attr:`IntentResponse.OK` for peer_link,
+    :attr:`IntentResponse.APPROVED` for pair_status).
+
+    Returns ``REJECTED`` when no row matches OR pin doesn't
+    match — the offloader treats either case the same (drop
+    local row + surface re-pair UI).
+    """
+    # PENDING dict first — most pair-flow traffic is pending
+    # peers polling pair_status. Both lookups are RAM reads
+    # (the APPROVED list moved off disk into
+    # ``state.approved_peers`` at startup).
+    pending = controller.state.pending_peers.get(dashboard_id)
+    if pending is not None:
+        if pending.pin_sha256 != pin_sha256:
+            return IntentResponse.REJECTED
+        return IntentResponse.PENDING
+    peer = controller.state.approved_peers.get(dashboard_id)
+    if peer is None or peer.pin_sha256 != pin_sha256:
+        return IntentResponse.REJECTED
+    return approved_response

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -38,11 +38,8 @@ from ...models import (
     PeerSummary,
     ReceiverPeers,
     RemoteBuildPairingWindowChangedData,
-    RemoteBuildPairRequestReceivedData,
-    RemoteBuildPairStatusChangedData,
     RemoteBuildSettings,
     RemoteBuildSettingsView,
-    StoredPeer,
 )
 from ..config import (
     load_remote_build_settings,
@@ -50,6 +47,7 @@ from ..config import (
 from . import (
     cleanup_loop,
     identity_commands,
+    pair_flow,
     peer_crud,
     peer_link_sessions,
     settings_receiver,
@@ -317,179 +315,29 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         label: str,
         peer_ip: str,
     ) -> IntentResponse:
-        """
-        Process an ``intent="pair_request"`` Noise session.
-
-        Returns:
-        * ``APPROVED`` — row exists for ``dashboard_id`` with
-          APPROVED status and matching pin. Re-pair against
-          existing trust bypasses the pairing window so an
-          offloader hiccup doesn't force a re-approve.
-        * ``PENDING`` — new ``StoredPeer`` created or existing
-          PENDING row refreshed. Only reachable inside an open
-          pairing window; fires
-          :attr:`EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED`
-          so the receiver UI surfaces the inbox row.
-        * ``REJECTED`` — APPROVED row exists but pin doesn't
-          match: offloader rotated identity, or someone is
-          claiming a stranger's ``dashboard_id``. Refused
-          regardless of window state.
-        * ``NO_PAIRING_WINDOW`` — closed window for a request
-          that would create/refresh a PENDING row.
-        """
-        # Already-APPROVED row: re-pair against existing trust
-        # bypasses the window. Pin mismatch is refused regardless
-        # (rotation or impersonation).
-        approved_peer = self.state.approved_peers.get(dashboard_id)
-        if approved_peer is not None:
-            if approved_peer.pin_sha256 != pin_sha256:
-                return IntentResponse.REJECTED
-            return IntentResponse.APPROVED
-
-        if not self.is_pairing_window_open():
-            return IntentResponse.NO_PAIRING_WINDOW
-
-        # Refuse to overwrite a PENDING entry's pubkey — defense
-        # in depth against a LAN attacker injecting a rival key
-        # under the same scraped dashboard_id (the OOB fingerprint
-        # check at approve-time is the load-bearing gate, but
-        # silent overwrite enables a DoS). Same-pubkey retries
-        # refresh label / peer_ip / paired_at via the path below.
-        existing = self.state.pending_peers.get(dashboard_id)
-        if existing is not None and existing.static_x25519_pub != static_x25519_pub:
-            _LOGGER.warning(
-                "pair_request from %s claims dashboard_id=%s but presented "
-                "a different X25519 pubkey than the existing PENDING entry "
-                "from %s; refusing the overwrite",
-                peer_ip,
-                dashboard_id,
-                existing.peer_ip,
-            )
-            return IntentResponse.REJECTED
-
-        paired_at = time.time()
-        self.state.pending_peers[dashboard_id] = StoredPeer(
+        """Process an ``intent="pair_request"`` Noise session."""
+        return await pair_flow.record_pair_request(
+            self,
             dashboard_id=dashboard_id,
             pin_sha256=pin_sha256,
             static_x25519_pub=static_x25519_pub,
             label=label,
-            paired_at=paired_at,
             peer_ip=peer_ip,
         )
-        payload: RemoteBuildPairRequestReceivedData = {
-            "dashboard_id": dashboard_id,
-            "pin_sha256": pin_sha256,
-            "label": label,
-            "peer_ip": peer_ip,
-            "paired_at": paired_at,
-        }
-        self._db.bus.fire(EventType.REMOTE_BUILD_PAIR_REQUEST_RECEIVED, payload)
-        return IntentResponse.PENDING
 
     async def lookup_peer_for_session(
-        self,
-        *,
-        dashboard_id: str,
-        pin_sha256: str,
+        self, *, dashboard_id: str, pin_sha256: str
     ) -> IntentResponse:
-        """
-        Resolve an ``intent="peer_link"`` request.
-
-        Returns ``OK`` if APPROVED + pin matches, ``PENDING`` if
-        the row's still in the pending dict (admin hasn't clicked
-        Accept), ``REJECTED`` for no row or pin drift. The
-        offloader treats REJECTED as "send a fresh pair_request".
-        """
-        return await self._lookup_peer_response(
-            dashboard_id=dashboard_id,
-            pin_sha256=pin_sha256,
-            approved_response=IntentResponse.OK,
+        """Resolve an ``intent="peer_link"`` request."""
+        return await pair_flow.lookup_peer_for_session(
+            self, dashboard_id=dashboard_id, pin_sha256=pin_sha256
         )
 
-    async def lookup_peer_for_status(
-        self,
-        *,
-        dashboard_id: str,
-        pin_sha256: str,
-    ) -> IntentResponse:
-        """
-        Resolve an ``intent="pair_status"`` query, long-polling on PENDING.
-
-        Returns :attr:`IntentResponse.APPROVED` or ``REJECTED``.
-        REJECTED is reached four ways: never paired, admin
-        clicked Reject, offloader's peer-link identity rotated,
-        or window-close cleared the pending dict mid-wait. The
-        offloader treats all of them as peer-revoked.
-
-        Long-poll: with snapshot=PENDING, await
-        :attr:`EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED` for
-        the matching ``dashboard_id``. No timeout — WS hangs
-        until the offloader cancels or the dict mutates.
-
-        Listener-attach-before-snapshot ordering is
-        load-bearing: an ``approve_peer`` firing between
-        snapshot and wait must not slip past. Window-gating is
-        implicit — closed window = empty pending dict = REJECTED
-        on snapshot, long-poll never starts.
-
-        Differs from :meth:`lookup_peer_for_session` only in
-        returning ``APPROVED`` vs ``OK`` — pair_status is
-        informational, peer_link is connection-establishing.
-        """
-        flip_event = asyncio.Event()
-
-        def _on_pair_status(event: Event[RemoteBuildPairStatusChangedData]) -> None:
-            if event.data["dashboard_id"] == dashboard_id:
-                flip_event.set()
-
-        with self._db.bus.listening([EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED], _on_pair_status):
-            snapshot = await self._lookup_peer_response(
-                dashboard_id=dashboard_id,
-                pin_sha256=pin_sha256,
-                approved_response=IntentResponse.APPROVED,
-            )
-            if snapshot is not IntentResponse.PENDING:
-                return snapshot
-            await flip_event.wait()
-            return await self._lookup_peer_response(
-                dashboard_id=dashboard_id,
-                pin_sha256=pin_sha256,
-                approved_response=IntentResponse.APPROVED,
-            )
-
-    async def _lookup_peer_response(
-        self,
-        *,
-        dashboard_id: str,
-        pin_sha256: str,
-        approved_response: IntentResponse,
-    ) -> IntentResponse:
-        """
-        Shared lookup core for the peer_link / pair_status WS dispatch paths.
-
-        Walks the in-memory PENDING dict first, then the persisted
-        APPROVED list. Both intents need the same pin-match check
-        on either store; only the APPROVED return value differs
-        (caller passes :attr:`IntentResponse.OK` for peer_link,
-        :attr:`IntentResponse.APPROVED` for pair_status).
-
-        Returns ``REJECTED`` when no row matches OR pin doesn't
-        match — the offloader treats either case the same (drop
-        local row + surface re-pair UI).
-        """
-        # PENDING dict first — most pair-flow traffic is pending
-        # peers polling pair_status. Both lookups are RAM reads
-        # (the APPROVED list moved off disk into
-        # ``state.approved_peers`` at startup).
-        pending = self.state.pending_peers.get(dashboard_id)
-        if pending is not None:
-            if pending.pin_sha256 != pin_sha256:
-                return IntentResponse.REJECTED
-            return IntentResponse.PENDING
-        peer = self.state.approved_peers.get(dashboard_id)
-        if peer is None or peer.pin_sha256 != pin_sha256:
-            return IntentResponse.REJECTED
-        return approved_response
+    async def lookup_peer_for_status(self, *, dashboard_id: str, pin_sha256: str) -> IntentResponse:
+        """Resolve an ``intent="pair_status"`` query, long-polling on PENDING."""
+        return await pair_flow.lookup_peer_for_status(
+            self, dashboard_id=dashboard_id, pin_sha256=pin_sha256
+        )
 
     # ------------------------------------------------------------------
     # Pairing window — in-process deadline that gates
@@ -567,11 +415,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         self, dashboard_id: str, status: Literal["approved", "removed"]
     ) -> None:
         """Fire ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` for a peer transition."""
-        payload: RemoteBuildPairStatusChangedData = {
-            "dashboard_id": dashboard_id,
-            "status": status,
-        }
-        self._db.bus.fire(EventType.REMOTE_BUILD_PAIR_STATUS_CHANGED, payload)
+        pair_flow.fire_pair_status_changed(self, dashboard_id, status)
 
     def _fire_pairing_window_changed(self) -> None:
         """Fire ``REMOTE_BUILD_PAIRING_WINDOW_CHANGED`` with the current state."""


### PR DESCRIPTION
# What does this implement/fix?

Sixth in the receiver-split arc (after #809 cleanup loop, #815 peer-link sessions, #821 identity, #826 settings, #828 peer CRUD). Extracts the receiver-side peer-link Noise WS dispatch helpers into a new sibling module `controllers/remote_build/pair_flow.py`:

- `record_pair_request` — processes `intent="pair_request"` Noise sessions; returns `APPROVED` / `PENDING` / `REJECTED` / `NO_PAIRING_WINDOW` based on existing peer state and pairing window.
- `lookup_peer_for_session` — resolves `intent="peer_link"` requests; `OK` / `PENDING` / `REJECTED`.
- `lookup_peer_for_status` — resolves `intent="pair_status"` with long-poll on `PENDING`; `APPROVED` or `REJECTED`.
- `fire_pair_status_changed` — bus event helper used by both pair_flow's own approve path and the peer-CRUD module's `approve_peer` / `remove_peer`.
- `_lookup_peer_response` — shared lookup core for the two `lookup_peer_for_*` entry points; module-private.

The four public entry points stay as bound-method delegates on the controller because the peer-link Noise WS dispatcher (`controllers.remote_build.peer_link.session`) calls them via the controller surface. `_fire_pair_status_changed` also stays as a bound delegate because peer_crud calls it via the controller.

## Imports

Moved out of `receiver.py`: `StoredPeer`, `RemoteBuildPairRequestReceivedData`, `RemoteBuildPairStatusChangedData`.

## Test impact

Zero test changes — the controller surface is unchanged and tests instance-call through the bound delegates.

`receiver.py`: **649 → 495 lines** (-154). Combined with the prior five splits: 1083 → 495 (-588, **-54%**). All 3418 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Part of the ReceiverController split arc. One concern remaining: pairing window (9 helpers).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
