### PR TITLE
Probe new devices via ICMP on add so ping-only YAMLs flip ONLINE promptly

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -403,6 +403,16 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service."""
         self._importable.probe_device(device_name, service_name)
 
+    def probe_device_ping(self, device_name: str) -> None:
+        """Schedule a fire-and-forget ICMP probe for *device_name*."""
+        # Bootstrap-window guard up here so the cold-start
+        # scanner-ADDED storm (one per cached YAML) doesn't spawn N
+        # no-op tasks; ``PingSource.probe_device`` keeps the same
+        # check as defence-in-depth.
+        if not self._ping._bootstrap_complete:
+            return
+        self._track_task(self._ping.probe_device(device_name))
+
     def revisit_importable(self, device_name: str) -> None:
         """Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached."""
         self._importable.revisit_importable(device_name)

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -40,9 +40,20 @@ class PingSource:
 
     def __init__(self, monitor: DeviceStateMonitor) -> None:
         self._monitor = monitor
+        # ``probe_device`` short-circuits while False so the
+        # cold-start scanner-ADDED storm doesn't fan out a
+        # full-fleet ping during the mDNS bootstrap window. Flipped
+        # True after the bootstrap sleep.
+        self._bootstrap_complete = False
+        # Shared across the periodic sweep and eager per-device
+        # probes so the combined concurrent-ICMP load can't exceed
+        # icmplib's reliability ceiling (`_PING_BATCH_SIZE`) when
+        # both paths fire at once.
+        self._concurrency = asyncio.Semaphore(_PING_BATCH_SIZE)
 
     async def run(self) -> None:
         await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+        self._bootstrap_complete = True
         # Strict pause when wired to a SubscriberPresence gate: only
         # sweep while at least one dashboard client is subscribed,
         # so a quiet network with no observers generates no ICMP
@@ -73,57 +84,31 @@ class PingSource:
     async def _ping_sweep(self) -> None:
         if icmp_ping is None:
             return
-
         devices_to_ping = self._select_ping_targets()
         if not devices_to_ping:
             return
-
-        monitor = self._monitor
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
                 "Pinging %d devices: %s",
                 len(devices_to_ping),
                 ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
             )
-
-        for i in range(0, len(devices_to_ping), _PING_BATCH_SIZE):
-            batch = devices_to_ping[i : i + _PING_BATCH_SIZE]
-            # Pre-resolve through our DNS cache. icmplib would
-            # otherwise re-resolve internally on every ping,
-            # bypassing the cache that the OTA address-cache args
-            # also draw on for non-mDNS hostnames.
-            resolved = await asyncio.gather(
-                *(monitor.state.dns_cache.async_resolve(d.address) for d in batch),
-                return_exceptions=True,
-            )
-            ping_targets: list[tuple[Device, str]] = []
-            for device, addresses in zip(batch, resolved, strict=True):
-                if isinstance(addresses, list) and addresses:
-                    target = addresses[0]
-                    # ``apply_ip`` is the only path that populates
-                    # ``device.ip`` for ``.local`` hosts that don't
-                    # broadcast ``_esphomelib._tcp`` (non-API ESPHome
-                    # devices); without it those devices would show
-                    # an em-dash in the drawer's IP row even after
-                    # successful pings.
-                    monitor.apply_ip(device.name, target)
-                    ping_targets.append((device, target))
-                else:
-                    # DNS-failure cache entry — don't hand the bare
-                    # hostname to icmplib (it would hammer the system
-                    # resolver every sweep). Apply OFFLINE under the
-                    # ``ping`` source so a future successful resolve
-                    # can flip the device back.
-                    monitor.apply(device.name, DeviceState.OFFLINE, "ping")
-            if ping_targets:
-                await asyncio.gather(
-                    *(self._ping_device(device, target) for device, target in ping_targets),
-                    return_exceptions=True,
-                )
+        # Single ``gather`` plus ``self._concurrency`` semaphore
+        # caps in-flight ICMP at ``_PING_BATCH_SIZE`` across the
+        # sweep and any concurrent eager probes; no need to
+        # pre-chunk here.
+        await asyncio.gather(
+            *(self._resolve_and_ping(device) for device in devices_to_ping),
+            return_exceptions=True,
+        )
 
     def _select_ping_targets(self) -> list[Device]:
+        """Filter the device list down to actual ping candidates."""
+        return [d for d in self._monitor._get_devices() if self._classify_for_ping(d)]
+
+    def _classify_for_ping(self, device: Device) -> bool:
         """
