### PR TITLE
Enable FBT (flake8-boolean-trap) and fix 4 production sites

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -71,7 +71,7 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
 
     # Route ``warnings.warn`` through the logging system instead of
     # raw stderr so the queue handler and our formatter apply.
-    logging.captureWarnings(True)
+    logging.captureWarnings(capture=True)
 
     if log_file:
         file_handler = RotatingFileHandler(log_file, maxBytes=_MAX_LOG_SIZE, backupCount=1)

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
@@ -98,7 +98,12 @@ def dispatch_queue_status(client: PeerLinkClient, parsed: dict[str, Any]) -> Non
     if not is_valid_frame(_QUEUE_STATUS_SCHEMA, parsed):
         log_malformed(client, "queue_status", parsed)
         return
-    fire_queue_status(client, parsed["idle"], parsed["running"], parsed["queue_depth"])
+    fire_queue_status(
+        client,
+        idle=parsed["idle"],
+        running=parsed["running"],
+        queue_depth=parsed["queue_depth"],
+    )
 
 
 def dispatch_submit_job_ack(client: PeerLinkClient, parsed: dict[str, Any]) -> None:
@@ -313,7 +318,9 @@ def fire_pin_mismatch(client: PeerLinkClient, *, observed: bytes) -> None:
     client._bus.fire(EventType.OFFLOADER_PAIR_PIN_MISMATCH, payload)
 
 
