### PR TITLE
Enable BLE (flake8-blind-except) with narrowed excepts at each site

### DIFF
--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 import aiohttp
 from aiohttp import web
 from esphome import yaml_util
+from esphome.core import EsphomeError
 
 from ..helpers.api import CommandError
 from ..helpers.event_bus import Event, StreamControls, stream_events
@@ -329,12 +330,12 @@ def create_legacy_routes() -> web.RouteTableDef:
         try:
             # ``yaml_util.load_yaml`` expects a ``Path`` (it calls
             # ``fname.open(...)``); a string would raise
-            # ``AttributeError: 'str' object has no attribute 'open'``
-            # at parse time and the bare ``except`` below would
-            # surface it as 500 with that opaque message rather than
-            # a real YAML error. Keep the real ``Path`` here.
+            # ``AttributeError`` deep in the loader, which falls
+            # past the ``EsphomeError`` catch below and surfaces as
+            # the default aiohttp 500 instead of our diagnostic
+            # ``{"error": ...}`` body. Keep the real ``Path`` here.
             config = await loop.run_in_executor(None, yaml_util.load_yaml, config_path)
-        except Exception as exc:
+        except EsphomeError as exc:
             return json_response({"error": str(exc)}, status=500)
 
         # ESPHome's ``yaml_util.load_yaml`` returns an ``OrderedDict``

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -21,7 +21,7 @@ from ..controllers.auth import AuthError
 from ..helpers.api import CommandError
 from ..helpers.auth import extract_bearer_token
 from ..helpers.event_bus import StreamBackpressureError
