### PR TITLE
Extract reset_offloader_firmware_stub helper; DRY 5 sites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,28 @@ def make_remote_build_controller(
     )
 
 
+def reset_offloader_firmware_stub(
+    handles: RemoteBuildTestHandles,
+    *,
+    reset_bus: bool = False,
+    **queue_status_kwargs: Any,
+) -> MagicMock:
+    """Re-stub ``handles.offloader._db.firmware`` for queue-status broadcast tests.
+
+    ``queue_status_kwargs`` is forwarded to ``MagicMock(...)`` on
+    the new ``queue_status_snapshot`` attribute — typically
+    ``return_value=(idle, running, queue_depth)`` or
+    ``side_effect=Exception(...)``. Pass ``reset_bus=True`` to
+    also replace ``_db.bus`` with a fresh ``MagicMock`` (tests
+    asserting against ``bus.fire`` want a clean slate).
+    """
+    if reset_bus:
+        handles.offloader._db.bus = MagicMock()
+    firmware = handles.offloader._db.firmware = MagicMock()
+    firmware.queue_status_snapshot = MagicMock(**queue_status_kwargs)
+    return firmware
+
+
 def wire_firmware_remote_peer_api_mocks(firmware: Any, jobs_by_id: dict[str, Any]) -> None:
     """Wire a MagicMock firmware controller's remote-peer lookup API against *jobs_by_id*.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,15 +305,7 @@ def reset_offloader_firmware_stub(
     reset_bus: bool = False,
     **queue_status_kwargs: Any,
 ) -> MagicMock:
-    """Re-stub ``handles.offloader._db.firmware`` for queue-status broadcast tests.
-
-    ``queue_status_kwargs`` is forwarded to ``MagicMock(...)`` on
-    the new ``queue_status_snapshot`` attribute — typically
-    ``return_value=(idle, running, queue_depth)`` or
-    ``side_effect=Exception(...)``. Pass ``reset_bus=True`` to
-    also replace ``_db.bus`` with a fresh ``MagicMock`` (tests
-    asserting against ``bus.fire`` want a clean slate).
-    """
+    """Re-stub the offloader's firmware mock; ``queue_status_kwargs`` go to ``MagicMock(...)``."""
     if reset_bus:
         handles.offloader._db.bus = MagicMock()
     firmware = handles.offloader._db.firmware = MagicMock()

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -80,7 +80,7 @@ from esphome_device_builder.models import (
 )
 
 from .conftest import RemoteBuildTestHandles as RemoteBuildController
-from .conftest import make_remote_build_controller
+from .conftest import make_remote_build_controller, reset_offloader_firmware_stub
 
 # ---------------------------------------------------------------------------
 # Helpers used by the tests
@@ -3710,9 +3710,8 @@ async def test_on_firmware_queue_transition_broadcasts_to_every_session(
 ) -> None:
     """A ``JOB_STARTED`` tick broadcasts a fresh snapshot to all paired offloaders."""
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot.return_value = QueueStatus(
-        idle=False, running=True, queue_depth=2
+    reset_offloader_firmware_stub(
+        controller, return_value=QueueStatus(idle=False, running=True, queue_depth=2)
     )
     # ``create_background_task`` on the real ``DeviceBuilder``
     # schedules onto the running loop; the MagicMock-backed
@@ -3747,9 +3746,8 @@ async def test_on_firmware_queue_transition_broadcasts_to_every_session(
 def test_on_firmware_queue_transition_skips_when_no_sessions(tmp_path: Path) -> None:
     """No paired offloaders → no background task scheduled."""
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot.return_value = QueueStatus(
-        idle=True, running=False, queue_depth=0
+    reset_offloader_firmware_stub(
+        controller, return_value=QueueStatus(idle=True, running=False, queue_depth=0)
     )
     controller.offloader._db.create_background_task = MagicMock()
 

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -96,6 +96,7 @@ from .conftest import (
     make_remote_build_controller,
     make_submit_job_frames,
     make_tar_bundle,
+    reset_offloader_firmware_stub,
 )
 
 
@@ -1626,10 +1627,10 @@ async def test_register_peer_link_session_pushes_initial_queue_status(tmp_path: 
     silently fall back to LOCAL on every install request.
     """
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._db.bus = MagicMock()
-    controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot = MagicMock(
-        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    reset_offloader_firmware_stub(
+        controller,
+        reset_bus=True,
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0),
     )
 
     session = MagicMock(spec=PeerLinkSession)
@@ -1687,11 +1688,7 @@ async def test_register_peer_link_session_swallows_snapshot_exception(tmp_path: 
     :meth:`_broadcast_queue_status` for per-session sends.
     """
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._db.bus = MagicMock()
-    controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot = MagicMock(
-        side_effect=RuntimeError("boom")
-    )
+    reset_offloader_firmware_stub(controller, reset_bus=True, side_effect=RuntimeError("boom"))
 
     session = MagicMock(spec=PeerLinkSession)
     session.dashboard_id = "alpha"
@@ -1724,10 +1721,10 @@ async def test_register_peer_link_session_swallows_send_app_frame_exception(
     catches up on the next queue transition instead.
     """
     controller = _make_controller(config_dir=tmp_path)
-    controller.offloader._db.bus = MagicMock()
-    controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot = MagicMock(
-        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    reset_offloader_firmware_stub(
+        controller,
+        reset_bus=True,
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0),
     )
 
     session = MagicMock(spec=PeerLinkSession)


### PR DESCRIPTION
# What does this implement/fix?

Five sites across two test files were re-stubbing the
offloader's `_db.firmware` mock to override the conftest-
installed `queue_status_snapshot` default. The 4-line block
(re-attach `firmware` mock, set `queue_status_snapshot` to a
custom return / side_effect, sometimes also re-attach `bus`)
collapses to a single helper call.

## New helper

`tests/conftest.py::reset_offloader_firmware_stub(handles, *, reset_bus=False, **queue_status_kwargs)`:

- `**queue_status_kwargs` forwards to `MagicMock(...)` on the
  new `queue_status_snapshot`: typically
  `return_value=(idle, running, queue_depth)` or
  `side_effect=Exception(...)`.
- `reset_bus=True` also re-attaches `_db.bus = MagicMock()`
  (the peer-link tests assert on `bus.fire` and want a clean
  slate; the controller-level tests don't).
- Returns the new firmware mock for callers that want to
  assert against further attributes.

## Refactored sites

| File:Line | Shape |
|---|---|
| `test_remote_build_controller.py:3712` | broadcast-to-every-session: `return_value=(False, True, 2)` |
| `test_remote_build_controller.py:3747` | no-sessions branch: `return_value=(True, False, 0)` |
| `test_remote_build_peer_link.py:1628` | register-session default: `reset_bus=True, return_value=(True, False, 0)` |
| `test_remote_build_peer_link.py:1688` | snapshot raises: `reset_bus=True, side_effect=RuntimeError(...)` |
| `test_remote_build_peer_link.py:1725` | broadcast send raises: `reset_bus=True, return_value=(True, False, 0)` |

## Net diff

`tests/conftest.py` gains ~22 lines (helper + docstring); the
test files shrink by 20 lines. The win is uniformity — future
tests that need an offloader firmware stub override now have
one helper to call instead of choosing which existing test
file's snippet to copy.

All 3402 tests pass, pre-commit clean.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