-        Filter the device list down to actual ping candidates.
+        Return True iff *device* needs an ICMP probe; apply any short-circuit side-effects.
 
         Three filters apply: skip when a higher-priority source
         owns the device; claim ``.local`` cache hits for mDNS so
@@ -132,33 +117,45 @@ class PingSource:
         failed (no point hammering the resolver).
         """
         monitor = self._monitor
-        devices_to_ping: list[Device] = []
-        dns_skipped: list[Device] = []
-        for device in monitor._get_devices():
-            if not device.address or not shared.should_ping(monitor, device):
-                continue
-            if is_local_hostname(device.address) and (
-                cached := monitor.get_cached_addresses(device.address)
-            ):
-                monitor.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                # Forward every cached IP so the dashboard shows
-                # all of them; ``apply_ip_addresses`` picks the
-                # IPv4 primary for ICMP / OTA targeting.
-                monitor.apply_ip_addresses(device.name, cached)
-                continue
-            if monitor.state.dns_cache.has_cached_failure(device.address):
-                dns_skipped.append(device)
-                monitor.apply(device.name, DeviceState.OFFLINE, "ping")
-                continue
-            devices_to_ping.append(device)
-
-        if dns_skipped and _LOGGER.isEnabledFor(logging.DEBUG):
+        if not device.address or not shared.should_ping(monitor, device):
+            return False
+        if is_local_hostname(device.address) and (
+            cached := monitor.get_cached_addresses(device.address)
+        ):
+            monitor.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+            # Forward every cached IP so the dashboard shows all
+            # of them; ``apply_ip_addresses`` picks the IPv4
+            # primary for ICMP / OTA targeting.
+            monitor.apply_ip_addresses(device.name, cached)
+            return False
+        if monitor.state.dns_cache.has_cached_failure(device.address):
+            # DNS-failure cache entry: don't hand the bare hostname
+            # to icmplib (it would hammer the system resolver every
+            # sweep). Apply OFFLINE under the ``ping`` source so a
+            # future successful resolve can flip the device back.
             _LOGGER.debug(
-                "Skipping ping for %d device(s) with cached DNS failure: %s",
-                len(dns_skipped),
-                ", ".join(f"{d.name} ({d.address})" for d in dns_skipped),
+                "Skipping ping for %s (%s): cached DNS failure", device.name, device.address
             )
-        return devices_to_ping
+            monitor.apply(device.name, DeviceState.OFFLINE, "ping")
+            return False
+        return True
+
+    async def _resolve_and_ping(self, device: Device) -> None:
+        """Resolve *device.address* through the DNS cache and ICMP it."""
+        monitor = self._monitor
+        async with self._concurrency:
+            addresses = await monitor.state.dns_cache.async_resolve(device.address)
+            if not addresses:
+                monitor.apply(device.name, DeviceState.OFFLINE, "ping")
+                return
+            target = addresses[0]
+            # ``apply_ip`` is the only path that populates
+            # ``device.ip`` for ``.local`` hosts that don't broadcast
+            # ``_esphomelib._tcp`` (non-API ESPHome devices); without
+            # it those devices would show an em-dash in the drawer's
+            # IP row even after successful pings.
+            monitor.apply_ip(device.name, target)
+            await self._ping_device(device, target)
 
     async def _ping_device(self, device: Device, target: str) -> None:
         # Any failure mode flips OFFLINE rather than staying
@@ -186,3 +183,12 @@ class PingSource:
         if is_alive and rtt_ms is not None and monitor.state.reachability is not None:
             monitor.state.reachability.record_ping_rtt(device.name, rtt_ms)
         monitor.apply(device.name, new_state, "ping")
+
+    async def probe_device(self, name: str) -> None:
+        """Eagerly ICMP-probe *name* instead of waiting on the next periodic sweep."""
+        if not self._bootstrap_complete or icmp_ping is None:
+            return
+        bucket = self._monitor._get_devices_by_name(name)
+        if not bucket or not self._classify_for_ping(bucket[0]):
+            return
+        await self._resolve_and_ping(bucket[0])

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -27,6 +27,10 @@ def on_scan_change(controller: DevicesController, kind: ScanChange, device: Devi
         # another dashboard) sit at "Unknown" until the next
         # periodic ping sweep.
         controller._state_monitor.probe_device(device.name)
+        # Paired ICMP probe covers ping-only devices that don't
+        # broadcast ``_esphomelib._tcp``; the bootstrap-window
+        # guard inside the monitor wrapper skips it on cold start.
+        controller._state_monitor.probe_device_ping(device.name)
     if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
         # YAML cache key changed; clear any prior failure
         # marker so the next edit gets a fresh chance at

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -44,7 +44,8 @@ class RecordingStateMonitor:
     ``apply_version`` / ``apply_api_encryption`` /
     ``apply_config_hash`` / ``get_cached_addresses`` /
     ``get_cached_dns_addresses`` / ``probe_device`` /
-    ``priority_for`` / ``revisit_importable`` /
+    ``probe_device_ping`` / ``priority_for`` /
+    ``revisit_importable`` /
     ``revisit_all_importables`` / ``get_importable_devices``)
     without any of the real monitor's I/O. Calls land in
     ``self.calls`` as flat tuples ``(method_name, *args)`` —
@@ -127,6 +128,9 @@ class RecordingStateMonitor:
 
     def probe_device(self, device_name: str, service_name: str | None = None) -> None:
         self.calls.append(("probe_device", device_name, service_name))
+
+    def probe_device_ping(self, device_name: str) -> None:
+        self.calls.append(("probe_device_ping", device_name))
 
     def priority_for(self, name: str) -> str:
         self.calls.append(("priority_for", name))

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -171,9 +171,13 @@ def test_added_device_without_hash_triggers_regenerate(
     assert [(e.event_type, e.data) for e in captured] == [
         (EventType.DEVICE_ADDED, {"device": device})
     ]
-    # Probe fires too — the eager mDNS probe on ADDED is what catches
-    # YAMLs dropped on disk outside the API path.
-    assert controller._state_monitor.calls == [("probe_device", "apollo", None)]
+    # Probes fire too — the eager mDNS probe on ADDED catches YAMLs
+    # dropped on disk outside the API path, and the paired ping probe
+    # covers ping-only devices that never broadcast ``_esphomelib._tcp``.
+    assert controller._state_monitor.calls == [
+        ("probe_device", "apollo", None),
+        ("probe_device_ping", "apollo"),
+    ]
 
 
 def test_added_device_fully_populated_does_not_regenerate(

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -16,39 +16,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers._device_state_monitor import (
-    DeviceStateMonitor,
-)
-from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
-from esphome_device_builder.controllers._device_state_monitor.importable import ImportableDiscovery
-from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
-from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import RecordingMonitorCallbacks
-
-
-def _make_monitor(device: Device) -> tuple[DeviceStateMonitor, RecordingMonitorCallbacks]:
-    monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
-    monitor.state = MonitorState()
-    monitor._importable = ImportableDiscovery(monitor)
-    monitor._mdns = MdnsSource(monitor)
-    monitor._ping = PingSource(monitor)
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
-    monitor._tasks = set()
-    monitor._presence = None
-    monitor._get_devices = lambda: [device]
-    monitor._get_devices_by_name = lambda name: [device] if device.name == name else []
-    monitor._is_ignored = lambda _name: False
-    callbacks = RecordingMonitorCallbacks([device])
-    monitor._on_state_change = callbacks.on_state_change
-    monitor._on_ip_change = callbacks.on_ip_change
-    monitor._on_version_change = callbacks.on_version_change
-    monitor._on_config_hash_change = callbacks.on_config_hash_change
-    monitor._on_api_encryption_change = callbacks.on_api_encryption_change
-    monitor._on_mac_address_change = callbacks.on_mac_address_change
-    return monitor, callbacks
+from .conftest import make_state_monitor_with_callbacks
 
 
 def _ping_only_device() -> Device:
@@ -74,8 +44,7 @@ async def test_probe_device_noop_during_bootstrap() -> None:
     flag-gate makes the cold-start case fall back to the next
     scheduled sweep.
     """
