### PR TITLE
Type firmware queue_status_snapshot as a QueueStatus NamedTuple

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -26,6 +26,7 @@ from ...models import (
     JobBuildSource,
     JobStatus,
     JobType,
+    QueueStatus,
 )
 from . import bulk, cli, factories, follow, jobs, lifecycle, persistence, runner
 from . import clean as clean_mod
@@ -67,8 +68,8 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def queue_status_snapshot(self) -> tuple[bool, bool, int]:
-        """Return ``(idle, running, queue_depth)`` for the firmware queue; sync, no I/O.
+    def queue_status_snapshot(self) -> QueueStatus:
+        """Return a :class:`QueueStatus` snapshot of the firmware queue; sync, no I/O.
 
         ``idle`` and ``running`` aren't redundant with each other:
         ``running=False, queue_depth>0`` is the window between
@@ -79,7 +80,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         running = self.state.current_job is not None
         queue_depth = self.state.queue.qsize()
         idle = not running and queue_depth == 0
-        return idle, running, queue_depth
+        return QueueStatus(idle=idle, running=running, queue_depth=queue_depth)
 
     async def start(self) -> None:
         """Start the queue processor and restore persisted jobs."""

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -4,11 +4,28 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TypedDict
+from typing import NamedTuple, TypedDict
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .common import EventType
+
+
+class QueueStatus(NamedTuple):
+    """Snapshot of the firmware queue's RAM state.
+
+    Returned by :meth:`FirmwareController.queue_status_snapshot` —
+    a tuple subclass so the existing
+    ``idle, running, queue_depth = ...`` unpacking on the
+    receiver-side broadcast paths keeps working, plus named
+    access (``snapshot.idle``) for test stubs and any future
+    caller that wants to read one field without unpacking the
+    rest.
+    """
+
+    idle: bool
+    running: bool
+    queue_depth: int
 
 
 class JobStatus(StrEnum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,13 @@ from esphome_device_builder.controllers.remote_build import (
     ReceiverController,
 )
 from esphome_device_builder.helpers.event_bus import Event, EventBus
-from esphome_device_builder.models import AdoptableDevice, Device, DeviceState, EventType
+from esphome_device_builder.models import (
+    AdoptableDevice,
+    Device,
+    DeviceState,
+    EventType,
+    QueueStatus,
+)
 
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
@@ -282,7 +288,9 @@ def make_remote_build_controller(
     db.settings = MagicMock()
     db.settings.config_dir = config_dir
     db.create_background_task = asyncio.create_task
-    db.firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+    db.firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    )
     if bus is not None:
         db.bus = bus
     return RemoteBuildTestHandles(

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -45,6 +45,7 @@ import pytest
 from esphome_device_builder.models import (
     EventType,
     JobLifecycleData,
+    QueueStatus,
 )
 
 from ..conftest import capture_events
@@ -90,7 +91,9 @@ def receiver_firmware_cancel(paired_instances: PairedInstances) -> _FirmwareCanc
     cancel = AsyncMock(side_effect=_record_call)
     firmware = MagicMock()
     firmware.cancel = cancel
-    firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+    firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    )
     paired_instances.receiver._db.firmware = firmware
     return _FirmwareCancelStub(mock=cancel, called=called)
 

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -83,6 +83,7 @@ from esphome_device_builder.models import (
     JobLifecycleData,
     JobStatus,
     JobType,
+    QueueStatus,
 )
 
 from .._storage_fixtures import write_storage_json
@@ -170,7 +171,9 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
     # ValueError. Pin a sane tuple so the listener runs cleanly
     # rather than spamming the test log with swallowed
     # exceptions on every fire().
-    firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+    firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    )
     return created_jobs
 
 
@@ -569,17 +572,23 @@ def _drive_receiver_lifecycle(
     bus = paired_instances.receiver_bus
 
     # JOB_QUEUED: queue_depth bumped, runner not yet picking up.
-    firmware.queue_status_snapshot = MagicMock(return_value=(False, False, 1))
+    firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=False, running=False, queue_depth=1)
+    )
     bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
 
     # JOB_STARTED: runner picked up, queue_depth back to 0.
-    firmware.queue_status_snapshot = MagicMock(return_value=(False, True, 0))
+    firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=False, running=True, queue_depth=0)
+    )
     bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
 
     # Terminal: post-``_finalize_terminal`` state — slot
     # released, nothing queued. The fix this test pins is that
     # this snapshot is what the broadcast carries.
