### PR TITLE
Quiet steady-state ping/DNS debug logging

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -50,6 +50,11 @@ class PingSource:
         # icmplib's reliability ceiling (`_PING_BATCH_SIZE`) when
         # both paths fire at once.
         self._concurrency = asyncio.Semaphore(_PING_BATCH_SIZE)
+        # Tuple of ``(name, address)`` from the last DEBUG-logged
+        # sweep; suppresses re-logging the identical line every
+        # 60s when the target set hasn't changed. New devices,
+        # mDNS claims, and removals re-surface the line.
+        self._last_logged_targets: tuple[tuple[str, str], ...] = ()
 
     async def run(self) -> None:
         await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
@@ -88,11 +93,14 @@ class PingSource:
         if not devices_to_ping:
             return
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            _LOGGER.debug(
-                "Pinging %d devices: %s",
-                len(devices_to_ping),
-                ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
-            )
+            signature = tuple((d.name, d.address) for d in devices_to_ping)
+            if signature != self._last_logged_targets:
+                self._last_logged_targets = signature
+                _LOGGER.debug(
+                    "Pinging %d devices: %s",
+                    len(devices_to_ping),
+                    ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
+                )
         # Single ``gather`` plus ``self._concurrency`` semaphore
         # caps in-flight ICMP at ``_PING_BATCH_SIZE`` across the
         # sweep and any concurrent eager probes; no need to

--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -18,7 +18,6 @@ hostnames.
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from contextlib import suppress
 from ipaddress import ip_address
@@ -31,8 +30,6 @@ except ImportError:  # pragma: no cover — icmplib is optional
     async_resolve = None  # type: ignore[assignment]
 
 from ..helpers.hostname import normalize_hostname
-
-_LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_TTL_SECONDS = 120
 _RESOLVE_TIMEOUT_SECONDS = 3.0
@@ -141,8 +138,6 @@ class DNSCache:
         if hostname.endswith(".local"):
             bare = hostname.removesuffix(".local")
             addresses = await self._try_resolve(bare)
-            if addresses is not None:
-                _LOGGER.debug("Resolved %s via bare-hostname fallback (%s)", hostname, bare)
         return addresses
 
     @staticmethod

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1418,6 +1418,42 @@ async def test_start_logs_ping_count_at_debug(
 
 
 @pytest.mark.asyncio
+async def test_repeat_sweep_with_unchanged_targets_logs_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``Pinging N devices`` only fires once when the target set is stable.
+
+    Without this dedup the line re-emits every ``_PING_INTERVAL``
+    forever on a steady fleet, spamming DEBUG-enabled logs with
+    identical content. New devices, mDNS claims, or removals
+    re-surface the line.
+    """
+    device = _device(address="example.com", state=DeviceState.UNKNOWN)
+    monitor, _callbacks = _make_monitor([device])
+
+    async def _icmp(_target: str, **_kw: Any) -> Any:
+        return MagicMock(is_alive=True)
+
+    monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
+    # Run three sweeps so a regression that re-logs every cycle
+    # would emit 3 lines instead of 1.
+    monkeypatch.setattr(ping_module.asyncio, "sleep", _bounded_sleep_factory(4))
+
+    with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
+        await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
+        try:
+            await _drain_ping_task(monitor)
+        finally:
+            await _stop_and_drain(monitor)
+
+    ping_logs = [r for r in caplog.records if "Pinging" in r.message]
+    assert len(ping_logs) == 1
+
+
+@pytest.mark.asyncio
 async def test_start_skips_devices_without_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Two DEBUG lines repeated identically on every sweep in
production: the `Pinging N devices: ...` ping-sweep header
(every 60s) and the `Resolved X.local via bare-hostname
fallback` DNS-cache line (every 120s per `.local` host whose
mDNS lookup keeps failing). Both filled DEBUG-enabled logs
with no new information per cycle.

- **`ping.py`**: track the last DEBUG-logged target set on
  `PingSource` as a `(name, address)` tuple and suppress the
  log when the next sweep's signature matches. New devices,
  mDNS claims, and removals re-surface the line.
- **`_dns_cache.py`**: drop the bare-hostname-fallback log
  outright. The explanatory comment above the fallback
  documents the behaviour; the log gave no actionable signal
  (the mDNS-failure half is never logged, so the "fallback
  worked" half was asymmetric noise). `_LOGGER` + the
  `logging` import drop with it.

Test added: `test_repeat_sweep_with_unchanged_targets_logs_once`
runs three sweeps with a stable fleet and pins exactly one
`Pinging` log line. The existing first-sweep test still passes
(dedup only kicks in on repeats).

**Related issue or feature (if applicable):**

- fixes (no issue filed; reported in-session)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
