### PR TITLE
Extract PingSource and shared cross-cutting helpers

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -16,7 +16,6 @@ lower-priority source can never override the state set by a higher one.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from collections.abc import Callable
 from operator import attrgetter
@@ -27,17 +26,14 @@ from esphome.zeroconf import (
     DashboardImportDiscovery,
     DiscoveredImport,
 )
-from zeroconf import AddressResolver, IPVersion, ServiceStateChange
+from zeroconf import (
+    AddressResolver,
+    IPVersion,
+    ServiceStateChange,
+    current_time_millis,
+    millis_to_seconds,
+)
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
-
-try:
-    from icmplib import async_ping as icmp_ping
-    from icmplib.exceptions import ICMPLibError
-except ImportError:  # pragma: no cover — icmplib is optional
-    icmp_ping = None  # type: ignore[assignment]
-    ICMPLibError = Exception  # type: ignore[misc,assignment]
-
-from zeroconf import current_time_millis, millis_to_seconds
 from zeroconf.const import (
     _CLASS_IN,
     _TYPE_A,
@@ -46,7 +42,7 @@ from zeroconf.const import (
     _TYPE_TXT,
 )
 
-from ...helpers.hostname import is_local_hostname, normalize_hostname
+from ...helpers.hostname import normalize_hostname
 from ...helpers.subscriber_presence import SubscriberPresence
 from ...models import AdoptableDevice, Device, DeviceState, ReachabilitySource
 from .._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
@@ -60,6 +56,8 @@ from .helpers import (
     _pick_ipv4,
     device_name_from_service,
 )
+from .ping import PingSource
+from .shared import _MDNS_HOSTNAME_RESOLVE_TIMEOUT, _SOURCE_PRIORITY, apply_resolved_addresses
 
 _LOGGER = logging.getLogger(__name__)
 # A second mDNS browser watches for HTTP services so we can light up
@@ -68,23 +66,6 @@ _LOGGER = logging.getLogger(__name__)
 # importable-discovery flow; configured devices already get their
 # web_port from the YAML (``web_server:``).
 _HTTP_SERVICE_TYPE = "_http._tcp.local."
-# Ping fallback runs every 60s after a short bootstrap window.
-# ``_PING_BOOTSTRAP_DELAY`` gives the mDNS browser a head start so the
-# common case (everything announces) doesn't fire a ping sweep that
-# the browser would have answered for free a few seconds later. 10s
-# tracks the upstream esphome dashboard's ``MDNS_BOOTSTRAP_TIME``
-# (~7.5s) closely enough to stay correct without making the user wait
-# a full minute to see UNKNOWN devices flip OFFLINE on first load.
-_PING_INTERVAL = 60  # seconds between ping sweeps
-_PING_BOOTSTRAP_DELAY = 10  # seconds before the first ping sweep
-# Batch size matches the upstream esphome dashboard's
-# ``GROUP_SIZE = MAX_EXECUTOR_WORKERS / 2 = 24``. Each batch's pings
-# run in parallel via ``asyncio.gather``; the cap exists because
-# icmplib gets unreliable past a few dozen concurrent probes. With a
-# small fleet (≤24 ping candidates) one batch covers everything and
-# the sweep finishes in a single ICMP timeout window instead of
-# stacking N timeouts back-to-back.
-_PING_BATCH_SIZE = 24
 _MDNS_RESOLVE_TIMEOUT_MS = 2000
 # Padding added to the cached A record's TTL when the drawer's
 # refresh loop schedules its next probe. We sleep ``ttl + this``
@@ -96,23 +77,6 @@ _MDNS_RESOLVE_TIMEOUT_MS = 2000
 # broadcast…" between the record's natural expiry and our
 # scheduled wake-up.
 _MDNS_REFRESH_PADDING_SECONDS = 1.0
-# Timeout for the per-sweep mDNS hostname resolves we issue for
-# non-API devices. 3s is enough on a working LAN even when the
-# device is briefly slow to respond, and keeps the whole resolve
-# pass under the ping interval even if every target misses the
-# cache and has to round-trip on the network.
-_MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
-
-# Source priority for state observations. A new observation can only
-# override an existing one when its priority is greater than or equal
-# to the current source's. Keep ``unknown`` at zero so any source can
-# claim a device that no source has yet labelled.
-_SOURCE_PRIORITY: dict[str, int] = {
-    ReachabilitySource.UNKNOWN: 0,
-    ReachabilitySource.PING: 1,
-    ReachabilitySource.MQTT: 2,
-    ReachabilitySource.MDNS: 3,
-}
 
 
 # Callback signature used by DeviceStateMonitor to push state changes
@@ -264,11 +228,12 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # existing tests that build a monitor without a presence
         # gate keep working; ``None`` means "always run the loop".
         self._presence = presence
+        self._ping = PingSource(self)
 
     async def start(self) -> None:
         """Start the mDNS browser and the periodic ping sweep."""
         await self._start_mdns_browser()
-        self._ping_task = asyncio.create_task(self._ping_loop())
+        self._ping_task = asyncio.create_task(self._ping.run())
 
     async def stop(self) -> None:
         """Tear down the browser and cancel the ping loop."""
@@ -419,7 +384,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         except Exception:
             _LOGGER.debug("mDNS refresh of %s failed", name, exc_info=True)
             return
-        self._apply_resolved_addresses(name, addresses)
+        apply_resolved_addresses(self, name, addresses)
 
     def _get_address_records(self, name: str) -> list[Any]:
         """Return cached A and AAAA records for *name*, or ``[]``.
@@ -542,27 +507,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             ttl_remaining_seconds=ttl_remaining_s,
             txt_records=_decode_mdns_txt_records(txt_dns_records),
         )
-
-    def _apply_resolved_addresses(
-        self, name: str, addresses: list[str] | BaseException | None
-    ) -> None:
-        """Funnel a successful active-resolve into the apply path.
-
-        Both the per-subscription :meth:`refresh_mdns` and the
-        batch :meth:`_resolve_non_api_mdns_targets` need the same
-        "non-empty address list → claim mDNS-ONLINE + record IPs"
-        treatment. Sharing the branch keeps the deliberate
-        no-OFFLINE-on-miss rule (documented at the call site in
-        :meth:`_resolve_non_api_mdns_targets`) consistent across
-        both paths.
-
-        ``addresses`` accepts the union ``asyncio.gather(...,
-        return_exceptions=True)`` produces so the batch path can
-        thread its results in without a per-element type check.
-        """
-        if isinstance(addresses, list) and addresses:
-            self.apply(name, DeviceState.ONLINE, "mdns", claim=True)
-            self.apply_ip_addresses(name, addresses)
 
     def apply_ip(self, name: str, ip: str) -> bool:
         """
@@ -1197,257 +1141,3 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             self.apply_api_encryption(device_name, value if isinstance(value, str) else "")
         elif props:
             self.apply_api_encryption(device_name, "")
-
-    async def _ping_loop(self) -> None:
-        # First sweep after the short bootstrap window — gives mDNS a
-        # head start so we don't redundantly ping devices the browser
-        # is about to flip ONLINE for free, but still gets the UNKNOWN
-        # → OFFLINE transition in front of the user within ~10s of
-        # startup instead of after a full minute.
-        await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
-        # Strict pause: when wired to a SubscriberPresence gate, only
-        # sweep while at least one dashboard client is subscribed.
-        # The 0→1 transition wakes ``wait_for_subscriber`` immediately
-        # so the first user to open the dashboard sees fresh ICMP-
-        # source state within one sweep instead of waiting up to
-        # ``_PING_INTERVAL``. mDNS browsing keeps running
-        # unconditionally (it's passive), so devices that announce
-        # flip ONLINE the moment the bus delivers their cached state
-        # to the new subscriber.
-        while True:
-            if self._presence is not None:
-                await self._presence.wait_for_subscriber()
-            await self._resolve_non_api_mdns_targets()
-            await self._ping_sweep()
-            if self._presence is not None:
-                # Interruptible idle wait: bail early if the last
-                # subscriber leaves so the next one to connect
-                # doesn't sit through the rest of a stale interval.
-                # ``wait_for`` raises ``TimeoutError`` after
-                # ``_PING_INTERVAL`` when the gate stays open the
-                # whole time (the normal "still subscribed, sweep
-                # again" path). Either branch loops back to the top
-                # where ``wait_for_subscriber`` parks if the gate
-                # has since closed.
-                with contextlib.suppress(TimeoutError):
-                    await asyncio.wait_for(
-                        self._presence.wait_for_no_subscribers(),
-                        timeout=_PING_INTERVAL,
-                    )
-                continue
-            await asyncio.sleep(_PING_INTERVAL)
-
-    async def _resolve_non_api_mdns_targets(self) -> None:
-        """Actively resolve ``.local`` hostnames for non-API devices.
-
-        Devices whose YAML doesn't load the ``api`` integration
-        (web_server-only, MQTT-only, OTA-only configs) never
-        broadcast on ``_esphomelib._tcp.local.`` so the browser
-        callback never fires for them. The cache-based fallback in
-        :meth:`_select_ping_targets` only catches them when the
-        zeroconf A-record cache happens to be primed (e.g. by an
-        unrelated query). On a quiet network where ICMP is also
-        filtered (some corporate / HA setups), those devices stay
-        UNKNOWN forever even though they're reachable.
-
-        Issue an active mDNS A-record resolve for each non-API
-        device every sweep so the indicator flips ONLINE even
-        without an esphomelib service announcement. Mirrors the
-        legacy dashboard's ``async_refresh_hosts`` poll path
-        (``esphome/dashboard/status/mdns.py``). No-op when the
-        zeroconf browser failed to start.
-        """
-        if self._zeroconf is None:
-            return
-        candidates = [
-            d
-            for d in self._get_devices()
-            if d.address
-            and is_local_hostname(d.address)
-            and d.loaded_integrations
-            and "api" not in d.loaded_integrations
-            and self._should_ping(d)
-        ]
-        if not candidates:
-            return
-        results = await asyncio.gather(
-            *(
-                self._zeroconf.async_resolve_host(d.address, _MDNS_HOSTNAME_RESOLVE_TIMEOUT)
-                for d in candidates
-            ),
-            return_exceptions=True,
-        )
-        for device, addresses in zip(candidates, results, strict=True):
-            # Trust mDNS for ONLINE — the active A-record query
-            # answered, so the device is live on this LAN. Claim
-            # under the ``mdns`` source (priority 3) so the
-            # subsequent ICMP sweep skips this device entirely.
-            # Keeping ping / DNS traffic to a minimum for fleets
-            # that broadcast is a deliberate trade-off: we want
-            # mDNS to be the single source of truth for devices
-            # that respond to it.
-            self._apply_resolved_addresses(device.name, addresses)
-            # No OFFLINE branch — deliberate. The browser path can
-            # trust mDNS in both directions because the
-            # ServiceBrowser delivers a ``Removed`` event when a
-            # cached record's TTL expires without renewal; that's
-            # the canonical "I'm gone" signal. The one-off active
-            # resolve we run here has no such subscription — a
-            # miss is just "this single query didn't get a reply
-            # in time", which conflates "device gone", "device
-            # slow", and "transient packet loss". Falling back to
-            # ICMP for the OFFLINE decision in this path is the
-            # right shape: an mDNS hit upgrades to mDNS-owned
-            # ONLINE; a miss leaves the source slot at whatever
-            # ping last claimed (or unknown), and ping decides.
-
-    async def _ping_sweep(self) -> None:
-        if icmp_ping is None:
-            return
-
-        devices_to_ping = self._select_ping_targets()
-        if not devices_to_ping:
-            return
-
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug(
-                "Pinging %d devices: %s",
-                len(devices_to_ping),
-                ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
-            )
-
-        for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
-            batch = devices_to_ping[i : i + _PING_BATCH_SIZE]
-            # Pre-resolve every batch via the DNS cache. icmplib would
-            # otherwise re-resolve internally on every ping (going to
-            # the system resolver each time and ignoring our cache),
-            # and the OTA cache args would have nothing to draw on for
-            # non-mDNS hostnames.
-            resolved = await asyncio.gather(
-                *(self.state.dns_cache.async_resolve(d.address) for d in batch),
-                return_exceptions=True,
-            )
-            ping_targets: list[tuple[Device, str]] = []
-            for device, addresses in zip(batch, resolved, strict=True):
-                if isinstance(addresses, list) and addresses:
-                    target = addresses[0]
-                    # Apply the resolved target so the drawer / table
-                    # have an IP to show. ``apply_ip`` already
-                    # preserves an existing multi-IP set when the
-                    # incoming target is already in it (the typical
-                    # case for a ``.local`` host with an active
-                    # ``_esphomelib._tcp`` broadcast — the ping
-                    # target is the IPv4 primary the browser
-                    # callback already populated). For ``.local``
-                    # hosts that don't broadcast ``_esphomelib._tcp``
-                    # (non-API ESPHome devices, the
-                    # zwave-proxy-seeedw5500 case) this is the only
-                    # path that ever populates ``device.ip``, so a
-                    # ping-source-only device would otherwise show
-                    # an em-dash in the drawer's IP row even after
-                    # successful pings.
-                    self.apply_ip(device.name, target)
-                    ping_targets.append((device, target))
-                else:
-                    # DNS cache says we can't resolve this hostname
-                    # (the entry is cached as a failure for the cache
-                    # TTL). Don't hand the bare hostname to icmplib —
-                    # it would re-resolve via the system resolver every
-                    # sweep, hammering DNS for nothing. Treat the cache
-                    # miss as the "we tried, can't reach" signal and
-                    # apply OFFLINE via the same source ``_ping_device``
-                    # would have used.
-                    self.apply(device.name, DeviceState.OFFLINE, "ping")
-            if ping_targets:
-                await asyncio.gather(
-                    *(self._ping_device(device, target) for device, target in ping_targets),
-                    return_exceptions=True,
-                )
-
-    def _select_ping_targets(self) -> list[Device]:
-        """
-        Filter the device list down to actual ping candidates.
-
-        Devices already known to be ONLINE via a higher-priority source
-        are skipped. ``.local`` hosts that show up in zeroconf's cache
-        are claimed for mDNS so the bare-hostname DNS fallback can't
-        resolve them to an unreachable IP on a different subnet.
-        Hostnames with a fresh DNS-failure cache entry are flipped
-        OFFLINE without a ping attempt — there's nothing to resolve, so
-        re-trying every minute would just hammer the resolver.
-        """
-        devices_to_ping: list[Device] = []
-        dns_skipped: list[Device] = []
-        for device in self._get_devices():
-            if not device.address or not self._should_ping(device):
-                continue
-            if is_local_hostname(device.address) and (
-                cached := self.get_cached_addresses(device.address)
-            ):
-                self.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                # Forward every cached IP so the dashboard shows all
-                # of them; ``apply_ip_addresses`` picks an IPv4 primary
-                # for ``device.ip`` so ICMP probes and OTA cache args
-                # still hit the cross-subnet-friendly entry.
-                self.apply_ip_addresses(device.name, cached)
-                continue
-            if self.state.dns_cache.has_cached_failure(device.address):
-                dns_skipped.append(device)
-                self.apply(device.name, DeviceState.OFFLINE, "ping")
-                continue
-            devices_to_ping.append(device)
-
-        if dns_skipped and _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug(
-                "Skipping ping for %d device(s) with cached DNS failure: %s",
-                len(dns_skipped),
-                ", ".join(f"{d.name} ({d.address})" for d in dns_skipped),
-            )
-        return devices_to_ping
-
-    def _should_ping(self, device: Device) -> bool:
-        """
-        Decide whether *device* needs an ICMP probe this sweep.
-
-        Mirrors the upstream dashboard's rule: skip the device only when
-        it's already ONLINE *and* a higher-priority source (mDNS / MQTT)
-        owns it. We still ping devices that are OFFLINE or UNKNOWN so an
-        off-network host — one mDNS can't reach because it's on a
-        different subnet — has a path to come online via DNS + ping.
-        """
-        if device.state != DeviceState.ONLINE:
-            return True
-        source = self.state.state_source.get(device.name, ReachabilitySource.UNKNOWN)
-        return _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY[ReachabilitySource.PING]
-
-    async def _ping_device(self, device: Device, target: str) -> None:
-        # Treat any failure mode as "not reachable" → OFFLINE, not as
-        # "still unknown". An exception here means resolution failed
-        # (NameLookupError), the network refused us (NoRouteToHost,
-        # PermissionError, OSError), or icmplib couldn't open a socket.
-        # In every case the user wants the dot to flip red, not stay
-        # grey forever — once mDNS / MQTT / ping have all tried, the
-        # signal is "we couldn't reach this device". A subsequent
-        # successful ping will flip it right back to ONLINE.
-        rtt_ms: float | None = None
-        try:
-            result = await icmp_ping(target, count=1, timeout=3, privileged=False)
-            is_alive = result.is_alive
-            # icmplib's ``Host.min_rtt`` is the lowest round-trip in
-            # milliseconds across the count we sent (1 here). Capture
-            # it before discarding ``result`` so the drawer can show
-            # "4 ms" beside the Ping row. ``min_rtt`` is 0.0 on a
-            # failed ping which would surface as "0 ms" — gate on
-            # ``is_alive`` so failures stay null.
-            if is_alive:
-                rtt_ms = float(result.min_rtt)
-        except (ICMPLibError, OSError) as exc:
-            # ``.local`` hosts on systems without Avahi / mdnsd hit
-            # this every sweep; the traceback adds nothing and floods
-            # the logs. One-line debug is plenty.
-            _LOGGER.debug("Ping of %s (%s) failed: %s", device.name, target, exc)
-            is_alive = False
-        new_state = DeviceState.ONLINE if is_alive else DeviceState.OFFLINE
-        if is_alive and rtt_ms is not None and self.state.reachability is not None:
-            self.state.reachability.record_ping_rtt(device.name, rtt_ms)
-        self.apply(device.name, new_state, "ping")

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -1,0 +1,243 @@
+"""ICMP ping fallback source for the device-state monitor.
+
+Mirrors the legacy ``esphome/dashboard/status/ping.py`` shape:
+a :class:`PingSource` taking the monitor in ``__init__``, owning
+the periodic sweep, target selection, and per-device probe.
+Reads from and writes back through ``monitor.state`` /
+``monitor.apply(...)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+from ...helpers.hostname import is_local_hostname
+from ...models import Device, DeviceState
+from . import shared
+
+try:
+    from icmplib import async_ping as icmp_ping
+    from icmplib.exceptions import ICMPLibError
+except ImportError:  # pragma: no cover — icmplib is optional
+    icmp_ping = None  # type: ignore[assignment]
+    ICMPLibError = Exception  # type: ignore[misc,assignment]
+
+if TYPE_CHECKING:
+    from .controller import DeviceStateMonitor
+
+_LOGGER = logging.getLogger(__name__)
+
+# Ping fallback runs every 60s after a short bootstrap window.
+# ``_PING_BOOTSTRAP_DELAY`` gives the mDNS browser a head start so the
+# common case (everything announces) doesn't fire a ping sweep that
+# the browser would have answered for free a few seconds later. 10s
+# tracks the upstream esphome dashboard's ``MDNS_BOOTSTRAP_TIME``
+# (~7.5s) closely enough to stay correct without making the user wait
+# a full minute to see UNKNOWN devices flip OFFLINE on first load.
+_PING_INTERVAL = 60  # seconds between ping sweeps
+_PING_BOOTSTRAP_DELAY = 10  # seconds before the first ping sweep
+# Batch size matches the upstream esphome dashboard's
+# ``GROUP_SIZE = MAX_EXECUTOR_WORKERS / 2 = 24``. Each batch's pings
+# run in parallel via ``asyncio.gather``; the cap exists because
+# icmplib gets unreliable past a few dozen concurrent probes. With a
+# small fleet (≤24 ping candidates) one batch covers everything and
+# the sweep finishes in a single ICMP timeout window instead of
+# stacking N timeouts back-to-back.
+_PING_BATCH_SIZE = 24
+
+
+class PingSource:
+    """ICMP ping loop owning the periodic sweep and per-device probe.
+
+    Takes the monitor in ``__init__`` and reads / writes through it
+    (``monitor.state.dns_cache``, ``monitor.apply(...)``, etc.).
+    The shared cross-cutting bits — should_ping precedence,
+    apply_resolved_addresses funnel, the active mDNS resolve path
+    that primes ONLINE before the sweep — live in
+    :mod:`._device_state_monitor.shared`.
+    """
+
+    def __init__(self, monitor: DeviceStateMonitor) -> None:
+        self._monitor = monitor
+
+    async def run(self) -> None:
+        # First sweep after the short bootstrap window — gives mDNS a
+        # head start so we don't redundantly ping devices the browser
+        # is about to flip ONLINE for free, but still gets the UNKNOWN
+        # → OFFLINE transition in front of the user within ~10s of
+        # startup instead of after a full minute.
+        await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+        # Strict pause: when wired to a SubscriberPresence gate, only
+        # sweep while at least one dashboard client is subscribed.
+        # The 0→1 transition wakes ``wait_for_subscriber`` immediately
+        # so the first user to open the dashboard sees fresh ICMP-
+        # source state within one sweep instead of waiting up to
+        # ``_PING_INTERVAL``. mDNS browsing keeps running
+        # unconditionally (it's passive), so devices that announce
+        # flip ONLINE the moment the bus delivers their cached state
+        # to the new subscriber.
+        monitor = self._monitor
+        while True:
+            if monitor._presence is not None:
+                await monitor._presence.wait_for_subscriber()
+            await shared.resolve_non_api_mdns_targets(monitor)
+            await self._ping_sweep()
+            if monitor._presence is not None:
+                # Interruptible idle wait: bail early if the last
+                # subscriber leaves so the next one to connect
+                # doesn't sit through the rest of a stale interval.
+                # ``wait_for`` raises ``TimeoutError`` after
+                # ``_PING_INTERVAL`` when the gate stays open the
+                # whole time (the normal "still subscribed, sweep
+                # again" path). Either branch loops back to the top
+                # where ``wait_for_subscriber`` parks if the gate
+                # has since closed.
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(
+                        monitor._presence.wait_for_no_subscribers(),
+                        timeout=_PING_INTERVAL,
+                    )
+                continue
+            await asyncio.sleep(_PING_INTERVAL)
+
+    async def _ping_sweep(self) -> None:
+        if icmp_ping is None:
+            return
+
+        devices_to_ping = self._select_ping_targets()
+        if not devices_to_ping:
+            return
+
+        monitor = self._monitor
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Pinging %d devices: %s",
+                len(devices_to_ping),
+                ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
+            )
+
+        for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
+            batch = devices_to_ping[i : i + _PING_BATCH_SIZE]
+            # Pre-resolve every batch via the DNS cache. icmplib would
+            # otherwise re-resolve internally on every ping (going to
+            # the system resolver each time and ignoring our cache),
+            # and the OTA cache args would have nothing to draw on for
+            # non-mDNS hostnames.
+            resolved = await asyncio.gather(
+                *(monitor.state.dns_cache.async_resolve(d.address) for d in batch),
+                return_exceptions=True,
+            )
+            ping_targets: list[tuple[Device, str]] = []
+            for device, addresses in zip(batch, resolved, strict=True):
+                if isinstance(addresses, list) and addresses:
+                    target = addresses[0]
+                    # Apply the resolved target so the drawer / table
+                    # have an IP to show. ``apply_ip`` already
+                    # preserves an existing multi-IP set when the
+                    # incoming target is already in it (the typical
+                    # case for a ``.local`` host with an active
+                    # ``_esphomelib._tcp`` broadcast — the ping
+                    # target is the IPv4 primary the browser
+                    # callback already populated). For ``.local``
+                    # hosts that don't broadcast ``_esphomelib._tcp``
+                    # (non-API ESPHome devices, the
+                    # zwave-proxy-seeedw5500 case) this is the only
+                    # path that ever populates ``device.ip``, so a
+                    # ping-source-only device would otherwise show
+                    # an em-dash in the drawer's IP row even after
+                    # successful pings.
+                    monitor.apply_ip(device.name, target)
+                    ping_targets.append((device, target))
+                else:
+                    # DNS cache says we can't resolve this hostname
+                    # (the entry is cached as a failure for the cache
+                    # TTL). Don't hand the bare hostname to icmplib —
+                    # it would re-resolve via the system resolver every
+                    # sweep, hammering DNS for nothing. Treat the cache
+                    # miss as the "we tried, can't reach" signal and
+                    # apply OFFLINE via the same source ``_ping_device``
+                    # would have used.
+                    monitor.apply(device.name, DeviceState.OFFLINE, "ping")
+            if ping_targets:
+                await asyncio.gather(
+                    *(self._ping_device(device, target) for device, target in ping_targets),
+                    return_exceptions=True,
+                )
+
+    def _select_ping_targets(self) -> list[Device]:
+        """
+        Filter the device list down to actual ping candidates.
+
+        Devices already known to be ONLINE via a higher-priority source
+        are skipped. ``.local`` hosts that show up in zeroconf's cache
+        are claimed for mDNS so the bare-hostname DNS fallback can't
+        resolve them to an unreachable IP on a different subnet.
+        Hostnames with a fresh DNS-failure cache entry are flipped
+        OFFLINE without a ping attempt — there's nothing to resolve, so
+        re-trying every minute would just hammer the resolver.
+        """
+        monitor = self._monitor
+        devices_to_ping: list[Device] = []
+        dns_skipped: list[Device] = []
+        for device in monitor._get_devices():
+            if not device.address or not shared.should_ping(monitor, device):
+                continue
+            if is_local_hostname(device.address) and (
+                cached := monitor.get_cached_addresses(device.address)
+            ):
+                monitor.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+                # Forward every cached IP so the dashboard shows all
+                # of them; ``apply_ip_addresses`` picks an IPv4 primary
+                # for ``device.ip`` so ICMP probes and OTA cache args
+                # still hit the cross-subnet-friendly entry.
+                monitor.apply_ip_addresses(device.name, cached)
+                continue
+            if monitor.state.dns_cache.has_cached_failure(device.address):
+                dns_skipped.append(device)
+                monitor.apply(device.name, DeviceState.OFFLINE, "ping")
+                continue
+            devices_to_ping.append(device)
+
+        if dns_skipped and _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Skipping ping for %d device(s) with cached DNS failure: %s",
+                len(dns_skipped),
+                ", ".join(f"{d.name} ({d.address})" for d in dns_skipped),
+            )
+        return devices_to_ping
+
+    async def _ping_device(self, device: Device, target: str) -> None:
+        # Treat any failure mode as "not reachable" → OFFLINE, not as
+        # "still unknown". An exception here means resolution failed
+        # (NameLookupError), the network refused us (NoRouteToHost,
+        # PermissionError, OSError), or icmplib couldn't open a socket.
+        # In every case the user wants the dot to flip red, not stay
+        # grey forever — once mDNS / MQTT / ping have all tried, the
+        # signal is "we couldn't reach this device". A subsequent
+        # successful ping will flip it right back to ONLINE.
+        monitor = self._monitor
+        rtt_ms: float | None = None
+        try:
+            result = await icmp_ping(target, count=1, timeout=3, privileged=False)
+            is_alive = result.is_alive
+            # icmplib's ``Host.min_rtt`` is the lowest round-trip in
+            # milliseconds across the count we sent (1 here). Capture
+            # it before discarding ``result`` so the drawer can show
+            # "4 ms" beside the Ping row. ``min_rtt`` is 0.0 on a
+            # failed ping which would surface as "0 ms" — gate on
+            # ``is_alive`` so failures stay null.
+            if is_alive:
+                rtt_ms = float(result.min_rtt)
+        except (ICMPLibError, OSError) as exc:
+            # ``.local`` hosts on systems without Avahi / mdnsd hit
+            # this every sweep; the traceback adds nothing and floods
+            # the logs. One-line debug is plenty.
+            _LOGGER.debug("Ping of %s (%s) failed: %s", device.name, target, exc)
+            is_alive = False
+        new_state = DeviceState.ONLINE if is_alive else DeviceState.OFFLINE
+        if is_alive and rtt_ms is not None and monitor.state.reachability is not None:
+            monitor.state.reachability.record_ping_rtt(device.name, rtt_ms)
+        monitor.apply(device.name, new_state, "ping")

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -1,4 +1,5 @@
-"""ICMP ping fallback source for the device-state monitor.
+"""
+ICMP ping fallback source for the device-state monitor.
 
 Mirrors the legacy ``esphome/dashboard/status/ping.py`` shape:
 a :class:`PingSource` taking the monitor in ``__init__``, owning
@@ -50,7 +51,8 @@ _PING_BATCH_SIZE = 24
 
 
 class PingSource:
-    """ICMP ping loop owning the periodic sweep and per-device probe.
+    """
+    ICMP ping loop owning the periodic sweep and per-device probe.
 
     Takes the monitor in ``__init__`` and reads / writes through it
     (``monitor.state.dns_cache``, ``monitor.apply(...)``, etc.).

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -1,0 +1,154 @@
+"""Cross-cutting helpers used by both the mdns browser path and the ping source.
+
+Lives outside both ``mdns.py`` and ``ping.py`` because each function
+straddles concerns:
+
+* ``resolve_non_api_mdns_targets`` issues active mDNS resolves but
+  runs in the ping loop's pre-sweep step, and is gated by the same
+  ``should_ping`` rule the ICMP path consults.
+* ``apply_resolved_addresses`` funnels both the browser-callback
+  refresh path and the active-resolve batch into ``monitor.apply``
+  with the same "non-empty list → claim mDNS-ONLINE + record IPs"
+  treatment.
+* ``should_ping`` and the ``_SOURCE_PRIORITY`` ledger are read by
+  the central ``apply()`` write path AND by both modules above.
+
+Free functions taking the monitor — same shape as the
+firmware-sync helpers. ``DeviceStateMonitor`` reaches back through
+``state`` for everything sibling modules need.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ...helpers.hostname import is_local_hostname
+from ...models import Device, DeviceState, ReachabilitySource
+
+if TYPE_CHECKING:
+    from .controller import DeviceStateMonitor
+
+
+# Source priority for state observations. A new observation can only
+# override an existing one when its priority is greater than or equal
+# to the current source's. Keep ``unknown`` at zero so any source can
+# claim a device that no source has yet labelled.
+_SOURCE_PRIORITY: dict[str, int] = {
+    ReachabilitySource.UNKNOWN: 0,
+    ReachabilitySource.PING: 1,
+    ReachabilitySource.MQTT: 2,
+    ReachabilitySource.MDNS: 3,
+}
+
+# Timeout for the per-sweep mDNS hostname resolves we issue for
+# non-API devices. 3s is enough on a working LAN even when the
+# device is briefly slow to respond, and keeps the whole resolve
+# pass under the ping interval even if every target misses the
+# cache and has to round-trip on the network.
+_MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
+
+
+def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
+    """
+    Decide whether *device* needs an ICMP probe this sweep.
+
+    Mirrors the upstream dashboard's rule: skip the device only when
+    it's already ONLINE *and* a higher-priority source (mDNS / MQTT)
+    owns it. We still ping devices that are OFFLINE or UNKNOWN so an
+    off-network host — one mDNS can't reach because it's on a
+    different subnet — has a path to come online via DNS + ping.
+    """
+    if device.state != DeviceState.ONLINE:
+        return True
+    source = monitor.state.state_source.get(device.name, ReachabilitySource.UNKNOWN)
+    return _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY[ReachabilitySource.PING]
+
+
+def apply_resolved_addresses(
+    monitor: DeviceStateMonitor,
+    name: str,
+    addresses: list[str] | BaseException | None,
+) -> None:
+    """Funnel a successful active-resolve into the apply path.
+
+    Both the per-subscription :meth:`refresh_mdns` and the batch
+    :func:`resolve_non_api_mdns_targets` need the same "non-empty
+    address list → claim mDNS-ONLINE + record IPs" treatment.
+    Sharing the branch keeps the deliberate no-OFFLINE-on-miss rule
+    (documented at the call site in
+    :func:`resolve_non_api_mdns_targets`) consistent across both
+    paths.
+
+    ``addresses`` accepts the union ``asyncio.gather(...,
+    return_exceptions=True)`` produces so the batch path can thread
+    its results in without a per-element type check.
+    """
+    if isinstance(addresses, list) and addresses:
+        monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
+        monitor.apply_ip_addresses(name, addresses)
+
+
+async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
+    """Actively resolve ``.local`` hostnames for non-API devices.
+
+    Devices whose YAML doesn't load the ``api`` integration
+    (web_server-only, MQTT-only, OTA-only configs) never broadcast
+    on ``_esphomelib._tcp.local.`` so the browser callback never
+    fires for them. The cache-based fallback in the ping target
+    selector only catches them when the zeroconf A-record cache
+    happens to be primed (e.g. by an unrelated query). On a quiet
+    network where ICMP is also filtered (some corporate / HA
+    setups), those devices stay UNKNOWN forever even though
+    they're reachable.
+
+    Issue an active mDNS A-record resolve for each non-API device
+    every sweep so the indicator flips ONLINE even without an
+    esphomelib service announcement. Mirrors the legacy
+    dashboard's ``async_refresh_hosts`` poll path
+    (``esphome/dashboard/status/mdns.py``). No-op when the
+    zeroconf browser failed to start.
+    """
+    if monitor._zeroconf is None:
+        return
+    candidates = [
+        d
+        for d in monitor._get_devices()
+        if d.address
+        and is_local_hostname(d.address)
+        and d.loaded_integrations
+        and "api" not in d.loaded_integrations
+        and should_ping(monitor, d)
+    ]
+    if not candidates:
+        return
+    results = await asyncio.gather(
+        *(
+            monitor._zeroconf.async_resolve_host(d.address, _MDNS_HOSTNAME_RESOLVE_TIMEOUT)
+            for d in candidates
+        ),
+        return_exceptions=True,
+    )
+    for device, addresses in zip(candidates, results, strict=True):
+        # Trust mDNS for ONLINE — the active A-record query
+        # answered, so the device is live on this LAN. Claim
+        # under the ``mdns`` source (priority 3) so the
+        # subsequent ICMP sweep skips this device entirely.
+        # Keeping ping / DNS traffic to a minimum for fleets
+        # that broadcast is a deliberate trade-off: we want
+        # mDNS to be the single source of truth for devices
+        # that respond to it.
+        apply_resolved_addresses(monitor, device.name, addresses)
+        # No OFFLINE branch — deliberate. The browser path can
+        # trust mDNS in both directions because the
+        # ServiceBrowser delivers a ``Removed`` event when a
+        # cached record's TTL expires without renewal; that's
+        # the canonical "I'm gone" signal. The one-off active
+        # resolve we run here has no such subscription — a
+        # miss is just "this single query didn't get a reply
+        # in time", which conflates "device gone", "device
+        # slow", and "transient packet loss". Falling back to
+        # ICMP for the OFFLINE decision in this path is the
+        # right shape: an mDNS hit upgrades to mDNS-owned
+        # ONLINE; a miss leaves the source slot at whatever
+        # ping last claimed (or unknown), and ping decides.

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -1,4 +1,5 @@
-"""Cross-cutting helpers used by both the mdns browser path and the ping source.
+"""
+Cross-cutting helpers used by both the mdns browser path and the ping source.
 
 Lives outside both ``mdns.py`` and ``ping.py`` because each function
 straddles concerns:

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -14,9 +14,7 @@ from esphome_device_builder.controllers import (
     _dns_cache as dns_cache_mod,
 )
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.controllers._device_state_monitor import (
-    controller as sm,
-)
+from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
 from esphome_device_builder.controllers._dns_cache import DNSCache
 from esphome_device_builder.controllers.config import (
     get_board_id,
@@ -253,9 +251,9 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
 
     with (
         patch.object(dns_cache_mod, "async_resolve", resolver),
-        patch.object(sm, "icmp_ping", fake_ping),
+        patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping_sweep()
+        await monitor._ping._ping_sweep()
 
     assert pinged == ["10.0.0.1"]
     assert ip_changes == [("kitchen", "10.0.0.1", ["10.0.0.1"])]
@@ -295,9 +293,9 @@ async def test_ping_sweep_applies_ip_for_local_hosts(fake_resolver) -> None:
 
     with (
         patch.object(dns_cache_mod, "async_resolve", resolver),
-        patch.object(sm, "icmp_ping", fake_ping),
+        patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping_sweep()
+        await monitor._ping._ping_sweep()
 
     assert ip_changes == [("kitchen", "192.168.1.50", ["192.168.1.50"])]
 
@@ -334,9 +332,9 @@ async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
 
     with (
         patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
-        patch.object(sm, "icmp_ping", fake_ping),
+        patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping_sweep()
+        await monitor._ping._ping_sweep()
 
     assert pinged == []
     assert state_changes == [("winefridge", DeviceState.ONLINE, "mdns")]
@@ -374,9 +372,9 @@ async def test_ping_sweep_marks_offline_directly_on_dns_failure(fake_resolver) -
 
     with (
         patch.object(dns_cache_mod, "async_resolve", resolver),
-        patch.object(sm, "icmp_ping", fake_ping),
+        patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping_sweep()
+        await monitor._ping._ping_sweep()
 
     # Crucially: ``icmp_ping`` was NOT called. The resolution failure
     # was enough to declare the device offline.
@@ -416,9 +414,9 @@ async def test_ping_sweep_skips_devices_with_cached_dns_failure(fake_resolver) -
 
     with (
         patch.object(dns_cache_mod, "async_resolve", resolver),
-        patch.object(sm, "icmp_ping", fake_ping),
+        patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping_sweep()
+        await monitor._ping._ping_sweep()
 
     assert pinged == []
     assert resolver.calls == []
@@ -450,9 +448,9 @@ async def test_ping_marks_offline_when_icmp_raises(fake_resolver) -> None:
 
     with (
         patch.object(dns_cache_mod, "async_resolve", resolver),
-        patch.object(sm, "icmp_ping", raising_ping),
+        patch.object(ping_module, "icmp_ping", raising_ping),
     ):
-        await monitor._ping_sweep()
+        await monitor._ping._ping_sweep()
 
     assert state_changes == [("kitchen", DeviceState.OFFLINE, "ping")]
 

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor, shared
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import make_state_monitor_with_callbacks
@@ -89,7 +89,7 @@ async def test_non_api_device_marked_online_when_mdns_resolves() -> None:
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, resolver = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     assert devices[0].state == DeviceState.ONLINE
     assert devices[0].ip == "192.168.1.42"
@@ -107,7 +107,7 @@ async def test_api_device_skipped() -> None:
     devices = [_device(loaded_integrations=["api", "web_server"])]
     monitor, resolver = _make_monitor(devices)
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     resolver.assert_not_called()
     assert devices[0].state == DeviceState.UNKNOWN
@@ -126,7 +126,7 @@ async def test_uncompiled_device_skipped() -> None:
     devices = [_device(loaded_integrations=[])]
     monitor, resolver = _make_monitor(devices)
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     resolver.assert_not_called()
 
@@ -137,7 +137,7 @@ async def test_non_local_hostname_skipped() -> None:
     devices = [_device(address="device.example.com", loaded_integrations=["mqtt"])]
     monitor, resolver = _make_monitor(devices)
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     resolver.assert_not_called()
 
@@ -159,7 +159,7 @@ async def test_resolve_miss_is_silent_no_offline_branch_by_design() -> None:
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, _resolver = _make_monitor(devices, resolved={"kitchen.local": None})
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     assert devices[0].state == DeviceState.UNKNOWN  # not OFFLINE
     assert devices[0].ip == ""
@@ -190,7 +190,7 @@ async def test_resolve_exception_does_not_propagate() -> None:
 
     monitor._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     # bedroom resolves cleanly even though kitchen blew up.
     bedroom = next(d for d in devices if d.name == "bedroom")
@@ -210,7 +210,7 @@ async def test_no_zeroconf_is_a_noop() -> None:
     monitor._zeroconf = None  # simulate ``async_setup`` failure
 
     # No exception, no state change.
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
     assert devices[0].state == DeviceState.UNKNOWN
 
 
@@ -227,7 +227,7 @@ async def test_already_online_via_higher_priority_skipped() -> None:
     monitor, resolver = _make_monitor(devices)
     monitor.state.state_source["kitchen"] = "mdns"  # higher than ping
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     resolver.assert_not_called()
 
@@ -248,11 +248,11 @@ async def test_resolve_hit_locks_out_ping() -> None:
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, _ = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     assert devices[0].state == DeviceState.ONLINE
     assert monitor.priority_for("kitchen") == "mdns"
-    assert monitor._should_ping(devices[0]) is False
+    assert shared.should_ping(monitor, devices[0]) is False
 
 
 @pytest.mark.asyncio
@@ -268,7 +268,7 @@ async def test_offline_via_ping_still_resolved() -> None:
     monitor, resolver = _make_monitor(devices, resolved={"kitchen.local": ["192.168.1.42"]})
     monitor.state.state_source["kitchen"] = "ping"
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     resolver.assert_awaited_once()
     assert devices[0].state == DeviceState.ONLINE
@@ -289,7 +289,7 @@ async def test_resolve_picks_ipv4_for_apply_ip() -> None:
         resolved={"kitchen.local": ["fe80::1%en0", "192.168.1.42", "fe80::2%en0"]},
     )
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     assert devices[0].ip == "192.168.1.42"
     assert devices[0].ip_addresses == ["fe80::1%en0", "192.168.1.42", "fe80::2%en0"]
@@ -307,7 +307,7 @@ async def test_no_candidates_skips_zeroconf_call() -> None:
     devices = [_device(loaded_integrations=["api"])]
     monitor, resolver = _make_monitor(devices)
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     resolver.assert_not_called()
 
@@ -345,6 +345,6 @@ async def test_multiple_devices_resolve_in_parallel(monkeypatch: Any) -> None:
 
     monitor._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
 
-    await monitor._resolve_non_api_mdns_targets()
+    await shared.resolve_non_api_mdns_targets(monitor)
 
     assert max_concurrent == 3

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -28,19 +28,20 @@ import pytest
 
 from esphome_device_builder import device_builder as device_builder_module
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.controllers._device_state_monitor import (
-    controller as state_monitor_module,
-)
+from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
+from esphome_device_builder.controllers._device_state_monitor import shared as shared_module
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.device_builder import DeviceBuilder
 from esphome_device_builder.helpers.subscriber_presence import SubscriberPresence
 
 
 def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
-    """Bypass __init__ — ``_ping_loop`` only touches a few attrs."""
+    """Bypass __init__ — ``PingSource.run`` only touches a few attrs."""
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
     monitor.state = MonitorState()
     monitor._presence = presence
+    monitor._ping = PingSource(monitor)
     return monitor
 
 
@@ -56,17 +57,21 @@ def _instrument_loop(
     """
     counts = {"sweeps": 0, "resolves": 0, "sleeps": 0}
 
-    async def _resolve() -> None:
+    async def _resolve(_monitor: DeviceStateMonitor) -> None:
         counts["resolves"] += 1
 
     async def _sweep() -> None:
         counts["sweeps"] += 1
 
-    monitor._resolve_non_api_mdns_targets = _resolve  # type: ignore[method-assign]
-    monitor._ping_sweep = _sweep  # type: ignore[method-assign]
+    # ``resolve_non_api_mdns_targets`` is a free function in ``shared``;
+    # patch the module attribute so ``PingSource.run``'s call sees the
+    # stub. ``_ping_sweep`` is a method on ``PingSource``; replace it
+    # on the per-test instance.
+    monkeypatch.setattr(shared_module, "resolve_non_api_mdns_targets", _resolve)
+    monitor._ping._ping_sweep = _sweep  # type: ignore[method-assign]
 
     # Skip the bootstrap delay outright.
-    monkeypatch.setattr(state_monitor_module, "_PING_BOOTSTRAP_DELAY", 0)
+    monkeypatch.setattr(ping_module, "_PING_BOOTSTRAP_DELAY", 0)
 
     # Patch the module-local sleep so each "interval wait" is a
     # zero-cost yield and a tick count. The test ends the loop by
@@ -78,7 +83,7 @@ def _instrument_loop(
         # Yield back so the test coroutine can observe the counters.
         await real_sleep(0)
 
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _fast_sleep)
     return counts
 
 
@@ -106,7 +111,7 @@ async def test_ping_loop_runs_unconditionally_without_presence(
     monitor = _build_monitor(presence=None)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping_loop())
+    task = asyncio.create_task(monitor._ping.run())
     try:
         await _drive_until(lambda: counts["sweeps"] >= 2)
     finally:
@@ -133,7 +138,7 @@ async def test_ping_loop_parks_until_first_subscriber(
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping_loop())
+    task = asyncio.create_task(monitor._ping.run())
     try:
         # Give the loop several scheduling ticks to confirm it
         # actually parks instead of running. Without the gate fix
@@ -168,7 +173,7 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping_loop())
+    task = asyncio.create_task(monitor._ping.run())
     try:
         # Cycle one subscriber in, drive at least one sweep, then out.
         with presence.subscriber():
@@ -264,9 +269,9 @@ async def test_ping_loop_aborts_idle_sleep_when_last_subscriber_leaves(
         # short-circuits the wait when the subscriber drops.
         return await real_wait_for(coro, timeout=timeout)
 
-    monkeypatch.setattr(state_monitor_module.asyncio, "wait_for", _spy_wait_for)
+    monkeypatch.setattr(ping_module.asyncio, "wait_for", _spy_wait_for)
 
-    task = asyncio.create_task(monitor._ping_loop())
+    task = asyncio.create_task(monitor._ping.run())
     try:
         # Bring a subscriber in; wait until the loop has done at
         # least one sweep AND entered the idle wait.
@@ -321,7 +326,7 @@ async def test_ping_loop_resumes_immediately_when_new_subscriber_arrives_mid_int
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping_loop())
+    task = asyncio.create_task(monitor._ping.run())
     try:
         # Cycle subscriber A in, drive a sweep, then out.
         with presence.subscriber():

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -21,6 +21,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
 )
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import RecordingMonitorCallbacks
@@ -30,6 +31,8 @@ def _make_monitor() -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
+
+    monitor._ping = PingSource(monitor)
     monitor._zeroconf = MagicMock()
     monitor._zeroconf.zeroconf = MagicMock()
     monitor._tasks = set()
@@ -149,6 +152,8 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
+
+    monitor._ping = PingSource(monitor)
     monitor._zeroconf = None
     monitor._tasks = set()
 

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -31,7 +31,9 @@ from esphome_device_builder.controllers._device_state_monitor import DeviceState
 from esphome_device_builder.controllers._device_state_monitor import (
     controller as state_monitor_module,
 )
+from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.models import Device, DeviceState
 
@@ -84,6 +86,8 @@ def _make_monitor(
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
+
+    monitor._ping = PingSource(monitor)
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
@@ -1275,10 +1279,10 @@ async def test_start_drives_ping_pipeline_to_online_state(
     async def _fake_ping(_target: str, **_kw: Any) -> Any:
         return MagicMock(is_alive=True)
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", _fake_ping)
+    monkeypatch.setattr(ping_module, "icmp_ping", _fake_ping)
     monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
     monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory())
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory())
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
@@ -1301,9 +1305,9 @@ async def test_start_with_icmplib_unavailable_skips_dns_resolution(
     """
     monitor, _callbacks = _make_monitor()
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", None)
+    monkeypatch.setattr(ping_module, "icmp_ping", None)
     monitor.state.dns_cache.async_resolve = AsyncMock()
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
@@ -1333,10 +1337,10 @@ async def test_start_marks_offline_on_icmp_exception(
     async def _boom(*_a: Any, **_kw: Any) -> None:
         raise OSError("name lookup failed")
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", _boom)
+    monkeypatch.setattr(ping_module, "icmp_ping", _boom)
     monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["10.0.0.1"])
     monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
@@ -1365,11 +1369,11 @@ async def test_start_skips_ping_for_cached_dns_failures(
         icmp_called.append(target)
         return MagicMock(is_alive=True)
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", _icmp)
+    monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
     monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=True)
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
-    with caplog.at_level(logging.DEBUG, logger=state_monitor_module.__name__):
+    with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
             await _drain_ping_task(monitor)
@@ -1393,12 +1397,12 @@ async def test_start_logs_ping_count_at_debug(
     async def _icmp(_target: str, **_kw: Any) -> Any:
         return MagicMock(is_alive=True)
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", _icmp)
+    monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
     monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
     monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
-    with caplog.at_level(logging.DEBUG, logger=state_monitor_module.__name__):
+    with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
             await _drain_ping_task(monitor)
@@ -1425,8 +1429,8 @@ async def test_start_skips_devices_without_address(
     async def _icmp(*_a: Any, **_kw: Any) -> Any:
         raise AssertionError("icmp_ping must not be called")
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", _icmp)
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
+    monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
@@ -1521,8 +1525,8 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
         # claims ONLINE and skips the icmp probe.
         raise AssertionError("icmp_ping must not be called for cached-mdns devices")
 
-    monkeypatch.setattr(state_monitor_module, "icmp_ping", _icmp)
-    monkeypatch.setattr(state_monitor_module.asyncio, "sleep", _bounded_sleep_factory(2))
+    monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(2))
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -47,6 +47,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
     controller as state_monitor_module,
 )
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.controllers._reachability_tracker import (
     MdnsCacheInfo,
     ReachabilityTracker,
@@ -90,6 +91,8 @@ def _make_monitor(
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
+
+    monitor._ping = PingSource(monitor)
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
@@ -199,10 +202,10 @@ async def test_ping_success_records_rtt_and_observation() -> None:
     fake_result.is_alive = True
     fake_result.min_rtt = 4.2
     with patch(
-        "esphome_device_builder.controllers._device_state_monitor.controller.icmp_ping",
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         AsyncMock(return_value=fake_result),
     ):
-        await monitor._ping_device(devices[0], "10.0.0.42")
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
 
     snap = tracker.snapshot(
         "kitchen", state=DeviceState.ONLINE, active_source="ping", ip="10.0.0.42"
@@ -222,10 +225,10 @@ async def test_ping_failure_does_not_record_rtt() -> None:
     fake_result.is_alive = False
     fake_result.min_rtt = 0.0
     with patch(
-        "esphome_device_builder.controllers._device_state_monitor.controller.icmp_ping",
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         AsyncMock(return_value=fake_result),
     ):
-        await monitor._ping_device(devices[0], "10.0.0.42")
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
 
     snap = tracker.snapshot(
         "kitchen", state=DeviceState.OFFLINE, active_source="ping", ip="10.0.0.42"


### PR DESCRIPTION
# What does this implement/fix?

Third PR in the device-state-monitor split arc — see `device_state_monitor_split.md` plan (untracked working-tree doc, content mirrored below). Mechanical-only structural extraction per `feedback_split_then_clean_strict`.

Mirrors the legacy `esphome/dashboard/status/ping.py` shape: a `PingSource` class taking the monitor in `__init__`, owning the ICMP loop and per-device probe.

**`ping.py`** — new `PingSource` class:

- `run` — was `_ping_loop`; bootstrap → presence-gated `resolve → sweep` → interval wait.
- `_ping_sweep` — batched DNS pre-resolve + per-batch `asyncio.gather` of `_ping_device`.
- `_select_ping_targets` — filters the device list against the shared source-precedence rules + DNS-failure cache.
- `_ping_device` — single ICMP probe + RTT capture + `apply(ONLINE/OFFLINE, "ping")`.

Constants `_PING_INTERVAL` / `_PING_BOOTSTRAP_DELAY` / `_PING_BATCH_SIZE` and the `icmp_ping` / `ICMPLibError` imports move to `ping.py`.

**`shared.py`** — new module for cross-cutting bits that straddle the mdns and ping concerns (per the plan's resolved question #1):

- `should_ping(monitor, device)` — source-precedence rule read by both the ping target selector and the active-resolve candidate filter.
- `apply_resolved_addresses(monitor, name, addresses)` — the "non-empty list → claim mDNS-ONLINE + record IPs" funnel, called from both the browser-callback refresh path and the active-resolve batch.
- `resolve_non_api_mdns_targets(monitor)` — was `_resolve_non_api_mdns_targets`; mirrors the legacy `async_refresh_hosts` poll path.
- `_SOURCE_PRIORITY` ledger and `_MDNS_HOSTNAME_RESOLVE_TIMEOUT` constant.

Free functions taking the monitor — same shape as the firmware-sync helpers. `controller.py` imports `_MDNS_HOSTNAME_RESOLVE_TIMEOUT` / `_SOURCE_PRIORITY` back for its remaining inline uses (`refresh_mdns` and the `apply()` family).

**`controller.py` wiring**: `__init__` now builds `self._ping = PingSource(self)`; `start()` schedules `asyncio.create_task(self._ping.run())`. `refresh_mdns`'s single `_apply_resolved_addresses` call becomes `apply_resolved_addresses(self, …)`.

**Test redirects** (mechanical):

- `monitor._ping_loop()` → `monitor._ping.run()`.
- `monitor._ping_sweep` → `monitor._ping._ping_sweep`.
- `monitor._ping_device` → `monitor._ping._ping_device`.
- `monitor._should_ping` → `shared.should_ping(monitor, …)`.
- `monitor._resolve_non_api_mdns_targets` → `shared.resolve_non_api_mdns_targets(monitor)`.
- Patches against `controller.icmp_ping` / `controller._PING_BOOTSTRAP_DELAY` / `controller.asyncio.sleep` redirect to the `ping` module.
- `caplog.at_level(…, logger=state_monitor_module.__name__)` → `ping_module.__name__` for the two log-line assertions whose log now fires from `ping.py`.
- `__new__`-built test fixtures now wire `monitor._ping = PingSource(monitor)` after constructing `MonitorState`.

**Sizes:** `controller.py` 1453 → 1143 lines. `ping.py` 243 lines. `shared.py` 154 lines. Full suite: 3424 passed.

**Related issue or feature (if applicable):**

- fixes none — third PR in a planned multi-PR split arc

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
