### PR TITLE
Extract ImportableDiscovery: HTTP browser + adoption flow

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -22,11 +22,7 @@ from typing import Any
 
 from esphome.zeroconf import (
     AsyncEsphomeZeroconf,
-    DashboardImportDiscovery,
-    DiscoveredImport,
 )
-from zeroconf import ServiceStateChange
-from zeroconf.asyncio import AsyncServiceInfo
 
 from ...helpers.subscriber_presence import SubscriberPresence
 from ...models import AdoptableDevice, Device, DeviceState, ReachabilitySource
@@ -34,13 +30,10 @@ from .._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
 from .._task_controller_base import TaskControllerBase
 from ._state import MonitorState
 from .helpers import (
-    _ESPHOME_SERVICE_TYPE,
-    _HTTP_SERVICE_TYPE,
-    _http_url_from_service_info,
     _normalize_mac,
     _pick_ipv4,
-    device_name_from_service,
 )
+from .importable import ImportableDiscovery
 from .mdns import MdnsSource
 from .ping import PingSource
 from .shared import _SOURCE_PRIORITY
@@ -181,13 +174,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # flow; ``dns_cache`` and ``reachability`` are shared
         # across mdns / ping / apply paths.
         self.state = MonitorState(reachability=reachability)
-        # ``DashboardImportDiscovery`` is the upstream esphome class
-        # that watches the same ``_esphomelib._tcp.local.`` browser for
-        # ``package_import_url`` TXT records and turns them into
-        # ``DiscoveredImport`` entries. Hooking it as a sibling
-        # browser-callback keeps us in lockstep with whatever the
-        # upstream considers an importable device.
-        self._import_discovery: DashboardImportDiscovery | None = None
         self._ping_task: asyncio.Task | None = None
         # ``self._tasks`` (fire-and-forget mDNS resolve refs) comes
         # from :class:`TaskControllerBase`; see :meth:`_track_task`.
@@ -202,6 +188,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # existing tests that build a monitor without a presence
         # gate keep working; ``None`` means "always run the loop".
         self._presence = presence
+        self._importable = ImportableDiscovery(self)
         self._mdns = MdnsSource(self)
         self._ping = PingSource(self)
 
@@ -508,99 +495,20 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         return self._mdns.get_cached_addresses(host_name)
 
     def probe_device(self, device_name: str, service_name: str | None = None) -> None:
-        """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
-
-        Adoption / import / wizard-created devices land in the
-        configured catalog the moment we write their YAML, but the
-        regular browser path only updates ONLINE / IP / version /
-        config_hash / api_encryption when the *next* mDNS announcement
-        arrives — which can be minutes for a quiet device. This method
-        short-circuits the wait by either reading the existing
-        zeroconf cache (sync hit, common case for a device that was
-        just on the discovery banner) or kicking off an
-        ``async_request`` in a fire-and-forget task. Either way the
-        apply path is the same one the browser uses, so the device's
-        card flips from "Unknown" to a fully-populated card
-        immediately instead of on the next periodic sweep.
-
-        ``service_name`` defaults to ``device_name`` and is the
-        broadcast name to look up in mDNS. Adoption surfaces a
-        device whose mDNS-advertised name (the original factory
-        firmware's hostname) differs from the user-chosen YAML name;
-        passing it explicitly lets the lookup hit the cached service
-        info while the apply still keys to the configured device's
-        name.
-        """
-        if (zc := self._mdns.zeroconf) is None:
-            return
-        zeroconf = zc.zeroconf
-        broadcast = service_name or device_name
-        full_service = f"{broadcast}.{_ESPHOME_SERVICE_TYPE}"
-        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, full_service)
-        if info.load_from_cache(zeroconf):
-            self._mdns._apply_service_info(device_name, info)
-            return
-        self._track_task(self._mdns._resolve_and_apply(zeroconf, info, device_name))
+        """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service."""
+        self._importable.probe_device(device_name, service_name)
 
     def revisit_importable(self, device_name: str) -> None:
-        """
-        Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached.
-
-        Used after a configured device is deleted: the device's mDNS
-        announcement was being suppressed by the ``configured-name``
-        filter in ``_on_import_update``, but upstream's
-        ``DashboardImportDiscovery.import_state`` already has the
-        ``DiscoveredImport`` entry from the original announcement.
-        Without this nudge the discovery banner stays silent until the
-        device re-announces (which can be minutes for a quiet device).
-
-        Ignored devices are skipped — the user already said "don't
-        show me this", so a deletion shouldn't unilaterally bring it
-        back. They can unignore through the menu if they change their
-        mind, and an unsolicited mDNS re-announce will surface it
-        through the normal callback path either way.
-        """
-        if self._import_discovery is None or self._is_ignored(device_name):
-            return
-        for service_name, discovered in self._import_discovery.import_state.items():
-            if discovered.device_name == device_name:
-                self._on_import_update(service_name, discovered)
+        """Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached."""
+        self._importable.revisit_importable(device_name)
 
     def revisit_all_importables(self) -> None:
-        """
-        Re-fire ``on_importable_added`` for every cached importable.
-
-        Used when a configured YAML is deleted but we don't know what
-        mDNS name it came from (the user may have picked a YAML name
-        that differs from the discovered hostname during adoption).
-        ``_on_import_update`` already filters configured + ignored
-        names so re-emitting the full set is safe; only the entries
-        that should appear in the banner do.
-        """
-        if self._import_discovery is None:
-            return
-        for service_name, discovered in self._import_discovery.import_state.items():
-            self._on_import_update(service_name, discovered)
+        """Re-fire ``on_importable_added`` for every cached importable."""
+        self._importable.revisit_all_importables()
 
     def get_importable_devices(self) -> list[AdoptableDevice]:
-        """
-        Snapshot of devices currently advertising as importable.
-
-        Built fresh each call from ``DashboardImportDiscovery``'s
-        ``import_state`` so the ``ignored`` flag and the configured-
-        device filter both reflect the live dashboard state. Callers
-        (e.g. the WebSocket ``initial_state`` event) get the same view
-        the per-device ADDED events would have surfaced incrementally.
-        """
-        if self._import_discovery is None:
-            return []
-        configured_names = {d.name for d in self._get_devices()}
-        out: list[AdoptableDevice] = []
-        for discovered in self._import_discovery.import_state.values():
-            if discovered.device_name in configured_names:
-                continue
-            out.append(self._build_adoptable(discovered))
-        return out
+        """Snapshot of devices currently advertising as importable."""
+        return self._importable.get_importable_devices()
 
     def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
         """
@@ -618,138 +526,3 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
     def _find_device_by_name(self, name: str) -> Device | None:
         bucket = self._get_devices_by_name(name)
         return bucket[0] if bucket else None
-
-    def _on_http_service_state_change(
-        self,
-        zeroconf: Any,
-        service_type: str,
-        name: str,
-        state_change: ServiceStateChange,
-    ) -> None:
-        """Track ``_http._tcp.local.`` services so discovered cards can show a Visit-web-UI link.
-
-        The browser fires for every HTTP service on the LAN — we only
-        care about the ones whose left-hand label matches an importable
-        device, so the matching is name-driven. When an HTTP service
-        appears (or disappears) for an existing importable, re-emit
-        the entry so the card's ``web_url`` field stays in sync
-        without waiting for the next esphomelib announcement.
-        """
-        device_name = device_name_from_service(name)
-        if state_change == ServiceStateChange.Removed:
-            if self.state.http_urls.pop(device_name, None) is None:
-                return
-            self._refire_importable_for(device_name)
-            return
-
-        info = AsyncServiceInfo(service_type, name)
-        if info.load_from_cache(zeroconf):
-            self._apply_http_service_info(device_name, info)
-            return
-        self._track_task(self._resolve_and_apply_http(zeroconf, info, device_name))
-
-    async def _resolve_and_apply_http(
-        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
-    ) -> None:
-        """Resolve a cache-miss HTTP service and store its URL."""
-        await self._mdns._resolve_then(zeroconf, info, device_name, self._apply_http_service_info)
-
-    def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
-        """Build the Visit-web-UI URL from a populated HTTP service info.
-
-        Only stored when an importable device with the same name is
-        currently advertising. Without this guard ``_http_urls`` grew
-        unbounded from every HTTP service on the LAN (printers, NAS
-        boxes, routers — none of which we have any use for); this
-        keeps the cache scoped to entries that can actually drive a
-        Visit-web-UI link on the discovered card.
-        """
-        if not self._has_importable(device_name):
-            return
-        url = _http_url_from_service_info(device_name, info)
-        if self.state.http_urls.get(device_name) == url:
-            return
-        self.state.http_urls[device_name] = url
-        self._refire_importable_for(device_name)
-
-    def _has_importable(self, device_name: str) -> bool:
-        """Return True when an importable currently exists for *device_name*."""
-        if self._import_discovery is None:
-            return False
-        return any(
-            d.device_name == device_name for d in self._import_discovery.import_state.values()
-        )
-
-    def _refire_importable_for(self, device_name: str) -> None:
-        """Re-emit ADDED for *device_name* so frontends pick up a web_url change."""
-        if self._import_discovery is None:
-            return
-        for service_name, discovered in self._import_discovery.import_state.items():
-            if discovered.device_name == device_name:
-                self._on_import_update(service_name, discovered)
-                return
-
-    def _seed_http_url_from_cache(self, device_name: str) -> None:
-        """Pull ``device_name``'s HTTP service URL out of zeroconf's cache.
-
-        Handles the case where the HTTP service arrived first: the
-        browser callback skipped storing the URL because no importable
-        existed for that name yet. Now that one does, look directly at
-        zeroconf's cache (no network round-trip) and stash the URL so
-        the about-to-fire ``on_importable_added`` carries the right
-        ``web_url``.
-        """
-        if (zc := self._mdns.zeroconf) is None or self.state.http_urls.get(device_name):
-            return
-        info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
-        if not info.load_from_cache(zc.zeroconf):
-            return
-        self.state.http_urls[device_name] = _http_url_from_service_info(device_name, info)
-
-    def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
-        """Bridge ``DashboardImportDiscovery`` → controller callbacks.
-
-        ``service_name`` is the full mDNS service-instance name
-        (``<device>._esphomelib._tcp.local.``); ``discovered`` is None
-        on removal. We re-key by device name so callers don't have to
-        carry the suffix, drop devices that are already configured
-        locally (since the dashboard knows about them already), and
-        translate the upstream ``DiscoveredImport`` shape into our
-        ``AdoptableDevice`` model with the ``ignored`` flag filled in.
-        """
-        device_name = device_name_from_service(service_name)
-        if discovered is None:
-            if self._on_importable_removed is not None:
-                self._on_importable_removed(device_name)
-            return
-        if self._find_device_by_name(device_name) is not None:
-            # Already configured — surfacing it as importable would
-            # confuse the dashboard.
-            return
-        # Late-binding: if the HTTP service for this device is already
-        # in zeroconf's cache (it arrived before the esphomelib
-        # service), pull its URL now so the AdoptableDevice we emit
-        # here carries it without waiting for the next HTTP re-announce.
-        self._seed_http_url_from_cache(discovered.device_name)
-        if self._on_importable_added is not None:
-            self._on_importable_added(self._build_adoptable(discovered))
-
-    def _build_adoptable(self, discovered: DiscoveredImport) -> AdoptableDevice:
-        """Translate an upstream ``DiscoveredImport`` into our ``AdoptableDevice``.
-
-        Single construction site for the cross-type mapping plus the
-        two locally-known fields (``ignored`` from the persisted set,
-        ``web_url`` from the HTTP-service cache). Used by both the
-        live ADD path (``_on_import_update``) and the snapshot path
-        (``get_importable_devices``) so the two views stay identical.
-        """
-        return AdoptableDevice(
-            name=discovered.device_name,
-            friendly_name=discovered.friendly_name or "",
-            package_import_url=discovered.package_import_url,
-            project_name=discovered.project_name,
-            project_version=discovered.project_version,
-            network=discovered.network,
-            ignored=self._is_ignored(discovered.device_name),
-            web_url=self.state.http_urls.get(discovered.device_name, ""),
-        )

--- a/esphome_device_builder/controllers/_device_state_monitor/importable.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/importable.py
@@ -1,0 +1,286 @@
+"""
+Importable-discovery source: HTTP browser callbacks + adoption flow.
+
+:class:`ImportableDiscovery` owns the upstream
+``DashboardImportDiscovery`` instance, the ``_http._tcp.local.``
+service-state callback used by the shared browser dispatch, the
+``DiscoveredImport`` → ``AdoptableDevice`` translation, and the
+public ``probe_device`` / ``revisit_*`` / ``get_importable_devices``
+surface the dashboard's discovery banner reads.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from esphome.zeroconf import DashboardImportDiscovery, DiscoveredImport
+from zeroconf import ServiceStateChange
+from zeroconf.asyncio import AsyncServiceInfo
+
+from ...models import AdoptableDevice
+from .helpers import (
+    _ESPHOME_SERVICE_TYPE,
+    _HTTP_SERVICE_TYPE,
+    _http_url_from_service_info,
+    device_name_from_service,
+)
+
+if TYPE_CHECKING:
+    from .controller import DeviceStateMonitor
+
+
+class ImportableDiscovery:
+    """Importable / discovered-device flow owning the HTTP browser and adoption surface."""
+
+    def __init__(self, monitor: DeviceStateMonitor) -> None:
+        self._monitor = monitor
+        self._import_discovery: DashboardImportDiscovery | None = None
+
+    def setup(self) -> None:
+        """Construct the upstream ``DashboardImportDiscovery``."""
+        self._import_discovery = DashboardImportDiscovery(self._on_import_update)
+
+    def browser_callback(
+        self, zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
+    ) -> None:
+        """Forward esphomelib browser events to the upstream DashboardImportDiscovery."""
+        if self._import_discovery is not None:
+            self._import_discovery.browser_callback(zeroconf, service_type, name, state_change)
+
+    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
+        """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
+
+        Adoption / import / wizard-created devices land in the
+        configured catalog the moment we write their YAML, but the
+        regular browser path only updates ONLINE / IP / version /
+        config_hash / api_encryption when the *next* mDNS announcement
+        arrives — which can be minutes for a quiet device. This method
+        short-circuits the wait by either reading the existing
+        zeroconf cache (sync hit, common case for a device that was
+        just on the discovery banner) or kicking off an
+        ``async_request`` in a fire-and-forget task. Either way the
+        apply path is the same one the browser uses, so the device's
+        card flips from "Unknown" to a fully-populated card
+        immediately instead of on the next periodic sweep.
+
+        ``service_name`` defaults to ``device_name`` and is the
+        broadcast name to look up in mDNS. Adoption surfaces a
+        device whose mDNS-advertised name (the original factory
+        firmware's hostname) differs from the user-chosen YAML name;
+        passing it explicitly lets the lookup hit the cached service
+        info while the apply still keys to the configured device's
+        name.
+        """
+        monitor = self._monitor
+        if (zc := monitor._mdns.zeroconf) is None:
+            return
+        zeroconf = zc.zeroconf
+        broadcast = service_name or device_name
+        full_service = f"{broadcast}.{_ESPHOME_SERVICE_TYPE}"
+        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, full_service)
+        if info.load_from_cache(zeroconf):
+            monitor._mdns._apply_service_info(device_name, info)
+            return
+        monitor._track_task(monitor._mdns._resolve_and_apply(zeroconf, info, device_name))
+
+    def revisit_importable(self, device_name: str) -> None:
+        """
+        Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached.
+
+        Used after a configured device is deleted: the device's mDNS
+        announcement was being suppressed by the ``configured-name``
+        filter in ``_on_import_update``, but upstream's
+        ``DashboardImportDiscovery.import_state`` already has the
+        ``DiscoveredImport`` entry from the original announcement.
+        Without this nudge the discovery banner stays silent until the
+        device re-announces (which can be minutes for a quiet device).
+
+        Ignored devices are skipped — the user already said "don't
+        show me this", so a deletion shouldn't unilaterally bring it
+        back. They can unignore through the menu if they change their
+        mind, and an unsolicited mDNS re-announce will surface it
+        through the normal callback path either way.
+        """
+        if self._import_discovery is None or self._monitor._is_ignored(device_name):
+            return
+        for service_name, discovered in self._import_discovery.import_state.items():
+            if discovered.device_name == device_name:
+                self._on_import_update(service_name, discovered)
+
+    def revisit_all_importables(self) -> None:
+        """
+        Re-fire ``on_importable_added`` for every cached importable.
+
+        Used when a configured YAML is deleted but we don't know what
+        mDNS name it came from (the user may have picked a YAML name
+        that differs from the discovered hostname during adoption).
+        ``_on_import_update`` already filters configured + ignored
+        names so re-emitting the full set is safe; only the entries
+        that should appear in the banner do.
+        """
+        if self._import_discovery is None:
+            return
+        for service_name, discovered in self._import_discovery.import_state.items():
+            self._on_import_update(service_name, discovered)
+
+    def get_importable_devices(self) -> list[AdoptableDevice]:
+        """
+        Snapshot of devices currently advertising as importable.
+
+        Built fresh each call from ``DashboardImportDiscovery``'s
+        ``import_state`` so the ``ignored`` flag and the configured-
+        device filter both reflect the live dashboard state. Callers
+        (e.g. the WebSocket ``initial_state`` event) get the same view
+        the per-device ADDED events would have surfaced incrementally.
+        """
+        if self._import_discovery is None:
+            return []
+        configured_names = {d.name for d in self._monitor._get_devices()}
+        out: list[AdoptableDevice] = []
+        for discovered in self._import_discovery.import_state.values():
+            if discovered.device_name in configured_names:
+                continue
+            out.append(self._build_adoptable(discovered))
+        return out
+
+    def on_http_service_state_change(
+        self,
+        zeroconf: Any,
+        service_type: str,
+        name: str,
+        state_change: ServiceStateChange,
+    ) -> None:
+        """Track ``_http._tcp.local.`` services so discovered cards can show a Visit-web-UI link.
+
+        The browser fires for every HTTP service on the LAN — we only
+        care about the ones whose left-hand label matches an importable
+        device, so the matching is name-driven. When an HTTP service
+        appears (or disappears) for an existing importable, re-emit
+        the entry so the card's ``web_url`` field stays in sync
+        without waiting for the next esphomelib announcement.
+        """
+        monitor = self._monitor
+        device_name = device_name_from_service(name)
+        if state_change == ServiceStateChange.Removed:
+            if monitor.state.http_urls.pop(device_name, None) is None:
+                return
+            self._refire_importable_for(device_name)
+            return
+
+        info = AsyncServiceInfo(service_type, name)
+        if info.load_from_cache(zeroconf):
+            self._apply_http_service_info(device_name, info)
+            return
+        monitor._track_task(self._resolve_and_apply_http(zeroconf, info, device_name))
+
+    async def _resolve_and_apply_http(
+        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
+    ) -> None:
+        """Resolve a cache-miss HTTP service and store its URL."""
+        await self._monitor._mdns._resolve_then(
+            zeroconf, info, device_name, self._apply_http_service_info
+        )
+
+    def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
+        """Build the Visit-web-UI URL from a populated HTTP service info.
+
+        Only stored when an importable device with the same name is
+        currently advertising. Without this guard ``_http_urls`` grew
+        unbounded from every HTTP service on the LAN (printers, NAS
+        boxes, routers — none of which we have any use for); this
+        keeps the cache scoped to entries that can actually drive a
+        Visit-web-UI link on the discovered card.
+        """
+        if not self._has_importable(device_name):
+            return
+        url = _http_url_from_service_info(device_name, info)
+        monitor = self._monitor
+        if monitor.state.http_urls.get(device_name) == url:
+            return
+        monitor.state.http_urls[device_name] = url
+        self._refire_importable_for(device_name)
+
+    def _has_importable(self, device_name: str) -> bool:
+        """Return True when an importable currently exists for *device_name*."""
+        if self._import_discovery is None:
+            return False
+        return any(
+            d.device_name == device_name for d in self._import_discovery.import_state.values()
+        )
+
+    def _refire_importable_for(self, device_name: str) -> None:
+        """Re-emit ADDED for *device_name* so frontends pick up a web_url change."""
+        if self._import_discovery is None:
+            return
+        for service_name, discovered in self._import_discovery.import_state.items():
+            if discovered.device_name == device_name:
+                self._on_import_update(service_name, discovered)
+                return
+
+    def _seed_http_url_from_cache(self, device_name: str) -> None:
+        """Pull ``device_name``'s HTTP service URL out of zeroconf's cache.
+
+        Handles the case where the HTTP service arrived first: the
+        browser callback skipped storing the URL because no importable
+        existed for that name yet. Now that one does, look directly at
+        zeroconf's cache (no network round-trip) and stash the URL so
+        the about-to-fire ``on_importable_added`` carries the right
+        ``web_url``.
+        """
+        monitor = self._monitor
+        if (zc := monitor._mdns.zeroconf) is None or monitor.state.http_urls.get(device_name):
+            return
+        info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
+        if not info.load_from_cache(zc.zeroconf):
+            return
+        monitor.state.http_urls[device_name] = _http_url_from_service_info(device_name, info)
+
+    def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
+        """Bridge ``DashboardImportDiscovery`` → controller callbacks.
+
+        ``service_name`` is the full mDNS service-instance name
+        (``<device>._esphomelib._tcp.local.``); ``discovered`` is None
+        on removal. We re-key by device name so callers don't have to
+        carry the suffix, drop devices that are already configured
+        locally (since the dashboard knows about them already), and
+        translate the upstream ``DiscoveredImport`` shape into our
+        ``AdoptableDevice`` model with the ``ignored`` flag filled in.
+        """
+        monitor = self._monitor
+        device_name = device_name_from_service(service_name)
+        if discovered is None:
+            if monitor._on_importable_removed is not None:
+                monitor._on_importable_removed(device_name)
+            return
+        if monitor._find_device_by_name(device_name) is not None:
+            # Already configured — surfacing it as importable would
+            # confuse the dashboard.
+            return
+        # Late-binding: if the HTTP service for this device is already
+        # in zeroconf's cache (it arrived before the esphomelib
+        # service), pull its URL now so the AdoptableDevice we emit
+        # here carries it without waiting for the next HTTP re-announce.
+        self._seed_http_url_from_cache(discovered.device_name)
+        if monitor._on_importable_added is not None:
+            monitor._on_importable_added(self._build_adoptable(discovered))
+
+    def _build_adoptable(self, discovered: DiscoveredImport) -> AdoptableDevice:
+        """Translate an upstream ``DiscoveredImport`` into our ``AdoptableDevice``.
+
+        Single construction site for the cross-type mapping plus the
+        two locally-known fields (``ignored`` from the persisted set,
+        ``web_url`` from the HTTP-service cache). Used by both the
+        live ADD path (``_on_import_update``) and the snapshot path
+        (``get_importable_devices``) so the two views stay identical.
+        """
+        monitor = self._monitor
+        return AdoptableDevice(
+            name=discovered.device_name,
+            friendly_name=discovered.friendly_name or "",
+            package_import_url=discovered.package_import_url,
+            project_name=discovered.project_name,
+            project_version=discovered.project_version,
+            network=discovered.network,
+            ignored=monitor._is_ignored(discovered.device_name),
+            web_url=monitor.state.http_urls.get(discovered.device_name, ""),
+        )

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
-from esphome.zeroconf import AsyncEsphomeZeroconf, DashboardImportDiscovery
+from esphome.zeroconf import AsyncEsphomeZeroconf
 from zeroconf import (
     AddressResolver,
     IPVersion,
@@ -71,14 +71,11 @@ class MdnsSource:
             return
 
         monitor = self._monitor
-
-        # ``DashboardImportDiscovery`` from upstream esphome owns the
-        # TXT-record parsing for adoptable factory firmwares — its
-        # ``browser_callback`` only acts on services that carry the
-        # ``package_import_url`` TXT records, so harmlessly receiving
-        # HTTP events is fine.
-        import_discovery = DashboardImportDiscovery(monitor._on_import_update)
-        monitor._import_discovery = import_discovery
+        importable = monitor._importable
+        # Construct the upstream ``DashboardImportDiscovery`` inside
+        # ImportableDiscovery so its lifetime tracks the importable
+        # source's own state.
+        importable.setup()
 
         def _dispatch(
             zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
@@ -89,16 +86,11 @@ class MdnsSource:
             # halves the zeroconf bookkeeping vs running two separate
             # browsers and lets the upstream ``DashboardImportDiscovery``
             # callback piggy-back on the same dispatch path.
-            #
-            # Closes over the local ``import_discovery`` rather than
-            # ``monitor._import_discovery`` so mypy sees a non-None
-            # value (the attribute is typed ``... | None`` for the
-            # pre-``start()`` window). Same instance either way.
             if service_type == _ESPHOME_SERVICE_TYPE:
                 self._on_esphomelib_service_state_change(zeroconf, service_type, name, state_change)
-                import_discovery.browser_callback(zeroconf, service_type, name, state_change)
+                importable.browser_callback(zeroconf, service_type, name, state_change)
             elif service_type == _HTTP_SERVICE_TYPE:
-                monitor._on_http_service_state_change(zeroconf, service_type, name, state_change)
+                importable.on_http_service_state_change(zeroconf, service_type, name, state_change)
 
         try:
             self._mdns_browser = AsyncServiceBrowser(

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -51,7 +51,7 @@ def _removed(callbacks) -> list[str]:
 def test_on_import_update_translates_to_adoptable_device() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([])
 
-    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
 
     assert _added(callbacks) == [
         AdoptableDevice(
@@ -69,7 +69,7 @@ def test_on_import_update_translates_to_adoptable_device() -> None:
 def test_on_import_update_emits_removed_with_device_name() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([])
 
-    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", None)
+    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", None)
 
     # The mDNS service name is sliced down to the device-name label so
     # the dashboard can index ``import_result`` by ``device.name``.
@@ -80,7 +80,7 @@ def test_on_import_update_skips_already_configured_devices() -> None:
     """Configured devices never surface as importable."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device("kitchen-1a2b3c")])
 
-    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
     assert _added(callbacks) == []
 
 
@@ -90,7 +90,7 @@ def test_on_import_update_threads_ignored_flag() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([])
     monitor._is_ignored = ignored.__contains__
 
-    monitor._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
     added = _added(callbacks)
     assert len(added) == 1 and added[0].ignored is True
 
@@ -107,7 +107,7 @@ def test_on_import_update_friendly_name_none_becomes_empty_string() -> None:
         project_version="1.0",
         network="wifi",
     )
-    monitor._on_import_update("kitchen._esphomelib._tcp.local.", discovered)
+    monitor._importable._on_import_update("kitchen._esphomelib._tcp.local.", discovered)
 
     assert _added(callbacks)[0].friendly_name == ""
 
@@ -117,8 +117,8 @@ def test_get_importable_devices_filters_configured() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([_device("garage")])
     # Stand in for a started DashboardImportDiscovery — populate its
     # ``import_state`` directly so we don't have to spin up zeroconf.
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
         "garage._esphomelib._tcp.local.": _discovered("garage"),
     }
@@ -144,8 +144,8 @@ def test_revisit_importable_refires_added_when_cached() -> None:
     fires; we have to nudge the cache ourselves.
     """
     monitor, callbacks = make_state_monitor_with_callbacks([])  # device just got deleted
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {
         "kitchen-1a2b3c._esphomelib._tcp.local.": _discovered("kitchen-1a2b3c"),
     }
 
@@ -159,8 +159,8 @@ def test_revisit_importable_refires_added_when_cached() -> None:
 def test_revisit_importable_noop_for_unknown_name() -> None:
     """No cached entry → no callback fires (and no crash)."""
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {}
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {}
 
     monitor.revisit_importable("unknown")
 
@@ -182,8 +182,8 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
     card's Visit-web-UI link in place.
     """
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
     }
 
@@ -191,7 +191,7 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
     info.server = "kitchen.local."
     info.port = 80
 
-    monitor._apply_http_service_info("kitchen", info)
+    monitor._importable._apply_http_service_info("kitchen", info)
 
     assert monitor.state.http_urls == {"kitchen": "http://kitchen.local"}
     added = _added(callbacks)
@@ -202,8 +202,8 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
 def test_apply_http_service_info_includes_non_default_port() -> None:
     """Non-port-80 services build URLs with the explicit ``:port`` suffix."""
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
     }
 
@@ -211,15 +211,15 @@ def test_apply_http_service_info_includes_non_default_port() -> None:
     info.server = "kitchen.local."
     info.port = 8080
 
-    monitor._apply_http_service_info("kitchen", info)
+    monitor._importable._apply_http_service_info("kitchen", info)
     assert _added(callbacks)[0].web_url == "http://kitchen.local:8080"
 
 
 def test_apply_http_service_info_skips_when_unchanged() -> None:
     """Repeat announcements for the same URL don't re-fire ADDED."""
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
     }
 
@@ -227,8 +227,8 @@ def test_apply_http_service_info_skips_when_unchanged() -> None:
     info.server = "kitchen.local."
     info.port = 80
 
-    monitor._apply_http_service_info("kitchen", info)
-    monitor._apply_http_service_info("kitchen", info)
+    monitor._importable._apply_http_service_info("kitchen", info)
+    monitor._importable._apply_http_service_info("kitchen", info)
 
     # Single fire — duplicate calls are deduped by URL equality.
     assert len(_added(callbacks)) == 1
@@ -244,8 +244,8 @@ def test_revisit_importable_skips_ignored_devices() -> None:
     ignored = {"kitchen-1a2b3c"}
     monitor, callbacks = make_state_monitor_with_callbacks([])
     monitor._is_ignored = ignored.__contains__
-    monitor._import_discovery = DashboardImportDiscovery()
-    monitor._import_discovery.import_state = {
+    monitor._importable._import_discovery = DashboardImportDiscovery()
+    monitor._importable._import_discovery.import_state = {
         "kitchen-1a2b3c._esphomelib._tcp.local.": _discovered("kitchen-1a2b3c"),
     }
 

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -21,6 +21,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
 )
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.importable import ImportableDiscovery
 from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.models import Device, DeviceState
@@ -32,6 +33,8 @@ def _make_monitor() -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
+
+    monitor._importable = ImportableDiscovery(monitor)
 
     monitor._mdns = MdnsSource(monitor)
 
@@ -76,7 +79,7 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.controller.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.importable.AsyncServiceInfo",
         lambda *_args, **_kw: fake_info,
     )
 
@@ -108,7 +111,7 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
         return fake_info
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.controller.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.importable.AsyncServiceInfo",
         _info_ctor,
     )
 
@@ -131,7 +134,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.controller.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.importable.AsyncServiceInfo",
         lambda *_args, **_kw: fake_info,
     )
 
@@ -155,6 +158,8 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
+
+    monitor._importable = ImportableDiscovery(monitor)
 
     monitor._mdns = MdnsSource(monitor)
 

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -28,12 +28,11 @@ import pytest
 from zeroconf import ServiceStateChange
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.controllers._device_state_monitor import (
-    controller as state_monitor_module,
-)
+from esphome_device_builder.controllers._device_state_monitor import importable as importable_module
 from esphome_device_builder.controllers._device_state_monitor import mdns as mdns_module
 from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.importable import ImportableDiscovery
 from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
@@ -89,6 +88,8 @@ def _make_monitor(
 
     monitor.state = MonitorState()
 
+    monitor._importable = ImportableDiscovery(monitor)
+
     monitor._mdns = MdnsSource(monitor)
 
     monitor._ping = PingSource(monitor)
@@ -101,7 +102,7 @@ def _make_monitor(
     monitor._mdns._mdns_browser = None
     monitor._ping_task = None
     monitor._tasks = set()
-    monitor._import_discovery = None
+    monitor._importable._import_discovery = None
 
     callbacks = RecordingMonitorCallbacks(devices)
     monitor._on_state_change = callbacks.on_state_change
@@ -140,7 +141,7 @@ async def _start_with_captured_dispatch(
     fake_zeroconf.zeroconf = MagicMock()
     monkeypatch.setattr(mdns_module, "AsyncEsphomeZeroconf", lambda: fake_zeroconf)
     monkeypatch.setattr(
-        mdns_module,
+        importable_module,
         "DashboardImportDiscovery",
         lambda _cb: (
             import_discovery
@@ -327,7 +328,7 @@ async def test_start_continues_when_browser_construct_fails(
     fake_zeroconf.async_close = AsyncMock()
     monkeypatch.setattr(mdns_module, "AsyncEsphomeZeroconf", lambda: fake_zeroconf)
     monkeypatch.setattr(
-        state_monitor_module,
+        importable_module,
         "DashboardImportDiscovery",
         lambda _cb: MagicMock(),
     )
@@ -977,7 +978,7 @@ async def test_dispatch_http_service_added_records_url_and_refires_importable(
     fake_info.load_from_cache.return_value = True
     fake_info.server = "factory-firmware.local."
     fake_info.port = 8080
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
@@ -1010,7 +1011,7 @@ async def test_dispatch_http_service_added_skips_when_no_importable(
     fake_info.load_from_cache.return_value = True
     fake_info.server = "stranger.local."
     fake_info.port = 80
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
@@ -1045,7 +1046,7 @@ async def test_dispatch_http_service_removed_clears_url_and_refires(
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
@@ -1096,7 +1097,7 @@ async def test_dispatch_http_service_added_cache_miss_resolves_and_applies(
     fake_info.async_request = AsyncMock(return_value=True)
     fake_info.server = "factory-firmware.local."
     fake_info.port = 80
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
@@ -1126,7 +1127,7 @@ def test_revisit_all_importables_no_op_when_discovery_not_running() -> None:
     before the dashboard's mDNS browser has come up.
     """
     monitor, callbacks = _make_monitor()
-    monitor._import_discovery = None
+    monitor._importable._import_discovery = None
 
     monitor.revisit_all_importables()  # must not raise
 
@@ -1136,7 +1137,7 @@ def test_revisit_all_importables_no_op_when_discovery_not_running() -> None:
 def test_revisit_all_importables_re_emits_every_cached_entry() -> None:
     """``revisit_all_importables`` walks every entry and re-fires the ADD callback."""
     monitor, callbacks = _make_monitor(devices=[])
-    monitor._import_discovery = _make_import_discovery(
+    monitor._importable._import_discovery = _make_import_discovery(
         {
             f"a.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("a"),
             f"b.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("b"),
@@ -1166,7 +1167,7 @@ def test_revisit_importable_seeds_url_from_cache_when_http_already_resolved(
     monitor._mdns._zeroconf = MagicMock()
     monitor._mdns._zeroconf.zeroconf = MagicMock()
     discovered = _build_discovered("factory-firmware")
-    monitor._import_discovery = _make_import_discovery(
+    monitor._importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": discovered}
     )
 
@@ -1174,7 +1175,7 @@ def test_revisit_importable_seeds_url_from_cache_when_http_already_resolved(
     fake_info.load_from_cache.return_value = True
     fake_info.server = "factory-firmware.local."
     fake_info.port = 8080
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     monitor.revisit_importable("factory-firmware")
 
@@ -1194,7 +1195,7 @@ def test_revisit_importable_skips_seed_when_url_already_set() -> None:
     monitor, callbacks = _make_monitor(devices=[])
     monitor._mdns._zeroconf = MagicMock()
     monitor.state.http_urls["factory-firmware"] = "http://factory-firmware.local"
-    monitor._import_discovery = _make_import_discovery(
+    monitor._importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
 
@@ -1208,7 +1209,7 @@ def test_revisit_importable_skips_seed_when_zeroconf_down() -> None:
     """Pre-start monitor (zeroconf=None) silently bails out of the seed."""
     monitor, _callbacks = _make_monitor(devices=[])
     monitor._mdns._zeroconf = None
-    monitor._import_discovery = _make_import_discovery(
+    monitor._importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
 
@@ -1229,13 +1230,13 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
     monitor, _callbacks = _make_monitor(devices=[])
     monitor._mdns._zeroconf = MagicMock()
     monitor._mdns._zeroconf.zeroconf = MagicMock()
-    monitor._import_discovery = _make_import_discovery(
+    monitor._importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
 
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
-    monkeypatch.setattr(state_monitor_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
+    monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
     monitor.revisit_importable("factory-firmware")
 

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -43,10 +43,9 @@ from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
     _decode_txt_bytes_to_sorted_pairs,
 )
-from esphome_device_builder.controllers._device_state_monitor import (
-    controller as state_monitor_module,
-)
+from esphome_device_builder.controllers._device_state_monitor import helpers as helpers_module
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.importable import ImportableDiscovery
 from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.controllers._reachability_tracker import (
@@ -93,6 +92,8 @@ def _make_monitor(
 
     monitor.state = MonitorState()
 
+    monitor._importable = ImportableDiscovery(monitor)
+
     monitor._mdns = MdnsSource(monitor)
 
     monitor._ping = PingSource(monitor)
@@ -105,7 +106,7 @@ def _make_monitor(
     monitor._mdns._mdns_browser = None
     monitor._ping_task = None
     monitor._tasks = set()
-    monitor._import_discovery = None
+    monitor._importable._import_discovery = None
     monitor.state.reachability = tracker
     monitor._on_state_change = _flip_state(devices)
     monitor._on_ip_change = lambda _n, _i, _l: None
@@ -300,7 +301,7 @@ async def test_mdns_removed_via_dispatch_clears_tracker() -> None:
     # six lines here is honest about what we're testing.
     state_change = ServiceStateChange.Removed
     name = "kitchen._esphomelib._tcp.local."
-    device_name = state_monitor_module.device_name_from_service(name)
+    device_name = helpers_module.device_name_from_service(name)
     if state_change == ServiceStateChange.Removed:
         monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
         monitor.state.state_source.pop(device_name, None)


### PR DESCRIPTION
# What does this implement/fix?

**Fifth (final) PR in the device-state-monitor split arc.** Mechanical-only per `feedback_split_then_clean_strict`.

No direct legacy sibling — the HTTP browser + DashboardImportDiscovery layer is what the new dashboard added on top of the legacy mDNS browser, so it's grouped into its own module rather than folded into `MdnsSource`.

**`importable.py`** — new `ImportableDiscovery` class:

- `setup` — constructs the upstream `DashboardImportDiscovery` (callback wires through `self._on_import_update`). Called from `MdnsSource.start`.
- `browser_callback` — forwards esphomelib browser events to the upstream `DashboardImportDiscovery.browser_callback` so the dispatch closure in `mdns.py` no longer needs to know about it.
- `probe_device` / `revisit_importable` / `revisit_all_importables` / `get_importable_devices` — public discovery / adoption surface; reach through `self._monitor._mdns.zeroconf` / `._apply_service_info` / `._resolve_and_apply` for the cache-hit fast path.
- `on_http_service_state_change` — was `_on_http_service_state_change`; the HTTP-browser callback the dispatch closure invokes for `_http._tcp.local.` events.
- `_resolve_and_apply_http` / `_apply_http_service_info` / `_seed_http_url_from_cache` — HTTP-service-info plumbing.
- `_has_importable` / `_refire_importable_for` — importable-state inspection / re-emit helpers.
- `_on_import_update` / `_build_adoptable` — bridge from upstream `DiscoveredImport` to our `AdoptableDevice`.

The `_import_discovery` handle moves to `ImportableDiscovery`.

**`mdns.py`**: the dispatch closure routes esphomelib events to `self._on_esphomelib_service_state_change` AND `importable.browser_callback` (replacing the previous local `DashboardImportDiscovery` construction), and HTTP events to `importable.on_http_service_state_change`. `DashboardImportDiscovery` import dropped.

**`controller.py` wiring**:

- `__init__` builds `self._importable = ImportableDiscovery(self)` alongside `self._mdns` / `self._ping`.
- The `_import_discovery` field on the monitor goes away.
- Public methods (`probe_device`, `revisit_importable`, `revisit_all_importables`, `get_importable_devices`) become one-line delegates to `self._importable.*` so existing external callers (`controllers/devices/importable.py`, etc.) keep working unchanged.
- All HTTP / adoption private methods removed.

**Test redirects** (mechanical):

- HTTP `AsyncServiceInfo` patches: `state_monitor_module` → `importable_module`.
- `DashboardImportDiscovery` patches: `mdns_module` → `importable_module`.
- `monitor._import_discovery`, `monitor._on_import_update`, `monitor._apply_http_service_info`, `monitor._has_importable`, `monitor._refire_importable_for`, `monitor._seed_http_url_from_cache`, `monitor._on_http_service_state_change`, `monitor._resolve_and_apply_http`, `monitor._build_adoptable` → `monitor._importable.*`.
- `state_monitor_module.device_name_from_service` → `helpers_module.device_name_from_service` (the controller no longer needs to import the helper).
- Probe-device patches against `controller.AsyncServiceInfo` → `importable.AsyncServiceInfo`.
- `__new__`-built test fixtures now wire `monitor._importable = ImportableDiscovery(monitor)` before `monitor._mdns`.

## End-of-arc shape

`controller.py`: 1638 (start of arc, PR 1 was the package conversion) → 528 lines.

| File | Lines |
|---|---:|
| `__init__.py` | 25 |
| `_state.py` | 41 |
| `controller.py` | 528 |
| `helpers.py` | 208 |
| `importable.py` | 286 |
| `mdns.py` | 453 |
| `ping.py` | 245 |
| `shared.py` | 156 |

Every module under the 800-line soft cap. Per-concern modules testable in isolation. Each source (mdns, ping, importable) mirrors the legacy `esphome/dashboard/status/` shape — class taking the monitor in `__init__`, reading / writing through `monitor.state` and `monitor.apply(...)`.

**Related issue or feature (if applicable):**

- fixes none — final PR in the multi-PR split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
