### PR TITLE
Tighten _device_state_monitor/importable.py docstrings + comments

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/importable.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/importable.py
@@ -1,13 +1,4 @@
-"""
-Importable-discovery source: HTTP browser callbacks + adoption flow.
-
-:class:`ImportableDiscovery` owns the upstream
-``DashboardImportDiscovery`` instance, the ``_http._tcp.local.``
-service-state callback used by the shared browser dispatch, the
-``DiscoveredImport`` → ``AdoptableDevice`` translation, and the
-public ``probe_device`` / ``revisit_*`` / ``get_importable_devices``
-surface the dashboard's discovery banner reads.
-"""
+"""Importable-discovery source: HTTP browser callbacks + adoption flow."""
 
 from __future__ import annotations
 
@@ -48,28 +39,19 @@ class ImportableDiscovery:
             self._import_discovery.browser_callback(zeroconf, service_type, name, state_change)
 
     def probe_device(self, device_name: str, service_name: str | None = None) -> None:
-        """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
+        """
+        Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
 
-        Adoption / import / wizard-created devices land in the
-        configured catalog the moment we write their YAML, but the
-        regular browser path only updates ONLINE / IP / version /
-        config_hash / api_encryption when the *next* mDNS announcement
-        arrives — which can be minutes for a quiet device. This method
-        short-circuits the wait by either reading the existing
-        zeroconf cache (sync hit, common case for a device that was
-        just on the discovery banner) or kicking off an
-        ``async_request`` in a fire-and-forget task. Either way the
-        apply path is the same one the browser uses, so the device's
-        card flips from "Unknown" to a fully-populated card
-        immediately instead of on the next periodic sweep.
+        Short-circuits the post-adoption wait for the next mDNS
+        announce — flips the card from "Unknown" to fully-populated
+        immediately by reading the zeroconf cache (sync hit) or
+        kicking off a fire-and-forget ``async_request``.
 
-        ``service_name`` defaults to ``device_name`` and is the
-        broadcast name to look up in mDNS. Adoption surfaces a
-        device whose mDNS-advertised name (the original factory
-        firmware's hostname) differs from the user-chosen YAML name;
-        passing it explicitly lets the lookup hit the cached service
-        info while the apply still keys to the configured device's
-        name.
+        ``service_name`` defaults to ``device_name``; pass it
+        explicitly when the device's mDNS-advertised name (its
+        original factory-firmware hostname) differs from the
+        user-chosen YAML name so the lookup hits the cache while
+        the apply still keys to the configured name.
         """
         monitor = self._monitor
         if (zc := monitor._mdns.zeroconf) is None:
@@ -87,19 +69,12 @@ class ImportableDiscovery:
         """
         Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached.
 
-        Used after a configured device is deleted: the device's mDNS
-        announcement was being suppressed by the ``configured-name``
-        filter in ``_on_import_update``, but upstream's
-        ``DashboardImportDiscovery.import_state`` already has the
-        ``DiscoveredImport`` entry from the original announcement.
-        Without this nudge the discovery banner stays silent until the
-        device re-announces (which can be minutes for a quiet device).
-
-        Ignored devices are skipped — the user already said "don't
-        show me this", so a deletion shouldn't unilaterally bring it
-        back. They can unignore through the menu if they change their
-        mind, and an unsolicited mDNS re-announce will surface it
-        through the normal callback path either way.
+        Used after a configured device is deleted: upstream's
+        ``import_state`` still has the original announcement but
+        the ``_on_import_update`` configured-name filter was
+        suppressing it. Ignored devices are skipped — the user
+        already said "don't show me this" and a deletion shouldn't
+        unilaterally bring it back.
         """
         if self._import_discovery is None or self._monitor._is_ignored(device_name):
             return
@@ -111,12 +86,12 @@ class ImportableDiscovery:
         """
         Re-fire ``on_importable_added`` for every cached importable.
 
-        Used when a configured YAML is deleted but we don't know what
-        mDNS name it came from (the user may have picked a YAML name
-        that differs from the discovered hostname during adoption).
-        ``_on_import_update`` already filters configured + ignored
-        names so re-emitting the full set is safe; only the entries
-        that should appear in the banner do.
+        Used when a configured YAML is deleted but we don't know
+        what mDNS name it came from — adoption may have picked a
+        YAML name that differs from the discovered hostname.
+        ``_on_import_update`` filters configured + ignored names,
+        so the re-emit only surfaces entries that belong on the
+        banner.
         """
         if self._import_discovery is None:
             return
@@ -127,11 +102,10 @@ class ImportableDiscovery:
         """
         Snapshot of devices currently advertising as importable.
 