-def fire_queue_status(client: PeerLinkClient, idle: bool, running: bool, queue_depth: int) -> None:
+def fire_queue_status(
+    client: PeerLinkClient, *, idle: bool, running: bool, queue_depth: int
+) -> None:
     """Fire ``OFFLOADER_QUEUE_STATUS_CHANGED`` for an inbound snapshot."""
     payload: OffloaderQueueStatusChangedData = {
         "receiver_hostname": client._hostname,

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -622,8 +622,8 @@ class PeerLinkClient:
     def _fire_pin_mismatch(self, *, observed: bytes) -> None:
         _dispatch.fire_pin_mismatch(self, observed=observed)
 
-    def _fire_queue_status(self, idle: bool, running: bool, queue_depth: int) -> None:
-        _dispatch.fire_queue_status(self, idle, running, queue_depth)
+    def _fire_queue_status(self, *, idle: bool, running: bool, queue_depth: int) -> None:
+        _dispatch.fire_queue_status(self, idle=idle, running=running, queue_depth=queue_depth)
 
     def _on_self_static_observed(self, peer: Any) -> str:
         """Skip *peer*'s IP next resolve, log ERROR, return the transport-error close reason."""

--- a/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_sessions.py
@@ -44,12 +44,12 @@ def on_firmware_queue_transition(controller: ReceiverController, event: Event[An
     if not controller.state.peer_link_sessions:
         return
     controller._db.create_background_task(
-        broadcast_queue_status(controller, idle, running, queue_depth)
+        broadcast_queue_status(controller, idle=idle, running=running, queue_depth=queue_depth)
     )
 
 
 async def broadcast_queue_status(
-    controller: ReceiverController, idle: bool, running: bool, queue_depth: int
+    controller: ReceiverController, *, idle: bool, running: bool, queue_depth: int
 ) -> None:
     """Send a ``queue_status`` frame to every active peer-link session.
 
@@ -112,7 +112,9 @@ async def register_peer_link_session(
             )
         else:
             controller._db.create_background_task(
-                _send_initial_queue_status(session, idle, running, queue_depth)
+                _send_initial_queue_status(
+                    session, idle=idle, running=running, queue_depth=queue_depth
+                )
             )
     # Fire AFTER the dict insert so subscriber lookups see
     # the just-registered session.
@@ -213,6 +215,7 @@ async def handle_cancel_job(
 
 async def _send_initial_queue_status(
     session: PeerLinkSession,
+    *,
     idle: bool,
     running: bool,
     queue_depth: int,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ select = [
   "DTZ", # flake8-datetimez — flag naive datetime construction; force explicit tz
   "E", # pycodestyle errors
   "F", # pyflakes
+  "FBT", # flake8-boolean-trap — flag positional ``bool`` params / calls
   "FLY", # flynt: convert string formatting to f-strings
   "FURB", # refurb
   "G", # flake8-logging-format — flag % / .format / f-string in logger calls
@@ -191,7 +192,7 @@ select = [
 # BLE001 is waived because sync scripts iterate over hundreds of catalog
 # entries and want "log + continue" for any failure shape; per-entry noqa
 # would be noise.
-"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001", "BLE001"]
+"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001", "BLE001", "FBT001", "FBT002"]
 # Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
 "esphome_device_builder/discover.py" = ["T20"]
 # Tests need free access to controller privates for setup / assertion;
@@ -201,7 +202,7 @@ select = [
 # legitimately poll for "until condition" without the production-side
 # ``asyncio.Event`` plumbing the rule suggests; in production this rule
 # stays load-bearing.
-"tests/*" = ["S105", "S106", "SLF001", "ASYNC110", "BLE001"] # hardcoded test credentials
+"tests/*" = ["S105", "S106", "SLF001", "ASYNC110", "BLE001", "FBT001", "FBT002", "FBT003"] # hardcoded test credentials
 # Manual scripts: print is the UX, late imports gate optional setup,
 # subprocess + tempdir paths are part of the CLI contract.
 "tests/manual/*" = ["T20", "S108", "PLC0415"]


### PR DESCRIPTION
# What does this implement/fix?

Enables `flake8-boolean-trap` (FBT) and fixes the 4 production
sites. Positional `bool` parameters at the call boundary are a
real bug class — `foo(True, False)` silently flips semantics
depending on argument order, and reads wrong on review.

Followup to #822 (SLF001), #824 (LOG / G / ICN / INP / ISC),
#829 (PTH), #830 (DTZ), #832 (ASYNC), and #835 (BLE).

## Triage of 34 sites

| Bucket | Sites | Disposition |
|---|---:|---|
| Production code | 4 functions | **Fixed** — added `*` keyword-only marker + named-arg call rewrites |
| Tests | 23 | Per-file-ignored via `tests/*`. Test helpers; call sites already use named args, and `test_validate_port_rejects_bool` is *testing* the bool-trap rejection itself |
| Scripts | 7 | Per-file-ignored via `script/*`. CLI scripts with bool flags as part of their shape; bounded blast radius |

## Production fixes

- **`__main__.py:74`** — `logging.captureWarnings(True)` →
  `logging.captureWarnings(capture=True)`. Stdlib API; the
  parameter name is documented.
- **`peer_link_client/_dispatch.py:316` `fire_queue_status`** —
  added `*` keyword-only marker for `idle` / `running`; updated
  the one call site to pass them by name.
- **`peer_link_client/client.py:625` `_fire_queue_status`** —
  same. Preserves the existing `_fire_*` wrapper pattern but
  with named-arg discipline.
- **`peer_link_sessions.py:51` `broadcast_queue_status` /
  `:213` `_send_initial_queue_status`** — same; updated both
  internal call sites (no test changes — the existing tests
  already used named args).

## What FBT001/FBT002 vs FBT003 catch

- **FBT001** (Boolean-typed positional argument) — function
  signature defines a positional `bool` parameter. Forces the
  definition to use `*` to mark following args keyword-only.
- **FBT002** (Boolean default positional argument) — same
  shape with a default.
- **FBT003** (Boolean positional value in function call) —
  the call site passes `True` / `False` positionally to a
  function whose signature still allows it (third-party APIs,
  legacy code). Fix at the call site.

All 3402 tests pass, pre-commit clean.

**Related issue or feature (if applicable):**

- Companion to the ruff-family enable arc: #822 / #824 / #829 / #830 / #832 / #835.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
