### PR TITLE
Tighten _device_state_monitor/helpers.py docstrings + comments

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/helpers.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/helpers.py
@@ -15,36 +15,36 @@ from zeroconf.asyncio import AsyncServiceInfo
 from ...helpers.hostname import is_local_hostname
 
 _ESPHOME_SERVICE_TYPE = "_esphomelib._tcp.local."
-
-# A second mDNS browser watches for HTTP services so we can light up
-# a "Visit web UI" link on discovered devices that are running their
-# factory firmware's built-in web server. The browser only feeds the
-# importable-discovery flow; configured devices already get their
-# web_port from the YAML (``web_server:``).
+# Watched by the shared zeroconf browser so the discovery banner can
+# surface a Visit-web-UI link on importable devices running their
+# factory firmware's built-in web server. Configured devices already
+# get ``web_port`` from the YAML (``web_server:``).
 _HTTP_SERVICE_TYPE = "_http._tcp.local."
 
-
-# Allowed separators between the six octets of a MAC.
-# ESPHome firmware today broadcasts the compact 12-hex-char form
-# (no separators); the dashboard's *canonical* form
-# (``XX:XX:XX:XX:XX:XX``, applied at ingest by ``_normalize_mac``)
-# uses ``:``. We normalize away ``-`` (Windows-style) and ``.``
-# (Cisco) too so a future firmware change or vendored tool can't
-# slip a non-canonical form into the dedupe path or the sidecar.
+# Strip ``-`` (Windows) and ``.`` (Cisco) too so a vendored tool or
+# future firmware can't slip a non-canonical form into the dedupe
+# path or the sidecar.
 _MAC_SEPARATORS = str.maketrans("", "", ":-.")
 
 
-def _normalize_mac(value: str) -> str:
-    """Canonicalise a broadcast MAC to ``XX:XX:XX:XX:XX:XX`` form.
+def device_name_from_service(service_name: str) -> str:
+    """
+    Extract the device name from an mDNS service-instance name.
 
