### PR TITLE
Tighten _device_state_monitor/_state.py field comments

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/_state.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_state.py
@@ -13,29 +13,23 @@ class MonitorState:
     """Mutable state for :class:`DeviceStateMonitor`."""
 
     # Source-precedence ledger: device name → ``"mdns"`` /
-    # ``"mqtt"`` / ``"ping"``. Only one source can own a
-    # device's state at a time; mDNS always wins, ping only
-    # writes when mDNS hasn't already resolved the device.
-    # Every ``apply_*`` path consults this to gate writes.
+    # ``"mqtt"`` / ``"ping"``. The ``apply`` write path gates
+    # observations on this so a lower-priority source can't
+    # clobber an mDNS-owned state.
     state_source: dict[str, str] = field(default_factory=dict)
 
-    # Device name → web-UI URL discovered via the
-    # ``_http._tcp.local.`` browser. Populated by the
-    # importable-discovery flow; rendered on the
-    # discovered-device card so the frontend can show a
-    # Visit-web-UI link without knowing which factory
-    # firmwares ship a web server.
+    # Device name → web-UI URL from the ``_http._tcp.local.``
+    # browser. Populated by the importable-discovery flow,
+    # read when building each ``AdoptableDevice``.
     http_urls: dict[str, str] = field(default_factory=dict)
 
-    # DNS resolutions for non-mDNS hostnames, cached with TTLs
-    # so the ping sweep, OTA cache args, and ``device.ip``
-    # tracking all share the same lookup result instead of
-    # re-resolving every cycle.
+    # TTL'd DNS cache shared across the ping sweep, OTA cache
+    # args, and ``device.ip`` tracking so the three paths agree
+    # on the resolved IP without re-resolving each cycle.
     dns_cache: DNSCache = field(default_factory=DNSCache)
 
-    # Per-signal freshness tracker (mDNS / ping / MQTT
-    # last-seen, ping RTT). Optional dependency: callers
-    # that don't care about reachability metadata pass
-    # ``None`` and the monitor's observation hooks become
-    # no-ops.
+    # Optional per-signal freshness tracker (mDNS / ping / MQTT
+    # last-seen, ping RTT). ``None`` makes the monitor's
+    # observation hooks no-ops — kept for tests that don't wire
+    # the drawer.
     reachability: ReachabilityTracker | None = None


### PR DESCRIPTION
# What does this implement/fix?

Per-file cleanup PR for `controllers/_device_state_monitor/_state.py`. Second in the cleanup arc that follows the device-state-monitor structural split.

Per CLAUDE.md style: trim each field's comment to the load-bearing WHY (precedence-gating, populated-by / read-by lifecycle, shared-cache rationale, optional-with-tests-fallback). The detailed precedence rules already live in the module docstring; restating them on the field would be redundant.

**Sizes**: `_state.py` 41 → 35 lines. Full suite: 3432 passed.

**Related issue or feature (if applicable):**

- fixes none — per-file cleanup follow-up to the device-state-monitor split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
