### PR TITLE
Skip firmware-job refresh for receiver-side remote builds

### DIFF
--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING
 
 from ...helpers.config_hash import compute_yaml_config_hash
 from ...helpers.event_bus import Event
+from ...helpers.remote_build_layout import (
+    parse_from_configuration as parse_remote_build_path,
+)
 from ...models import JobLifecycleData, JobStatus, JobType
 
 if TYPE_CHECKING:
@@ -40,6 +43,10 @@ def on_job_completed(controller: DevicesController, event: Event[JobLifecycleDat
         return
     configuration = job.configuration
     if not configuration:
+        return
+    if parse_remote_build_path(configuration) is not None:
+        # Receiver-side remote-build job; the YAML belongs to
+        # a paired offloader, not this dashboard.
         return
     if job_type == JobType.CLEAN:
         # ``esphome clean`` wipes the build tree; the

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -238,6 +238,21 @@ def test_reset_build_env_does_not_schedule_refresh() -> None:
     assert captured == []
 
 
+def test_receiver_side_remote_build_job_skips_refresh() -> None:
+    """Remote-build configurations skip the refresh and build-size hooks."""
+    controller, captured = _make_controller()
+    job = _job(
+        JobType.INSTALL,
+        JobStatus.COMPLETED,
+        configuration=".esphome/.remote_builds/abc/kitchen/kitchen.yaml",
+    )
+
+    controller._on_firmware_job_completed(Event(EventType.JOB_COMPLETED, {"job": job}))
+
+    assert captured == []
+    controller._build_size.request.assert_not_called()
+
+
 def test_unhandled_job_type_with_configuration_falls_through_silently() -> None:
     """Job types outside CLEAN/COMPILE/UPLOAD/INSTALL/RENAME bail at the type check.
 


### PR DESCRIPTION
# What does this implement/fix?

`DevicesController._on_firmware_job_completed` fires for every
successful COMPILE/INSTALL job on the bus, including jobs the
receiver dashboard runs on behalf of a paired offloader. Those
YAMLs live under `.esphome/.remote_builds/<dashboard_id>/<device>/`
and have no matching `Device` row on the receiver, so the refresh
ends up doing three no-op I/O hops:

* `_persist_expected_config_hash` calls `read_build_info_hash`,
  which routes through `resolve_storage_path(yaml_path.name)`
  with only the basename and so misses the per-dashboard
  remote-build storage subtree at
  `<data_dir>/.remote_builds/<id>/.esphome/storage/<name>.json`.
  Result: a spurious
  `WARNING ... Could not read config_hash from build_info.json
  for .esphome/.remote_builds/<id>/<device>/<device>.yaml`
  on every remote compile.
* `_scanner.reload(configuration)` returns `False` immediately;
  the scanner only tracks YAMLs at the top of `config_dir`.
* `_sync_deployed_hash_after_flash` finds no device matching the
  remote-build configuration.

Bail at the top of `on_job_completed` when
`parse_from_configuration` recognises the path as a remote-build
configuration. The offloader-side dashboard already owns the
post-build hash sync via the artifacts tarball shipped in #656,
so user-visible state stays correct; the receiver just stops
logging the warning and skips the wasted work.

**Related issue or feature (if applicable):**

- closes #849

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
