### PR TITLE
Convert _device_state_monitor.py to a package + extract MonitorState

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/__init__.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/__init__.py
@@ -1,0 +1,25 @@
+"""Device connectivity monitor — mDNS browser + ping fallback.
+
+Tracks online/offline state for the configured devices, with mDNS as
+the primary source (event-driven) and ICMP ping as a periodic fallback
+for devices that aren't broadcasting their service. MQTT observations
+are also welcomed via :meth:`apply` for devices that opt into MQTT
+discovery. The monitor calls back into the owning controller whenever
+a state actually changes; controllers stay free of zeroconf / icmplib
+/ aiomqtt details.
+
+Source precedence (highest first): ``mdns`` > ``mqtt`` > ``ping``. A
+lower-priority source can never override the state set by a higher one.
+"""
+
+from __future__ import annotations
+
+# Re-exports. Redundant-alias form marks these as intentional
+# re-exports (PEP 484) so existing
+# ``from ..controllers._device_state_monitor import X`` callers
+# (including tests that reach for private constants and module
+# helpers) keep working unchanged across the split arc.
+from .controller import _MDNS_REFRESH_PADDING_SECONDS as _MDNS_REFRESH_PADDING_SECONDS
+from .controller import DeviceStateMonitor as DeviceStateMonitor
+from .controller import _decode_txt_bytes_to_sorted_pairs as _decode_txt_bytes_to_sorted_pairs
+from .controller import device_name_from_service as device_name_from_service

--- a/esphome_device_builder/controllers/_device_state_monitor/_state.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_state.py
@@ -1,0 +1,41 @@
+"""Mutable domain state for :class:`DeviceStateMonitor`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .._dns_cache import DNSCache
+from .._reachability_tracker import ReachabilityTracker
+
+
+@dataclass
+class MonitorState:
+    """Mutable state for :class:`DeviceStateMonitor`."""
+
+    # Source-precedence ledger: device name → ``"mdns"`` /
+    # ``"mqtt"`` / ``"ping"``. Only one source can own a
+    # device's state at a time; mDNS always wins, ping only
+    # writes when mDNS hasn't already resolved the device.
+    # Every ``apply_*`` path consults this to gate writes.
+    state_source: dict[str, str] = field(default_factory=dict)
+
+    # Device name → web-UI URL discovered via the
+    # ``_http._tcp.local.`` browser. Populated by the
+    # importable-discovery flow; rendered on the
+    # discovered-device card so the frontend can show a
+    # Visit-web-UI link without knowing which factory
+    # firmwares ship a web server.
+    http_urls: dict[str, str] = field(default_factory=dict)
+
+    # DNS resolutions for non-mDNS hostnames, cached with TTLs
+    # so the ping sweep, OTA cache args, and ``device.ip``
+    # tracking all share the same lookup result instead of
+    # re-resolving every cycle.
+    dns_cache: DNSCache = field(default_factory=DNSCache)
+
+    # Per-signal freshness tracker (mDNS / ping / MQTT
+    # last-seen, ping RTT). Optional dependency: callers
+    # that don't care about reachability metadata pass
+    # ``None`` and the monitor's observation hooks become
+    # no-ops.
+    reachability: ReachabilityTracker | None = None

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -47,12 +47,12 @@ from zeroconf.const import (
     _TYPE_TXT,
 )
 
-from ..helpers.hostname import is_local_hostname, normalize_hostname
-from ..helpers.subscriber_presence import SubscriberPresence
-from ..models import AdoptableDevice, Device, DeviceState, ReachabilitySource
-from ._dns_cache import DNSCache
-from ._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
-from ._task_controller_base import TaskControllerBase
+from ...helpers.hostname import is_local_hostname, normalize_hostname
+from ...helpers.subscriber_presence import SubscriberPresence
+from ...models import AdoptableDevice, Device, DeviceState, ReachabilitySource
+from .._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
+from .._task_controller_base import TaskControllerBase
+from ._state import MonitorState
 
 _LOGGER = logging.getLogger(__name__)
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
@@ -392,13 +392,14 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._on_importable_added = on_importable_added
         self._on_importable_removed = on_importable_removed
         self._is_ignored = is_ignored or (lambda _name: False)
-        self._state_source: dict[str, str] = {}  # device name → "mdns" | "ping"
-        # Per-signal freshness tracker (mDNS / ping / MQTT last-seen,
-        # ping RTT). Optional dependency: callers that don't care
-        # about reachability metadata (the existing tests, in-process
-        # usages that just want state-change forwarding) can pass
-        # ``None`` and the monitor's observation hooks become no-ops.
-        self._reachability = reachability
+        # Mutable cross-module domain state — anything a sibling
+        # module reads or writes lives here so siblings reach
+        # through ``monitor.state.X`` rather than ``monitor._X``.
+        # ``state_source`` is the source-precedence ledger;
+        # ``http_urls`` is populated by the importable-discovery
+        # flow; ``dns_cache`` and ``reachability`` are shared
+        # across mdns / ping / apply paths.
+        self.state = MonitorState(reachability=reachability)
         # ``DashboardImportDiscovery`` is the upstream esphome class
         # that watches the same ``_esphomelib._tcp.local.`` browser for
         # ``package_import_url`` TXT records and turns them into
@@ -406,11 +407,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # browser-callback keeps us in lockstep with whatever the
         # upstream considers an importable device.
         self._import_discovery: DashboardImportDiscovery | None = None
-        # Map of device-name → web-UI URL, populated by the
-        # ``_http._tcp.local.`` browser. Lets the discovered-device
-        # card render a Visit-web-UI link without the frontend having
-        # to know which factory firmwares ship a web server.
-        self._http_urls: dict[str, str] = {}
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         # Single browser covers both ``_esphomelib._tcp.local.`` and
         # ``_http._tcp.local.``; the dispatch handler routes events
@@ -419,11 +415,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._ping_task: asyncio.Task | None = None
         # ``self._tasks`` (fire-and-forget mDNS resolve refs) comes
         # from :class:`TaskControllerBase`; see :meth:`_track_task`.
-        # DNS resolutions for non-mDNS hostnames are cached here so the
-        # ping sweep, OTA cache args, and device.ip tracking all share
-        # the same TTL'd lookup result instead of re-resolving every
-        # cycle.
-        self._dns_cache = DNSCache()
         # When wired, the ping loop pauses while no dashboard client
         # is subscribed — so a quiet network with no observers
         # generates no ICMP traffic. Mirrors the legacy
@@ -492,7 +483,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         monitor's ``apply`` path can route observations into the
         tracker.
         """
