### PR TITLE
Extract MdnsSource: zeroconf browser + cache accessors

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
-from operator import attrgetter
 from typing import Any
 
 from esphome.zeroconf import (
@@ -26,23 +25,9 @@ from esphome.zeroconf import (
     DashboardImportDiscovery,
     DiscoveredImport,
 )
-from zeroconf import (
-    AddressResolver,
-    IPVersion,
-    ServiceStateChange,
-    current_time_millis,
-    millis_to_seconds,
-)
-from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
-from zeroconf.const import (
-    _CLASS_IN,
-    _TYPE_A,
-    _TYPE_AAAA,
-    _TYPE_SRV,
-    _TYPE_TXT,
-)
+from zeroconf import ServiceStateChange
+from zeroconf.asyncio import AsyncServiceInfo
 
-from ...helpers.hostname import normalize_hostname
 from ...helpers.subscriber_presence import SubscriberPresence
 from ...models import AdoptableDevice, Device, DeviceState, ReachabilitySource
 from .._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
@@ -50,23 +35,17 @@ from .._task_controller_base import TaskControllerBase
 from ._state import MonitorState
 from .helpers import (
     _ESPHOME_SERVICE_TYPE,
-    _decode_mdns_txt_records,
+    _HTTP_SERVICE_TYPE,
     _http_url_from_service_info,
     _normalize_mac,
     _pick_ipv4,
     device_name_from_service,
 )
+from .mdns import MdnsSource
 from .ping import PingSource
-from .shared import _MDNS_HOSTNAME_RESOLVE_TIMEOUT, _SOURCE_PRIORITY, apply_resolved_addresses
+from .shared import _SOURCE_PRIORITY
 
 _LOGGER = logging.getLogger(__name__)
-# A second mDNS browser watches for HTTP services so we can light up
-# a "Visit web UI" link on discovered devices that are running their
-# factory firmware's built-in web server. The browser only feeds the
-# importable-discovery flow; configured devices already get their
-# web_port from the YAML (``web_server:``).
-_HTTP_SERVICE_TYPE = "_http._tcp.local."
-_MDNS_RESOLVE_TIMEOUT_MS = 2000
 # Padding added to the cached A record's TTL when the drawer's
 # refresh loop schedules its next probe. We sleep ``ttl + this``
 # so by the time we wake up the cache record has aged past
@@ -209,11 +188,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # browser-callback keeps us in lockstep with whatever the
         # upstream considers an importable device.
         self._import_discovery: DashboardImportDiscovery | None = None
-        self._zeroconf: AsyncEsphomeZeroconf | None = None
-        # Single browser covers both ``_esphomelib._tcp.local.`` and
-        # ``_http._tcp.local.``; the dispatch handler routes events
-        # by ``service_type`` to the right per-type logic.
-        self._mdns_browser: AsyncServiceBrowser | None = None
         self._ping_task: asyncio.Task | None = None
         # ``self._tasks`` (fire-and-forget mDNS resolve refs) comes
         # from :class:`TaskControllerBase`; see :meth:`_track_task`.
@@ -228,11 +202,12 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # existing tests that build a monitor without a presence
         # gate keep working; ``None`` means "always run the loop".
         self._presence = presence
+        self._mdns = MdnsSource(self)
         self._ping = PingSource(self)
 
     async def start(self) -> None:
         """Start the mDNS browser and the periodic ping sweep."""
-        await self._start_mdns_browser()
+        await self._mdns.start()
         self._ping_task = asyncio.create_task(self._ping.run())
 
     async def stop(self) -> None:
@@ -244,12 +219,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # callbacks. If we drained ``self._tasks`` first, the browser
         # could still spawn new resolve tasks during the ``gather``
         # await and they'd miss the snapshot we took.
-        if self._mdns_browser is not None:
-            try:
-                await self._mdns_browser.async_cancel()
-            except Exception:
-                _LOGGER.debug("mDNS browser cancel failed", exc_info=True)
-            self._mdns_browser = None
+        await self._mdns.cancel_browser()
         # Now drain any in-flight resolve tasks. New tasks can no
         # longer appear, so a single snapshot is safe.
         for task in self._tasks:
@@ -257,12 +227,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         if self._tasks:
             await asyncio.gather(*self._tasks, return_exceptions=True)
             self._tasks.clear()
-        if self._zeroconf is not None:
-            try:
-                await self._zeroconf.async_close()
-            except Exception:
-                _LOGGER.debug("zeroconf close failed", exc_info=True)
-            self._zeroconf = None
+        await self._mdns.close_zeroconf()
 
     @property
     def zeroconf(self) -> AsyncEsphomeZeroconf | None:
@@ -275,7 +240,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         start (port held by avahi / ``mDNSResponder``); callers are
         expected to skip their advertise in that case.
         """
-        return self._zeroconf
+        return self._mdns.zeroconf
 
     def set_reachability(self, tracker: ReachabilityTracker) -> None:
         """Wire (or rewire) the per-signal freshness tracker.
@@ -356,157 +321,16 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         return True
 
     async def refresh_mdns(self, name: str) -> None:
-        """Re-query a device's mDNS A/AAAA records via the wire.
-
-        Caller (the drawer's reachability subscription) is
-        expected to schedule this *after* the cached A record's
-        TTL has elapsed — at that point ``async_resolve_host``'s
-        ``load_from_cache`` short-circuit fails (the record is
-        expired and skipped by ``_process_record_threadsafe``),
-        the call falls through to ``async_request``, and we
-        actually go on the wire.
-
-        ESPHome devices are mDNS-silent except in response to
-        probes, so this is the only mechanism that keeps an
-        A record alive once it ages out. The
-        ``ServiceBrowser``-managed PTR has a 4500s TTL and is
-        kept alive by the browser, but A's 120s TTL decays on
-        its own and the browser does not re-query A.
-
-        No-op when zeroconf failed to start.
-        """
-        if self._zeroconf is None:
-            return
-        try:
-            addresses = await self._zeroconf.async_resolve_host(
-                f"{name}.local", _MDNS_HOSTNAME_RESOLVE_TIMEOUT
-            )
-        except Exception:
-            _LOGGER.debug("mDNS refresh of %s failed", name, exc_info=True)
-            return
-        apply_resolved_addresses(self, name, addresses)
-
-    def _get_address_records(self, name: str) -> list[Any]:
-        """Return cached A and AAAA records for *name*, or ``[]``.
-
-        Used by both :meth:`get_mdns_a_record_ttl_remaining`
-        (which scopes to address records to drive the refresh
-        loop) and :meth:`get_mdns_cache_info` (which folds the
-        addresses into a union with SRV / TXT / PTR for the
-        drawer's "last seen" display).
-        """
-        if self._zeroconf is None:
-            return []
-        cache = self._zeroconf.zeroconf.cache
-        local_name = f"{name}.local."
-        return [
-            *cache.get_all_by_details(local_name, _TYPE_A, _CLASS_IN),
-            *cache.get_all_by_details(local_name, _TYPE_AAAA, _CLASS_IN),
-        ]
+        """Re-query a device's mDNS A/AAAA records via the wire."""
+        await self._mdns.refresh_mdns(name)
 
     def get_mdns_a_record_ttl_remaining(self, name: str) -> float | None:
-        """Return the minimum remaining TTL across cached A/AAAA records.
-
-        Distinct from :meth:`get_mdns_cache_info` because the
-        drawer's refresh loop needs the A-record-specific
-        expiry to schedule its next wire query — not the
-        union-of-types "last seen" age the snapshot uses for
-        display. PTR has a 4500s TTL and stays cached for
-        ages, so a sleep based on the PTR's remaining TTL
-        would never trigger the A-record refresh that's the
-        whole point of the loop.
-
-        Returns the smallest remaining TTL across whatever
-        A/AAAA records are cached (covers the case where one
-        family expires before the other), or ``None`` if no
-        A/AAAA is cached.
-        """
-        records = self._get_address_records(name)
-        if not records:
-            return None
-        now_ms = current_time_millis()
-        return max(0.0, min(float(r.get_remaining_ttl(now_ms)) for r in records))
+        """Return the minimum remaining TTL across cached A/AAAA records."""
+        return self._mdns.get_mdns_a_record_ttl_remaining(name)
 
     def get_mdns_cache_info(self, name: str) -> MdnsCacheInfo | None:
-        """
-        Read the truthful "last heard via mDNS" age + remaining TTL.
-
-        Returns the most-recent ``DNSRecord.created`` across
-        every cached record we have for the device, paired with
-        the matching record's
-        :meth:`zeroconf.DNSRecord.get_remaining_ttl`. The records
-        we look at:
-
-        * ``A`` / ``AAAA`` at ``<name>.local.`` — the IP-address
-          announces (120s TTL by default).
-        * ``SRV`` / ``TXT`` at ``<name>._esphomelib._tcp.local.``
-          — the API service-instance records (only present for
-          devices running the native API).
-        * ``PTR`` at ``_esphomelib._tcp.local.`` filtered to
-          alias matches — the long-TTL pointer record
-          (~4500s) the ``ServiceBrowser`` keeps alive.
-
-        Walking multiple record types matters because each one
-        has its own TTL: A/AAAA decay at 120s, but the PTR
-        kept alive by the browser stays fresh for tens of
-        minutes. After A expires, an SRV refresh from a probe
-        — or even just the still-live PTR — still tells us
-        "we heard mDNS for this device N seconds ago"
-        truthfully, which is what the drawer's "Last seen"
-        line is asking. Only when *every* record we know about
-        has been evicted from the cache do we return ``None``
-        (and the drawer hides the mDNS row).
-
-        Returns ``None`` when zeroconf isn't running, or when
-        the cache has nothing under any of the record types we
-        check.
-        """
-        if self._zeroconf is None:
-            return None
-        cache = self._zeroconf.zeroconf.cache
-        service_name = f"{name}.{_ESPHOME_SERVICE_TYPE}"
-        txt_dns_records = list(cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN))
-        records: list[Any] = [
-            *self._get_address_records(name),
-            *cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN),
-            *txt_dns_records,
-        ]
-        # PTR is owned by the type-domain (``_esphomelib._tcp.local.``)
-        # and carries the service-instance as its ``alias`` —
-        # zeroconf already exposes ``current_entry_with_name_and_alias``
-        # for exactly this lookup so we don't have to walk every
-        # PTR and filter ourselves. Helper filters expired
-        # internally, which is fine for the 4500s-TTL PTR (won't
-        # expire in any realistic drawer-open window).
-        ptr = cache.current_entry_with_name_and_alias(_ESPHOME_SERVICE_TYPE, service_name)
-        if ptr is not None:
-            records.append(ptr)
-        if not records:
-            return None
-        # Don't filter expired records — the drawer wants the
-        # truthful "last seen" age even when the cached record
-        # has aged past its TTL. With multiple record types
-        # contributing, the PTR (~4500s TTL) typically
-        # outlives A/AAAA (120s) so the row stays populated
-        # via the PTR's ``created`` even during the brief
-        # expiry-to-refresh window for the address records.
-        # The row only hides once *every* cached record has
-        # been evicted, which the empty-check above handles.
-        now_ms = current_time_millis()
-        latest = max(records, key=attrgetter("created"))
-        # ``DNSAddress.created`` is millis; ``now_ms - created`` is
-        # millis, hence ``millis_to_seconds`` here.
-        age_s = max(0.0, millis_to_seconds(now_ms - latest.created))
-        # ``get_remaining_ttl`` already returns seconds (the
-        # impl divides by 1000.0 internally). Don't convert again
-        # — that would turn "108 seconds remaining" into 0.108
-        # and render as "TTL: 0s".
-        ttl_remaining_s = max(0.0, float(latest.get_remaining_ttl(now_ms)))
-        return MdnsCacheInfo(
-            age_seconds=age_s,
-            ttl_remaining_seconds=ttl_remaining_s,
-            txt_records=_decode_mdns_txt_records(txt_dns_records),
-        )
+        """Read the truthful "last heard via mDNS" age + remaining TTL."""
+        return self._mdns.get_mdns_cache_info(name)
 
     def apply_ip(self, name: str, ip: str) -> bool:
         """
@@ -680,29 +504,8 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         return any(getattr(device, attr) != value for device in self._get_devices_by_name(name))
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
-        """
-        Return all zeroconf-cached IPs for *host_name* without issuing a query.
-
-        Both IPv4 and IPv6 (scoped) entries are included — the OTA
-        address-cache CLI args need every IP we know so the runtime
-        can try them in turn. Callers that want a single best target
-        for, say, ICMP should pick IPv4 first themselves.
-
-        Returns ``None`` when zeroconf isn't running, the cache misses,
-        or the entry has expired. mDNS-only — see
-        :meth:`get_cached_dns_addresses` for non-``.local`` hostnames.
-        """
-        if self._zeroconf is None:
-            return None
-
-        normalized = normalize_hostname(host_name)
-        base_name = normalized.partition(".")[0]
-        resolver_name = f"{base_name}.local."
-        info = AddressResolver(resolver_name)
-        if not info.load_from_cache(self._zeroconf.zeroconf):
-            return None
-        addresses = info.parsed_scoped_addresses(IPVersion.All)
-        return addresses or None
+        """Return all zeroconf-cached IPs for *host_name* without issuing a query."""
+        return self._mdns.get_cached_addresses(host_name)
 
     def probe_device(self, device_name: str, service_name: str | None = None) -> None:
         """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
