### PR TITLE
Reject editor !include paths outside the config directory

### DIFF
--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -142,10 +142,21 @@ class EditorController:
         try:
             req_path = Path(requested).resolve()
         except OSError:
-            req_path = Path(requested)
+            # Canonicalisation failed (broken symlink, ENOTDIR,
+            # EACCES). The unresolved form can't be safely
+            # containment-checked, and read_text would fault for
+            # the same reason — refuse.
+            return ""
         main_path = (cfg_dir / configuration).resolve()
         if req_path == main_path or Path(requested).name == configuration:
             return content
+        # Containment check: the validator subprocess is fed
+        # attacker-controlled YAML, and ``!include /etc/passwd``
+        # would otherwise route through here and surface the
+        # file's bytes back to the client as ``yaml_errors``
+        # parse snippets. Refuse anything outside the config dir.
+        if not req_path.is_relative_to(cfg_dir):
+            return ""
         try:
             return req_path.read_text(encoding="utf-8")
         except OSError:

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -141,14 +141,19 @@ class EditorController:
         cfg_dir = Path(self._db.settings.config_dir).resolve()
         try:
             req_path = Path(requested).resolve()
-        except OSError:
-            # Canonicalisation failed (broken symlink, ENOTDIR,
-            # EACCES). The unresolved form can't be safely
-            # containment-checked, and read_text would fault for
-            # the same reason — refuse.
+        except (OSError, RuntimeError):
+            # Canonicalisation failed: broken symlink / ENOTDIR /
+            # EACCES (OSError), or an infinite symlink loop
+            # (RuntimeError on 3.12). The unresolved form can't
+            # be containment-checked, and read_text would fault
+            # for the same reason — refuse.
             return ""
         main_path = (cfg_dir / configuration).resolve()
-        if req_path == main_path or Path(requested).name == configuration:
+        # Bare-basename shortcut: the validator sometimes asks for
+        # the file by name only. Structural ``Path`` equality (not
+        # just ``.name``) keeps ``/tmp/kitchen.yaml`` from sneaking
+        # past the containment check below by colliding on basename.
+        if req_path == main_path or Path(requested) == Path(configuration):
             return content
         # Containment check: the validator subprocess is fed
         # attacker-controlled YAML, and ``!include /etc/passwd``

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -142,24 +142,16 @@ class EditorController:
         try:
             req_path = Path(requested).resolve()
         except (OSError, RuntimeError):
-            # Canonicalisation failed: broken symlink / ENOTDIR /
-            # EACCES (OSError), or an infinite symlink loop
-            # (RuntimeError on 3.12). The unresolved form can't
-            # be containment-checked, and read_text would fault
-            # for the same reason — refuse.
+            # Unresolvable (broken symlink / EACCES / 3.12 symlink-loop
+            # RuntimeError) can't be containment-checked — refuse.
             return ""
         main_path = (cfg_dir / configuration).resolve()
-        # Bare-basename shortcut: the validator sometimes asks for
-        # the file by name only. Structural ``Path`` equality (not
-        # just ``.name``) keeps ``/tmp/kitchen.yaml`` from sneaking
-        # past the containment check below by colliding on basename.
+        # Structural equality, not basename: ``/tmp/kitchen.yaml`` must not
+        # ride the in-memory shortcut past the containment check below.
         if req_path == main_path or Path(requested) == Path(configuration):
             return content
-        # Containment check: the validator subprocess is fed
-        # attacker-controlled YAML, and ``!include /etc/passwd``
-        # would otherwise route through here and surface the
-        # file's bytes back to the client as ``yaml_errors``
-        # parse snippets. Refuse anything outside the config dir.
+        # Attacker-controlled ``!include /etc/passwd`` would otherwise echo
+        # the file's bytes back as ``yaml_errors`` parse snippets.
         if not req_path.is_relative_to(cfg_dir):
             return ""
         try:

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -113,15 +113,7 @@ def test_resolve_file_reads_disk_for_include(tmp_path: Path) -> None:
 
 
 def test_resolve_file_refuses_paths_outside_config_dir(tmp_path: Path) -> None:
-    """Paths outside the config dir return ``""`` — never disk bytes.
-
-    The validator subprocess is fed attacker-controlled YAML and
-    follows ``!include`` by calling back into ``_resolve_file``; an
-    unscoped read would surface the bytes as ``yaml_errors`` parse
-    snippets to the client. Pin the containment: an absolute path
-    pointing at a file *outside* ``config_dir`` is dropped to ``""``
-    even when the file exists and is readable.
-    """
+    """An absolute path outside ``config_dir`` is dropped to ``""``."""
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     outside = tmp_path / "secret.txt"
@@ -133,12 +125,7 @@ def test_resolve_file_refuses_paths_outside_config_dir(tmp_path: Path) -> None:
 
 
 def test_resolve_file_refuses_symlink_escape(tmp_path: Path) -> None:
-    """A symlink inside the config dir pointing outside is also refused.
-
-    ``Path.resolve()`` follows symlinks, so the realpath check
-    catches the "symlink in config_dir → /etc/passwd" trick that
-    a basename-only filter would miss.
-    """
+    """A symlink inside ``config_dir`` pointing outside is refused after realpath."""
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     secret = tmp_path / "secret.txt"
@@ -149,6 +136,42 @@ def test_resolve_file_refuses_symlink_escape(tmp_path: Path) -> None:
     controller = _make_controller(config_dir)
     result = controller._resolve_file(str(link), "kitchen.yaml", "")
     assert result == ""
+
+
+def test_resolve_file_basename_shortcut_rejects_abs_path_with_matching_name(
+    tmp_path: Path,
+) -> None:
+    """``/elsewhere/kitchen.yaml`` does not short-circuit to in-memory content."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    decoy = elsewhere / "kitchen.yaml"
+    decoy.write_text("on-disk-elsewhere\n", encoding="utf-8")
+
+    controller = _make_controller(config_dir)
+    result = controller._resolve_file(str(decoy), "kitchen.yaml", "esphome:\n  name: in-memory\n")
+    # Falls through to the containment check → out-of-tree → "".
+    assert result == ""
+
+
+def test_resolve_file_returns_empty_on_symlink_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``Path.resolve()`` raising ``RuntimeError`` (symlink loop) → ``""``."""
+    controller = _make_controller(tmp_path)
+    include = tmp_path / "loop.yaml"
+
+    real_resolve = Path.resolve
+
+    def _raise_for_loop(self: Path, *args: Any, **kwargs: Any) -> Path:
+        if self.name == "loop.yaml":
+            raise RuntimeError("Symlink loop in path")
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _raise_for_loop)
+
+    assert controller._resolve_file(str(include), "kitchen.yaml", "") == ""
 
 
 def test_resolve_file_returns_empty_on_missing_include(tmp_path: Path) -> None:
@@ -636,14 +659,7 @@ async def test_terminate_subprocess_swallows_stdin_write_failure(
 def test_resolve_file_returns_empty_when_requested_path_unresolvable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``Path.resolve()`` raising → ``""``, never an unconfined read.
-
-    An unresolved path can't be containment-checked against the
-    config dir, so trusting it would re-open the arbitrary-file-read
-    hole the containment check exists to close. Pin that the
-    fallback drops to empty content rather than reading the
-    unresolved form.
-    """
+    """``Path.resolve()`` raising → ``""`` (unresolved paths can't be containment-checked)."""
     controller = _make_controller(tmp_path)
     include = tmp_path / "common.yaml"
     include.write_text("ok\n", encoding="utf-8")

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -112,6 +112,45 @@ def test_resolve_file_reads_disk_for_include(tmp_path: Path) -> None:
     assert result == "captive_portal:\n"
 
 
+def test_resolve_file_refuses_paths_outside_config_dir(tmp_path: Path) -> None:
+    """Paths outside the config dir return ``""`` — never disk bytes.
+
+    The validator subprocess is fed attacker-controlled YAML and
+    follows ``!include`` by calling back into ``_resolve_file``; an
+    unscoped read would surface the bytes as ``yaml_errors`` parse
+    snippets to the client. Pin the containment: an absolute path
+    pointing at a file *outside* ``config_dir`` is dropped to ``""``
+    even when the file exists and is readable.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_text("super-secret\n", encoding="utf-8")
+
+    controller = _make_controller(config_dir)
+    result = controller._resolve_file(str(outside), "kitchen.yaml", "")
+    assert result == ""
+
+
+def test_resolve_file_refuses_symlink_escape(tmp_path: Path) -> None:
+    """A symlink inside the config dir pointing outside is also refused.
+
+    ``Path.resolve()`` follows symlinks, so the realpath check
+    catches the "symlink in config_dir → /etc/passwd" trick that
+    a basename-only filter would miss.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("super-secret\n", encoding="utf-8")
+    link = config_dir / "leak.yaml"
+    link.symlink_to(secret)
+
+    controller = _make_controller(config_dir)
+    result = controller._resolve_file(str(link), "kitchen.yaml", "")
+    assert result == ""
+
+
 def test_resolve_file_returns_empty_on_missing_include(tmp_path: Path) -> None:
     """Missing include → empty string, never a raise.
 
@@ -594,16 +633,16 @@ async def test_terminate_subprocess_swallows_stdin_write_failure(
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_file_falls_back_when_requested_path_unresolvable(
+def test_resolve_file_returns_empty_when_requested_path_unresolvable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``Path.resolve()`` raising on the requested path → use the unresolved Path.
+    """``Path.resolve()`` raising → ``""``, never an unconfined read.
 
-    macOS / Linux with a long enough path (or a path through a
-    broken symlink) can fault ``resolve()`` even when ``read_text``
-    later succeeds against the unresolved form. The except branch
-    keeps the read-from-disk fallback usable in that case rather
-    than 500-ing the validator round-trip.
+    An unresolved path can't be containment-checked against the
+    config dir, so trusting it would re-open the arbitrary-file-read
+    hole the containment check exists to close. Pin that the
+    fallback drops to empty content rather than reading the
+    unresolved form.
     """
     controller = _make_controller(tmp_path)
     include = tmp_path / "common.yaml"
@@ -623,7 +662,7 @@ def test_resolve_file_falls_back_when_requested_path_unresolvable(
 
     result = controller._resolve_file(str(include), "kitchen.yaml", "")
 
-    assert result == "ok\n"
+    assert result == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -151,7 +151,6 @@ def test_resolve_file_basename_shortcut_rejects_abs_path_with_matching_name(
 
     controller = _make_controller(config_dir)
     result = controller._resolve_file(str(decoy), "kitchen.yaml", "esphome:\n  name: in-memory\n")
-    # Falls through to the containment check → out-of-tree → "".
     assert result == ""
 
 


### PR DESCRIPTION
# What does this implement/fix?

`EditorController._resolve_file` answered `read_file` callbacks
from the `esphome vscode --ace` validator subprocess by resolving
the requested path and `read_text`-ing it with no containment
check. A `!include /etc/passwd` (or any other absolute path —
`/data/.env`, `/config/secrets.yaml`) in the editor buffer would
route through here and the file's bytes would surface back to the
client as `yaml_errors` parse snippets.

**Not a security fix.** The dashboard's threat model already
assumes the authenticated user is fully privileged on the host:
`external_components:` in any compiled YAML runs arbitrary Python
at compile time, so an authenticated client already has RCE — a
file read is strictly weaker than what they can do through the
normal compile path. This change is hygiene: the editor shouldn't
be a surprising side-channel for `cat`-ing arbitrary files, and
the validator's `read_file` callback has no legitimate reason to
reach outside the config tree.

Mechanics:

- After `Path.resolve()`, require `req_path.is_relative_to(cfg_dir)`
  before reading; out-of-tree paths return `""` and the validator
  surfaces its own "file not found" parse error.
- `resolve()` follows symlinks, so an in-config-dir symlink that
  points outside the tree is also caught.
- The previous `OSError`-on-resolve fallback (which fell through
  to `read_text` on the *unresolved* path) is dropped — an
  un-canonicalised path can't be containment-checked and
  `read_text` would fault for the same underlying reason anyway.

**Related issue or feature (if applicable):**

- fixes <none — reported in-conversation>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