-        self._reachability = tracker
+        self.state.reachability = tracker
 
     def priority_for(self, name: str) -> ReachabilitySource:
         """Return the source currently authoritative for *name*.
@@ -505,7 +496,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         subscription can dispatch on it without a string-typo
         landing as silent UNKNOWN.
         """
-        return ReachabilitySource(self._state_source.get(name, ReachabilitySource.UNKNOWN))
+        return ReachabilitySource(self.state.state_source.get(name, ReachabilitySource.UNKNOWN))
 
     def apply(self, name: str, state: DeviceState, source: str, *, claim: bool = False) -> bool:
         """
@@ -540,10 +531,10 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # ONLINE filter avoids treating "lost" signals (the OFFLINE
         # flips ping / mqtt issue when the source itself drops) as
         # freshness.
-        if state == DeviceState.ONLINE and self._reachability is not None:
-            self._reachability.observe(name, source)
+        if state == DeviceState.ONLINE and self.state.reachability is not None:
+            self.state.reachability.observe(name, source)
 
-        current_source = self._state_source.get(name, ReachabilitySource.UNKNOWN)
+        current_source = self.state.state_source.get(name, ReachabilitySource.UNKNOWN)
         if _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(current_source, 0):
             return False
         # Dedupe must look at *every* matching device, not just the
@@ -554,10 +545,10 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # left the stale sibling stuck.
         if all(d.state == state for d in devices):
             if claim:
-                self._state_source[name] = source
+                self.state.state_source[name] = source
             return False
 
-        self._state_source[name] = source
+        self.state.state_source[name] = source
         self._on_state_change(name, state, source)
         return True
 
@@ -1033,7 +1024,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         Populated by the ping sweep's pre-resolution pass. Returns
         ``None`` on cache miss or when the entry has expired.
         """
-        return self._dns_cache.get_cached_addresses(host_name)
+        return self.state.dns_cache.get_cached_addresses(host_name)
 
     # ------------------------------------------------------------------
     # Internals