@@ -728,16 +531,16 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         info while the apply still keys to the configured device's
         name.
         """
-        if self._zeroconf is None:
+        if (zc := self._mdns.zeroconf) is None:
             return
-        zeroconf = self._zeroconf.zeroconf
+        zeroconf = zc.zeroconf
         broadcast = service_name or device_name
         full_service = f"{broadcast}.{_ESPHOME_SERVICE_TYPE}"
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, full_service)
         if info.load_from_cache(zeroconf):
-            self._apply_service_info(device_name, info)
+            self._mdns._apply_service_info(device_name, info)
             return
-        self._track_task(self._resolve_and_apply(zeroconf, info, device_name))
+        self._track_task(self._mdns._resolve_and_apply(zeroconf, info, device_name))
 
     def revisit_importable(self, device_name: str) -> None:
         """
@@ -816,121 +619,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         bucket = self._get_devices_by_name(name)
         return bucket[0] if bucket else None
 
-    async def _start_mdns_browser(self) -> None:
-        try:
-            self._zeroconf = AsyncEsphomeZeroconf()
-        except Exception:
-            _LOGGER.exception("Could not start zeroconf — falling back to ping only")
-            self._zeroconf = None
-            return
-
-        def _on_esphomelib_service_state_change(
-            zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
-        ) -> None:
-            # ``AsyncServiceBrowser`` dispatches handlers on the asyncio
-            # loop, so call apply methods directly. For Added/Updated,
-            # try the zeroconf cache first (sync) — only fall back to a
-            # network query (async task) when the cache misses.
-            device_name = device_name_from_service(name)
-            _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
-
-            # Short-circuit unconfigured devices so we don't spawn
-            # ServiceInfo lookups / resolve tasks for unrelated ESPHome
-            # nodes on the LAN.
-            if self._find_device_by_name(device_name) is None:
-                return
-
-            if state_change == ServiceStateChange.Removed:
-                self.apply(device_name, DeviceState.OFFLINE, "mdns")
-                self.apply_ip(device_name, "")
-                self.state.state_source.pop(device_name, None)
-                if self.state.reachability is not None:
-                    self.state.reachability.clear(device_name)
-                return
-
-            # ``claim=True`` so mDNS takes ownership even when the
-            # device is already ONLINE via a lower-priority source
-            # (ping / MQTT), preventing later ping observations from
-            # clobbering the now-authoritative mDNS view.
-            self.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
-
-            info = AsyncServiceInfo(service_type, name)
-            if info.load_from_cache(zeroconf):
-                self._apply_service_info(device_name, info)
-                return
-
-            self._track_task(self._resolve_and_apply(zeroconf, info, device_name))
-
-        # ``DashboardImportDiscovery`` from upstream esphome owns the
-        # TXT-record parsing for adoptable factory firmwares — its
-        # ``browser_callback`` only acts on services that carry the
-        # ``package_import_url`` TXT records, so harmlessly receiving
-        # HTTP events is fine.
-        import_discovery = DashboardImportDiscovery(self._on_import_update)
-        self._import_discovery = import_discovery
-
-        def _dispatch(
-            zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
-        ) -> None:
-            # Single ``AsyncServiceBrowser`` covers both service types;
-            # dispatch by ``service_type`` so each inner handler only
-            # sees the events it cares about. Sharing one browser
-            # halves the zeroconf bookkeeping vs running two separate
-            # browsers and lets the upstream ``DashboardImportDiscovery``
-            # callback piggy-back on the same dispatch path.
-            #
-            # Closes over the local ``import_discovery`` rather than
-            # ``self._import_discovery`` so mypy sees a non-None value
-            # (the attribute is typed ``... | None`` for the
-            # pre-``start()`` window). Same instance either way.
-            if service_type == _ESPHOME_SERVICE_TYPE:
-                _on_esphomelib_service_state_change(zeroconf, service_type, name, state_change)
-                import_discovery.browser_callback(zeroconf, service_type, name, state_change)
-            elif service_type == _HTTP_SERVICE_TYPE:
-                self._on_http_service_state_change(zeroconf, service_type, name, state_change)
-
-        try:
-            self._mdns_browser = AsyncServiceBrowser(
-                self._zeroconf.zeroconf,
-                [_ESPHOME_SERVICE_TYPE, _HTTP_SERVICE_TYPE],
-                handlers=[_dispatch],
-            )
-            _LOGGER.info(
-                "mDNS browser started for %s, %s",
-                _ESPHOME_SERVICE_TYPE,
-                _HTTP_SERVICE_TYPE,
-            )
-        except Exception:
-            _LOGGER.exception("Could not start mDNS browser — device discovery limited to ping")
-
-    async def _resolve_and_apply(
-        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
-    ) -> None:
-        """Resolve a cache-miss esphomelib mDNS service and propagate its details."""
-        await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
-
-    async def _resolve_then(
-        self,
-        zeroconf: Any,
-        info: AsyncServiceInfo,
-        device_name: str,
-        apply: Callable[[str, AsyncServiceInfo], None],
-    ) -> None:
-        """Resolve a cache-miss service and hand the result to *apply*.
-
-        The esphomelib and HTTP browsers share the same fire-and-forget
-        shape: spawn a task on cache miss, ``async_request`` the
-        record, swallow exceptions to a debug log, then dispatch to
-        the per-type applier when resolution succeeds.
-        """
-        try:
-            if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
-                return
-        except Exception:
-            _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
-            return
-        apply(device_name, info)
-
     def _on_http_service_state_change(
         self,
         zeroconf: Any,
@@ -964,7 +652,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
     ) -> None:
         """Resolve a cache-miss HTTP service and store its URL."""