-    device = _ping_only_device()
-    monitor, callbacks = _make_monitor(device)
+    monitor, callbacks = make_state_monitor_with_callbacks([_ping_only_device()])
     assert monitor._ping._bootstrap_complete is False
 
     await monitor._ping.probe_device("garage")
@@ -92,8 +61,7 @@ async def test_probe_device_pings_after_bootstrap(monkeypatch: pytest.MonkeyPatc
     device's newly-dropped YAML lands the card at ONLINE within
     one ICMP round-trip instead of waiting on ``_PING_INTERVAL``.
     """
-    device = _ping_only_device()
-    monitor, callbacks = _make_monitor(device)
+    monitor, callbacks = make_state_monitor_with_callbacks([_ping_only_device()])
     monitor._ping._bootstrap_complete = True
 
     ping_targets: list[str] = []
@@ -119,8 +87,7 @@ async def test_probe_device_pings_after_bootstrap(monkeypatch: pytest.MonkeyPatc
 @pytest.mark.asyncio
 async def test_probe_device_unknown_name_is_noop() -> None:
     """A probe for a name not in the catalog short-circuits silently."""
-    device = _ping_only_device()
-    monitor, callbacks = _make_monitor(device)
+    monitor, callbacks = make_state_monitor_with_callbacks([_ping_only_device()])
     monitor._ping._bootstrap_complete = True
 
     await monitor._ping.probe_device("not-a-device")
@@ -141,7 +108,7 @@ async def test_probe_device_skipped_when_higher_priority_source_owns(
     """
     device = _ping_only_device()
     device.state = DeviceState.ONLINE
-    monitor, _callbacks = _make_monitor(device)
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["garage"] = "mdns"
     monitor._ping._bootstrap_complete = True
 
@@ -172,8 +139,7 @@ async def test_probe_device_ping_skips_scheduling_during_bootstrap() -> None:
     makes the wrapper a no-op so the storm never reaches the
     scheduler.
     """
-    device = _ping_only_device()
-    monitor, _ = _make_monitor(device)
+    monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     assert monitor._ping._bootstrap_complete is False
 
     monitor.probe_device_ping("garage")
@@ -184,8 +150,7 @@ async def test_probe_device_ping_skips_scheduling_during_bootstrap() -> None:
 @pytest.mark.asyncio
 async def test_probe_device_ping_schedules_task_after_bootstrap() -> None:
     """Post-bootstrap the wrapper hands a coroutine to ``_track_task``."""
-    device = _ping_only_device()
-    monitor, _ = _make_monitor(device)
+    monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     monitor._ping._bootstrap_complete = True
 
     monitor.probe_device_ping("garage")

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -148,8 +148,22 @@ async def test_probe_device_ping_skips_scheduling_during_bootstrap() -> None:
 
 
 @pytest.mark.asyncio
-async def test_probe_device_ping_schedules_task_after_bootstrap() -> None:
+async def test_probe_device_ping_schedules_task_after_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Post-bootstrap the wrapper hands a coroutine to ``_track_task``."""
+
+    # Stub ``icmp_ping`` so the scheduled task can't fire a real
+    # ICMP probe at ``192.168.1.42`` (up to 3s flake on machines
+    # with icmplib installed); this test only verifies scheduling.
+    async def _noop_ping(_target: str, **_kwargs: object) -> MagicMock:
+        return MagicMock(is_alive=False, min_rtt=0.0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        _noop_ping,
+    )
+
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     monitor._ping._bootstrap_complete = True
 

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -1,0 +1,194 @@
+"""
+Tests for ``PingSource.probe_device`` and ``DeviceStateMonitor.probe_device_ping``.
+
+A YAML dropped on disk for a ping-only device (no
+``_esphomelib._tcp`` broadcast) would otherwise sit at UNKNOWN
+until the next scheduled ICMP sweep (up to ``_PING_INTERVAL``
+seconds), blocking the log-stream UI on the freshly-created
+card. The eager per-device probe closes that window down to an
+ICMP round-trip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import (
+    DeviceStateMonitor,
+)
+from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
+from esphome_device_builder.controllers._device_state_monitor.importable import ImportableDiscovery
+from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
+from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
+from esphome_device_builder.models import Device, DeviceState
+
+from .conftest import RecordingMonitorCallbacks
+
+
+def _make_monitor(device: Device) -> tuple[DeviceStateMonitor, RecordingMonitorCallbacks]:
+    monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
+    monitor.state = MonitorState()
+    monitor._importable = ImportableDiscovery(monitor)
+    monitor._mdns = MdnsSource(monitor)
+    monitor._ping = PingSource(monitor)
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor._tasks = set()
+    monitor._presence = None
+    monitor._get_devices = lambda: [device]
+    monitor._get_devices_by_name = lambda name: [device] if device.name == name else []
+    monitor._is_ignored = lambda _name: False
+    callbacks = RecordingMonitorCallbacks([device])
+    monitor._on_state_change = callbacks.on_state_change
+    monitor._on_ip_change = callbacks.on_ip_change
+    monitor._on_version_change = callbacks.on_version_change
+    monitor._on_config_hash_change = callbacks.on_config_hash_change
+    monitor._on_api_encryption_change = callbacks.on_api_encryption_change
+    monitor._on_mac_address_change = callbacks.on_mac_address_change
+    return monitor, callbacks
+
+
+def _ping_only_device() -> Device:
+    """Build a no-API device (ICMP-reachable only) for the test fixtures."""
+    return Device(
+        name="garage",
+        friendly_name="Garage",
+        configuration="garage.yaml",
+        address="192.168.1.42",
+        state=DeviceState.UNKNOWN,
+        loaded_integrations=["wifi"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_device_noop_during_bootstrap() -> None:
+    """During the bootstrap window the probe is a no-op.
+
+    Cold-start ``ScanChange.ADDED`` fires once per cached YAML;
+    if every one of those triggered an immediate ICMP, a 100-
+    device fleet would emit 100 concurrent pings before mDNS even
+    had its grace period to claim the API devices for free. The
+    flag-gate makes the cold-start case fall back to the next
+    scheduled sweep.
+    """
+    device = _ping_only_device()
+    monitor, callbacks = _make_monitor(device)
+    assert monitor._ping._bootstrap_complete is False
+
+    await monitor._ping.probe_device("garage")
+
+    # No state change, no DNS lookup, no ICMP: completely silent.
+    assert callbacks.calls == []
+
+
+@pytest.mark.asyncio
+async def test_probe_device_pings_after_bootstrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After bootstrap, an alive ICMP target flips the device ONLINE.
+
+    The end-to-end contract: an immediate probe on a ping-only
+    device's newly-dropped YAML lands the card at ONLINE within
+    one ICMP round-trip instead of waiting on ``_PING_INTERVAL``.
+    """
+    device = _ping_only_device()
+    monitor, callbacks = _make_monitor(device)
+    monitor._ping._bootstrap_complete = True
+
+    ping_targets: list[str] = []
+
+    async def _fake_ping(target: str, **_kwargs: object) -> MagicMock:
+        ping_targets.append(target)
+        result = MagicMock()
+        result.is_alive = True
+        result.min_rtt = 4.2
+        return result
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        _fake_ping,
+    )
+
+    await monitor._ping.probe_device("garage")
+
+    assert ping_targets == ["192.168.1.42"]
+    assert ("on_state_change", "garage", DeviceState.ONLINE, "ping") in callbacks.calls
+
+
+@pytest.mark.asyncio
+async def test_probe_device_unknown_name_is_noop() -> None:
+    """A probe for a name not in the catalog short-circuits silently."""
+    device = _ping_only_device()
+    monitor, callbacks = _make_monitor(device)
+    monitor._ping._bootstrap_complete = True
+
+    await monitor._ping.probe_device("not-a-device")
+
+    assert callbacks.calls == []
+
+
+@pytest.mark.asyncio
+async def test_probe_device_skipped_when_higher_priority_source_owns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An mDNS-claimed device doesn't get a redundant ping.
+
+    Mirrors :func:`shared.should_ping`: once mDNS owns the
+    device at ONLINE the ping source has nothing to add. Without
+    this guard, dropping a new YAML for a device that just
+    announced via mDNS would still fire an unnecessary ICMP.
+    """
+    device = _ping_only_device()
+    device.state = DeviceState.ONLINE
+    monitor, _callbacks = _make_monitor(device)
+    monitor.state.state_source["garage"] = "mdns"
+    monitor._ping._bootstrap_complete = True
+
+    ping_calls: list[str] = []
+
+    async def _fake_ping(target: str, **_kwargs: object) -> MagicMock:
+        ping_calls.append(target)
+        return MagicMock(is_alive=True, min_rtt=1.0)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        _fake_ping,
+    )
+
+    await monitor._ping.probe_device("garage")
+
+    assert ping_calls == []
+
+
+@pytest.mark.asyncio
+async def test_probe_device_ping_skips_scheduling_during_bootstrap() -> None:
+    """No task is allocated until bootstrap completes.
+
+    Critical for cold-start: the scanner fires ``ScanChange.ADDED``
+    once per cached YAML, and without this guard a 1000-device
+    fleet would allocate 1000 coroutines and 1000 tasks just to
+    have each one short-circuit internally. The hoisted guard
+    makes the wrapper a no-op so the storm never reaches the
+    scheduler.
+    """
+    device = _ping_only_device()
+    monitor, _ = _make_monitor(device)
+    assert monitor._ping._bootstrap_complete is False
+
+    monitor.probe_device_ping("garage")
+
+    assert monitor._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_probe_device_ping_schedules_task_after_bootstrap() -> None:
+    """Post-bootstrap the wrapper hands a coroutine to ``_track_task``."""
+    device = _ping_only_device()
+    monitor, _ = _make_monitor(device)
+    monitor._ping._bootstrap_complete = True
+
+    monitor.probe_device_ping("garage")
+
+    assert len(monitor._tasks) == 1
+    await asyncio.gather(*monitor._tasks, return_exceptions=True)


### PR DESCRIPTION
# What does this implement/fix?

A freshly-created device YAML for a ping-only target (no
`_esphomelib._tcp` broadcast — e.g. a non-API ESPHome device, or
a device whose firmware hasn't booted yet) used to sit at
`UNKNOWN` until the next periodic ICMP sweep, up to
`_PING_INTERVAL = 60` seconds away. The frontend's log-stream
UI is gated on the device being reachable, so the user couldn't
open logs immediately after creating the YAML.

The scan-change handler already fires `probe_device` (mDNS) on
`ScanChange.ADDED`; that path is a no-op for ping-only devices.
This PR adds a paired `probe_device_ping` so the card flips
`ONLINE` within an ICMP round-trip.

Along the way, the sweep path was refactored to share the
filter chain and resolve-then-ping logic with the new probe
path:

- New `_classify_for_ping(device) -> bool` holds the
  `should_ping` / mDNS-cache-claim / cached-DNS-failure filter
  chain previously inlined in `_select_ping_targets`. The
  eager probe reuses it so the load-bearing invariants
  (priority gating, `apply_ip_addresses` from the mDNS cache,
  `apply(OFFLINE, "ping")` on cached DNS failure) can't drift
  between the two sites.
- New `_resolve_and_ping(device)` wraps DNS resolve +
  `apply_ip` + `_ping_device`. The sweep's old two-stage
  `gather` (resolve all, then ping all) collapses to one
  stage; a new `asyncio.Semaphore(_PING_BATCH_SIZE)` shared
  between the sweep and the eager path caps concurrent ICMP
  at icmplib's reliability ceiling regardless of how many
  YAMLs land at once (e.g. a restore-from-backup dropping
  50 files).
- `PingSource` carries a `_bootstrap_complete` flag flipped
  on inside `run()` after the existing
  `_PING_BOOTSTRAP_DELAY` sleep. The cold-start scanner emits
  `ADDED` once per cached YAML, so the monitor wrapper's
  hoisted `if not self._ping._bootstrap_complete: return`
  guards against allocating N coroutines + N tasks for a
  1000-device fleet during the mDNS grace period.
  `PingSource.probe_device` keeps the same check as
  defence-in-depth.

**Related issue or feature (if applicable):**

- fixes (no issue filed; reported in-session)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