-    firmware.queue_status_snapshot = MagicMock(return_value=(True, False, 0))
+    firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    )
     bus.fire(terminal, JobLifecycleData(job=job))
 
 

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -71,6 +71,7 @@ from esphome_device_builder.models import (
     PairingSummary,
     PeerQueueStatusSnapshotEntry,
     PeerStatus,
+    QueueStatus,
     RemoteBuildPeer,
     RemoteBuildPeerSource,
     RemoteBuildSettingsView,
@@ -3710,7 +3711,9 @@ async def test_on_firmware_queue_transition_broadcasts_to_every_session(
     """A ``JOB_STARTED`` tick broadcasts a fresh snapshot to all paired offloaders."""
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot.return_value = (False, True, 2)
+    controller.offloader._db.firmware.queue_status_snapshot.return_value = QueueStatus(
+        idle=False, running=True, queue_depth=2
+    )
     # ``create_background_task`` on the real ``DeviceBuilder``
     # schedules onto the running loop; the MagicMock-backed
     # parent here doesn't have a loop, so route through the
@@ -3745,7 +3748,9 @@ def test_on_firmware_queue_transition_skips_when_no_sessions(tmp_path: Path) -> 
     """No paired offloaders → no background task scheduled."""
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.firmware = MagicMock()
-    controller.offloader._db.firmware.queue_status_snapshot.return_value = (True, False, 0)
+    controller.offloader._db.firmware.queue_status_snapshot.return_value = QueueStatus(
+        idle=True, running=False, queue_depth=0
+    )
     controller.offloader._db.create_background_task = MagicMock()
 
     controller.receiver._on_firmware_queue_transition(

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -87,6 +87,7 @@ from esphome_device_builder.models import (
     ErrorCode,
     IntentResponse,
     PeerLinkIntent,
+    QueueStatus,
     StoredPeer,
 )
 
@@ -1628,7 +1629,7 @@ async def test_register_peer_link_session_pushes_initial_queue_status(tmp_path: 
     controller.offloader._db.bus = MagicMock()
     controller.offloader._db.firmware = MagicMock()
     controller.offloader._db.firmware.queue_status_snapshot = MagicMock(
-        return_value=(True, False, 0)
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
     )
 
     session = MagicMock(spec=PeerLinkSession)
@@ -1726,7 +1727,7 @@ async def test_register_peer_link_session_swallows_send_app_frame_exception(
     controller.offloader._db.bus = MagicMock()
     controller.offloader._db.firmware = MagicMock()
     controller.offloader._db.firmware.queue_status_snapshot = MagicMock(
-        return_value=(True, False, 0)
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
     )
 
     session = MagicMock(spec=PeerLinkSession)


### PR DESCRIPTION
# What does this implement/fix?

`FirmwareController.queue_status_snapshot()` returned a bare
`tuple[bool, bool, int]`. Production reads it via destructuring
(`idle, running, queue_depth = ...`) so the field names live
at the call site — but test stubs wrote the literal tuple,
which reads as `(False, True, 2)` with no hint about which
slot is which.

This PR types the return as a `QueueStatus` NamedTuple so the
field names live on the value itself.

## Diff at a glance

```python
# models/firmware.py
class QueueStatus(NamedTuple):
    idle: bool
    running: bool
    queue_depth: int

# controllers/firmware/controller.py
-    def queue_status_snapshot(self) -> tuple[bool, bool, int]:
-        ...
-        return idle, running, queue_depth
+    def queue_status_snapshot(self) -> QueueStatus:
+        ...
+        return QueueStatus(idle=idle, running=running, queue_depth=queue_depth)

# tests
- firmware.queue_status_snapshot.return_value = (False, True, 2)
+ firmware.queue_status_snapshot.return_value = QueueStatus(
+     idle=False, running=True, queue_depth=2
+ )
```

## Why NamedTuple (not dataclass)

`QueueStatus` is a tuple subclass, so the existing destructuring
in production (`peer_link_sessions.py:43`, `:104`) keeps working
unchanged. A dataclass would have forced rewriting every caller
to use attribute access.

## Sites updated

| File | Sites |
|---|---:|
| `tests/conftest.py` (default stub in `make_remote_build_controller`) | 1 |
| `tests/test_remote_build_controller.py` | 2 |
| `tests/e2e/test_install_round_trip.py` | 4 |
| `tests/e2e/test_cancel_job.py` | 1 |

Production callers needed no changes.

## Cost

`queue_status_snapshot` fires on each firmware queue transition
(`JOB_QUEUED` / `JOB_STARTED` / terminal) plus once per peer-link
session register — a handful of calls per build. The
NamedTuple-vs-tuple construction overhead is irrelevant at this
rate.

All 3402 tests pass, pre-commit clean.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