-    Strips ``:`` / ``-`` / ``.`` separators, uppercases, validates
-    the result is 12 hex chars, then re-inserts ``:`` between every
-    octet. Returns ``""`` when the input doesn't shape into a
-    48-bit hex MAC — callers treat that the same as "TXT absent"
-    and skip the apply path. Done at ingest so the dedupe, sidecar,
-    in-memory model, and frontend wire all carry one canonical form
-    regardless of which case / separator style the firmware happens
-    to broadcast.
+    Don't substitute hyphens for underscores or vice versa — the
+    broadcast preserves the device's ``esphome.name`` verbatim and
+    the catalog lookup matches on that exact value.
+    """
+    return service_name.split(".", maxsplit=1)[0]
+
+
+def _normalize_mac(value: str) -> str:
+    """
+    Canonicalise a broadcast MAC to ``XX:XX:XX:XX:XX:XX`` form.
+
+    Returns ``""`` when the input doesn't shape into a 48-bit hex
+    MAC — callers treat that the same as "TXT absent" and skip
+    the apply path.
     """
     stripped = value.translate(_MAC_SEPARATORS).upper()
     if len(stripped) != 12:
@@ -57,15 +57,11 @@ def _normalize_mac(value: str) -> str:
 
 
 def _http_url_from_service_info(device_name: str, info: AsyncServiceInfo) -> str:
-    """Build ``http://<host>[:port]`` from a populated HTTP service info.
+    """
+    Build ``http://<host>[:port]`` from a populated HTTP service info.
 
-    Single source of truth for the URL shape — ``_apply_http_service_info``
-    (browser callback path) and ``_seed_http_url_from_cache`` (late-binding
-    path when the HTTP service was already cached before the importable
-    arrived) both call this so the format stays consistent.
-
-    ``info.server`` is trusted only when it's an ``.local`` hostname.
-    Anything else (a routable hostname, a remote SRV target) gets
+    ``info.server`` is trusted only when it's an ``.local`` hostname;
+    anything else (routable hostname, remote SRV target) gets
     rewritten to ``<device_name>.local`` so a malicious or
     misconfigured announcement can't surface a clickable link
     pointing somewhere off-LAN.
@@ -76,97 +72,19 @@ def _http_url_from_service_info(device_name: str, info: AsyncServiceInfo) -> str
     return f"http://{host}{'' if port == 80 else f':{port}'}"
 
 
-@lru_cache(maxsize=256)
-def _decode_txt_bytes_to_sorted_pairs(txt_bytes: bytes) -> tuple[tuple[str, str], ...]:
-    """
-    Bytes-keyed memoised TXT decode — the reusable hot path.
-
-    The reachability snapshot fires on every observation; for a
-    50-device fleet with the drawer open that's ~50 calls/sec
-    against a ``DNSText`` cache where each device's TXT bytes
-    rarely change between firmware flashes. The decode itself
-    (``ServiceInfo.text`` setter → ``decoded_properties`` →
-    sort + filter) costs about an allocation-heavy 50µs per call;
-    keying on the immutable raw bytes turns 49 of every 50 of
-    those calls into hash-table lookups.
-
-    Returns an immutable ``tuple[tuple[str, str], ...]`` rather
-    than a dict so a downstream caller mutating the result can't
-    poison subsequent cache hits. Callers materialise a fresh
-    dict via ``dict(pairs)``.
-
-    Bytes are content-addressed: two devices broadcasting
-    byte-identical TXT payloads share a cache entry, which is
-    correct (the decoded output is the same).
-
-    ``maxsize=256`` covers fleet sizes well past the typical
-    tens-to-low-hundreds, with headroom for a device that
-    re-broadcasts a slightly different TXT payload (firmware
-    upgrade, ``config_hash`` change) without immediately
-    evicting another device's stable entry. Still bounded so a
-    long-running dashboard with rotating device names can't grow
-    the cache without limit.
-    """
-    # ``service_name`` is required by the ctor but doesn't affect
-    # ``set_text`` parsing — pass a placeholder so the cache key
-    # stays bytes-only.
-    info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"_decode.{_ESPHOME_SERVICE_TYPE}")
-    info.text = txt_bytes
-    decoded = info.decoded_properties
-    # Filter to string keys *before* sorting — ``decoded`` can
-    # contain ``bytes`` keys when a TXT entry fails UTF-8 decode,
-    # and ``sorted()`` of a mixed ``str | bytes`` set raises
-    # ``TypeError`` in Python 3. Binding ``value`` to a local also
-    # lets mypy narrow with ``isinstance(value, str)`` — narrowing
-    # on a subscript expression (``decoded[key]``) doesn't carry
-    # across the two references in the inline conditional.
-    str_keys = sorted(key for key in decoded if isinstance(key, str))
-    pairs: list[tuple[str, str]] = []
-    for key in str_keys:
-        value = decoded[key]
-        pairs.append((key, value if isinstance(value, str) else ""))
-    return tuple(pairs)
-
-
 def _decode_mdns_txt_records(txt_dns_records: list[Any]) -> dict[str, str]:
     """
-    Decode the freshest cached ``DNSText`` record into a sorted ``key=value`` dict.
+    Decode the freshest cached ``DNSText`` record to a sorted ``key=value`` dict.
 