-        Built fresh each call from ``DashboardImportDiscovery``'s
-        ``import_state`` so the ``ignored`` flag and the configured-
-        device filter both reflect the live dashboard state. Callers
-        (e.g. the WebSocket ``initial_state`` event) get the same view
-        the per-device ADDED events would have surfaced incrementally.
+        Built fresh each call so the ``ignored`` flag and the
+        configured-device filter reflect live state. Callers
+        (the WS ``initial_state`` event) get the same view the
+        per-device ADDED events would have surfaced incrementally.
         """
         if self._import_discovery is None:
             return []
@@ -150,14 +124,13 @@ class ImportableDiscovery:
         name: str,
         state_change: ServiceStateChange,
     ) -> None:
-        """Track ``_http._tcp.local.`` services so discovered cards can show a Visit-web-UI link.
+        """
+        Track ``_http._tcp.local.`` services so the discovered card can show a Visit-web-UI link.
 
-        The browser fires for every HTTP service on the LAN — we only
-        care about the ones whose left-hand label matches an importable
-        device, so the matching is name-driven. When an HTTP service
-        appears (or disappears) for an existing importable, re-emit
-        the entry so the card's ``web_url`` field stays in sync
-        without waiting for the next esphomelib announcement.
+        Name-driven match against existing importables: re-emit
+        the entry whenever an HTTP service appears or disappears
+        so the ``web_url`` field stays in sync without waiting
+        for the next esphomelib announcement.
         """
         monitor = self._monitor
         device_name = device_name_from_service(name)
@@ -182,14 +155,12 @@ class ImportableDiscovery:
         )
 
     def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
-        """Build the Visit-web-UI URL from a populated HTTP service info.
+        """
+        Build the Visit-web-UI URL from a populated HTTP service info.
 
-        Only stored when an importable device with the same name is
-        currently advertising. Without this guard ``_http_urls`` grew
-        unbounded from every HTTP service on the LAN (printers, NAS
-        boxes, routers — none of which we have any use for); this
-        keeps the cache scoped to entries that can actually drive a
-        Visit-web-UI link on the discovered card.
+        Only stored when an importable with the same name exists —
+        without this guard ``http_urls`` would grow unbounded from
+        every HTTP service on the LAN (printers, NAS boxes, routers).
         """
         if not self._has_importable(device_name):
             return
@@ -218,14 +189,14 @@ class ImportableDiscovery:
                 return
 
     def _seed_http_url_from_cache(self, device_name: str) -> None:
-        """Pull ``device_name``'s HTTP service URL out of zeroconf's cache.
+        """
+        Pull ``device_name``'s HTTP service URL out of zeroconf's cache.
 
-        Handles the case where the HTTP service arrived first: the
-        browser callback skipped storing the URL because no importable
-        existed for that name yet. Now that one does, look directly at
-        zeroconf's cache (no network round-trip) and stash the URL so
-        the about-to-fire ``on_importable_added`` carries the right
-        ``web_url``.
+        Handles the HTTP-first ordering: the browser callback
+        skipped storing the URL when no importable existed yet;
+        now one does, so look at the cache (no network round-trip)
+        and stash the URL before the about-to-fire
+        ``on_importable_added``.
         """
         monitor = self._monitor
         if (zc := monitor._mdns.zeroconf) is None or monitor.state.http_urls.get(device_name):
@@ -236,15 +207,13 @@ class ImportableDiscovery:
         monitor.state.http_urls[device_name] = _http_url_from_service_info(device_name, info)
 
     def _on_import_update(self, service_name: str, discovered: DiscoveredImport | None) -> None:
-        """Bridge ``DashboardImportDiscovery`` → controller callbacks.
+        """
+        Bridge ``DashboardImportDiscovery`` → controller callbacks.
 