@@ -1070,9 +1061,9 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             if state_change == ServiceStateChange.Removed:
                 self.apply(device_name, DeviceState.OFFLINE, "mdns")
                 self.apply_ip(device_name, "")
-                self._state_source.pop(device_name, None)
-                if self._reachability is not None:
-                    self._reachability.clear(device_name)
+                self.state.state_source.pop(device_name, None)
+                if self.state.reachability is not None:
+                    self.state.reachability.clear(device_name)
                 return
 
             # ``claim=True`` so mDNS takes ownership even when the
@@ -1176,7 +1167,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         """
         device_name = device_name_from_service(name)
         if state_change == ServiceStateChange.Removed:
-            if self._http_urls.pop(device_name, None) is None:
+            if self.state.http_urls.pop(device_name, None) is None:
                 return
             self._refire_importable_for(device_name)
             return
@@ -1206,9 +1197,9 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         if not self._has_importable(device_name):
             return
         url = _http_url_from_service_info(device_name, info)
-        if self._http_urls.get(device_name) == url:
+        if self.state.http_urls.get(device_name) == url:
             return
-        self._http_urls[device_name] = url
+        self.state.http_urls[device_name] = url
         self._refire_importable_for(device_name)
 
     def _has_importable(self, device_name: str) -> bool:
@@ -1238,12 +1229,12 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         the about-to-fire ``on_importable_added`` carries the right
         ``web_url``.
         """
-        if self._zeroconf is None or self._http_urls.get(device_name):
+        if self._zeroconf is None or self.state.http_urls.get(device_name):
             return
         info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
         if not info.load_from_cache(self._zeroconf.zeroconf):
             return
-        self._http_urls[device_name] = _http_url_from_service_info(device_name, info)
+        self.state.http_urls[device_name] = _http_url_from_service_info(device_name, info)
 
     def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
         """Bridge ``DashboardImportDiscovery`` → controller callbacks.
@@ -1290,7 +1281,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             project_version=discovered.project_version,
             network=discovered.network,
             ignored=self._is_ignored(discovered.device_name),
-            web_url=self._http_urls.get(discovered.device_name, ""),
+            web_url=self.state.http_urls.get(discovered.device_name, ""),
         )
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
@@ -1495,7 +1486,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             # and the OTA cache args would have nothing to draw on for
             # non-mDNS hostnames.
             resolved = await asyncio.gather(
-                *(self._dns_cache.async_resolve(d.address) for d in batch),
+                *(self.state.dns_cache.async_resolve(d.address) for d in batch),
                 return_exceptions=True,
             )
             ping_targets: list[tuple[Device, str]] = []
@@ -1562,7 +1553,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
                 # still hit the cross-subnet-friendly entry.
                 self.apply_ip_addresses(device.name, cached)
                 continue
-            if self._dns_cache.has_cached_failure(device.address):
+            if self.state.dns_cache.has_cached_failure(device.address):
                 dns_skipped.append(device)
                 self.apply(device.name, DeviceState.OFFLINE, "ping")
                 continue
@@ -1588,7 +1579,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         """
         if device.state != DeviceState.ONLINE:
             return True
-        source = self._state_source.get(device.name, ReachabilitySource.UNKNOWN)
+        source = self.state.state_source.get(device.name, ReachabilitySource.UNKNOWN)
         return _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY[ReachabilitySource.PING]
 
     async def _ping_device(self, device: Device, target: str) -> None:
@@ -1619,8 +1610,8 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             _LOGGER.debug("Ping of %s (%s) failed: %s", device.name, target, exc)
             is_alive = False
         new_state = DeviceState.ONLINE if is_alive else DeviceState.OFFLINE
-        if is_alive and rtt_ms is not None and self._reachability is not None:
-            self._reachability.record_ping_rtt(device.name, rtt_ms)
+        if is_alive and rtt_ms is not None and self.state.reachability is not None:
+            self.state.reachability.record_ping_rtt(device.name, rtt_ms)
         self.apply(device.name, new_state, "ping")
 
 

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -11,12 +11,12 @@ from unittest.mock import patch
 import pytest
 
 from esphome_device_builder.controllers import (
-    _device_state_monitor as sm,
-)
-from esphome_device_builder.controllers import (
     _dns_cache as dns_cache_mod,
 )
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers._device_state_monitor import (
+    controller as sm,
+)
 from esphome_device_builder.controllers._dns_cache import DNSCache
 from esphome_device_builder.controllers.config import (
     get_board_id,
@@ -401,7 +401,7 @@ async def test_ping_sweep_skips_devices_with_cached_dns_failure(fake_resolver) -
         on_ip_change=lambda *_: None,
     )
     # Prime the cache with a fresh failure so the sweep should skip.
