### PR TITLE
Enable TRY (tryceratops) with TRY003 globally ignored

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -837,7 +837,7 @@ def set_device_labels(config_dir: Path, configuration: str, label_ids: list[str]
             # become an effective ``[]`` (clear-all) write — surprising
             # and user-hostile. Surface a clear error instead so the
             # frontend can fix the payload.
-            raise ValueError(f"label_ids must be strings, got {type(lid).__name__}: {lid!r}")
+            raise TypeError(f"label_ids must be strings, got {type(lid).__name__}: {lid!r}")
         if lid in seen:
             continue
         deduped.append(lid)

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -84,7 +84,10 @@ async def set_labels(
     def _persist() -> None:
         try:
             set_device_labels(config_dir, configuration, label_ids)
-        except ValueError as err:
+        except (TypeError, ValueError) as err:
+            # ``set_device_labels`` raises ``TypeError`` for non-string
+            # items and ``ValueError`` for unknown label ids; both
+            # surface as ``INVALID_ARGS`` to the WS caller.
             raise CommandError(ErrorCode.INVALID_ARGS, str(err)) from err
 
     await asyncio.to_thread(_persist)

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -239,12 +239,13 @@ def _validate_port(port: str) -> None:
     if looks_ip:
         try:
             ipaddress.ip_address(port)
-            return
         except ValueError as exc:
             raise CommandError(
                 ErrorCode.INVALID_ARGS,
                 f"Invalid device target {port!r} — looks like an IP but didn't parse: {exc}",
             ) from exc
+        else:
+            return
     # Hostnames: a sequence of dot-separated labels, each
     # ``[a-z0-9](?:[a-z0-9-]*[a-z0-9])?``. Strip a single trailing
     # FQDN dot before matching — zeroconf and the system resolver

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -219,7 +219,7 @@ async def execute_job(  # noqa: PLR0912, PLR0915
         else:
             job.error = str(exc)
             controller._finalize_terminal(job, JobStatus.FAILED)
-            _LOGGER.exception("Job %s failed: %s", job.job_id, exc)
+            _LOGGER.exception("Job %s failed", job.job_id)
     finally:
         controller.state.current_job = None
         controller.state.current_process = None

--- a/esphome_device_builder/helpers/build_artifacts.py
+++ b/esphome_device_builder/helpers/build_artifacts.py
@@ -184,7 +184,7 @@ def load_build_artifacts(configuration: str) -> BuildArtifacts:
         msg = (
             f"idedata.json for {configuration} is not a JSON object (got {type(idedata).__name__})"
         )
-        raise ValueError(msg)
+        raise TypeError(msg)
 
     # ``firmware.bin`` is the only image consistently
     # reported by ``StorageJSON.firmware_bin_path`` upstream.

--- a/esphome_device_builder/helpers/event_bus.py
+++ b/esphome_device_builder/helpers/event_bus.py
@@ -257,7 +257,6 @@ async def stream_events(
         while True:
             try:
                 queue.put_nowait(item)
-                return
             except asyncio.QueueFull:
                 try:
                     queue.get_nowait()
@@ -266,6 +265,8 @@ async def stream_events(
                     # synchronous listener path, but bail rather
                     # than spin if it does.
                     return
+            else:
+                return
 
     def _push_or_terminate(name: str, payload: Any) -> None:
         try:

--- a/esphome_device_builder/helpers/single_instance.py
+++ b/esphome_device_builder/helpers/single_instance.py
@@ -234,11 +234,10 @@ def ensure_single_execution(config_dir: Path) -> Generator[SingleInstanceLock]:
         lock_file_ctx = open(  # noqa: SIM115 — closed in finally
             lock_file_path, "a+", encoding="utf-8", opener=_open_lock_file
         )
-    except OSError as exc:
-        _LOGGER.error(
-            "Could not open lock file %s (refusing to start): %s",
+    except OSError:
+        _LOGGER.exception(
+            "Could not open lock file %s (refusing to start)",
             lock_file_path,
-            exc,
         )
         lock.exit_code = 1
         yield lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,12 @@ ignore = [
   # ``run_in_executor`` where they actually block. False positive for
   # this codebase.
   "ASYNC240",
+  # TRY003 wants every ``raise ExceptionType("msg")`` replaced with a
+  # custom exception class. We deliberately use the ``CommandError(code,
+  # msg)`` API + ``EsphomeError("msg")`` from upstream for ad-hoc
+  # errors; the custom-class-per-raise discipline would explode the
+  # exception-class surface for no callable benefit.
+  "TRY003",
 ]
 select = [
   "A", # flake8-builtins
@@ -180,6 +186,7 @@ select = [
   # dataclass boundary stays load-bearing; sibling-module access within a
   # controller package is exempted via per-file-ignores below.
   "T20", # flake8-print
+  "TRY", # tryceratops — exception-handling antipatterns (TRY003 globally ignored above)
   "UP", # pyupgrade
   "W", # pycodestyle warnings
 ]
@@ -192,7 +199,7 @@ select = [
 # BLE001 is waived because sync scripts iterate over hundreds of catalog
 # entries and want "log + continue" for any failure shape; per-entry noqa
 # would be noise.
-"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001", "BLE001", "FBT001", "FBT002"]
+"script/*" = ["T20", "S108", "S310", "S110", "S603", "S607", "E501", "PLC0415", "SLF001", "BLE001", "FBT001", "FBT002", "TRY400"]
 # Discovery CLI: prints are the entire UX (mirrors aioesphomeapi-discover).
 "esphome_device_builder/discover.py" = ["T20"]
 # Tests need free access to controller privates for setup / assertion;
@@ -202,7 +209,7 @@ select = [
 # legitimately poll for "until condition" without the production-side
 # ``asyncio.Event`` plumbing the rule suggests; in production this rule
 # stays load-bearing.
-"tests/*" = ["S105", "S106", "SLF001", "ASYNC110", "BLE001", "FBT001", "FBT002", "FBT003"] # hardcoded test credentials
+"tests/*" = ["S105", "S106", "SLF001", "ASYNC110", "BLE001", "FBT001", "FBT002", "FBT003", "TRY301"] # hardcoded test credentials
 # Manual scripts: print is the UX, late imports gate optional setup,
 # subprocess + tempdir paths are part of the CLI contract.
 "tests/manual/*" = ["T20", "S108", "PLC0415"]

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -1716,7 +1716,7 @@ def test_delete_label_cascade_removes_corrupt_entry(tmp_path: Path) -> None:
 
 
 def test_set_device_labels_rejects_non_string_items(tmp_path: Path) -> None:
-    """Non-string items in ``label_ids`` raise ``ValueError``.
+    """Non-string items in ``label_ids`` raise ``TypeError``.
 
     The controller wraps this into ``CommandError(INVALID_ARGS)``.
     Silent skipping would let a bad payload effectively clear all
@@ -1724,7 +1724,7 @@ def test_set_device_labels_rejects_non_string_items(tmp_path: Path) -> None:
     """
     save_labels(tmp_path, [Label(id="known", name="Known")])
 
-    with pytest.raises(ValueError, match="label_ids must be strings"):
+    with pytest.raises(TypeError, match="label_ids must be strings"):
         set_device_labels(tmp_path, "kitchen.yaml", ["known", 42])  # type: ignore[list-item]
 
     # No partial write happened.

--- a/tests/test_event_payload_contracts.py
+++ b/tests/test_event_payload_contracts.py
@@ -117,7 +117,7 @@ def _outermost_return_dict_keys(func: Callable[..., Any]) -> set[str]:
                 f"Non-string-literal key in {func!r} dict literal — the "
                 "drift check assumes a flat ``{'k': v, ...}`` dict."
             )
-            raise AssertionError(msg)
+            raise AssertionError(msg)  # noqa: TRY004 — contract drift in the test fixture, not a runtime type error
         keys.add(key_node.value)
     return keys
 

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -997,7 +997,7 @@ def test_unpack_artifacts_response_handles_non_dict_extra() -> None:
 def test_load_build_artifacts_rejects_non_dict_idedata(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Corrupt-but-parseable idedata.json (``null`` / list) raises :class:`ValueError`.
+    """Corrupt-but-parseable idedata.json (``null`` / list) raises :class:`TypeError`.
 
     Pins the defensive check that surfaces "esphome wrote a
     weird idedata.json" as a clean error reachable through the
@@ -1025,7 +1025,7 @@ def test_load_build_artifacts_rejects_non_dict_idedata(
         lambda _configuration, *, name: idedata_path,
     )
 
-    with pytest.raises(ValueError, match="not a JSON object"):
+    with pytest.raises(TypeError, match="not a JSON object"):
         load_build_artifacts("kitchen.yaml")
 
 


### PR DESCRIPTION
# What does this implement/fix?

Enables `tryceratops` (TRY) with `TRY003` globally ignored.
TRY catches exception-handling antipatterns; one sub-rule
(`TRY003`) accounts for 112 of 122 violations and is a
controversial "always make a custom exception class" stance
that doesn't fit this codebase's API.

Followup to #822 (SLF001), #824 (LOG / G / ICN / INP / ISC),
#829 (PTH), #830 (DTZ), #832 (ASYNC), #835 (BLE), and
#836 (FBT).

## Sub-rule breakdown

| Sub-rule | Sites | Disposition |
|---|---:|---|
| `TRY003` (raise-vanilla-args) | 112 | **Globally ignored** — codebase uses `CommandError(code, msg)` + upstream `EsphomeError("msg")` for ad-hoc errors; custom-class-per-raise would explode the exception-class surface |
| `TRY004` (type-check-without-type-error) | 3 | 2 production fixes, 1 test noqa |
| `TRY300` (try-consider-else) | 2 | Both fixed |
| `TRY301` (raise-within-try) | 2 | Both in `test_main_cli.py` exercising `sys.exc_info()`; `tests/*` per-file-ignore |
| `TRY400` (error-instead-of-exception) | 2 | 1 production fix, 1 script `script/*` per-file-ignore |
| `TRY401` (verbose-log-message) | 1 | Fixed |

## Production fixes

- **`controllers/config.py:840`** `set_device_labels` —
  `ValueError` for non-string `label_ids` → `TypeError`. Wrapper
  in `mutations_simple.py` widened to catch both
  `(TypeError, ValueError)` since the same function still
  raises `ValueError` for unknown-label-id rejections.
- **`helpers/build_artifacts.py:187`** — non-dict idedata
  `ValueError` → `TypeError`.
- **`controllers/firmware/helpers.py:240`** port validation —
  moved the success `return` into an `else:` block.
- **`helpers/event_bus.py:257`** backpressure put-with-evict
  loop — same `else:` reshape.
- **`helpers/single_instance.py:238`** lock-file open failure
  — `_LOGGER.error(...)` → `.exception(...)` preserves the
  traceback through the exit path.
- **`controllers/firmware/runner.py:222`** job failure log —
  dropped the redundant `%s, exc` argument since
  `_LOGGER.exception` already carries it.

## Caller updates

`set_device_labels` now raises `TypeError` for non-string
items (was `ValueError`). The wrapper in
`controllers/devices/mutations_simple.py:_persist` catches
both `(TypeError, ValueError)` and wraps as
`CommandError(INVALID_ARGS)`. Tests updated:

- `test_set_device_labels_rejects_non_string_items` → asserts
  `TypeError`.
- `test_load_build_artifacts_rejects_non_dict_idedata` →
  asserts `TypeError`.

All 3402 tests pass, pre-commit clean.

**Related issue or feature (if applicable):**

- Companion to the ruff-family enable arc: #822 / #824 / #829 / #830 / #832 / #835 / #836.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
