### PR TITLE
Enable ASYNC (flake8-async) with two targeted ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,9 +133,24 @@ ignore = [
   "RUF003", # ambiguous-unicode-character-comment
   "S101", # assert used for type checking
   "S104", # binding to all interfaces
+  # ASYNC109 wants async fns to use ``asyncio.timeout()`` ctx manager instead
+  # of accepting a ``timeout: float`` parameter, but our subprocess /
+  # config-bundle helpers (``_run_esptool``, ``run_subprocess_capture``,
+  # etc.) deliberately surface ``timeout`` as part of their API — callers
+  # pass per-call values, not constants. Forcing every caller to wrap in
+  # ``async with asyncio.timeout():`` would be more boilerplate, not less.
+  "ASYNC109",
+  # ASYNC240 flags ``pathlib.Path`` methods inside async functions and
+  # recommends ``trio.Path`` / ``anyio.path``. We use plain asyncio (no
+  # trio / anyio), and asyncio has no async filesystem API — sync
+  # ``Path`` methods are the correct shape, hopped through
+  # ``run_in_executor`` where they actually block. False positive for
+  # this codebase.
+  "ASYNC240",
 ]
 select = [
   "A", # flake8-builtins
+  "ASYNC", # flake8-async — catch blocking calls / busy-wait in async funcs
   "B", # flake8-bugbear
   "C4", # flake8-comprehensions
   "D", # pydocstyle
@@ -176,7 +191,11 @@ select = [
 # Tests need free access to controller privates for setup / assertion;
 # enforcing SLF001 here would mean a noqa on nearly every fixture and
 # would obscure the cases where the protection actually matters.
-"tests/*" = ["S105", "S106", "SLF001"] # hardcoded test credentials
+# ASYNC110 (``while: await asyncio.sleep``) is also waived — tests
+# legitimately poll for "until condition" without the production-side
+# ``asyncio.Event`` plumbing the rule suggests; in production this rule
+# stays load-bearing.
+"tests/*" = ["S105", "S106", "SLF001", "ASYNC110"] # hardcoded test credentials
 # Manual scripts: print is the UX, late imports gate optional setup,
 # subprocess + tempdir paths are part of the CLI contract.
 "tests/manual/*" = ["T20", "S108", "PLC0415"]


### PR DESCRIPTION
# What does this implement/fix?

Enables `flake8-async` (ASYNC) with two targeted ignores so
the family's real forward protection kicks in without burning
churn on framework / API mismatches.

Followup to #822 (SLF001), #824 (LOG / G / ICN / INP / ISC),
#829 (PTH), and #830 (DTZ).

## ASYNC sub-rule breakdown on the current tree

| Rule | Sites | Disposition |
|---|---:|---|
| `ASYNC110` (busy-wait `while: await asyncio.sleep`) | 8 | **Enabled** for production; per-file-ignored in `tests/*` |
| `ASYNC109` (async fn with `timeout` parameter) | 17 | **Globally ignored** — false positive for library-style helpers |
| `ASYNC240` (use `trio.Path` / `anyio.path`) | 21 | **Globally ignored** — wrong framework |
| Everything else in the family | 0 | Pure forward protection |

## What's locked in

- **`ASYNC110`** — `while ...: await asyncio.sleep(...)` busy-wait.
  Zero production sites today, 8 in tests. Per-file-ignored
  for `tests/*` (tests legitimately poll-for-condition without
  the production-side `asyncio.Event` plumbing the rule
  recommends). Future production busy-wait now lights up at
  lint time.
- **`ASYNC100`, `ASYNC115`, `ASYNC116`, `ASYNC200`,
  `ASYNC210`, `ASYNC220`, `ASYNC221`, `ASYNC222`, `ASYNC230`,
  `ASYNC251`** — zero violations today; locked in as forward
  protection against any new code that blocks the event loop,
  uses dangerous sleep shapes, calls blocking I/O, etc.

## What's ignored globally (with rationale)

- **`ASYNC109`** — flags async functions that accept a
  `timeout` parameter, recommending `async with
  asyncio.timeout()` at the call site instead. Our subprocess
  / config-bundle helpers (`_run_esptool`,
  `run_subprocess_capture`) deliberately surface `timeout`
  as part of their API — callers pass per-call values, not
  constants. Forcing every call site into `async with
  asyncio.timeout():` would be more boilerplate, not less.
  All 17 sites are this shape.
- **`ASYNC240`** — recommends `trio.Path` / `anyio.path`
  inside async functions. We use plain asyncio (no trio /
  anyio), and asyncio has no async filesystem API. Sync
  `Path` methods hopped through `run_in_executor` are the
  correct shape for this codebase. All 21 sites are false
  positives.

All 3402 tests pass, pre-commit clean.

**Related issue or feature (if applicable):**

- Companion to the ruff-family enable arc: #822 / #824 / #829 / #830.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