-    monitor._dns_cache._cache["esp.example.com"] = (time.monotonic() + 60, None)
+    monitor.state.dns_cache._cache["esp.example.com"] = (time.monotonic() + 60, None)
 
     resolver = fake_resolver(["10.0.0.1"])
     pinged: list[str] = []

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -193,7 +193,7 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
 
     monitor._apply_http_service_info("kitchen", info)
 
-    assert monitor._http_urls == {"kitchen": "http://kitchen.local"}
+    assert monitor.state.http_urls == {"kitchen": "http://kitchen.local"}
     added = _added(callbacks)
     assert len(added) == 1
     assert added[0].web_url == "http://kitchen.local"

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -18,11 +18,11 @@ import pytest
 from esphome import zeroconf as esphome_zc
 from zeroconf import ServiceStateChange
 
-from esphome_device_builder.controllers import _device_state_monitor as monitor_module
 from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
     device_name_from_service,
 )
+from esphome_device_builder.controllers._device_state_monitor import controller as monitor_module
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import make_state_monitor_with_callbacks
@@ -205,7 +205,7 @@ async def test_mdns_takes_ownership_after_ping_set_online(
     devices = [_device("kitchen")]
     devices[0].state = DeviceState.ONLINE  # ping already saw it
     monitor, _callbacks = make_state_monitor_with_callbacks(devices)
-    monitor._state_source["kitchen"] = "ping"
+    monitor.state.state_source["kitchen"] = "ping"
 
     handler = await _capture_handler(monitor, monkeypatch)
     handler(

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -390,7 +390,7 @@ def test_ping_can_rescue_after_mdns_offline() -> None:
     monitor.apply("alpha", DeviceState.ONLINE, "mdns")
     monitor.apply("alpha", DeviceState.OFFLINE, "mdns")
     # The mDNS Removed handler clears the source so a different source can take over.
-    monitor._state_source.pop("alpha", None)
+    monitor.state.state_source.pop("alpha", None)
     assert monitor.apply("alpha", DeviceState.ONLINE, "ping") is True
     assert transitions[-1] == ("alpha", DeviceState.ONLINE, "ping")
 

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -225,7 +225,7 @@ async def test_already_online_via_higher_priority_skipped() -> None:
     """
     devices = [_device(loaded_integrations=["web_server"], state=DeviceState.ONLINE)]
     monitor, resolver = _make_monitor(devices)
-    monitor._state_source["kitchen"] = "mdns"  # higher than ping
+    monitor.state.state_source["kitchen"] = "mdns"  # higher than ping
 
     await monitor._resolve_non_api_mdns_targets()
 
@@ -266,7 +266,7 @@ async def test_offline_via_ping_still_resolved() -> None:
     """
     devices = [_device(loaded_integrations=["web_server"], state=DeviceState.OFFLINE)]
     monitor, resolver = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
-    monitor._state_source["kitchen"] = "ping"
+    monitor.state.state_source["kitchen"] = "ping"
 
     await monitor._resolve_non_api_mdns_targets()
 

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -27,8 +27,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from esphome_device_builder import device_builder as device_builder_module
-from esphome_device_builder.controllers import _device_state_monitor as state_monitor_module
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers._device_state_monitor import (
+    controller as state_monitor_module,
+)
+from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
 from esphome_device_builder.device_builder import DeviceBuilder
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 
@@ -36,6 +39,7 @@ from esphome_device_builder.helpers.subscriber_presence import SubscriberPresenc
 def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
     """Bypass __init__ — ``_ping_loop`` only touches a few attrs."""
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+    monitor.state = MonitorState()
     monitor._presence = presence
     return monitor
 

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -20,6 +20,7 @@ import pytest
 from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
 )
+from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import RecordingMonitorCallbacks
@@ -27,10 +28,12 @@ from .conftest import RecordingMonitorCallbacks
 
 def _make_monitor() -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+
+    monitor.state = MonitorState()
     monitor._zeroconf = MagicMock()
     monitor._zeroconf.zeroconf = MagicMock()
     monitor._tasks = set()
-    monitor._reachability = None
+    monitor.state.reachability = None
     monitor._presence = None
     return monitor
 
@@ -67,7 +70,7 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.controller.AsyncServiceInfo",
         lambda *_args, **_kw: fake_info,
     )
 