-        await self._resolve_then(zeroconf, info, device_name, self._apply_http_service_info)
+        await self._mdns._resolve_then(zeroconf, info, device_name, self._apply_http_service_info)
 
     def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """Build the Visit-web-UI URL from a populated HTTP service info.
@@ -1011,10 +699,10 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         the about-to-fire ``on_importable_added`` carries the right
         ``web_url``.
         """
-        if self._zeroconf is None or self.state.http_urls.get(device_name):
+        if (zc := self._mdns.zeroconf) is None or self.state.http_urls.get(device_name):
             return
         info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
-        if not info.load_from_cache(self._zeroconf.zeroconf):
+        if not info.load_from_cache(zc.zeroconf):
             return
         self.state.http_urls[device_name] = _http_url_from_service_info(device_name, info)
 
@@ -1065,79 +753,3 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             ignored=self._is_ignored(discovered.device_name),
             web_url=self.state.http_urls.get(discovered.device_name, ""),
         )
-
-    def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
-        """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``.
-
-        A successful apply is itself proof the device is reachable —
-        we have its broadcast TXT records and address from zeroconf —
-        so claim ONLINE under the mDNS source. The browser callback
-        already calls ``apply(...ONLINE..., claim=True)`` itself, so
-        for that path this is a no-op dedupe; the eager
-        ``probe_device`` path needs it because it skips the
-        browser-callback prelude.
-        """
-        # ``claim=True`` so mDNS owns the slot even when ping/MQTT
-        # had already labelled the device — same shape the browser
-        # callback uses on its way into this method.
-        self.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
-        # Pull every announced address (IPv4 first, then scoped IPv6
-        # — link-local entries keep the ``%scope`` suffix that's
-        # required to connect at all). ``apply_ip_addresses`` picks
-        # the IPv4 primary for ``device.ip`` and forwards the whole
-        # list so ``device.ip_addresses`` reflects what's actually
-        # broadcast — a multi-homed dual-stack device used to surface
-        # only its V4 here.
-        if addresses := info.parsed_scoped_addresses(IPVersion.All):
-            self.apply_ip_addresses(device_name, addresses)
-        # ``decoded_properties`` is a ``dict[str, str | None]`` — zeroconf
-        # already handles the UTF-8 decode and None-on-bad-bytes for us.
-        props = info.decoded_properties
-        if version := props.get("version"):
-            self.apply_version(device_name, version)
-        if config_hash := props.get("config_hash"):
-            self.apply_config_hash(device_name, config_hash)
-        if mac := props.get("mac"):
-            self.apply_mac_address(device_name, mac)
-        # api_encryption tri-state semantics on this announce:
-        #
-        # * Key present with truthy value (``Noise_...``):
-        #   encryption confirmed live → apply with that string.
-        #
-        # * Key present with bare-key / ``api_encryption=`` empty
-        #   value (zeroconf collapses both to ``None`` in
-        #   ``decoded_properties``): device explicitly broadcast
-        #   "no key" → apply with ``""``. The pre-fix code used
-        #   ``props.get("api_encryption") is not None`` which
-        #   dropped this case onto the floor; with the explicit
-        #   ``in props`` check it now flows through.
-        #
-        # * Key absent AND the announce carried other content
-        #   (``version`` / ``mac`` / ``config_hash`` / ...): the
-        #   firmware was rebuilt without encryption and is
-        #   re-announcing its real new state. Apply with ``""``
-        #   so the dashboard's encryption indicator follows the
-        #   wire instead of staying frozen on a stale truthy
-        #   value. ESPHome's TXT broadcasts are atomic per
-        #   announce — there's no fragmentation shape that would
-        #   carry ``version`` but drop ``api_encryption`` — so a
-        #   TXT with content but no encryption key IS
-        #   authoritative for "encryption was removed."
-        #
-        # * Key absent AND props is empty (no other keys either):
-        #   preserve. This is the cache-eviction /
-        #   truly-empty-fragment shape the original guard was
-        #   written for; a non-content announce shouldn't
-        #   overwrite a previously-truthy state and prompt an
-        #   unnecessary reinstall.
-        #
-        # Older firmwares that never broadcast the TXT keep the
-        # ``None`` initial value — the frontend's
-        # ``getEncryptionState`` falls back to the YAML's
-        # ``api_encrypted`` flag in that case, which is the right
-        # behaviour.
-        if "api_encryption" in props:
-            value = props["api_encryption"]
-            self.apply_api_encryption(device_name, value if isinstance(value, str) else "")
-        elif props:
-            self.apply_api_encryption(device_name, "")

--- a/esphome_device_builder/controllers/_device_state_monitor/helpers.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/helpers.py
@@ -16,6 +16,13 @@ from ...helpers.hostname import is_local_hostname
 
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
 
+# A second mDNS browser watches for HTTP services so we can light up
+# a "Visit web UI" link on discovered devices that are running their
+# factory firmware's built-in web server. The browser only feeds the
+# importable-discovery flow; configured devices already get their
+# web_port from the YAML (``web_server:``).
+_HTTP_SERVICE_TYPE = "_http._tcp.local."
+
 
 # Allowed separators between the six octets of a MAC.
 # ESPHome firmware today broadcasts the compact 12-hex-char form

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -1,18 +1,12 @@
 """
-mDNS source for the device-state monitor.
+mDNS source: zeroconf responder, browser, and cache accessors.
 
-Mirrors the legacy ``esphome/dashboard/status/mdns.py`` shape: an
-:class:`MdnsSource` taking the monitor in ``__init__``, owning the
-zeroconf responder, the ``AsyncServiceBrowser``, the esphomelib
-service-state callback, and the cache accessors the drawer's
-reachability subscription uses.
-
-The HTTP-service / importable-discovery browser callbacks still
-live on the monitor for now — they reach back through
-``self._monitor._on_http_service_state_change`` / ``_on_import_update``
-from the browser's dispatch closure. PR 5 lifts those into a
-dedicated ``ImportableDiscovery`` and registers them with this
-source so the dispatch loses its monitor coupling.
+:class:`MdnsSource` owns the ``AsyncEsphomeZeroconf`` responder and
+the ``AsyncServiceBrowser`` it drives, the esphomelib service-state
+callback that reaches into the monitor's apply path, and the
+cache-inspection accessors the drawer's reachability snapshot reads.
+The HTTP-service / importable-discovery callbacks reach back through
+the monitor from the browser's dispatch closure.
 """
 
 from __future__ import annotations
@@ -53,16 +47,7 @@ _MDNS_RESOLVE_TIMEOUT_MS = 2000
 
 
 class MdnsSource:
