### PR TITLE
Tighten _device_state_monitor/shared.py docstrings + comments

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -1,22 +1,8 @@
-"""
-Cross-cutting helpers used by both the mdns browser path and the ping source.
+"""Cross-cutting helpers shared by the mDNS browser path and the ping source.
 
-Lives outside both ``mdns.py`` and ``ping.py`` because each function
-straddles concerns:
-
-* ``resolve_non_api_mdns_targets`` issues active mDNS resolves but
-  runs in the ping loop's pre-sweep step, and is gated by the same
-  ``should_ping`` rule the ICMP path consults.
-* ``apply_resolved_addresses`` funnels both the browser-callback
-  refresh path and the active-resolve batch into ``monitor.apply``
-  with the same "non-empty list → claim mDNS-ONLINE + record IPs"
-  treatment.
-* ``should_ping`` and the ``_SOURCE_PRIORITY`` ledger are read by
-  the central ``apply()`` write path AND by both modules above.
-
-Free functions taking the monitor — same shape as the
-firmware-sync helpers. ``DeviceStateMonitor`` reaches back through
-``state`` for everything sibling modules need.
+Each free function takes the monitor as its first argument; the
+monitor reaches sibling sources through ``state`` and through
+``_mdns`` / ``_ping`` / ``_importable`` attributes.
 """
 
 from __future__ import annotations
@@ -31,10 +17,9 @@ if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
 
 
-# Source priority for state observations. A new observation can only
-# override an existing one when its priority is greater than or equal
-# to the current source's. Keep ``unknown`` at zero so any source can
-# claim a device that no source has yet labelled.
+# Source-precedence ledger. An observation can only override the
+# current source when its priority is ≥ the recorded one;
+# ``unknown`` at zero lets any source claim a yet-unlabelled device.
 _SOURCE_PRIORITY: dict[str, int] = {
     ReachabilitySource.UNKNOWN: 0,
     ReachabilitySource.PING: 1,
@@ -42,11 +27,9 @@ _SOURCE_PRIORITY: dict[str, int] = {
     ReachabilitySource.MDNS: 3,
 }
 
-# Timeout for the per-sweep mDNS hostname resolves we issue for
-# non-API devices. 3s is enough on a working LAN even when the
-# device is briefly slow to respond, and keeps the whole resolve
-# pass under the ping interval even if every target misses the
-# cache and has to round-trip on the network.
+# Per-sweep mDNS A-record resolve timeout — 3s keeps the whole
+# pass under one ``_PING_INTERVAL`` even if every target misses
+# the cache.
 _MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
 
 
@@ -54,11 +37,10 @@ def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
     """
     Decide whether *device* needs an ICMP probe this sweep.
 
-    Mirrors the upstream dashboard's rule: skip the device only when
-    it's already ONLINE *and* a higher-priority source (mDNS / MQTT)
-    owns it. We still ping devices that are OFFLINE or UNKNOWN so an
-    off-network host — one mDNS can't reach because it's on a
-    different subnet — has a path to come online via DNS + ping.
+    Skip the device only when it's already ONLINE *and* a
+    higher-priority source (mDNS / MQTT) owns it. OFFLINE / UNKNOWN
+    devices always get pinged so off-network hosts mDNS can't reach
+    have a path to come online via DNS + ping.
     """
     if device.state != DeviceState.ONLINE:
         return True
@@ -71,19 +53,13 @@ def apply_resolved_addresses(
     name: str,
     addresses: list[str] | BaseException | None,
 ) -> None:
-    """Funnel a successful active-resolve into the apply path.
+    """
+    Funnel a successful active-resolve into the apply path.
 
-    Both the per-subscription :meth:`refresh_mdns` and the batch
-    :func:`resolve_non_api_mdns_targets` need the same "non-empty
-    address list → claim mDNS-ONLINE + record IPs" treatment.
-    Sharing the branch keeps the deliberate no-OFFLINE-on-miss rule
-    (documented at the call site in
-    :func:`resolve_non_api_mdns_targets`) consistent across both
-    paths.
-
-    ``addresses`` accepts the union ``asyncio.gather(...,
-    return_exceptions=True)`` produces so the batch path can thread
-    its results in without a per-element type check.
+    Deliberate no-OFFLINE-on-miss — see the rationale at the
+    call site in :func:`resolve_non_api_mdns_targets`. ``addresses``
+    accepts the ``BaseException | None`` union ``asyncio.gather(...,
+    return_exceptions=True)`` produces.
     """
     if isinstance(addresses, list) and addresses:
         monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