-    Reuses ``ServiceInfo.text`` setter so we get zeroconf's canonical
-    RFC-6763 split (length-prefixed UTF-8 entries → ``key=value``
-    pairs) and ``decoded_properties`` for the UTF-8 decode +
-    bad-bytes-to-``None`` handling. Skips ``load_from_cache`` so
-    tests can stub the cache with a ``MagicMock``: that helper's
-    strict ``DNSCache`` isinstance check would crash the test path,
-    and the only thing we need from the cache here is the
-    already-fetched TXT bytes.
-
-    Empty / bare-key handling: zeroconf collapses both bare keys
-    (``foo`` with no ``=``) and empty-value entries (``foo=`` with
-    ``=`` but no value) to the same ``None`` in
-    ``decoded_properties``. The diagnostic value is the same in
-    both cases — the user wants to see that the key IS present
-    even if the value is empty — so we surface those as ``""``
-    rather than dropping them. The empty string is the signal the
-    upstream ``api_encryption`` tri-state already uses for "device
-    confirmed plaintext" (issue #437) and the whole point of the
-    debug collapsible is to make those advertisements observable.
-
-    Order stability: zeroconf preserves the bytes-order of the
-    raw TXT entries, which can shift on a fresh announce or when
-    the cache rebuilds an entry. We sort by key so the wire
-    output is deterministic across snapshots, letting downstream
-    consumers dedupe with plain equality / ``JSON.stringify``
-    instead of comparing dicts set-wise.
-
-    The actual bytes-to-dict decode is delegated to
-    ``_decode_txt_bytes_to_sorted_pairs`` so consecutive calls
-    with the same TXT bytes reuse the cached result — typical
-    for a stable fleet where each device's TXT rarely changes
-    between firmware flashes.
+    Bare keys (``foo`` with no ``=``) and empty-value entries
+    (``foo=``) both collapse to ``None`` in zeroconf's
+    ``decoded_properties``; we surface those as ``""`` rather than
+    drop them so the ``api_encryption`` empty-string tri-state
+    (plaintext-confirmed) survives the round trip.
 
     Returns ``{}`` when no TXT records are passed or the freshest
-    record's ``text`` attribute is missing / not bytes-like.
+    record's ``text`` attribute is missing / not bytes-like. Keys
+    are sorted so the wire output is deterministic across snapshots.
     """
     if not txt_dns_records:
         return {}
@@ -177,30 +95,47 @@ def _decode_mdns_txt_records(txt_dns_records: list[Any]) -> dict[str, str]:
     return dict(_decode_txt_bytes_to_sorted_pairs(bytes(txt_bytes)))
 
 
-def device_name_from_service(service_name: str) -> str:
-    """Extract the device name from an mDNS service-instance name.
-
-    The mDNS service announcement is
-    ``<device-name>._esphomelib._tcp.local.``; the left-hand label is
-    the device's ``esphome.name`` *verbatim* — modern configs use
-    ``friendly_name_slugify``-style names with hyphens
-    (``apollo-r-pro-1-eth-5938e0``) and the broadcast preserves them.
-    Older underscored names (``my_device``) are likewise broadcast as
-    given. Don't substitute hyphens for underscores or vice versa or
-    the catalog lookup will silently miss every match.
+@lru_cache(maxsize=256)
+def _decode_txt_bytes_to_sorted_pairs(txt_bytes: bytes) -> tuple[tuple[str, str], ...]:
     """
-    return service_name.split(".", maxsplit=1)[0]
+    Bytes-keyed memoised TXT decode — the reusable hot path.
+
+    The reachability snapshot fires on every observation; keying
+    on the immutable raw bytes turns repeat calls against a stable
+    fleet into hash-table lookups instead of allocation-heavy
+    ``ServiceInfo.text`` re-parses.
+
+    Returns an immutable ``tuple[tuple[str, str], ...]`` rather
+    than a dict so a downstream caller mutating the result can't
+    poison subsequent cache hits. Callers materialise a fresh
+    dict via ``dict(pairs)``.
+    """
+    # ``service_name`` is required by the ctor but doesn't affect
+    # ``set_text`` parsing — pass a placeholder so the cache key
+    # stays bytes-only.
+    info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"_decode.{_ESPHOME_SERVICE_TYPE}")
+    info.text = txt_bytes
+    decoded = info.decoded_properties
+    # Filter to string keys *before* sorting — ``decoded`` can
+    # contain ``bytes`` keys when a TXT entry fails UTF-8 decode,
+    # and ``sorted()`` of a mixed ``str | bytes`` set raises
+    # ``TypeError`` in Python 3.
+    str_keys = sorted(key for key in decoded if isinstance(key, str))
+    pairs: list[tuple[str, str]] = []
+    for key in str_keys:
+        value = decoded[key]
+        pairs.append((key, value if isinstance(value, str) else ""))
+    return tuple(pairs)
 
 
 def _pick_ipv4(addresses: list[str]) -> str:
     """
     Return the first IPv4 address in *addresses*, or the first entry overall.
 
-    ``Device.ip`` only carries one IP, so when a host has both V4 and V6
-    we lock onto the V4 entry — it's friendlier for ICMP across subnets
-    and avoids the IPv6 scope-ID gymnastics that ``apply_ip`` consumers
-    aren't prepared for. Callers that need every address (CLI cache args)
-    should iterate the list themselves rather than going through this.
+    ``Device.ip`` only carries one IP, so when a host has both V4
+    and V6 we lock onto the V4 entry — friendlier for ICMP across
+    subnets and avoids the IPv6 scope-ID gymnastics ``apply_ip``
+    consumers aren't prepared for.
     """
     for address in addresses:
         if "." in address and ":" not in address:

