### PR TITLE
Split ReceiverController: extract pairing window

### DIFF
--- a/esphome_device_builder/controllers/remote_build/pairing_window.py
+++ b/esphome_device_builder/controllers/remote_build/pairing_window.py
@@ -1,0 +1,171 @@
+"""Receiver-side pairing-window gate for ``intent="pair_request"`` Noise frames."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Hashable
+from typing import TYPE_CHECKING
+
+from ...helpers.api import CommandError
+from ...models import (
+    ErrorCode,
+    EventType,
+    PairingWindowState,
+    RemoteBuildPairingWindowChangedData,
+)
+
+if TYPE_CHECKING:
+    from .receiver import ReceiverController
+
+
+# Pairing-window lifetime. Auto-closes after this much idle;
+# the frontend extends on each activity tick.
+_PAIRING_WINDOW_DURATION_SECONDS = 300.0
+
+
+async def set_pairing_window(
+    controller: ReceiverController,
+    *,
+    open: bool,  # noqa: A002 — wire format names this field "open"
+    client: Hashable,
+) -> PairingWindowState:
+    """
+    Open, extend, or close the pairing window for the calling client.
+
+    Refcounted per WS client: ``open=true`` adds/refreshes
+    the caller's entry, ``open=false`` removes it. Window is
+    open iff any client has a non-stale entry. Crashed tabs
+    age out via the 5min idle timeout; a graceful close from
+    one tab leaves the window open for others.
+
+    ``client`` is the WS connection injected by the
+    dispatcher — used as the refcount key so two tabs get
+    distinct entries. Required kwarg (a default would
+    silently bucket every caller under the same key).
+
+    Fires :attr:`EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED`
+    only on real state transitions; idempotent calls don't.
+    """
+    if not isinstance(open, bool):
+        msg = "remote_build/set_pairing_window: 'open' must be a bool"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+
+    was_open = is_pairing_window_open(controller)
+    if open:
+        controller.state.pairing_window_clients[client] = time.monotonic()
+    else:
+        controller.state.pairing_window_clients.pop(client, None)
+    _reschedule_pairing_window_close(controller)
+    is_open = bool(controller.state.pairing_window_clients)
+
+    # Fire on state transitions AND on every extend (so the
+    # frontend countdown re-syncs against the bumped deadline).
+    if was_open != is_open or (open and is_open):
+        _fire_pairing_window_changed(controller)
+    if was_open and not is_open:
+        clear_pending_peers_on_window_close(controller)
+    return _pairing_window_state(controller)
+
+
+def is_pairing_window_open(controller: ReceiverController) -> bool:
+    """Return whether the pairing window is currently open (post-prune)."""
+    _prune_stale_pairing_window_clients(controller)
+    return bool(controller.state.pairing_window_clients)
+
+
+def clear_pending_peers_on_window_close(controller: ReceiverController) -> None:
+    """Drop every PENDING peer + fire ``status="removed"`` for each.
+
+    Wakes any in-flight ``lookup_peer_for_status`` long-poll
+    so its offloader sees REJECTED.
+    """
+    if not controller.state.pending_peers:
+        return
+    cleared = list(controller.state.pending_peers)
+    controller.state.pending_peers.clear()
+    for dashboard_id in cleared:
+        controller._fire_pair_status_changed(dashboard_id, "removed")
+
+
+def _pairing_window_remaining(controller: ReceiverController) -> float | None:
+    """Seconds until the latest-extend deadline, or ``None`` if closed."""
+    _prune_stale_pairing_window_clients(controller)
+    if not controller.state.pairing_window_clients:
+        return None
+    latest_extend = max(controller.state.pairing_window_clients.values())
+    return max(0.0, latest_extend + _PAIRING_WINDOW_DURATION_SECONDS - time.monotonic())
+
+
+def _pairing_window_state(controller: ReceiverController) -> PairingWindowState:
+    """Project the in-memory client map into a wire-shape response."""
+    remaining = _pairing_window_remaining(controller)
+    if remaining is None:
+        return PairingWindowState(open=False, expires_in_seconds=None)
+    return PairingWindowState(open=True, expires_in_seconds=remaining)
+
+
+def _fire_pairing_window_changed(controller: ReceiverController) -> None:
+    """Fire ``REMOTE_BUILD_PAIRING_WINDOW_CHANGED`` with the current state."""
+    state = _pairing_window_state(controller)
+    payload: RemoteBuildPairingWindowChangedData = {
+        "open": state.open,
+        "expires_in_seconds": state.expires_in_seconds,
+    }
+    controller._db.bus.fire(EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED, payload)
+
+
+def _prune_stale_pairing_window_clients(controller: ReceiverController) -> None:
+    """Drop client entries whose last-extend timestamp aged out."""
+    if not controller.state.pairing_window_clients:
+        return
+    cutoff = time.monotonic() - _PAIRING_WINDOW_DURATION_SECONDS
+    controller.state.pairing_window_clients = {
+        client: extended_at
+        for client, extended_at in controller.state.pairing_window_clients.items()
+        if extended_at >= cutoff
+    }
+
+
+def _reschedule_pairing_window_close(controller: ReceiverController) -> None:
+    """
+    Cancel any pending close handle and schedule a fresh one.
+
+    Called after every :func:`set_pairing_window` mutation. The
+    handle always reflects the current latest-extend deadline,
+    so on every extend we cancel and reschedule rather than
+    letting an old handle wake up and re-check; this avoids the
+    duplicate-close-event class of bug where an old handle
+    would fire after an explicit close.
+
+    When the client map is empty (the explicit-close case where
+    the last client just dropped out), no new handle is
+    scheduled and ``state.pairing_window_handle`` stays ``None``.
+    """
+    if controller.state.pairing_window_handle is not None:
+        controller.state.pairing_window_handle.cancel()
+        controller.state.pairing_window_handle = None
+    remaining = _pairing_window_remaining(controller)
+    if remaining is None:
+        return
+    loop = asyncio.get_running_loop()
+    controller.state.pairing_window_handle = loop.call_later(
+        remaining, lambda: _on_pairing_window_deadline(controller)
+    )
+
+
+def _on_pairing_window_deadline(controller: ReceiverController) -> None:
+    """
+    Sync callback fired by the TimerHandle when the deadline lapses.
+
+    The handle was scheduled to the latest-extend deadline; if
+    any later extend had bumped the deadline, the handle would
+    have been cancelled and rescheduled, so by the time we run
+    every client has aged out. Clear the client refcount + the
+    in-memory PENDING peers dict, fire the close event +
+    cancellation events, done.
+    """
+    controller.state.pairing_window_handle = None
+    controller.state.pairing_window_clients.clear()
+    _fire_pairing_window_changed(controller)
+    clear_pending_peers_on_window_close(controller)

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -20,16 +20,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Any, Literal
 
-from ...helpers.api import CommandError, api_command
+from ...helpers.api import api_command
 from ...helpers.event_bus import Event
 from ...helpers.storage import Store
 from ...models import (
     TERMINAL_JOB_EVENTS,
-    ErrorCode,
     EventType,
     IdentityView,
     IntentResponse,
@@ -37,7 +35,6 @@ from ...models import (
     PeerStatus,
     PeerSummary,
     ReceiverPeers,
-    RemoteBuildPairingWindowChangedData,
     RemoteBuildSettings,
     RemoteBuildSettingsView,
 )
@@ -48,6 +45,7 @@ from . import (
     cleanup_loop,
     identity_commands,
     pair_flow,
+    pairing_window,
     peer_crud,
     peer_link_sessions,
     settings_receiver,
@@ -69,11 +67,6 @@ if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
-
-
-# Pairing-window lifetime. Auto-closes after this much idle;
-# the frontend extends on each activity tick.
-_PAIRING_WINDOW_DURATION_SECONDS = 300.0
 
 
 class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
@@ -354,62 +347,12 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         client: Hashable,
         **kwargs: Any,
     ) -> PairingWindowState:
-        """
-        Open, extend, or close the pairing window for the calling client.
-
-        Refcounted per WS client: ``open=true`` adds/refreshes
-        the caller's entry, ``open=false`` removes it. Window is
-        open iff any client has a non-stale entry. Crashed tabs
-        age out via the 5min idle timeout; a graceful close from
-        one tab leaves the window open for others.
-
-        ``client`` is the WS connection injected by the
-        dispatcher — used as the refcount key so two tabs get
-        distinct entries. Required kwarg (a default would
-        silently bucket every caller under the same key).
-
-        Fires :attr:`EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED`
-        only on real state transitions; idempotent calls don't.
-        """
-        if not isinstance(open, bool):
-            msg = "remote_build/set_pairing_window: 'open' must be a bool"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
-
-        was_open = self.is_pairing_window_open()
-        if open:
-            self.state.pairing_window_clients[client] = time.monotonic()
-        else:
-            self.state.pairing_window_clients.pop(client, None)
-        self._reschedule_pairing_window_close()
-        is_open = bool(self.state.pairing_window_clients)
-
-        # Fire on state transitions AND on every extend (so the
-        # frontend countdown re-syncs against the bumped deadline).
-        if was_open != is_open or (open and is_open):
-            self._fire_pairing_window_changed()
-        if was_open and not is_open:
-            self._clear_pending_peers_on_window_close()
-        return self._pairing_window_state()
+        """Open, extend, or close the pairing window for the calling client."""
+        return await pairing_window.set_pairing_window(self, open=open, client=client)
 
     def is_pairing_window_open(self) -> bool:
         """Return whether the pairing window is currently open (post-prune)."""
-        self._prune_stale_pairing_window_clients()
-        return bool(self.state.pairing_window_clients)
-
-    def _pairing_window_remaining(self) -> float | None:
-        """Seconds until the latest-extend deadline, or ``None`` if closed."""
-        self._prune_stale_pairing_window_clients()
-        if not self.state.pairing_window_clients:
-            return None
-        latest_extend = max(self.state.pairing_window_clients.values())
-        return max(0.0, latest_extend + _PAIRING_WINDOW_DURATION_SECONDS - time.monotonic())
-
-    def _pairing_window_state(self) -> PairingWindowState:
-        """Project the in-memory client map into a wire-shape response."""
-        remaining = self._pairing_window_remaining()
-        if remaining is None:
-            return PairingWindowState(open=False, expires_in_seconds=None)
-        return PairingWindowState(open=True, expires_in_seconds=remaining)
+        return pairing_window.is_pairing_window_open(self)
 
     def _fire_pair_status_changed(
         self, dashboard_id: str, status: Literal["approved", "removed"]
@@ -417,77 +360,6 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         """Fire ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` for a peer transition."""
         pair_flow.fire_pair_status_changed(self, dashboard_id, status)
 
-    def _fire_pairing_window_changed(self) -> None:
-        """Fire ``REMOTE_BUILD_PAIRING_WINDOW_CHANGED`` with the current state."""
-        state = self._pairing_window_state()
-        payload: RemoteBuildPairingWindowChangedData = {
-            "open": state.open,
-            "expires_in_seconds": state.expires_in_seconds,
-        }
-        self._db.bus.fire(EventType.REMOTE_BUILD_PAIRING_WINDOW_CHANGED, payload)
-
-    def _prune_stale_pairing_window_clients(self) -> None:
-        """Drop client entries whose last-extend timestamp aged out."""
-        if not self.state.pairing_window_clients:
-            return
-        cutoff = time.monotonic() - _PAIRING_WINDOW_DURATION_SECONDS
-        self.state.pairing_window_clients = {
-            client: extended_at
-            for client, extended_at in self.state.pairing_window_clients.items()
-            if extended_at >= cutoff
-        }
-
-    def _reschedule_pairing_window_close(self) -> None:
-        """
-        Cancel any pending close handle and schedule a fresh one.
-
-        Called after every :meth:`set_pairing_window` mutation. The
-        handle always reflects the current latest-extend deadline,
-        so on every extend we cancel and reschedule rather than
-        letting an old handle wake up and re-check; this avoids the
-        duplicate-close-event class of bug where an old handle
-        would fire after an explicit close.
-
-        When the client map is empty (the explicit-close case where
-        the last client just dropped out), no new handle is
-        scheduled and ``_pairing_window_handle`` stays ``None``.
-        """
-        if self.state.pairing_window_handle is not None:
-            self.state.pairing_window_handle.cancel()
-            self.state.pairing_window_handle = None
-        remaining = self._pairing_window_remaining()
-        if remaining is None:
-            return
-        loop = asyncio.get_running_loop()
-        self.state.pairing_window_handle = loop.call_later(
-            remaining, self._on_pairing_window_deadline
-        )
-
-    def _on_pairing_window_deadline(self) -> None:
-        """
-        Sync callback fired by the TimerHandle when the deadline lapses.
-
-        The handle was scheduled to the latest-extend deadline; if
-        any later extend had bumped the deadline, the handle would
-        have been cancelled and rescheduled, so by the time we run
-        every client has aged out. Clear the client refcount + the
-        in-memory PENDING peers dict, fire the close event +
-        cancellation events, done.
-        """
-        self.state.pairing_window_handle = None
-        self.state.pairing_window_clients.clear()
-        self._fire_pairing_window_changed()
-        self._clear_pending_peers_on_window_close()
-
     def _clear_pending_peers_on_window_close(self) -> None:
-        """Drop every PENDING peer + fire ``status="removed"`` for each.
-
-        Wakes any in-flight ``lookup_peer_for_status`` long-poll
-        so its offloader sees REJECTED.
-        """
-        if not self.state.pending_peers:
-            return
-        cleared = list(self.state.pending_peers)
-        self.state.pending_peers.clear()
-        for dashboard_id in cleared:
-            self._fire_pair_status_changed(dashboard_id, "removed")
+        """Drop every PENDING peer + fire ``status="removed"`` for each."""
+        pairing_window.clear_pending_peers_on_window_close(self)

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -30,10 +30,12 @@ from esphome_device_builder.controllers.remote_build import (
     ReceiverController,
 )
 from esphome_device_builder.controllers.remote_build import (
+    pairing_window as rb_pairing_window,
+)
+from esphome_device_builder.controllers.remote_build import (
     peer_link_sessions as rb_peer_link_sessions,
 )
 from esphome_device_builder.controllers.remote_build import rebind as rb_rebind
-from esphome_device_builder.controllers.remote_build import receiver as rb_rcv
 from esphome_device_builder.controllers.remote_build._mdns import (
     decode_txt_value,
     peer_from_service_info,
@@ -2718,7 +2720,7 @@ async def test_pairing_window_auto_closes_when_clients_age_out(
     bus.fire.side_effect = _fire_side_effect
     controller.offloader._db.bus = bus
 
-    monkeypatch.setattr(rb_rcv, "_PAIRING_WINDOW_DURATION_SECONDS", 0.5)
+    monkeypatch.setattr(rb_pairing_window, "_PAIRING_WINDOW_DURATION_SECONDS", 0.5)
 
     await controller.receiver.set_pairing_window(open=True, client="tab-1")
     assert controller.receiver.is_pairing_window_open() is True
@@ -2780,7 +2782,7 @@ async def test_explicit_close_cancels_handle_no_duplicate_event(
     # required — the explicit-close path schedules no replacement
     # handle, so checking ``_pairing_window_handle is None`` after
     # a tick is sufficient).
-    monkeypatch.setattr(rb_rcv, "_PAIRING_WINDOW_DURATION_SECONDS", 1.0)
+    monkeypatch.setattr(rb_pairing_window, "_PAIRING_WINDOW_DURATION_SECONDS", 1.0)
 
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

**Final split in the receiver-split arc** (after #809 cleanup loop, #815 peer-link sessions, #821 identity, #826 settings, #828 peer CRUD, #831 pair flow). Extracts the in-process pairing-window gate that fronts `intent="pair_request"` Noise frames into a new sibling module `controllers/remote_build/pairing_window.py`:

**Public entry points** (kept as bound delegates on the controller):
- `set_pairing_window` — `@api_command` WS body that refcounts per-WS-client open/close requests.
- `is_pairing_window_open` — listener-facing gate consumed by `pair_flow.record_pair_request`.
- `clear_pending_peers_on_window_close` — drops PENDING rows + fires `status="removed"` events; called by the controller's `stop()` lifecycle and by `set_pairing_window` itself.

**Module-private helpers**:
- `_pairing_window_remaining` — deadline computation.
- `_pairing_window_state` — wire-shape projection.
- `_fire_pairing_window_changed` — bus event helper.
- `_prune_stale_pairing_window_clients` — refcount aging.
- `_reschedule_pairing_window_close` — TimerHandle re-scheduler.
- `_on_pairing_window_deadline` — TimerHandle callback.

## Imports

Moved out of `receiver.py`: `time`, `RemoteBuildPairingWindowChangedData`, the `_PAIRING_WINDOW_DURATION_SECONDS` constant.

## Test impact

2 `monkeypatch.setattr` sites for `_PAIRING_WINDOW_DURATION_SECONDS` in `tests/test_remote_build_controller.py` move from `rb_rcv` to `rb_pairing_window` (added the matching alias import). The `rb_rcv` import becomes unused and is dropped.

`receiver.py`: **495 → 365 lines** (-130). Combined with the prior six splits: 1083 → 365 (-718, **-66%**). All 3424 tests pass; pre-commit clean.

The receiver controller is now well under the 800-line cap; the controller floor is `__init__` / `start` / `stop` / `_load_settings_async` + the bound delegates + snapshot helpers (`_peer_summaries`, `peers_snapshot`, `_serialize_peers`, `approved_peer_label`) + the `get_submit_job_receiver` / `get_artifacts_download_sender` service-ref accessors.

**Related issue or feature (if applicable):**

- Final PR in the ReceiverController split arc. The split sits beside the OffloaderController and DevicesController splits, all sharing the same shape: State dataclass + sibling concern modules + thin bound-method delegates on the controller.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
