### PR TITLE
Extract bare_firmware_controller_factory fixture; DRY 5 test files

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -205,27 +205,7 @@ BareFirmwareControllerFactory = Callable[..., FirmwareController]
 
 @pytest.fixture
 def bare_firmware_controller_factory() -> BareFirmwareControllerFactory:
-    """
-    Build a bare ``FirmwareController`` shell — just ``state``, no DB / bus.
-
-    For tests that want to exercise a single helper (``_build_command``,
-    ``_terminate_current_process``, etc.) without the full DB / bus /
-    runner kit ``firmware_controller_factory`` produces.
-
-    Keyword-only knobs cover the two recurring shapes:
-
-    - ``esphome_cmd=...`` — seed ``state.esphome_cmd``; ``_build_command``
-      tests use ``["esphome"]``.
-    - ``current_job=<MagicMock>`` — seed ``state.current_job`` so
-      ``_terminate_current_process`` has something to look at.
-    - ``with_mock_db=True`` — attach ``_db = MagicMock()`` with
-      ``_db.devices = None``; ``_build_command`` needs this so its
-      address-cache lookup short-circuits.
-
-    Default-empty ``FirmwareState()`` fields (``jobs``, ``queue``,
-    ``current_process``, ``cancel_requested``, ``cancel_events``)
-    cover everything else.
-    """
+    """Build a bare ``FirmwareController`` shell — ``state`` only, no DB / bus / runner kit."""
 
     def _make(
         *,

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -200,6 +200,53 @@ def firmware_controller_factory(
     return _make
 
 
+BareFirmwareControllerFactory = Callable[..., FirmwareController]
+
+
+@pytest.fixture
+def bare_firmware_controller_factory() -> BareFirmwareControllerFactory:
+    """
+    Build a bare ``FirmwareController`` shell — just ``state``, no DB / bus.
+
+    For tests that want to exercise a single helper (``_build_command``,
+    ``_terminate_current_process``, etc.) without the full DB / bus /
+    runner kit ``firmware_controller_factory`` produces.
+
+    Keyword-only knobs cover the two recurring shapes:
+
+    - ``esphome_cmd=...`` — seed ``state.esphome_cmd``; ``_build_command``
+      tests use ``["esphome"]``.
+    - ``current_job=<MagicMock>`` — seed ``state.current_job`` so
+      ``_terminate_current_process`` has something to look at.
+    - ``with_mock_db=True`` — attach ``_db = MagicMock()`` with
+      ``_db.devices = None``; ``_build_command`` needs this so its
+      address-cache lookup short-circuits.
+
+    Default-empty ``FirmwareState()`` fields (``jobs``, ``queue``,
+    ``current_process``, ``cancel_requested``, ``cancel_events``)
+    cover everything else.
+    """
+
+    def _make(
+        *,
+        esphome_cmd: list[str] | None = None,
+        current_job: object | None = None,
+        with_mock_db: bool = False,
+    ) -> FirmwareController:
+        controller = FirmwareController.__new__(FirmwareController)
+        controller.state = FirmwareState()
+        if esphome_cmd is not None:
+            controller.state.esphome_cmd = esphome_cmd
+        if current_job is not None:
+            controller.state.current_job = current_job
+        if with_mock_db:
+            controller._db = MagicMock()
+            controller._db.devices = None
+        return controller
+
+    return _make
+
+
 CaptureEventsFactory = Callable[..., list[Event]]
 CaptureEnqueueOrderFactory = Callable[..., list[tuple[EnqueueStep, Any]]]
 

--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -32,8 +32,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import (
     ErrorCode,
@@ -42,6 +40,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 from tests.controllers.firmware.conftest import (
+    BareFirmwareControllerFactory,
     FirmwareControllerFactory,
 )
 
@@ -232,7 +231,9 @@ async def test_terminate_current_process_no_op_when_no_process(
 # ---------------------------------------------------------------------------
 
 
-def test_build_command_for_rename_appends_new_name_positional() -> None:
+def test_build_command_for_rename_appends_new_name_positional(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
     """``RENAME`` appends ``new_name`` as a trailing positional arg.
 
     ``esphome rename <yaml> <new_name>`` is the CLI shape;
@@ -240,11 +241,7 @@ def test_build_command_for_rename_appends_new_name_positional() -> None:
     touching the YAML, and the dashboard would report
     "rename failed" with no actionable hint. Pin the arg order.
     """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller.state = FirmwareState()
-    controller.state.esphome_cmd = ["esphome"]
-    controller._db = MagicMock()
-    controller._db.devices = None
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
 
     cmd = controller._build_command(JobType.RENAME, "kitchen.yaml", port="", new_name="livingroom")
 

--- a/tests/controllers/firmware/test_install_to_specific_address.py
+++ b/tests/controllers/firmware/test_install_to_specific_address.py
@@ -22,31 +22,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.controllers.firmware.helpers import (
     PortType,
     _validate_port,
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode, FirmwareJob, JobType
-
-
-def _controller() -> FirmwareController:
-    """Build a controller skeleton with just the surface ``_build_command`` needs.
-
-    ``_build_command`` only reads ``self.state.esphome_cmd``; the rest of
-    the controller (queue, scanner, bus) isn't relevant for these
-    tests. ``__new__`` skips ``__init__`` so we don't have to seed a
-    full ``DeviceBuilder``.
-    """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller.state = FirmwareState()
-    controller.state.esphome_cmd = ["esphome"]
-    controller._db = MagicMock()
-    controller._db.devices = None  # cache args become a no-op
-    return controller
-
+from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
 
 # ---------------------------------------------------------------------------
 # _validate_port
@@ -141,7 +123,9 @@ def test_validate_port_consults_get_port_type_for_serial_accept(
 # ---------------------------------------------------------------------------
 
 
-def test_install_to_ip_emits_device_arg_with_no_cache_args() -> None:
+def test_install_to_ip_emits_device_arg_with_no_cache_args(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
     """Explicit IP installs route ``--device <ip>`` with no address-cache args.
 
     The cache shortcut is keyed on the device's *configured*
@@ -153,7 +137,7 @@ def test_install_to_ip_emits_device_arg_with_no_cache_args() -> None:
     non-OTA ports, and this test pins that the resulting command
     line stays clean.
     """
-    controller = _controller()
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
     job = FirmwareJob(
         job_id="install-1",
         configuration="kitchen.yaml",
@@ -179,14 +163,16 @@ def test_install_to_ip_emits_device_arg_with_no_cache_args() -> None:
     ]
 
 
-def test_upload_to_ip_emits_device_arg_with_no_cache_args() -> None:
+def test_upload_to_ip_emits_device_arg_with_no_cache_args(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
     """``firmware/upload`` with an IP target gets the same shape as install.
 
     Both endpoints route through ``_build_command``; the
     ``UPLOAD`` job type just runs ``upload`` instead of ``run``
     and skips the ``--no-logs`` suffix the install path adds.
     """
-    controller = _controller()
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
     job = FirmwareJob(
         job_id="upload-1",
         configuration="kitchen.yaml",
@@ -208,7 +194,9 @@ def test_upload_to_ip_emits_device_arg_with_no_cache_args() -> None:
     ]
 
 
-def test_install_to_hostname_routes_through_device_arg() -> None:
+def test_install_to_hostname_routes_through_device_arg(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
     """A bare or ``.local`` hostname reaches the CLI verbatim.
 
     The CLI does its own resolution; we shouldn't second-guess it
@@ -216,12 +204,14 @@ def test_install_to_hostname_routes_through_device_arg() -> None:
     user's intent intact even when the device's mDNS broadcast is
     flaky or the cached A-record is stale.
     """
-    controller = _controller()
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
     cmd = controller._build_command(JobType.INSTALL, "kitchen.yaml", "kitchen.local", [])
     assert cmd[-2:] == ["--device", "kitchen.local"]
 
 
-def test_install_ota_default_keeps_cache_args() -> None:
+def test_install_ota_default_keeps_cache_args(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
     """The OTA default still gets the address-cache shortcut.
 
     Regression guard for the cache path — locking IP-target
@@ -229,7 +219,7 @@ def test_install_ota_default_keeps_cache_args() -> None:
     too. Builds a controller whose devices controller surfaces
     cache args and verifies they pass through to the command.
     """
-    controller = _controller()
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
     cache = ["--mdns-address-cache", "kitchen.local=192.168.1.50"]
     controller._db.devices = MagicMock()
     controller._db.devices.get_address_cache_args.return_value = cache

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -29,14 +29,12 @@ test that verifies the dispatch through the queue).
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.models import EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
+    BareFirmwareControllerFactory,
     CaptureEnqueueOrderFactory,
     EnqueueStep,
     FirmwareControllerFactory,
@@ -155,6 +153,7 @@ async def test_reset_build_env_accepts_arbitrary_kwargs(
 
 def test_build_command_for_reset_build_env_uses_clean_all_with_config_dir(
     tmp_path: Path,
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
 ) -> None:
     """``RESET_BUILD_ENV`` shells out to ``esphome --dashboard clean-all <config_dir>``.
 
@@ -173,11 +172,7 @@ def test_build_command_for_reset_build_env_uses_clean_all_with_config_dir(
     trailing ``--device`` because clean-all doesn't talk to a
     device.
     """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller.state = FirmwareState()
-    controller.state.esphome_cmd = ["esphome"]
-    controller._db = MagicMock()
-    controller._db.devices = None
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
 
     # ``rel_path("")`` resolves to the config_dir Path itself (joinpath
     # with an empty segment is a no-op) — that's what the runner passes
@@ -194,6 +189,7 @@ def test_build_command_for_reset_build_env_uses_clean_all_with_config_dir(
 
 def test_build_command_for_reset_build_env_ignores_port_and_cache_args(
     tmp_path: Path,
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
 ) -> None:
     """``RESET_BUILD_ENV`` neither flashes nor talks to the network.
 
@@ -206,11 +202,7 @@ def test_build_command_for_reset_build_env_ignores_port_and_cache_args(
     short-circuits to ``[]`` for non-OTA job types, but a direct
     invocation could still pass them).
     """
-    controller = FirmwareController.__new__(FirmwareController)
-    controller.state = FirmwareState()
-    controller.state.esphome_cmd = ["esphome"]
-    controller._db = MagicMock()
-    controller._db.devices = None
+    controller = bare_firmware_controller_factory(esphome_cmd=["esphome"], with_mock_db=True)
 
     cmd = controller._build_command(
         JobType.RESET_BUILD_ENV,

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -26,10 +26,10 @@ import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import lifecycle as _firmware_lifecycle_mod
-from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers import process as _process_mod
 from esphome_device_builder.helpers.process import _signal_process_group
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
+from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
 
 # Process groups, ``os.fork``, and ``SIGKILL`` are POSIX-only. The
 # whole stop-button cancellation strategy here (``killpg`` against the
@@ -143,13 +143,11 @@ def test_signal_process_group_returns_false_on_permission_error(
 
 
 @pytest.fixture
-def controller() -> FirmwareController:
+def controller(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
-    ctrl = FirmwareController.__new__(FirmwareController)
-    ctrl.state = FirmwareState()
-    ctrl.state.current_process = None  # type: ignore[attr-defined]
-    ctrl.state.current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
-    return ctrl
+    return bare_firmware_controller_factory(current_job=MagicMock(job_id="test-job"))
 
 
 async def test_terminate_kills_grandchild_via_process_group(

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -16,10 +16,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
-from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.helpers import process as process_module
 from esphome_device_builder.helpers.process import _terminate_subtree_windows
 from esphome_device_builder.helpers.subprocess import create_subprocess_exec
+from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
 
 # Only the integration test below — which spawns a real subprocess
 # and exercises ``_terminate_current_process``'s Windows branch end
@@ -34,13 +34,11 @@ windows_only = pytest.mark.skipif(
 
 
 @pytest.fixture
-def controller() -> FirmwareController:
+def controller(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
-    ctrl = FirmwareController.__new__(FirmwareController)
-    ctrl.state = FirmwareState()
-    ctrl.state.current_process = None  # type: ignore[attr-defined]
-    ctrl.state.current_job = MagicMock(job_id="test-job")  # type: ignore[attr-defined]
-    return ctrl
+    return bare_firmware_controller_factory(current_job=MagicMock(job_id="test-job"))
 
 
 @windows_only


### PR DESCRIPTION
# What does this implement/fix?

Five firmware test files were hand-rolling a near-identical
`FirmwareController.__new__` + `state = FirmwareState()`
skeleton for tests that only need a single helper
(`_build_command`, `_terminate_current_process`) and
deliberately bypass the heavier `firmware_controller_factory`.
Pulled the shared shape into a new conftest fixture with two
knobs covering the recurring seed patterns.

## New fixture: `bare_firmware_controller_factory`

In `tests/controllers/firmware/conftest.py`:

| Knob | Used by | Default |
|---|---|---|
| `esphome_cmd=[...]` | `_build_command` tests pass `["esphome"]` to seed `state.esphome_cmd` | `None` (leaves the default empty `[]`) |
| `current_job=<obj>` | `_terminate_current_process` tests pass a `MagicMock(job_id="test-job")` so the helper has something to look at | `None` (leaves `FirmwareState()`'s default `None`) |
| `with_mock_db=True` | `_build_command` tests need `_db = MagicMock()` with `_db.devices = None` so the address-cache lookup short-circuits | `False` |

Default-empty `FirmwareState()` fields (`jobs`, `queue`,
`current_process`, `cancel_requested`, `cancel_events`) cover
everything else.

## Refactored test files

- **`test_reset_build_env.py`** — 2 inline-builds collapsed;
  dropped unused `FirmwareController` / `FirmwareState` /
  `MagicMock` imports.
- **`test_install_to_specific_address.py`** — 4 calls to a
  local `_controller()` helper replaced with the fixture;
  helper removed.
- **`test_branches_coverage.py`** — 1 inline-build collapsed.
- **`test_stop.py`** and **`test_stop_windows.py`** —
  identical `controller` fixtures (literal copy-paste between
  the two files) both routed through the factory.

## Net diff

Conftest gains ~47 lines (fixture + docstring + type alias);
test files lose ~24 lines net across the 5 files. The win
isn't line count — it's that future `_build_command` /
`_terminate` tests now have one fixture to declare instead
of choosing which existing test file to copy the seed block
from.

All 3402 tests pass; pre-commit clean.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