@@ -91,24 +67,16 @@ def apply_resolved_addresses(
 
 
 async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
-    """Actively resolve ``.local`` hostnames for non-API devices.
+    """
+    Actively resolve ``.local`` hostnames for non-API devices.
 
     Devices whose YAML doesn't load the ``api`` integration
-    (web_server-only, MQTT-only, OTA-only configs) never broadcast
-    on ``_esphomelib._tcp.local.`` so the browser callback never
-    fires for them. The cache-based fallback in the ping target
-    selector only catches them when the zeroconf A-record cache
-    happens to be primed (e.g. by an unrelated query). On a quiet
-    network where ICMP is also filtered (some corporate / HA
-    setups), those devices stay UNKNOWN forever even though
-    they're reachable.
-
-    Issue an active mDNS A-record resolve for each non-API device
-    every sweep so the indicator flips ONLINE even without an
-    esphomelib service announcement. Mirrors the legacy
-    dashboard's ``async_refresh_hosts`` poll path
-    (``esphome/dashboard/status/mdns.py``). No-op when the
-    zeroconf browser failed to start.
+    (web_server / MQTT / OTA-only) never broadcast on
+    ``_esphomelib._tcp.local.``, so the browser callback can't
+    flip them ONLINE. On a quiet network where ICMP is also
+    filtered they'd stay UNKNOWN forever. Issue an active A-record
+    resolve for each such device every sweep so the indicator
+    catches up. No-op when zeroconf failed to start.
     """
     zeroconf = monitor._mdns.zeroconf
     if zeroconf is None:
@@ -132,25 +100,14 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
         return_exceptions=True,
     )
     for device, addresses in zip(candidates, results, strict=True):
-        # Trust mDNS for ONLINE — the active A-record query
-        # answered, so the device is live on this LAN. Claim
-        # under the ``mdns`` source (priority 3) so the
-        # subsequent ICMP sweep skips this device entirely.
-        # Keeping ping / DNS traffic to a minimum for fleets
-        # that broadcast is a deliberate trade-off: we want
-        # mDNS to be the single source of truth for devices
-        # that respond to it.
+        # Claim under the ``mdns`` source so the subsequent ICMP
+        # sweep skips this device entirely — mDNS is the single
+        # source of truth for devices that respond to it.
         apply_resolved_addresses(monitor, device.name, addresses)
         # No OFFLINE branch — deliberate. The browser path can
         # trust mDNS in both directions because the
-        # ServiceBrowser delivers a ``Removed`` event when a
-        # cached record's TTL expires without renewal; that's
-        # the canonical "I'm gone" signal. The one-off active
-        # resolve we run here has no such subscription — a
-        # miss is just "this single query didn't get a reply
-        # in time", which conflates "device gone", "device
-        # slow", and "transient packet loss". Falling back to
-        # ICMP for the OFFLINE decision in this path is the
-        # right shape: an mDNS hit upgrades to mDNS-owned
-        # ONLINE; a miss leaves the source slot at whatever
-        # ping last claimed (or unknown), and ping decides.
+        # ``ServiceBrowser`` delivers a ``Removed`` event on TTL
+        # expiry. The one-off active resolve here has no such
+        # subscription, so a miss conflates "device gone", "device
+        # slow", and "transient packet loss"; let ICMP decide
+        # instead.


### PR DESCRIPTION
# What does this implement/fix?

Per-file cleanup PR for `controllers/_device_state_monitor/shared.py`. Third in the cleanup arc that follows the device-state-monitor structural split.

Per CLAUDE.md:

- **Module docstring** — drop the per-function "lives here because" bullets (the function docstrings say what each does) and the "Mirrors firmware-sync" framing.
- `should_ping` / `apply_resolved_addresses` / `resolve_non_api_mdns_targets` — trim body restatement and long-form narrative. Keep the load-bearing WHY: skip-when-higher-source-owns, the no-OFFLINE-on-miss asymmetry, why-active-resolve-is-needed-at-all.
- `_SOURCE_PRIORITY` / `_MDNS_HOSTNAME_RESOLVE_TIMEOUT` block comments collapsed to the rule (precedence comparison with unknown=0) and the timeout rationale.

The two inside-loop body comments in `resolve_non_api_mdns_targets` are preserved — the no-OFFLINE-on-miss asymmetry is the kind of non-obvious invariant CLAUDE.md says comments are for, and the "claim under mdns so ICMP skips" sentence captures the cross-source interaction.

**Sizes**: `shared.py` 156 → 109 lines. Full suite: 3432 passed.

**Related issue or feature (if applicable):**

- fixes none — per-file cleanup follow-up to the device-state-monitor split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
