### PR TITLE
Audit cleanup: receiver-split docstring formatting + stale meth ref

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
@@ -140,10 +140,11 @@ def unregister_peer_link_session(controller: ReceiverController, session: PeerLi
         # Drop any in-flight ``submit_job`` upload state so a
         # bundle reception that was mid-stream when the
         # session ended doesn't outlive the session that owns
-        # it. ``submit_job_receiver`` is set in :meth:`start`;
-        # this branch only runs for sessions registered after
-        # ``start`` (live wire), so the attribute is always
-        # populated by the time we get here.
+        # it. ``submit_job_receiver`` is set in
+        # :meth:`ReceiverController.start`; this branch only
+        # runs for sessions registered after ``start`` (live
+        # wire), so the attribute is always populated by the
+        # time we get here.
         if controller.state.submit_job_receiver is not None:
             controller.state.submit_job_receiver.discard_session(session.dashboard_id)
         if controller.state.artifacts_download_sender is not None:


### PR DESCRIPTION
# What does this implement/fix?

Audit follow-up to the receiver-split arc (#809 / #815 / #821 / #826 / #828 / #831 / #833). Two classes of issue caught by an AST-driven re-audit after I initially misjudged how clean the modules were:

## 1. Stale `:meth:` cross-reference (1 site)

The body comment in `peer_link_sessions.unregister_peer_link_session` was moved from `receiver.py` to module scope by #815 but the cross-reference still read `:meth:`start`` — ambiguous from a sibling-module reader's perspective (a reader scanning `peer_link_sessions.py` for a local `start` finds none). Spelled out as `:meth:`ReceiverController.start``.

## 2. Inline-summary multi-line docstrings (8 sites)

Per CLAUDE.md, multi-line docstrings put content on the line **after** `\"\"\"`; only one-liners stay inline. The receiver split arc copied bodies 1:1 from pre-extraction `receiver.py`, which had a mix of inline-summary and content-on-next-line shapes; the inline ones slipped through the per-PR Copilot review on most modules.

Reformatted:

- `cleanup_loop.run_cleanup_loop`
- `peer_link_sessions.on_firmware_queue_transition`
- `peer_link_sessions.broadcast_queue_status`
- `peer_link_sessions.register_peer_link_session`
- `peer_link_sessions.handle_cancel_job`
- `identity_commands.get_identity`
- `settings_receiver.to_view`
- `pairing_window.clear_pending_peers_on_window_close`

AST re-audit reports zero remaining inline-summary multi-line docstrings across the receiver split modules.

## Test impact

None — comment / docstring reformat only.

**Related issue or feature (if applicable):**

- Audit follow-up to the receiver-split arc. The other long docstrings in the receiver modules are genuinely load-bearing per CLAUDE.md's "non-obvious priority orders / multi-stage flow whose ordering is load-bearing" carve-out.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — \`bugfix\`
- [ ] New feature (non-breaking change which adds functionality) — \`new-feature\`
- [ ] Enhancement to an existing feature — \`enhancement\`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — \`breaking-change\`
- [x] Refactor (no behaviour change) — \`refactor\`
- [ ] Documentation only — \`docs\`
- [ ] Maintenance / chore — \`maintenance\`
- [ ] CI / workflow change — \`ci\`
- [ ] Dependencies bump — \`dependencies\`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (\`ruff\`, \`codespell\`, yaml/json/python checks).
- [ ] Tests have been added or updated under \`tests/\` where applicable.
- [x] \`components.json\` has **not** been hand-edited (regenerate via \`script/sync_components.py\` if a sync is needed).
- [ ] Architecture-level changes are reflected in \`docs/ARCHITECTURE.md\` and/or \`docs/API.md\`.