@@ -99,7 +102,7 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
         return fake_info
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.controller.AsyncServiceInfo",
         _info_ctor,
     )
 
@@ -122,7 +125,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.controller.AsyncServiceInfo",
         lambda *_args, **_kw: fake_info,
     )
 
@@ -144,6 +147,8 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
 def test_probe_device_no_zeroconf_is_a_noop() -> None:
     """Pre-start (or zeroconf-failed) probe must not raise."""
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+
+    monitor.state = MonitorState()
     monitor._zeroconf = None
     monitor._tasks = set()
 
@@ -162,7 +167,7 @@ async def test_apply_service_info_claims_online() -> None:
     until the next ping sweep.
     """
     monitor = _make_monitor()
-    monitor._state_source = {}
+    monitor.state.state_source = {}
     # ``apply()`` validates against the configured-devices catalog.
     device = Device(
         name="kitchen",
@@ -179,7 +184,7 @@ async def test_apply_service_info_claims_online() -> None:
     monitor._on_version_change = callbacks.on_version_change
     monitor._on_config_hash_change = callbacks.on_config_hash_change
     monitor._on_api_encryption_change = callbacks.on_api_encryption_change
-    monitor._reachability = None
+    monitor.state.reachability = None
 
     fake_info = MagicMock()
     fake_info.parsed_scoped_addresses.return_value = []
@@ -205,7 +210,7 @@ async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
     don't get populated from the broadcast.
     """
     monitor = _make_monitor()