-        ``service_name`` is the full mDNS service-instance name
-        (``<device>._esphomelib._tcp.local.``); ``discovered`` is None
-        on removal. We re-key by device name so callers don't have to
-        carry the suffix, drop devices that are already configured
-        locally (since the dashboard knows about them already), and
-        translate the upstream ``DiscoveredImport`` shape into our
-        ``AdoptableDevice`` model with the ``ignored`` flag filled in.
+        Re-keys by device name (callers don't carry the
+        ``._esphomelib._tcp.local.`` suffix), drops devices already
+        configured locally, and translates the upstream shape into
+        :class:`AdoptableDevice`. ``discovered=None`` signals removal.
         """
         monitor = self._monitor
         device_name = device_name_from_service(service_name)
@@ -253,25 +222,24 @@ class ImportableDiscovery:
                 monitor._on_importable_removed(device_name)
             return
         if monitor._find_device_by_name(device_name) is not None:
-            # Already configured — surfacing it as importable would
-            # confuse the dashboard.
+            # Already configured — surfacing it as importable
+            # would confuse the dashboard.
             return
-        # Late-binding: if the HTTP service for this device is already
-        # in zeroconf's cache (it arrived before the esphomelib
-        # service), pull its URL now so the AdoptableDevice we emit
-        # here carries it without waiting for the next HTTP re-announce.
+        # Late-binding: if the HTTP service arrived first, its URL
+        # is already in zeroconf's cache; stash it now so the
+        # AdoptableDevice we emit here carries it.
         self._seed_http_url_from_cache(discovered.device_name)
         if monitor._on_importable_added is not None:
             monitor._on_importable_added(self._build_adoptable(discovered))
 
     def _build_adoptable(self, discovered: DiscoveredImport) -> AdoptableDevice:
-        """Translate an upstream ``DiscoveredImport`` into our ``AdoptableDevice``.
+        """
+        Translate an upstream ``DiscoveredImport`` into our ``AdoptableDevice``.
 
-        Single construction site for the cross-type mapping plus the
-        two locally-known fields (``ignored`` from the persisted set,
-        ``web_url`` from the HTTP-service cache). Used by both the
-        live ADD path (``_on_import_update``) and the snapshot path
-        (``get_importable_devices``) so the two views stay identical.
+        Single construction site shared by the live ADD path
+        (``_on_import_update``) and the snapshot path
+        (``get_importable_devices``); kept in one place so the
+        two views stay byte-identical.
         """
         monitor = self._monitor
         return AdoptableDevice(

--- a/esphome_device_builder/controllers/_device_state_monitor/importable.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/importable.py
@@ -159,8 +159,9 @@ class ImportableDiscovery:
         Build the Visit-web-UI URL from a populated HTTP service info.
 
         Only stored when an importable with the same name exists —
-        without this guard ``http_urls`` would grow unbounded from
-        every HTTP service on the LAN (printers, NAS boxes, routers).
+        without this guard ``monitor.state.http_urls`` would grow
+        unbounded from every HTTP service on the LAN (printers,
+        NAS boxes, routers).
         """
         if not self._has_importable(device_name):
             return
@@ -239,7 +240,7 @@ class ImportableDiscovery:
         Single construction site shared by the live ADD path
         (``_on_import_update``) and the snapshot path
         (``get_importable_devices``); kept in one place so the
-        two views stay byte-identical.
+        two views stay structurally identical.
         """
         monitor = self._monitor
         return AdoptableDevice(


### PR DESCRIPTION
# What does this implement/fix?

Per-file cleanup PR for `controllers/_device_state_monitor/importable.py`. Sixth in the cleanup arc that follows the device-state-monitor structural split.

Per CLAUDE.md:

- **Module docstring** collapsed to a one-liner — the per-attribute inventory belongs in the PR body, not the module docstring.
- **Public methods'** docstrings (`probe_device`, `revisit_importable`, `revisit_all_importables`, `get_importable_devices`, `on_http_service_state_change`) trimmed of body restatement and quiet-device tangents. Kept the load-bearing WHY:
  - `probe_device`: post-adoption short-circuit + the `service_name`-vs-`device_name` override contract.
  - `revisit_importable`: configured-name filter restoration after delete; ignored-devices opt-out.
  - `revisit_all_importables`: unknown-mDNS-name fallback after delete.
  - `get_importable_devices`: WS `initial_state` contract (matches incremental ADDED events).
  - `on_http_service_state_change`: name-driven matching, re-emit on appear / disappear.
- **Private helpers** (`_apply_http_service_info`, `_seed_http_url_from_cache`, `_on_import_update`, `_build_adoptable`) keep their load-bearing WHY: printers/NAS-boxes anti-pollution guard, HTTP-first ordering, configured-already short-circuit, single-construction-site contract.

Method order already matches CLAUDE.md (public methods first, then private helpers).

**Sizes**: `importable.py` 287 → 261 lines. Full suite: 3432 passed.

**Related issue or feature (if applicable):**

- fixes none — per-file cleanup follow-up to the device-state-monitor split arc

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