-from ..helpers.json import dumps_str, loads
+from ..helpers.json import JSONDecodeError, dumps_str, loads
 from ..models import (
     CommandMessage,
     ErrorCode,
@@ -202,7 +202,12 @@ class WebSocketClient:
         """Parse and dispatch a command."""
         try:
             cmd = CommandMessage.from_dict(raw)
-        except Exception:
+        except (ValueError, TypeError, LookupError):
+            # mashumaro's runtime data-shape errors all derive from
+            # one of these three: missing field, wrong type,
+            # rejected value. Programmer-bug shapes (NameError,
+            # ModuleNotFoundError) fall through to the outer error
+            # handler.
             await self.send_error("", ErrorCode.INVALID_MESSAGE, "Invalid command format")
             return
 
@@ -361,7 +366,7 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
             if msg.type in (WSMsgType.TEXT, WSMsgType.BINARY):
                 try:
                     raw = loads(msg.data)
-                except Exception:
+                except JSONDecodeError:
                     await client.send_error("", ErrorCode.INVALID_MESSAGE, "Invalid JSON")
                     continue
                 # Same-module call: the WS dispatch loop lives next to

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -150,7 +150,7 @@ class DeviceMqttMonitor:
                 raise
             except (TimeoutError, OSError, ConnectionError) as err:
                 self._log_reconnect_failure(err, expected=True)
-            except Exception as err:
+            except Exception as err:  # noqa: BLE001 — reconnect loop must outlive any unexpected error
                 self._log_reconnect_failure(err, expected=False)
             # Drop last-seen on any failure but leave device state
             # alone so a brief broker blip doesn't trigger an offline

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -390,6 +390,6 @@ class DeviceScanner:
                     metadata.labels,
                     previous=self._index.by_path.get(path),
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001 — best-effort scan; one bad YAML mustn't kill the sweep
                 _LOGGER.warning("Failed to load device from %s", path.name)
         return result

--- a/esphome_device_builder/controllers/_device_state_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor.py
@@ -33,8 +33,10 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 
 try:
     from icmplib import async_ping as icmp_ping
+    from icmplib.exceptions import ICMPLibError
 except ImportError:  # pragma: no cover — icmplib is optional
     icmp_ping = None  # type: ignore[assignment]
+    ICMPLibError = Exception  # type: ignore[misc,assignment]
 
 from zeroconf import current_time_millis, millis_to_seconds
 from zeroconf.const import (
@@ -1610,7 +1612,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             # ``is_alive`` so failures stay null.
             if is_alive:
                 rtt_ms = float(result.min_rtt)
-        except Exception as exc:
+        except (ICMPLibError, OSError) as exc:
             # ``.local`` hosts on systems without Avahi / mdnsd hit
             # this every sweep; the traceback adds nothing and floods
             # the logs. One-line debug is plenty.

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -13,6 +13,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ruamel.yaml import YAMLError
+
 from ...helpers.api import CommandError, api_command
 from ...models.api import ErrorCode
 from ...models.automations import (
@@ -217,7 +219,7 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
     yaml = parsing.make_yaml()
     try:
         data = yaml.load(text)
-    except Exception:
+    except YAMLError:
         return _ScopedYaml(domains=set(), scripts=[], devices=[])
     if not isinstance(data, dict):
         return _ScopedYaml(domains=set(), scripts=[], devices=[])

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -605,7 +605,10 @@ def load_preferences(config_dir: Path) -> UserPreferences:
     raw = _load_metadata(config_dir).get(_PREFS_KEY, {})
     try:
         return UserPreferences.from_dict(raw)
-    except Exception:
+    except (ValueError, TypeError, LookupError):
+        # mashumaro runtime-shape errors → defaults. Hand-edited
+        # sidecar with a malformed prefs blob shouldn't take the
+        # whole dashboard down.
         return UserPreferences()
 
 
@@ -763,7 +766,7 @@ def _decode_labels(raw: Any) -> list[Label]:
             continue
         try:
             out.append(Label.from_dict(entry))
-        except Exception as err:
+        except (ValueError, TypeError, LookupError) as err:
             # A hand-edited sidecar that landed a malformed entry
             # shouldn't take the whole catalog down — labels are
             # advisory. Debug-log so a developer hunting "why did

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -184,7 +184,7 @@ async def run_bulk_per_device(
         try:
             await action(configuration)
             results.append({"configuration": configuration, "success": True})
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — batch op: per-configuration error captured into the result row
             results.append(
                 {
                     "configuration": configuration,

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -117,7 +117,7 @@ def _remove_device_sidecars(config_dir: Path, configuration: str) -> None:
         _LOGGER.warning("Could not remove storage file for %s", configuration)
     try:
         remove_device_metadata(config_dir, configuration)
-    except Exception:
+    except OSError:
         _LOGGER.warning("Could not remove metadata for %s", configuration)
 
 
@@ -137,7 +137,7 @@ def _archive_clear_device_sidecars(config_dir: Path, configuration: str) -> None
         _LOGGER.warning("Could not remove storage file for %s", configuration)
     try:
         clear_volatile_device_metadata(config_dir, configuration)
-    except Exception:
+    except OSError:
         _LOGGER.warning("Could not clear volatile metadata for %s", configuration)
 
 

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -80,7 +80,7 @@ class DeviceMetadataBase(DeviceBuilderBase):
         # Backfill metadata so future scans skip the YAML parse.
         try:
             set_device_metadata(config_dir, filename, board_id=matched.id)
-        except Exception:
+        except OSError:
             _LOGGER.warning("Could not persist derived board_id for %s", filename)
         return matched.id
 

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -56,7 +56,7 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
             component = _resolve_download_component(storage.target_platform)
             module = importlib.import_module(f"esphome.components.{component}")
             return list(module.get_download_types(storage))
-        except Exception:
+        except Exception:  # noqa: BLE001 — third-party regression: upstream ``get_download_types`` could raise anything
             _LOGGER.warning("Could not determine download types for %s", configuration)
             return []
 

--- a/esphome_device_builder/controllers/labels.py
+++ b/esphome_device_builder/controllers/labels.py
@@ -212,7 +212,7 @@ class LabelsController:
             for filename in affected:
                 try:
                     await devices.reload_configuration(filename)
-                except Exception:
+                except Exception:  # noqa: BLE001 — cascade is best-effort; one bad device must not block the others
                     _LOGGER.warning("Failed to reload device %s after label cascade", filename)
 
         self._db.bus.fire(EventType.LABEL_DELETED, LabelDeletedData(label_id=label_id))

--- a/esphome_device_builder/helpers/build_size.py
+++ b/esphome_device_builder/helpers/build_size.py
@@ -150,7 +150,7 @@ def _load_full_metadata(config_dir: Path) -> dict[str, dict]:
 
     try:
         raw = _load_metadata(config_dir)
-    except Exception:
+    except OSError:
         return {}
     return {k: v for k, v in raw.items() if isinstance(v, dict)}
 

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from esphome import const, yaml_util
 from esphome.const import CONF_PACKAGES
+from esphome.core import EsphomeError
 from esphome.storage_json import StorageJSON
 
 from .storage_path import resolve_storage_path
@@ -489,11 +490,11 @@ def detect_platform_from_yaml(path: Path) -> str:
     """
     try:
         raw = path.read_text(encoding="utf-8")
-    except Exception:
+    except (OSError, UnicodeDecodeError):
         return ""
     try:
         platform, _, _ = parse_platform_from_yaml(raw)
-    except Exception:
+    except Exception:  # noqa: BLE001 — future-proof against parse_platform_from_yaml gaining a throw shape
         platform = ""
     if platform:
         return platform
@@ -1104,7 +1105,7 @@ def load_device_yaml(path: Path) -> dict | None:
         # pass the ``Path`` directly — handing it a stringified path
         # raises ``AttributeError`` deep inside the loader.
         config = yaml_util.load_yaml(path)
-    except Exception:
+    except EsphomeError:
         return None
     if not isinstance(config, dict):
         return None

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from esphome import yaml_util
+from esphome.core import EsphomeError
 
 # Bootstrap placeholder strings — hoisted from
 # ``controllers/config.py`` so the writer and the reader share a
@@ -41,15 +42,15 @@ def read_secrets_yaml(config_dir: Path) -> dict | None:
 
     ``yaml_util.load_yaml`` expects a ``Path``, not a ``str`` — the
     type signature pins this so a string slip from a caller fails
-    at type-check time instead of as a silently-swallowed
-    ``AttributeError`` inside the broad except.
+    at type-check time instead of as an ``AttributeError`` slipping
+    past the narrow ``EsphomeError`` catch below.
     """
     secrets_path = config_dir / "secrets.yaml"
     if not secrets_path.exists():
         return None
     try:
         data = yaml_util.load_yaml(secrets_path)
-    except Exception:
+    except EsphomeError:
         return None
     return data if isinstance(data, dict) else None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ select = [
   "A", # flake8-builtins
   "ASYNC", # flake8-async — catch blocking calls / busy-wait in async funcs
   "B", # flake8-bugbear
+  "BLE", # flake8-blind-except — flag ``except Exception:`` so the catch scope is deliberate
   "C4", # flake8-comprehensions
   "D", # pydocstyle
   "DTZ", # flake8-datetimez — flag naive datetime construction; force explicit tz
@@ -187,7 +188,10 @@ select = [
 # behind try/except ImportError, and several subprocess invocations are inherent.
 # SLF001 is also waived here so smoke-test scripts (``check_catalog.py``) can
 # inspect catalog internals (``_by_id``, ``_components``) without per-line noqa.
-"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001"]
+# BLE001 is waived because sync scripts iterate over hundreds of catalog
+# entries and want "log + continue" for any failure shape; per-entry noqa
+# would be noise.
+"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001", "BLE001"]
 # Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
 "esphome_device_builder/discover.py" = ["T20"]
 # Tests need free access to controller privates for setup / assertion;
@@ -197,7 +201,7 @@ select = [
 # legitimately poll for "until condition" without the production-side
 # ``asyncio.Event`` plumbing the rule suggests; in production this rule
 # stays load-bearing.
-"tests/*" = ["S105", "S106", "SLF001", "ASYNC110"] # hardcoded test credentials
+"tests/*" = ["S105", "S106", "SLF001", "ASYNC110", "BLE001"] # hardcoded test credentials
 # Manual scripts: print is the UX, late imports gate optional setup,
 # subprocess + tempdir paths are part of the CLI contract.
 "tests/manual/*" = ["T20", "S108", "PLC0415"]

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -561,10 +561,10 @@ def test_remove_device_sidecars_logs_oserror_on_storage_unlink(
 def test_remove_device_sidecars_logs_exception_on_metadata_remove(
     tmp_path: Path, monkeypatch: Any, caplog: Any
 ) -> None:
-    """Generic Exception from metadata-remove is logged, not raised."""
+    """OSError from metadata-remove is logged, not raised."""
 
     def _raise(*args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("disk full")
+        raise OSError("disk full")
 
     monkeypatch.setattr(devices_helpers, "remove_device_metadata", _raise)
 
@@ -626,7 +626,7 @@ def test_clear_volatile_device_metadata_drops_corrupt_non_dict_entry(
 def test_archive_clear_device_sidecars_logs_exception_on_metadata_clear(
     tmp_path: Path, monkeypatch: Any, caplog: Any
 ) -> None:
-    """Generic Exception from clear-volatile is logged, not raised.
+    """OSError from clear-volatile is logged, not raised.
 
     A failure scrubbing the volatile metadata fields shouldn't
     propagate — the YAML has already been moved to the archive
@@ -635,7 +635,7 @@ def test_archive_clear_device_sidecars_logs_exception_on_metadata_clear(
     """
 
     def _raise(*args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("disk full")
+        raise OSError("disk full")
 
     monkeypatch.setattr(devices_helpers, "clear_volatile_device_metadata", _raise)
 


### PR DESCRIPTION
# What does this implement/fix?

Enables `flake8-blind-except` (BLE001) and triages every
existing `except Exception:` site — narrowing the catch to the
call's documented exception surface where practical, leaving a
`# noqa: BLE001` with rationale where the broad scope is
intentional.

Followup to #822 (SLF001), #824 (LOG / G / ICN / INP / ISC),
#829 (PTH), #830 (DTZ), and #832 (ASYNC).

## Site breakdown (32 total)

- **10** in `script/sync_components.py` — CI sync scripts
  already iterate over hundreds of catalog entries with "log
  + continue on anything." Per-file-ignored via the existing
  `script/*` entry (added `BLE001` alongside the other waivers).
- **2** in tests — per-file-ignored via `tests/*`. Tests already
  inject custom exceptions to verify the catch path; widening
  to "any" is fine.
- **20** in production — narrowed or `noqa`'d individually.

## Narrowings (8 sites)

| Site | New scope | Notes |
|---|---|---|
| `api/ws.py:364` `loads()` | `JSONDecodeError` | orjson raises exactly this |
| `api/ws.py:205` `CommandMessage.from_dict` | `(ValueError, TypeError, LookupError)` | Mashumaro's runtime-shape errors all subclass one of those; schema-bug errors (`NameError`, etc.) fall through |
| `api/legacy.py:337` `yaml_util.load_yaml` | `EsphomeError` | Documented wrapping class |
| `helpers/secrets_state.py:52` `yaml_util.load_yaml` | `EsphomeError` | Same |
| `helpers/device_yaml.py:1107` `yaml_util.load_yaml` | `EsphomeError` | Same |
| `helpers/device_yaml.py:492` `Path.read_text` | `(OSError, UnicodeDecodeError)` | Documented surface |
| `controllers/automations/controller.py:220` ruamel `yaml.load` | `YAMLError` | Library base class |
| `controllers/config.py:608` `UserPreferences.from_dict` | `(ValueError, TypeError, LookupError)` | Mashumaro shape |
| `controllers/config.py:766` `Label.from_dict` | `(ValueError, TypeError, LookupError)` | Mashumaro shape |
| `controllers/_device_state_monitor.py:1613` `icmp_ping` | `(ICMPLibError, OSError)` | `ICMPLibError` is icmplib's base; `OSError` covers resolver leaks on some platforms |
| `controllers/devices/helpers.py:120,140` metadata-remove | `OSError` | Atomic file rewrite |
| `controllers/devices/metadata.py:83` `set_device_metadata` | `OSError` | Same |
| `helpers/build_size.py:153` `_load_metadata` | `OSError` | Same |

## `# noqa: BLE001` with rationale (7 sites)

- `controllers/_device_mqtt_monitor.py:153` — reconnect loop's
  catch-all-else arm after a narrow
  `(TimeoutError, OSError, ConnectionError)`; the broad scope
  IS the "unexpected" arm.
- `controllers/_device_scanner.py:393` — best-effort sweep; one
  bad YAML must not kill the loop.
- `controllers/devices/archive.py:187` — batch operation
  wrapper that captures each per-configuration error into the
  result row.
- `controllers/labels.py:215` — label-cascade reload; one bad
  device must not block the rest.
- `controllers/firmware/download.py:59` — third-party
  regression boundary; upstream esphome's
  `get_download_types` could raise anything on a schema
  change. (Pinned by `test_get_binaries_logs_and_returns_empty_on_module_failure`.)
- `helpers/device_yaml.py:496` — future-proof against
  `parse_platform_from_yaml` gaining a throw shape (currently
  pure string ops, but the wrap is documented "return empty on
  any error").

## Test updates

Two archive tests (`test_remove_device_sidecars_logs_exception_on_metadata_remove`,
`test_archive_clear_device_sidecars_logs_exception_on_metadata_clear`)
were raising `RuntimeError` to exercise the catch-all arm.
Switched to `OSError` so they pin the narrowed contract
(metadata-write failure = `OSError`); a `RuntimeError` from a
metadata helper would now correctly surface as a bug rather
than being silently swallowed.

All 3402 tests pass; pre-commit clean.

**Related issue or feature (if applicable):**

- Companion to the ruff-family enable arc: #822 / #824 / #829 / #830 / #832.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