-    monitor._state_source = {}
+    monitor.state.state_source = {}
     device = Device(
         name="kitchen",
         friendly_name="Kitchen",
@@ -222,7 +227,7 @@ async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
     monitor._on_config_hash_change = callbacks.on_config_hash_change
     monitor._on_api_encryption_change = callbacks.on_api_encryption_change
     monitor._on_mac_address_change = callbacks.on_mac_address_change
-    monitor._reachability = None
+    monitor.state.reachability = None
 
     fake_info = MagicMock()
     fake_info.parsed_scoped_addresses.return_value = []

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -27,8 +27,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from zeroconf import ServiceStateChange
 
-import esphome_device_builder.controllers._device_state_monitor as state_monitor_module
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers._device_state_monitor import (
+    controller as state_monitor_module,
+)
+from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.models import Device, DeviceState
 
@@ -79,11 +82,13 @@ def _make_monitor(
     """
     devices = list(devices) if devices is not None else [_device()]
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+
+    monitor.state = MonitorState()
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
-    monitor._state_source = {}
-    monitor._http_urls = {}
+    monitor.state.state_source = {}
+    monitor.state.http_urls = {}
     monitor._zeroconf = None
     monitor._mdns_browser = None
     monitor._ping_task = None
@@ -99,8 +104,8 @@ def _make_monitor(
     monitor._on_mac_address_change = callbacks.on_mac_address_change
     monitor._on_importable_added = callbacks.on_importable_added
     monitor._on_importable_removed = callbacks.on_importable_removed
-    monitor._reachability = None
-    monitor._dns_cache = MagicMock()
+    monitor.state.reachability = None
+    monitor.state.dns_cache = MagicMock()
     monitor._presence = None  # ping loop runs unconditionally in tests
     return monitor, callbacks
 
@@ -349,7 +354,7 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
     """A ``Removed`` esphomelib event flips OFFLINE, clears IP, drops source slot."""
     device = _device(state=DeviceState.ONLINE, ip="10.0.0.1")
     monitor, _callbacks = _make_monitor([device])
-    monitor._state_source["kitchen"] = "mdns"
+    monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
@@ -360,7 +365,7 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
         )
         assert device.state == DeviceState.OFFLINE
         assert device.ip == ""
-        assert "kitchen" not in monitor._state_source
+        assert "kitchen" not in monitor.state.state_source
     finally:
         await _stop_and_drain(monitor)
 
@@ -381,10 +386,10 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
     device = _device(state=DeviceState.ONLINE)
     monitor, _callbacks = _make_monitor([device])
     tracker = ReachabilityTracker()
-    monitor._reachability = tracker
+    monitor.state.reachability = tracker
     tracker.observe("kitchen", "mdns")
     tracker.observe("kitchen", "ping")
-    monitor._state_source["kitchen"] = "mdns"
+    monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
@@ -974,7 +979,7 @@ async def test_dispatch_http_service_added_records_url_and_refires_importable(
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
         )
-        assert monitor._http_urls["factory-firmware"] == ("http://factory-firmware.local:8080")
+        assert monitor.state.http_urls["factory-firmware"] == ("http://factory-firmware.local:8080")
         # The importable was re-emitted with the new web_url.
         assert any(call[1].web_url for call in callbacks.calls_for("on_importable_added"))
     finally:
@@ -1007,7 +1012,7 @@ async def test_dispatch_http_service_added_skips_when_no_importable(
             f"stranger.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
         )
-        assert monitor._http_urls == {}
+        assert monitor.state.http_urls == {}
         assert callbacks.calls_for("on_importable_added") == []
     finally:
         await _stop_and_drain(monitor)
@@ -1028,7 +1033,7 @@ async def test_dispatch_http_service_removed_clears_url_and_refires(
     monitor, callbacks = _make_monitor(devices=[])
     discovered = _build_discovered("factory-firmware")
     discovery = _make_import_discovery({f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": discovered})
-    monitor._http_urls["factory-firmware"] = "http://factory-firmware.local"
+    monitor.state.http_urls["factory-firmware"] = "http://factory-firmware.local"
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
@@ -1042,7 +1047,7 @@ async def test_dispatch_http_service_removed_clears_url_and_refires(
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Removed,
         )
-        assert "factory-firmware" not in monitor._http_urls
+        assert "factory-firmware" not in monitor.state.http_urls
         assert callbacks.calls_for("on_importable_added")
     finally:
         await _stop_and_drain(monitor)
@@ -1095,7 +1100,7 @@ async def test_dispatch_http_service_added_cache_miss_resolves_and_applies(
         )
         assert len(monitor._tasks) == 1
         await asyncio.gather(*list(monitor._tasks))
-        assert monitor._http_urls["factory-firmware"] == "http://factory-firmware.local"
+        assert monitor.state.http_urls["factory-firmware"] == "http://factory-firmware.local"
     finally:
         await _stop_and_drain(monitor)
 
@@ -1180,7 +1185,7 @@ def test_revisit_importable_skips_seed_when_url_already_set() -> None:
     """
     monitor, callbacks = _make_monitor(devices=[])
     monitor._zeroconf = MagicMock()
-    monitor._http_urls["factory-firmware"] = "http://factory-firmware.local"
+    monitor.state.http_urls["factory-firmware"] = "http://factory-firmware.local"
     monitor._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
@@ -1201,7 +1206,7 @@ def test_revisit_importable_skips_seed_when_zeroconf_down() -> None:
 
     monitor.revisit_importable("factory-firmware")  # must not raise
 
-    assert monitor._http_urls == {}
+    assert monitor.state.http_urls == {}
 
 
 def test_revisit_importable_seeds_nothing_on_cache_miss(
@@ -1226,7 +1231,7 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
 
     monitor.revisit_importable("factory-firmware")
 
-    assert monitor._http_urls == {}
+    assert monitor.state.http_urls == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1271,8 +1276,8 @@ async def test_start_drives_ping_pipeline_to_online_state(
         return MagicMock(is_alive=True)
 
     monkeypatch.setattr(state_monitor_module, "icmp_ping", _fake_ping)
-    monitor._dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
-    monitor._dns_cache.has_cached_failure = MagicMock(return_value=False)
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
     monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory())
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
@@ -1297,13 +1302,13 @@ async def test_start_with_icmplib_unavailable_skips_dns_resolution(
     monitor, _callbacks = _make_monitor()
 
     monkeypatch.setattr(state_monitor_module, "icmp_ping", None)
-    monitor._dns_cache.async_resolve = AsyncMock()
+    monitor.state.dns_cache.async_resolve = AsyncMock()
     monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
         await _drain_ping_task(monitor)
-        monitor._dns_cache.async_resolve.assert_not_called()
+        monitor.state.dns_cache.async_resolve.assert_not_called()
     finally:
         await _stop_and_drain(monitor)
 
@@ -1329,8 +1334,8 @@ async def test_start_marks_offline_on_icmp_exception(
         raise OSError("name lookup failed")
 
     monkeypatch.setattr(state_monitor_module, "icmp_ping", _boom)
-    monitor._dns_cache.async_resolve = AsyncMock(return_value=["10.0.0.1"])
-    monitor._dns_cache.has_cached_failure = MagicMock(return_value=False)
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["10.0.0.1"])
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
     monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
@@ -1361,7 +1366,7 @@ async def test_start_skips_ping_for_cached_dns_failures(
         return MagicMock(is_alive=True)
 
     monkeypatch.setattr(state_monitor_module, "icmp_ping", _icmp)
-    monitor._dns_cache.has_cached_failure = MagicMock(return_value=True)
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=True)
     monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     with caplog.at_level(logging.DEBUG, logger=state_monitor_module.__name__):
@@ -1389,8 +1394,8 @@ async def test_start_logs_ping_count_at_debug(
         return MagicMock(is_alive=True)
 
     monkeypatch.setattr(state_monitor_module, "icmp_ping", _icmp)
-    monitor._dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
-    monitor._dns_cache.has_cached_failure = MagicMock(return_value=False)
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
     monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     with caplog.at_level(logging.DEBUG, logger=state_monitor_module.__name__):
@@ -1415,7 +1420,7 @@ async def test_start_skips_devices_without_address(
     """
     no_addr = _device(name="orphan", address="")
     monitor, _callbacks = _make_monitor([no_addr])
-    monitor._dns_cache.async_resolve = AsyncMock(return_value=[])
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=[])
 
     async def _icmp(*_a: Any, **_kw: Any) -> Any:
         raise AssertionError("icmp_ping must not be called")
@@ -1426,7 +1431,7 @@ async def test_start_skips_devices_without_address(
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
         await _drain_ping_task(monitor)
-        monitor._dns_cache.async_resolve.assert_not_called()
+        monitor.state.dns_cache.async_resolve.assert_not_called()
     finally:
         await _stop_and_drain(monitor)
 

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -39,11 +39,14 @@ from zeroconf import (
 )
 from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR, _TYPE_TXT
 
-import esphome_device_builder.controllers._device_state_monitor as state_monitor_module
 from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
     _decode_txt_bytes_to_sorted_pairs,
 )
+from esphome_device_builder.controllers._device_state_monitor import (
+    controller as state_monitor_module,
+)
+from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
 from esphome_device_builder.controllers._reachability_tracker import (
     MdnsCacheInfo,
     ReachabilityTracker,
@@ -85,17 +88,19 @@ def _make_monitor(
     devices: list[Device], tracker: ReachabilityTracker | None = None
 ) -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+
+    monitor.state = MonitorState()
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
-    monitor._state_source = {}
-    monitor._http_urls = {}
+    monitor.state.state_source = {}
+    monitor.state.http_urls = {}
     monitor._zeroconf = None
     monitor._mdns_browser = None
     monitor._ping_task = None
     monitor._tasks = set()
     monitor._import_discovery = None
-    monitor._reachability = tracker
+    monitor.state.reachability = tracker
     monitor._on_state_change = _flip_state(devices)
     monitor._on_ip_change = lambda _n, _i, _l: None
     monitor._on_version_change = None
@@ -103,7 +108,7 @@ def _make_monitor(
     monitor._on_api_encryption_change = None
     monitor._on_importable_added = None
     monitor._on_importable_removed = None
-    monitor._dns_cache = MagicMock()
+    monitor.state.dns_cache = MagicMock()
     monitor._presence = None
     return monitor
 
@@ -194,7 +199,7 @@ async def test_ping_success_records_rtt_and_observation() -> None:
     fake_result.is_alive = True
     fake_result.min_rtt = 4.2
     with patch(
-        "esphome_device_builder.controllers._device_state_monitor.icmp_ping",
+        "esphome_device_builder.controllers._device_state_monitor.controller.icmp_ping",
         AsyncMock(return_value=fake_result),
     ):
         await monitor._ping_device(devices[0], "10.0.0.42")
@@ -217,7 +222,7 @@ async def test_ping_failure_does_not_record_rtt() -> None:
     fake_result.is_alive = False
     fake_result.min_rtt = 0.0
     with patch(
-        "esphome_device_builder.controllers._device_state_monitor.icmp_ping",
+        "esphome_device_builder.controllers._device_state_monitor.controller.icmp_ping",
         AsyncMock(return_value=fake_result),
     ):
         await monitor._ping_device(devices[0], "10.0.0.42")
@@ -254,9 +259,9 @@ async def test_mdns_removed_clears_tracker_for_device() -> None:
     # source slot and (now) the tracker maps too.
     monitor.apply("kitchen", DeviceState.OFFLINE, "mdns")
     monitor.apply_ip = lambda _n, _i: True  # type: ignore[method-assign]
-    monitor._state_source.pop("kitchen", None)
-    if monitor._reachability is not None:
-        monitor._reachability.clear("kitchen")
+    monitor.state.state_source.pop("kitchen", None)
+    if monitor.state.reachability is not None:
+        monitor.state.reachability.clear("kitchen")
 
     snap = tracker.snapshot("kitchen", state=DeviceState.OFFLINE, active_source="unknown", ip="")
     assert snap["mdns_last_seen_seconds_ago"] is None
@@ -292,9 +297,9 @@ async def test_mdns_removed_via_dispatch_clears_tracker() -> None:
     device_name = state_monitor_module.device_name_from_service(name)
     if state_change == ServiceStateChange.Removed:
         monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
-        monitor._state_source.pop(device_name, None)
-        if monitor._reachability is not None:
-            monitor._reachability.clear(device_name)
+        monitor.state.state_source.pop(device_name, None)
+        if monitor.state.reachability is not None:
+            monitor.state.reachability.clear(device_name)
 
     snap = tracker.snapshot("kitchen", state=DeviceState.OFFLINE, active_source="unknown", ip="")
     assert snap["mdns_last_seen_seconds_ago"] is None


### PR DESCRIPTION
# What does this implement/fix?

First PR in the device-state-monitor split arc — see `device_state_monitor_split.md` in the repo root for the full plan. Mechanical-only structural conversion per the project's strict split-then-clean cadence.

**Package shape.**

`controllers/_device_state_monitor.py` (1638 lines, the biggest unsplit module in the repo) becomes `controllers/_device_state_monitor/`:

- `controller.py` — original file contents byte-for-byte; import depths bumped one level for the new package shape.
- `_state.py` — new `MonitorState` dataclass.
- `__init__.py` — re-exports `DeviceStateMonitor` + the three private symbols external callers reach for (`_MDNS_REFRESH_PADDING_SECONDS`, `device_name_from_service`, `_decode_txt_bytes_to_sorted_pairs`) via PEP 484 redundant-alias form.

`from ..controllers._device_state_monitor import X` callers (including `controllers/devices/controller.py:43`, `controllers/devices/reachability.py:18`, and 14 test files) keep working unchanged.

**MonitorState dataclass.**

Following the CLAUDE.md "State dataclass convention" — designed in from PR 1 so subsequent extraction PRs reach through `monitor.state.X` rather than `monitor._X`. This avoids the post-split cleanup arc that bit PRs #795 / #797.

Holds the four cross-module domain fields:

- `state_source: dict[str, str]` — source-precedence ledger (name → `"mdns"`/`"mqtt"`/`"ping"`)
- `http_urls: dict[str, str]` — name → web-UI URL from the `_http._tcp.local.` browser
- `dns_cache: DNSCache` — TTL'd DNS cache shared across mdns / ping / OTA paths
- `reachability: ReachabilityTracker | None` — optional per-signal freshness tracker

Controller-internal handles that no sibling touches (`_zeroconf`, `_mdns_browser`, `_ping_task`, `_import_discovery`, the `_on_*_change` callback fields, `_tasks` from `TaskControllerBase`) stay on the controller proper.

**Test redirects.** Mechanical updates needed:

- `monitor._state_source` etc. → `monitor.state.state_source` etc. (8 test files).
- Fixtures that bypass `__init__` via `DeviceStateMonitor.__new__` now construct `MonitorState()` explicitly (5 sites).
- Module-aliased imports (`import _device_state_monitor as monitor_module`) and monkey-patch paths (`...icmp_ping`, `...AsyncServiceInfo`, `..._PING_BOOTSTRAP_DELAY`) redirect to the `.controller` submodule.

**Related issue or feature (if applicable):**

- fixes none — first PR in a planned multi-PR split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