-    """
-    mDNS source owning the zeroconf responder, browser, and cache accessors.
-
-    Takes the monitor in ``__init__`` and reads / writes through it
-    (``monitor.apply(...)``, ``monitor._find_device_by_name``, etc.).
-    The shared cross-cutting bits — ``apply_resolved_addresses``
-    funnel, the active-resolve path used by both the browser
-    callback and the ping pre-sweep — live in
-    :mod:`._device_state_monitor.shared`.
-    """
+    """mDNS source owning the zeroconf responder, browser, and cache accessors."""
 
     def __init__(self, monitor: DeviceStateMonitor) -> None:
         self._monitor = monitor

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -1,0 +1,476 @@
+"""
+mDNS source for the device-state monitor.
+
+Mirrors the legacy ``esphome/dashboard/status/mdns.py`` shape: an
+:class:`MdnsSource` taking the monitor in ``__init__``, owning the
+zeroconf responder, the ``AsyncServiceBrowser``, the esphomelib
+service-state callback, and the cache accessors the drawer's
+reachability subscription uses.
+
+The HTTP-service / importable-discovery browser callbacks still
+live on the monitor for now — they reach back through
+``self._monitor._on_http_service_state_change`` / ``_on_import_update``
+from the browser's dispatch closure. PR 5 lifts those into a
+dedicated ``ImportableDiscovery`` and registers them with this
+source so the dispatch loses its monitor coupling.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from operator import attrgetter
+from typing import TYPE_CHECKING, Any
+
+from esphome.zeroconf import AsyncEsphomeZeroconf, DashboardImportDiscovery
+from zeroconf import (
+    AddressResolver,
+    IPVersion,
+    ServiceStateChange,
+    current_time_millis,
+    millis_to_seconds,
+)
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
+from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_SRV, _TYPE_TXT
+
+from ...helpers.hostname import normalize_hostname
+from ...models import DeviceState
+from .._reachability_tracker import MdnsCacheInfo
+from .helpers import (
+    _ESPHOME_SERVICE_TYPE,
+    _HTTP_SERVICE_TYPE,
+    _decode_mdns_txt_records,
+    device_name_from_service,
+)
+from .shared import _MDNS_HOSTNAME_RESOLVE_TIMEOUT, apply_resolved_addresses
+
+if TYPE_CHECKING:
+    from .controller import DeviceStateMonitor
+
+_LOGGER = logging.getLogger(__name__)
+
+_MDNS_RESOLVE_TIMEOUT_MS = 2000
+
+
+class MdnsSource:
+    """
+    mDNS source owning the zeroconf responder, browser, and cache accessors.
+
+    Takes the monitor in ``__init__`` and reads / writes through it
+    (``monitor.apply(...)``, ``monitor._find_device_by_name``, etc.).
+    The shared cross-cutting bits — ``apply_resolved_addresses``
+    funnel, the active-resolve path used by both the browser
+    callback and the ping pre-sweep — live in
+    :mod:`._device_state_monitor.shared`.
+    """
+
+    def __init__(self, monitor: DeviceStateMonitor) -> None:
+        self._monitor = monitor
+        self._zeroconf: AsyncEsphomeZeroconf | None = None
+        # Single browser covers both ``_esphomelib._tcp.local.`` and
+        # ``_http._tcp.local.``; the dispatch handler routes events
+        # by ``service_type`` to the right per-type logic.
+        self._mdns_browser: AsyncServiceBrowser | None = None
+
+    @property
+    def zeroconf(self) -> AsyncEsphomeZeroconf | None:
+        """The mDNS responder, or ``None`` when zeroconf failed to start."""
+        return self._zeroconf
+
+    async def start(self) -> None:
+        try:
+            self._zeroconf = AsyncEsphomeZeroconf()
+        except Exception:
+            _LOGGER.exception("Could not start zeroconf — falling back to ping only")
+            self._zeroconf = None
+            return
+
+        monitor = self._monitor
+
+        # ``DashboardImportDiscovery`` from upstream esphome owns the
+        # TXT-record parsing for adoptable factory firmwares — its
+        # ``browser_callback`` only acts on services that carry the
+        # ``package_import_url`` TXT records, so harmlessly receiving
+        # HTTP events is fine.
+        import_discovery = DashboardImportDiscovery(monitor._on_import_update)
+        monitor._import_discovery = import_discovery
+
+        def _dispatch(
+            zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
+        ) -> None:
+            # Single ``AsyncServiceBrowser`` covers both service types;
+            # dispatch by ``service_type`` so each inner handler only
+            # sees the events it cares about. Sharing one browser
+            # halves the zeroconf bookkeeping vs running two separate
+            # browsers and lets the upstream ``DashboardImportDiscovery``
+            # callback piggy-back on the same dispatch path.
+            #
+            # Closes over the local ``import_discovery`` rather than
+            # ``monitor._import_discovery`` so mypy sees a non-None
+            # value (the attribute is typed ``... | None`` for the
+            # pre-``start()`` window). Same instance either way.
+            if service_type == _ESPHOME_SERVICE_TYPE:
+                self._on_esphomelib_service_state_change(zeroconf, service_type, name, state_change)
+                import_discovery.browser_callback(zeroconf, service_type, name, state_change)
+            elif service_type == _HTTP_SERVICE_TYPE:
+                monitor._on_http_service_state_change(zeroconf, service_type, name, state_change)
+
+        try:
+            self._mdns_browser = AsyncServiceBrowser(
+                self._zeroconf.zeroconf,
+                [_ESPHOME_SERVICE_TYPE, _HTTP_SERVICE_TYPE],
+                handlers=[_dispatch],
+            )
+            _LOGGER.info(
+                "mDNS browser started for %s, %s",
+                _ESPHOME_SERVICE_TYPE,
+                _HTTP_SERVICE_TYPE,
+            )
+        except Exception:
+            _LOGGER.exception("Could not start mDNS browser — device discovery limited to ping")
+
+    async def cancel_browser(self) -> None:
+        """Cancel the ``AsyncServiceBrowser`` so it stops dispatching new mDNS callbacks.
+
+        Called first during shutdown, BEFORE the monitor drains its
+        in-flight resolve tasks — otherwise the browser could spawn
+        new resolve tasks during the drain and they'd miss the
+        snapshot we took.
+        """
+        if self._mdns_browser is not None:
+            try:
+                await self._mdns_browser.async_cancel()
+            except Exception:
+                _LOGGER.debug("mDNS browser cancel failed", exc_info=True)
+            self._mdns_browser = None
+
+    async def close_zeroconf(self) -> None:
+        """Close the zeroconf responder. Called after the resolve-task drain."""
+        if self._zeroconf is not None:
+            try:
+                await self._zeroconf.async_close()
+            except Exception:
+                _LOGGER.debug("zeroconf close failed", exc_info=True)
+            self._zeroconf = None
+
+    def _on_esphomelib_service_state_change(
+        self, zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
+    ) -> None:
+        # ``AsyncServiceBrowser`` dispatches handlers on the asyncio
+        # loop, so call apply methods directly. For Added/Updated,
+        # try the zeroconf cache first (sync) — only fall back to a
+        # network query (async task) when the cache misses.
+        monitor = self._monitor
+        device_name = device_name_from_service(name)
+        _LOGGER.debug("mDNS: %s %s (raw: %s)", state_change, device_name, name)
+
+        # Short-circuit unconfigured devices so we don't spawn
+        # ServiceInfo lookups / resolve tasks for unrelated ESPHome
+        # nodes on the LAN.
+        if monitor._find_device_by_name(device_name) is None:
+            return
+
+        if state_change == ServiceStateChange.Removed:
+            monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
+            monitor.apply_ip(device_name, "")
+            monitor.state.state_source.pop(device_name, None)
+            if monitor.state.reachability is not None:
+                monitor.state.reachability.clear(device_name)
+            return
+
+        # ``claim=True`` so mDNS takes ownership even when the
+        # device is already ONLINE via a lower-priority source
+        # (ping / MQTT), preventing later ping observations from
+        # clobbering the now-authoritative mDNS view.
+        monitor.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
+
+        info = AsyncServiceInfo(service_type, name)
+        if info.load_from_cache(zeroconf):
+            self._apply_service_info(device_name, info)
+            return
+
+        monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name))
+
+    async def _resolve_and_apply(
+        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
+    ) -> None:
+        """Resolve a cache-miss esphomelib mDNS service and propagate its details."""
+        await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
+
+    async def _resolve_then(
+        self,
+        zeroconf: Any,
+        info: AsyncServiceInfo,
+        device_name: str,
+        apply: Callable[[str, AsyncServiceInfo], None],
+    ) -> None:
+        """Resolve a cache-miss service and hand the result to *apply*.
+
+        The esphomelib and HTTP browsers share the same fire-and-forget
+        shape: spawn a task on cache miss, ``async_request`` the
+        record, swallow exceptions to a debug log, then dispatch to
+        the per-type applier when resolution succeeds.
+        """
+        try:
+            if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
+                return
+        except Exception:
+            _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
+            return
+        apply(device_name, info)
+
+    def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
+        """Pull IP / version / config_hash off a populated ``AsyncServiceInfo``.
+
+        A successful apply is itself proof the device is reachable —
+        we have its broadcast TXT records and address from zeroconf —
+        so claim ONLINE under the mDNS source. The browser callback
+        already calls ``apply(...ONLINE..., claim=True)`` itself, so
+        for that path this is a no-op dedupe; the eager
+        ``probe_device`` path needs it because it skips the
+        browser-callback prelude.
+        """
+        monitor = self._monitor
+        # ``claim=True`` so mDNS owns the slot even when ping/MQTT
+        # had already labelled the device — same shape the browser
+        # callback uses on its way into this method.
+        monitor.apply(device_name, DeviceState.ONLINE, "mdns", claim=True)
+        # Pull every announced address (IPv4 first, then scoped IPv6
+        # — link-local entries keep the ``%scope`` suffix that's
+        # required to connect at all). ``apply_ip_addresses`` picks
+        # the IPv4 primary for ``device.ip`` and forwards the whole
+        # list so ``device.ip_addresses`` reflects what's actually
+        # broadcast — a multi-homed dual-stack device used to surface
+        # only its V4 here.
+        if addresses := info.parsed_scoped_addresses(IPVersion.All):
+            monitor.apply_ip_addresses(device_name, addresses)
+        # ``decoded_properties`` is a ``dict[str, str | None]`` — zeroconf
+        # already handles the UTF-8 decode and None-on-bad-bytes for us.
+        props = info.decoded_properties
+        if version := props.get("version"):
+            monitor.apply_version(device_name, version)
+        if config_hash := props.get("config_hash"):
+            monitor.apply_config_hash(device_name, config_hash)
+        if mac := props.get("mac"):
+            monitor.apply_mac_address(device_name, mac)
+        # api_encryption tri-state semantics on this announce:
+        #
+        # * Key present with truthy value (``Noise_...``):
+        #   encryption confirmed live → apply with that string.
+        #
+        # * Key present with bare-key / ``api_encryption=`` empty
+        #   value (zeroconf collapses both to ``None`` in
+        #   ``decoded_properties``): device explicitly broadcast
+        #   "no key" → apply with ``""``. The pre-fix code used
+        #   ``props.get("api_encryption") is not None`` which
+        #   dropped this case onto the floor; with the explicit
+        #   ``in props`` check it now flows through.
+        #
+        # * Key absent AND the announce carried other content
+        #   (``version`` / ``mac`` / ``config_hash`` / ...): the
+        #   firmware was rebuilt without encryption and is
+        #   re-announcing its real new state. Apply with ``""``
+        #   so the dashboard's encryption indicator follows the
+        #   wire instead of staying frozen on a stale truthy
+        #   value. ESPHome's TXT broadcasts are atomic per
+        #   announce — there's no fragmentation shape that would
+        #   carry ``version`` but drop ``api_encryption`` — so a
+        #   TXT with content but no encryption key IS
+        #   authoritative for "encryption was removed."
+        #
+        # * Key absent AND props is empty (no other keys either):
+        #   preserve. This is the cache-eviction /
+        #   truly-empty-fragment shape the original guard was
+        #   written for; a non-content announce shouldn't
+        #   overwrite a previously-truthy state and prompt an
+        #   unnecessary reinstall.
+        #
+        # Older firmwares that never broadcast the TXT keep the
+        # ``None`` initial value — the frontend's
+        # ``getEncryptionState`` falls back to the YAML's
+        # ``api_encrypted`` flag in that case, which is the right
+        # behaviour.
+        if "api_encryption" in props:
+            value = props["api_encryption"]
+            monitor.apply_api_encryption(device_name, value if isinstance(value, str) else "")
+        elif props:
+            monitor.apply_api_encryption(device_name, "")
+
+    async def refresh_mdns(self, name: str) -> None:
+        """Re-query a device's mDNS A/AAAA records via the wire.
+
+        Caller (the drawer's reachability subscription) is
+        expected to schedule this *after* the cached A record's
+        TTL has elapsed — at that point ``async_resolve_host``'s
+        ``load_from_cache`` short-circuit fails (the record is
+        expired and skipped by ``_process_record_threadsafe``),
+        the call falls through to ``async_request``, and we
+        actually go on the wire.
+
+        ESPHome devices are mDNS-silent except in response to
+        probes, so this is the only mechanism that keeps an
+        A record alive once it ages out. The
+        ``ServiceBrowser``-managed PTR has a 4500s TTL and is
+        kept alive by the browser, but A's 120s TTL decays on
+        its own and the browser does not re-query A.
+
+        No-op when zeroconf failed to start.
+        """
+        if self._zeroconf is None:
+            return
+        try:
+            addresses = await self._zeroconf.async_resolve_host(
+                f"{name}.local", _MDNS_HOSTNAME_RESOLVE_TIMEOUT
+            )
+        except Exception:
+            _LOGGER.debug("mDNS refresh of %s failed", name, exc_info=True)
+            return
+        apply_resolved_addresses(self._monitor, name, addresses)
+
+    def _get_address_records(self, name: str) -> list[Any]:
+        """Return cached A and AAAA records for *name*, or ``[]``.
+
+        Used by both :meth:`get_mdns_a_record_ttl_remaining`
+        (which scopes to address records to drive the refresh
+        loop) and :meth:`get_mdns_cache_info` (which folds the
+        addresses into a union with SRV / TXT / PTR for the
+        drawer's "last seen" display).
+        """
+        if self._zeroconf is None:
+            return []
+        cache = self._zeroconf.zeroconf.cache
+        local_name = f"{name}.local."
+        return [
+            *cache.get_all_by_details(local_name, _TYPE_A, _CLASS_IN),
+            *cache.get_all_by_details(local_name, _TYPE_AAAA, _CLASS_IN),
+        ]
+
+    def get_mdns_a_record_ttl_remaining(self, name: str) -> float | None:
+        """Return the minimum remaining TTL across cached A/AAAA records.
+
+        Distinct from :meth:`get_mdns_cache_info` because the
+        drawer's refresh loop needs the A-record-specific
+        expiry to schedule its next wire query — not the
+        union-of-types "last seen" age the snapshot uses for
+        display. PTR has a 4500s TTL and stays cached for
+        ages, so a sleep based on the PTR's remaining TTL
+        would never trigger the A-record refresh that's the
+        whole point of the loop.
+
+        Returns the smallest remaining TTL across whatever
+        A/AAAA records are cached (covers the case where one
+        family expires before the other), or ``None`` if no
+        A/AAAA is cached.
+        """
+        records = self._get_address_records(name)
+        if not records:
+            return None
+        now_ms = current_time_millis()
+        return max(0.0, min(float(r.get_remaining_ttl(now_ms)) for r in records))
+
+    def get_mdns_cache_info(self, name: str) -> MdnsCacheInfo | None:
+        """
+        Read the truthful "last heard via mDNS" age + remaining TTL.
+
+        Returns the most-recent ``DNSRecord.created`` across
+        every cached record we have for the device, paired with
+        the matching record's
+        :meth:`zeroconf.DNSRecord.get_remaining_ttl`. The records
+        we look at:
+
+        * ``A`` / ``AAAA`` at ``<name>.local.`` — the IP-address
+          announces (120s TTL by default).
+        * ``SRV`` / ``TXT`` at ``<name>._esphomelib._tcp.local.``
+          — the API service-instance records (only present for
+          devices running the native API).
+        * ``PTR`` at ``_esphomelib._tcp.local.`` filtered to
+          alias matches — the long-TTL pointer record
+          (~4500s) the ``ServiceBrowser`` keeps alive.
+
+        Walking multiple record types matters because each one
+        has its own TTL: A/AAAA decay at 120s, but the PTR
+        kept alive by the browser stays fresh for tens of
+        minutes. After A expires, an SRV refresh from a probe
+        — or even just the still-live PTR — still tells us
+        "we heard mDNS for this device N seconds ago"
+        truthfully, which is what the drawer's "Last seen"
+        line is asking. Only when *every* record we know about
+        has been evicted from the cache do we return ``None``
+        (and the drawer hides the mDNS row).
+
+        Returns ``None`` when zeroconf isn't running, or when
+        the cache has nothing under any of the record types we
+        check.
+        """
+        if self._zeroconf is None:
+            return None
+        cache = self._zeroconf.zeroconf.cache
+        service_name = f"{name}.{_ESPHOME_SERVICE_TYPE}"
+        txt_dns_records = list(cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN))
+        records: list[Any] = [
+            *self._get_address_records(name),
+            *cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN),
+            *txt_dns_records,
+        ]
+        # PTR is owned by the type-domain (``_esphomelib._tcp.local.``)
+        # and carries the service-instance as its ``alias`` —
+        # zeroconf already exposes ``current_entry_with_name_and_alias``
+        # for exactly this lookup so we don't have to walk every
+        # PTR and filter ourselves. Helper filters expired
+        # internally, which is fine for the 4500s-TTL PTR (won't
+        # expire in any realistic drawer-open window).
+        ptr = cache.current_entry_with_name_and_alias(_ESPHOME_SERVICE_TYPE, service_name)
+        if ptr is not None:
+            records.append(ptr)
+        if not records:
+            return None
+        # Don't filter expired records — the drawer wants the
+        # truthful "last seen" age even when the cached record
+        # has aged past its TTL. With multiple record types
+        # contributing, the PTR (~4500s TTL) typically
+        # outlives A/AAAA (120s) so the row stays populated
+        # via the PTR's ``created`` even during the brief
+        # expiry-to-refresh window for the address records.
+        # The row only hides once *every* cached record has
+        # been evicted, which the empty-check above handles.
+        now_ms = current_time_millis()
+        latest = max(records, key=attrgetter("created"))
+        # ``DNSAddress.created`` is millis; ``now_ms - created`` is
+        # millis, hence ``millis_to_seconds`` here.
+        age_s = max(0.0, millis_to_seconds(now_ms - latest.created))
+        # ``get_remaining_ttl`` already returns seconds (the
+        # impl divides by 1000.0 internally). Don't convert again
+        # — that would turn "108 seconds remaining" into 0.108
+        # and render as "TTL: 0s".
+        ttl_remaining_s = max(0.0, float(latest.get_remaining_ttl(now_ms)))
+        return MdnsCacheInfo(
+            age_seconds=age_s,
+            ttl_remaining_seconds=ttl_remaining_s,
+            txt_records=_decode_mdns_txt_records(txt_dns_records),
+        )
+
+    def get_cached_addresses(self, host_name: str) -> list[str] | None:
+        """
+        Return all zeroconf-cached IPs for *host_name* without issuing a query.
+
+        Both IPv4 and IPv6 (scoped) entries are included — the OTA
+        address-cache CLI args need every IP we know so the runtime
+        can try them in turn. Callers that want a single best target
+        for, say, ICMP should pick IPv4 first themselves.
+
+        Returns ``None`` when zeroconf isn't running, the cache misses,
+        or the entry has expired. mDNS-only — see
+        :meth:`DeviceStateMonitor.get_cached_dns_addresses` for
+        non-``.local`` hostnames.
+        """
+        if self._zeroconf is None:
+            return None
+
+        normalized = normalize_hostname(host_name)
+        base_name = normalized.partition(".")[0]
+        resolver_name = f"{base_name}.local."
+        info = AddressResolver(resolver_name)
+        if not info.load_from_cache(self._zeroconf.zeroconf):
+            return None
+        addresses = info.parsed_scoped_addresses(IPVersion.All)
+        return addresses or None

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -110,7 +110,8 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     (``esphome/dashboard/status/mdns.py``). No-op when the
     zeroconf browser failed to start.
     """
-    if monitor._zeroconf is None:
+    zeroconf = monitor._mdns.zeroconf
+    if zeroconf is None:
         return
     candidates = [
         d
@@ -125,7 +126,7 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
         return
     results = await asyncio.gather(
         *(
-            monitor._zeroconf.async_resolve_host(d.address, _MDNS_HOSTNAME_RESOLVE_TIMEOUT)
+            zeroconf.async_resolve_host(d.address, _MDNS_HOSTNAME_RESOLVE_TIMEOUT)
             for d in candidates
         ),
         return_exceptions=True,

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -22,7 +22,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
     device_name_from_service,
 )
-from esphome_device_builder.controllers._device_state_monitor import controller as monitor_module
+from esphome_device_builder.controllers._device_state_monitor import mdns as mdns_module
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import make_state_monitor_with_callbacks
@@ -103,9 +103,9 @@ async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.Monk
             captured["handler"] = handlers[0]
 
     fake_zc = MagicMock()
-    monkeypatch.setattr(monitor_module, "AsyncEsphomeZeroconf", lambda: fake_zc)
-    monkeypatch.setattr(monitor_module, "AsyncServiceInfo", _FakeServiceInfo)
-    monkeypatch.setattr(monitor_module, "AsyncServiceBrowser", _FakeBrowser)
+    monkeypatch.setattr(mdns_module, "AsyncEsphomeZeroconf", lambda: fake_zc)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", _FakeServiceInfo)
+    monkeypatch.setattr(mdns_module, "AsyncServiceBrowser", _FakeBrowser)
     # Upstream ``DashboardImportDiscovery.browser_callback`` builds
     # its own ``AsyncServiceInfo`` from the ``esphome.zeroconf``
     # module — patch that copy too so the dispatch handler can fan
@@ -113,7 +113,7 @@ async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.Monk
     # real zeroconf.
     monkeypatch.setattr(esphome_zc, "AsyncServiceInfo", _FakeServiceInfo)
 
-    await monitor._start_mdns_browser()
+    await monitor._mdns.start()
     return captured["handler"]
 
 

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -74,7 +74,7 @@ def _make_monitor(
         return resolve_map.get(host)
 
     fake_zc.async_resolve_host = AsyncMock(side_effect=_resolve)
-    monitor._zeroconf = fake_zc
+    monitor._mdns._zeroconf = fake_zc
     return monitor, fake_zc.async_resolve_host
 
 
@@ -188,7 +188,7 @@ async def test_resolve_exception_does_not_propagate() -> None:
             raise OSError("simulated zeroconf failure")
         return ["192.168.1.50"]
 
-    monitor._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
+    monitor._mdns._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
 
     await shared.resolve_non_api_mdns_targets(monitor)
 
@@ -207,7 +207,7 @@ async def test_no_zeroconf_is_a_noop() -> None:
     """Pre-start (or zeroconf-failed) sweep must not raise."""
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, _ = _make_monitor(devices)
-    monitor._zeroconf = None  # simulate ``async_setup`` failure
+    monitor._mdns._zeroconf = None  # simulate ``async_setup`` failure
 
     # No exception, no state change.
     await shared.resolve_non_api_mdns_targets(monitor)
@@ -343,7 +343,7 @@ async def test_multiple_devices_resolve_in_parallel(monkeypatch: Any) -> None:
         finally:
             pending -= 1
 
-    monitor._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
+    monitor._mdns._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
 
     await shared.resolve_non_api_mdns_targets(monitor)
 

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -21,6 +21,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
 )
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.models import Device, DeviceState
 
@@ -32,9 +33,11 @@ def _make_monitor() -> DeviceStateMonitor:
 
     monitor.state = MonitorState()
 
+    monitor._mdns = MdnsSource(monitor)
+
     monitor._ping = PingSource(monitor)
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
     monitor._tasks = set()
     monitor.state.reachability = None
     monitor._presence = None
@@ -60,7 +63,7 @@ def _capture_apply(
     def _apply(name: str, info: Any) -> None:
         calls.append((name, info))
 
-    monkeypatch.setattr(monitor, "_apply_service_info", _apply)
+    monkeypatch.setattr(monitor._mdns, "_apply_service_info", _apply)
     return calls
 
 
@@ -135,7 +138,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     async def fake_resolve(*_args, **_kw) -> None:
         return None
 
-    monkeypatch.setattr(monitor, "_resolve_and_apply", fake_resolve)
+    monkeypatch.setattr(monitor._mdns, "_resolve_and_apply", fake_resolve)
 
     monitor.probe_device("kitchen")
 
@@ -153,8 +156,10 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
 
     monitor.state = MonitorState()
 
+    monitor._mdns = MdnsSource(monitor)
+
     monitor._ping = PingSource(monitor)
-    monitor._zeroconf = None
+    monitor._mdns._zeroconf = None
     monitor._tasks = set()
 
     monitor.probe_device("kitchen")  # no exception, no tasks
@@ -194,7 +199,7 @@ async def test_apply_service_info_claims_online() -> None:
     fake_info = MagicMock()
     fake_info.parsed_scoped_addresses.return_value = []
     fake_info.decoded_properties = {}
-    monitor._apply_service_info("kitchen", fake_info)
+    monitor._mdns._apply_service_info("kitchen", fake_info)
 
     # ``_on_state_change`` is the bridge our owner registered for
     # state transitions; the call carries (name, state, source).
@@ -241,7 +246,7 @@ async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
     # the canonical form because ``apply_mac_address`` normalizes
     # before invoking the change callback.
     fake_info.decoded_properties = {"mac": "94c9601f8cf1"}
-    monitor._apply_service_info("kitchen", fake_info)
+    monitor._mdns._apply_service_info("kitchen", fake_info)
 
     assert callbacks.calls_for("on_mac_address_change") == [
         ("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -31,8 +31,10 @@ from esphome_device_builder.controllers._device_state_monitor import DeviceState
 from esphome_device_builder.controllers._device_state_monitor import (
     controller as state_monitor_module,
 )
+from esphome_device_builder.controllers._device_state_monitor import mdns as mdns_module
 from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.models import Device, DeviceState
@@ -87,14 +89,16 @@ def _make_monitor(
 
     monitor.state = MonitorState()
 
+    monitor._mdns = MdnsSource(monitor)
+
     monitor._ping = PingSource(monitor)
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
     monitor.state.state_source = {}
     monitor.state.http_urls = {}
-    monitor._zeroconf = None
-    monitor._mdns_browser = None
+    monitor._mdns._zeroconf = None
+    monitor._mdns._mdns_browser = None
     monitor._ping_task = None
     monitor._tasks = set()
     monitor._import_discovery = None
@@ -134,9 +138,9 @@ async def _start_with_captured_dispatch(
     captured: dict[str, Any] = {}
     fake_zeroconf = MagicMock()
     fake_zeroconf.zeroconf = MagicMock()
-    monkeypatch.setattr(state_monitor_module, "AsyncEsphomeZeroconf", lambda: fake_zeroconf)
+    monkeypatch.setattr(mdns_module, "AsyncEsphomeZeroconf", lambda: fake_zeroconf)
     monkeypatch.setattr(
-        state_monitor_module,
+        mdns_module,
         "DashboardImportDiscovery",
         lambda _cb: (
             import_discovery
@@ -149,7 +153,7 @@ async def _start_with_captured_dispatch(
         captured["dispatch"] = handlers[0]
         return MagicMock(async_cancel=AsyncMock())
 
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceBrowser", _capture)
+    monkeypatch.setattr(mdns_module, "AsyncServiceBrowser", _capture)
 
     # Park the ping loop forever so the bootstrap sleep + first
     # sweep don't fire during browser-only tests. Ping-pipeline
@@ -223,14 +227,14 @@ async def test_stop_cancels_every_async_resource(monkeypatch: pytest.MonkeyPatch
     in_flight = asyncio.create_task(_long_running())
     monitor._tasks.add(in_flight)
     # Replace the zeroconf with one that has an awaitable async_close.
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.async_close = AsyncMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.async_close = AsyncMock()
 
     await _stop_and_drain(monitor)
 
     assert monitor._ping_task is None
-    assert monitor._mdns_browser is None
-    assert monitor._zeroconf is None
+    assert monitor._mdns._mdns_browser is None
+    assert monitor._mdns._zeroconf is None
     assert monitor._tasks == set()
     assert in_flight.cancelled() or in_flight.done()
 
@@ -247,12 +251,12 @@ async def test_stop_swallows_browser_cancel_exception(
     """
     monitor, _callbacks = _make_monitor()
     await _start_with_captured_dispatch(monitor, monkeypatch)
-    monitor._mdns_browser.async_cancel = AsyncMock(side_effect=RuntimeError("browser broke"))
-    monitor._zeroconf.async_close = AsyncMock()
+    monitor._mdns._mdns_browser.async_cancel = AsyncMock(side_effect=RuntimeError("browser broke"))
+    monitor._mdns._zeroconf.async_close = AsyncMock()
 
     await _stop_and_drain(monitor)  # must not raise
 
-    assert monitor._mdns_browser is None
+    assert monitor._mdns._mdns_browser is None
 
 
 @pytest.mark.asyncio
@@ -262,11 +266,11 @@ async def test_stop_swallows_zeroconf_close_exception(
     """``zeroconf.async_close`` raise also lands at debug, not the caller."""
     monitor, _callbacks = _make_monitor()
     await _start_with_captured_dispatch(monitor, monkeypatch)
-    monitor._zeroconf.async_close = AsyncMock(side_effect=RuntimeError("zeroconf broke"))
+    monitor._mdns._zeroconf.async_close = AsyncMock(side_effect=RuntimeError("zeroconf broke"))
 
     await _stop_and_drain(monitor)  # must not raise
 
-    assert monitor._zeroconf is None
+    assert monitor._mdns._zeroconf is None
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +293,7 @@ async def test_start_falls_back_when_zeroconf_construct_fails(
     def _boom() -> None:
         raise RuntimeError("no zeroconf for you")
 
-    monkeypatch.setattr(state_monitor_module, "AsyncEsphomeZeroconf", _boom)
+    monkeypatch.setattr(mdns_module, "AsyncEsphomeZeroconf", _boom)
 
     async def _park() -> None:
         await asyncio.sleep(60)
@@ -298,8 +302,8 @@ async def test_start_falls_back_when_zeroconf_construct_fails(
 
     await monitor.start()
     try:
-        assert monitor._zeroconf is None
-        assert monitor._mdns_browser is None
+        assert monitor._mdns._zeroconf is None
+        assert monitor._mdns._mdns_browser is None
         # Ping task is still running — we want OFFLINE detection
         # even without zeroconf.
         assert monitor._ping_task is not None
@@ -321,7 +325,7 @@ async def test_start_continues_when_browser_construct_fails(
     fake_zeroconf = MagicMock()
     fake_zeroconf.zeroconf = MagicMock()
     fake_zeroconf.async_close = AsyncMock()
-    monkeypatch.setattr(state_monitor_module, "AsyncEsphomeZeroconf", lambda: fake_zeroconf)
+    monkeypatch.setattr(mdns_module, "AsyncEsphomeZeroconf", lambda: fake_zeroconf)
     monkeypatch.setattr(
         state_monitor_module,
         "DashboardImportDiscovery",
@@ -331,7 +335,7 @@ async def test_start_continues_when_browser_construct_fails(
     def _boom(*_a: Any, **_kw: Any) -> None:
         raise RuntimeError("browser broke")
 
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceBrowser", _boom)
+    monkeypatch.setattr(mdns_module, "AsyncServiceBrowser", _boom)
 
     async def _park() -> None:
         await asyncio.sleep(60)
@@ -340,8 +344,8 @@ async def test_start_continues_when_browser_construct_fails(
 
     await monitor.start()
     try:
-        assert monitor._zeroconf is fake_zeroconf
-        assert monitor._mdns_browser is None
+        assert monitor._mdns._zeroconf is fake_zeroconf
+        assert monitor._mdns._mdns_browser is None
     finally:
         await _stop_and_drain(monitor)
 
@@ -362,7 +366,7 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -397,7 +401,7 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -437,12 +441,12 @@ async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
         "config_hash": "abcd1234",
         "api_encryption": "Noise_NNpsk0_25519_ChaChaPoly_SHA256",
     }
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -477,12 +481,12 @@ async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
     fake_info.load_from_cache.return_value = True
     fake_info.parsed_scoped_addresses = lambda _mode: ["fe80::1%en0"]
     fake_info.decoded_properties = {}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -513,12 +517,12 @@ async def test_dispatch_added_with_explicit_empty_api_encryption_pushes_empty_st
     fake_info.load_from_cache.return_value = True
     fake_info.parsed_scoped_addresses = lambda _mode: []
     fake_info.decoded_properties = {"api_encryption": ""}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -555,12 +559,12 @@ async def test_dispatch_added_without_api_encryption_txt_preserves_last_known(
     fake_info.load_from_cache.return_value = True
     fake_info.parsed_scoped_addresses = lambda _mode: []
     fake_info.decoded_properties = {}  # no api_encryption key at all
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -591,12 +595,12 @@ async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
     fake_info.load_from_cache.return_value = True
     fake_info.parsed_scoped_addresses = lambda _mode: []
     fake_info.decoded_properties = {}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -641,12 +645,12 @@ async def test_dispatch_added_api_encryption_absent_with_other_content_clears_to
         "mac": "aabbccddeeff",
         "config_hash": "abc12345",
     }
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -688,12 +692,12 @@ async def test_dispatch_added_api_encryption_bare_key_pushes_empty_string(
     # or bare ``api_encryption``: the key is present in the dict
     # but the value is ``None``.
     fake_info.decoded_properties = {"api_encryption": None}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -773,12 +777,12 @@ async def test_dispatch_added_sparse_announce_preserves_last_known(
     fake_info.load_from_cache.return_value = True
     fake_info.parsed_scoped_addresses = lambda _mode: []
     fake_info.decoded_properties = make_props(txt_key)
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -810,12 +814,12 @@ async def test_dispatch_added_cache_miss_resolves_and_applies(
     fake_info.async_request = AsyncMock(return_value=True)
     fake_info.parsed_scoped_addresses = lambda _mode: ["10.0.0.5"]
     fake_info.decoded_properties = {"version": "2026.5.0"}
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -844,12 +848,12 @@ async def test_dispatch_added_cache_miss_skips_apply_when_request_returns_false(
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
     fake_info.async_request = AsyncMock(return_value=False)
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -876,12 +880,12 @@ async def test_dispatch_added_cache_miss_swallows_resolve_exception(
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
     fake_info.async_request = AsyncMock(side_effect=OSError("network flap"))
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -907,7 +911,7 @@ async def test_dispatch_skips_unconfigured_devices(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"stranger.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -978,7 +982,7 @@ async def test_dispatch_http_service_added_records_url_and_refires_importable(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1011,7 +1015,7 @@ async def test_dispatch_http_service_added_skips_when_no_importable(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"stranger.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1046,7 +1050,7 @@ async def test_dispatch_http_service_removed_clears_url_and_refires(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -1068,7 +1072,7 @@ async def test_dispatch_http_service_removed_for_untracked_is_noop(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"stranger.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -1097,7 +1101,7 @@ async def test_dispatch_http_service_added_cache_miss_resolves_and_applies(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._zeroconf.zeroconf,
+            monitor._mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1159,8 +1163,8 @@ def test_revisit_importable_seeds_url_from_cache_when_http_already_resolved(
     ``AdoptableDevice`` carries the link from the first event.
     """
     monitor, callbacks = _make_monitor(devices=[])
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
     discovered = _build_discovered("factory-firmware")
     monitor._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": discovered}
@@ -1188,7 +1192,7 @@ def test_revisit_importable_skips_seed_when_url_already_set() -> None:
     pre-populated one (no AsyncServiceInfo lookup at all).
     """
     monitor, callbacks = _make_monitor(devices=[])
-    monitor._zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
     monitor.state.http_urls["factory-firmware"] = "http://factory-firmware.local"
     monitor._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
@@ -1203,7 +1207,7 @@ def test_revisit_importable_skips_seed_when_url_already_set() -> None:
 def test_revisit_importable_skips_seed_when_zeroconf_down() -> None:
     """Pre-start monitor (zeroconf=None) silently bails out of the seed."""
     monitor, _callbacks = _make_monitor(devices=[])
-    monitor._zeroconf = None
+    monitor._mdns._zeroconf = None
     monitor._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
@@ -1223,8 +1227,8 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
     we leave it to the regular browser-callback path.
     """
     monitor, _callbacks = _make_monitor(devices=[])
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
     monitor._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
@@ -1450,13 +1454,13 @@ def test_get_cached_addresses_returns_addresses_on_cache_hit(
 ) -> None:
     """A cache hit returns the parsed addresses; miss returns None."""
     monitor, _callbacks = _make_monitor()
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
 
     info = MagicMock()
     info.load_from_cache.return_value = True
     info.parsed_scoped_addresses.return_value = ["10.0.0.1", "10.0.0.2"]
-    monkeypatch.setattr(state_monitor_module, "AddressResolver", lambda _name: info)
+    monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: info)
 
     assert monitor.get_cached_addresses("kitchen.local") == ["10.0.0.1", "10.0.0.2"]
 
@@ -1466,12 +1470,12 @@ def test_get_cached_addresses_returns_none_on_cache_miss(
 ) -> None:
     """``load_from_cache`` False → ``None`` (caller falls back to DNS / mDNS query)."""
     monitor, _callbacks = _make_monitor()
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
 
     info = MagicMock()
     info.load_from_cache.return_value = False
-    monkeypatch.setattr(state_monitor_module, "AddressResolver", lambda _name: info)
+    monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: info)
 
     assert monitor.get_cached_addresses("kitchen.local") is None
 
@@ -1487,13 +1491,13 @@ def test_get_cached_addresses_returns_none_when_addresses_empty(
     caller as "no addresses I can use".
     """
     monitor, _callbacks = _make_monitor()
-    monitor._zeroconf = MagicMock()
-    monitor._zeroconf.zeroconf = MagicMock()
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
 
     info = MagicMock()
     info.load_from_cache.return_value = True
     info.parsed_scoped_addresses.return_value = []
-    monkeypatch.setattr(state_monitor_module, "AddressResolver", lambda _name: info)
+    monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: info)
 
     assert monitor.get_cached_addresses("kitchen.local") is None
 
@@ -1518,7 +1522,7 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
     cached_info = MagicMock()
     cached_info.load_from_cache.return_value = True
     cached_info.parsed_scoped_addresses.return_value = ["fe80::1%en0"]
-    monkeypatch.setattr(state_monitor_module, "AddressResolver", lambda _name: cached_info)
+    monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: cached_info)
 
     async def _icmp(*_a: Any, **_kw: Any) -> Any:
         # Should not be reached — the cached-addresses path

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -47,6 +47,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
     controller as state_monitor_module,
 )
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.controllers._reachability_tracker import (
     MdnsCacheInfo,
@@ -92,14 +93,16 @@ def _make_monitor(
 
     monitor.state = MonitorState()
 
+    monitor._mdns = MdnsSource(monitor)
+
     monitor._ping = PingSource(monitor)
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
     monitor.state.state_source = {}
     monitor.state.http_urls = {}
-    monitor._zeroconf = None
-    monitor._mdns_browser = None
+    monitor._mdns._zeroconf = None
+    monitor._mdns._mdns_browser = None
     monitor._ping_task = None
     monitor._tasks = set()
     monitor._import_discovery = None
@@ -320,7 +323,7 @@ def test_get_mdns_cache_info_no_record_returns_none() -> None:
     fake_zeroconf = MagicMock()
     fake_zeroconf.zeroconf.cache.get_all_by_details = MagicMock(return_value=[])
     fake_zeroconf.zeroconf.cache.current_entry_with_name_and_alias = MagicMock(return_value=None)
-    monitor._zeroconf = fake_zeroconf
+    monitor._mdns._zeroconf = fake_zeroconf
     assert monitor.get_mdns_cache_info("kitchen") is None
 
 
@@ -357,7 +360,7 @@ def test_get_mdns_cache_info_against_real_zeroconf_record() -> None:
         monitor = _make_monitor([_make_device()], None)
         # The helper reads ``self._zeroconf.zeroconf`` — wrap the real
         # ``Zeroconf`` in a stub object exposing the same attribute.
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         info = monitor.get_mdns_cache_info("kitchen")
         assert info is not None
@@ -403,7 +406,7 @@ def test_get_mdns_a_record_ttl_remaining_picks_min_across_a_aaaa() -> None:
         zc.cache.async_add_records([a_rec, aaaa_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         ttl_remaining = monitor.get_mdns_a_record_ttl_remaining("kitchen")
         assert ttl_remaining is not None
@@ -418,7 +421,7 @@ def test_get_mdns_a_record_ttl_remaining_no_records_returns_none() -> None:
     monitor = _make_monitor([_make_device()], None)
     fake_zeroconf = MagicMock()
     fake_zeroconf.zeroconf.cache.get_all_by_details = MagicMock(return_value=[])
-    monitor._zeroconf = fake_zeroconf
+    monitor._mdns._zeroconf = fake_zeroconf
 
     assert monitor.get_mdns_a_record_ttl_remaining("kitchen") is None
 
@@ -455,7 +458,7 @@ def test_get_mdns_cache_info_picks_latest_across_record_types() -> None:
         zc.cache.async_add_records([a_rec, ptr_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         info = monitor.get_mdns_cache_info("kitchen")
         assert info is not None
@@ -513,7 +516,7 @@ def test_get_mdns_cache_info_decodes_txt_records() -> None:
         zc.cache.async_add_records([a_rec, txt_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         info = monitor.get_mdns_cache_info("kitchen")
         assert info is not None
@@ -577,7 +580,7 @@ def test_get_mdns_cache_info_sorts_txt_records_for_wire_stability() -> None:
         )
         zc.cache.async_add_records([a_rec])
         monitor = _make_monitor([_make_device()], None)
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         snapshots: list[dict[str, str]] = []
         for payload, age_offset in ((ascending, 4_000), (descending, 1_000)):
@@ -656,7 +659,7 @@ def test_get_mdns_cache_info_keeps_empty_value_keys_visible() -> None:
         zc.cache.async_add_records([a_rec, txt_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         info = monitor.get_mdns_cache_info("kitchen")
         assert info is not None
@@ -765,7 +768,7 @@ def test_get_mdns_cache_info_no_txt_records_returns_empty_mapping() -> None:
         zc.cache.async_add_records([a_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._zeroconf = MagicMock(zeroconf=zc)
+        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
 
         info = monitor.get_mdns_cache_info("kitchen")
         assert info is not None
@@ -797,7 +800,7 @@ def test_get_mdns_cache_info_picks_latest_record() -> None:
     fake_zeroconf.zeroconf.cache.current_entry_with_name_and_alias = MagicMock(return_value=None)
 
     monitor = _make_monitor([_make_device()], None)
-    monitor._zeroconf = fake_zeroconf
+    monitor._mdns._zeroconf = fake_zeroconf
 
     info = monitor.get_mdns_cache_info("kitchen")
     assert isinstance(info, MdnsCacheInfo)
@@ -846,7 +849,7 @@ async def test_refresh_mdns_calls_resolve_host() -> None:
     monitor = _make_monitor(devices, tracker)
     fake_zeroconf = MagicMock()
     fake_zeroconf.async_resolve_host = AsyncMock(return_value=["10.0.0.42"])
-    monitor._zeroconf = fake_zeroconf
+    monitor._mdns._zeroconf = fake_zeroconf
 
     await monitor.refresh_mdns("kitchen")
 
@@ -869,7 +872,7 @@ async def test_refresh_mdns_swallows_resolve_errors() -> None:
     monitor = _make_monitor(devices, ReachabilityTracker())
     fake_zeroconf = MagicMock()
     fake_zeroconf.async_resolve_host = AsyncMock(side_effect=OSError("network down"))
-    monitor._zeroconf = fake_zeroconf
+    monitor._mdns._zeroconf = fake_zeroconf
 
     await monitor.refresh_mdns("kitchen")
     assert devices[0].state is DeviceState.UNKNOWN
@@ -888,7 +891,7 @@ async def test_refresh_mdns_empty_resolve_no_state_change() -> None:
     monitor = _make_monitor(devices, ReachabilityTracker())
     fake_zeroconf = MagicMock()
     fake_zeroconf.async_resolve_host = AsyncMock(return_value=[])
-    monitor._zeroconf = fake_zeroconf
+    monitor._mdns._zeroconf = fake_zeroconf
 
     await monitor.refresh_mdns("kitchen")
     assert devices[0].state is DeviceState.UNKNOWN


### PR DESCRIPTION
# What does this implement/fix?

Fourth PR in the device-state-monitor split arc — see `device_state_monitor_split.md` (untracked working-tree plan, content mirrored below). Mechanical-only structural extraction per `feedback_split_then_clean_strict`.

Mirrors the legacy `esphome/dashboard/status/mdns.py` shape: an `MdnsSource` class taking the monitor in `__init__`, owning the zeroconf responder, the `AsyncServiceBrowser`, the esphomelib service-state callback, and the cache accessors the drawer's reachability subscription uses.

**`mdns.py`** — new `MdnsSource` class:

- `start` — was `_start_mdns_browser`. Constructs `AsyncEsphomeZeroconf`, `DashboardImportDiscovery`, and the dispatch closure that routes esphomelib events to its own `_on_esphomelib_service_state_change` and HTTP events back to `monitor._on_http_service_state_change` (HTTP / importable lives on the monitor for PR 4; PR 5 lifts it into `ImportableDiscovery`).
- `cancel_browser` / `close_zeroconf` — split `stop` into two so the monitor's resolve-task drain still happens between them (preserving the "cancel browser FIRST" invariant).
- `_on_esphomelib_service_state_change` — was the inner closure in `_start_mdns_browser`; now a private method.
- `_resolve_and_apply` / `_resolve_then` / `_apply_service_info` — service-info resolve + apply helpers; `_resolve_then` is also used by the HTTP path still in controller.py (`self._mdns._resolve_then`).
- `refresh_mdns` / `_get_address_records` / `get_mdns_a_record_ttl_remaining` / `get_mdns_cache_info` / `get_cached_addresses` — the cache accessors.
- `zeroconf` property — exposes the responder for the monitor's own `zeroconf` property to delegate.

The `_zeroconf` / `_mdns_browser` fields move with their class.

**`helpers.py`** — `_HTTP_SERVICE_TYPE` constant moves alongside `_ESPHOME_SERVICE_TYPE` so both `controller.py` (`_seed_http_url_from_cache`, `_on_http_service_state_change`) and `mdns.py` (browser construction + dispatch) can import it.

**`controller.py` wiring**:

- `__init__` builds `self._mdns = MdnsSource(self)` (alongside `self._ping = PingSource(self)`).
- `start` → `await self._mdns.start()`.
- `stop` → `await self._mdns.cancel_browser()` + drain + `await self._mdns.close_zeroconf()` preserving the cancel-browser-first invariant.
- Public mDNS surface (`refresh_mdns`, `get_mdns_a_record_ttl_remaining`, `get_mdns_cache_info`, `get_cached_addresses`) becomes thin one-line delegates to `self._mdns.*` so existing external callers (`controllers/devices/controller.py:178/200`, `controllers/devices/importable.py:123`, `controllers/devices/reachability.py:109/164`, `controllers/devices/helpers.py:402/404`, and the corresponding tests) keep working unchanged.
- `zeroconf` property delegates: `return self._mdns.zeroconf`.
- HTTP / importable methods that still reference the responder (`probe_device`, `_seed_http_url_from_cache`, `_resolve_and_apply_http`) reach through `self._mdns.zeroconf` / `self._mdns._resolve_then`; they'll move into `ImportableDiscovery` in PR 5.

**`shared.py`** — `resolve_non_api_mdns_targets`'s `monitor._zeroconf` reference becomes `monitor._mdns.zeroconf` (mypy verified).

**Test redirects** (mechanical):

- Patches against `state_monitor_module.AsyncEsphomeZeroconf` / `AsyncServiceBrowser` / `DashboardImportDiscovery` / `AddressResolver` redirect to `mdns_module`.
- `AsyncServiceInfo` patches redirect based on the test function name — `test_dispatch_added_*` go to `mdns_module` (esphomelib path); `test_dispatch_http_*` keep `state_monitor_module` (HTTP path stays in controller.py until PR 5).
- `monitor._zeroconf` / `monitor._mdns_browser` direct field access → `monitor._mdns._zeroconf` / `monitor._mdns._mdns_browser`.
- `monkeypatch.setattr(monitor, "_apply_service_info", …)` / `"_resolve_and_apply"` → `monitor._mdns`.
- `monitor._start_mdns_browser()` → `monitor._mdns.start()`.
- `__new__`-built test fixtures now wire `monitor._mdns = MdnsSource(monitor)` after constructing `MonitorState`.

**Sizes:** `controller.py` 1143 → 755 lines (-388). `mdns.py` 476 lines. Full suite: 3432 passed.

**Related issue or feature (if applicable):**

- fixes none — fourth PR in a planned multi-PR split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