--- a/esphome_device_builder/controllers/_device_state_monitor/helpers.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/helpers.py
@@ -83,8 +83,8 @@ def _decode_mdns_txt_records(txt_dns_records: list[Any]) -> dict[str, str]:
     (plaintext-confirmed) survives the round trip.
 
     Returns ``{}`` when no TXT records are passed or the freshest
-    record's ``text`` attribute is missing / not bytes-like. Keys
-    are sorted so the wire output is deterministic across snapshots.
+    record's ``text`` is not bytes-like. Keys are sorted so the
+    wire output is deterministic across snapshots.
     """
     if not txt_dns_records:
         return {}


### PR DESCRIPTION
# What does this implement/fix?

Per-file cleanup PR for `controllers/_device_state_monitor/helpers.py` — the first in the cleanup arc that follows the device-state-monitor structural split. Per `feedback_split_then_clean_strict` the split PRs ship byte-for-byte; the style cleanup happens here.

Per CLAUDE.md:

- Drop body-restatement from `_normalize_mac`, `_decode_*`, `_pick_ipv4`, `device_name_from_service`. Keep the load-bearing WHY:
  - security rewrite in `_http_url_from_service_info` (only trust `info.server` when `.local`)
  - str/bytes TypeError gate in `_decode_txt_bytes_to_sorted_pairs`
  - empty-string tri-state in `_decode_mdns_txt_records` (plaintext-confirmed)
- Drop caller-cross-refs (`_apply_http_service_info` (browser callback path)`) and the issue cross-ref (`#437`) per CLAUDE.md "Cross-references to issue numbers — the PR body carries those".
- Drop the "second mDNS browser" framing on `_HTTP_SERVICE_TYPE` (single-browser since the dispatch consolidation — Copilot flagged this during the structural-split arc; deferred to here).
- Reorder so the one public function (`device_name_from_service`) sits above the underscore-prefixed helpers per CLAUDE.md "Method order".
- `_MAC_SEPARATORS` comment trimmed to the `-` / `.` rationale (Windows / Cisco) — the `:` canonical form is obvious from the helper's body and the constant's name.

Two body comments preserved as-is — the load-bearing WHY (`service_name` placeholder so cache key stays bytes-only; filter str keys before sorting to avoid TypeError on mixed str/bytes) is non-obvious from the surrounding code.

**Sizes**: `helpers.py` 208 → 143 lines. Full suite: 3432 passed.

**Related issue or feature (if applicable):**

- fixes none — per-file cleanup follow-up to the device-state-monitor split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
