### PR TITLE
Stop ping log re-emitting when a device flickers between buckets

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import enum
 import logging
 from typing import TYPE_CHECKING
 
@@ -23,14 +22,6 @@ if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class _Classification(enum.Enum):
-    INELIGIBLE = enum.auto()
-    MDNS_CLAIMED = enum.auto()
-    DNS_FAILED = enum.auto()
-    PING = enum.auto()
-
 
 _PING_INTERVAL = 60  # seconds between ping sweeps
 # Bootstrap delay gives the mDNS browser a head start so the
@@ -53,11 +44,11 @@ class PingSource:
         # still triggers the next idle.
         self._wake = asyncio.Event()
         self._concurrency = asyncio.Semaphore(_PING_BATCH_SIZE)
-        # Tuple of ``(name, address)`` for every device that the
-        # classifier handed to either bucket on the last DEBUG sweep.
-        # Spanning both buckets keeps the signature stable across the
-        # DNS-failure-cache flicker (120s TTL vs 60s sweep), so the
-        # line only re-emits on real membership change.
+        # Sorted ``(name, address)`` of every device in the union of
+        # the last DEBUG sweep's pingable + dns_failed buckets. Spanning
+        # both keeps the signature stable across the DNS-failure cache
+        # flicker (120s TTL vs 60s sweep) so the line only re-emits on
+        # real membership change.
         self._last_logged_targets: tuple[tuple[str, str], ...] = ()
         # 0→1 multiplexed into the same wake event so a subscriber
         # arriving mid-idle gets fresh ICMP without waiting out the
@@ -103,11 +94,21 @@ class PingSource:
             # ``dns_failed`` every 60s sweep doesn't re-emit the log
             # line each cycle. New devices, mDNS claims, and removals
             # still resurface it.
-            all_targets = sorted(pingable + dns_failed, key=lambda d: d.name)
-            signature = tuple((d.name, d.address) for d in all_targets)
+            signature = tuple(sorted((d.name, d.address) for d in pingable + dns_failed))
             if signature != self._last_logged_targets:
                 self._last_logged_targets = signature
-                self._log_targets(pingable, dns_failed)
+                pingable_str = ", ".join(f"{d.name} ({d.address})" for d in pingable) or "(none)"
+                if dns_failed:
+                    skipped_str = ", ".join(f"{d.name} ({d.address})" for d in dns_failed)
+                    _LOGGER.debug(
+                        "Pinging %d devices: %s; skipping %d (cached DNS failure): %s",
+                        len(pingable),
+                        pingable_str,
+                        len(dns_failed),
+                        skipped_str,
+                    )
+                else:
+                    _LOGGER.debug("Pinging %d devices: %s", len(pingable), pingable_str)
         # ``self._concurrency`` semaphore caps in-flight ICMP at
         # ``_PING_BATCH_SIZE``; no need to pre-chunk the gather.
         await asyncio.gather(
@@ -116,48 +117,8 @@ class PingSource:
         )
 
     def _select_ping_targets(self) -> tuple[list[Device], list[Device]]:
-        """Return ``(pingable, dns_failed)`` after running classifier side-effects."""
-        pingable: list[Device] = []
-        dns_failed: list[Device] = []
-        for device in self._monitor._get_devices():
-            match self._classify_for_ping(device):
-                case _Classification.PING:
-                    pingable.append(device)
-                case _Classification.DNS_FAILED:
-                    dns_failed.append(device)
-                case _:
-                    continue
-        return pingable, dns_failed
-
-    @staticmethod
-    def _log_targets(pingable: list[Device], dns_failed: list[Device]) -> None:
-        """Emit the per-membership-change DEBUG line for the next sweep."""
-        if dns_failed:
-            skipped = ", ".join(f"{d.name} ({d.address})" for d in dns_failed)
-            if pingable:
-                _LOGGER.debug(
-                    "Pinging %d devices: %s; skipping %d (cached DNS failure): %s",
-                    len(pingable),
-                    ", ".join(f"{d.name} ({d.address})" for d in pingable),
-                    len(dns_failed),
-                    skipped,
-                )
-            else:
-                _LOGGER.debug(
-                    "Skipping %d devices (cached DNS failure): %s",
-                    len(dns_failed),
-                    skipped,
-                )
-        else:
-            _LOGGER.debug(
-                "Pinging %d devices: %s",
-                len(pingable),
-                ", ".join(f"{d.name} ({d.address})" for d in pingable),
-            )
-
-    def _classify_for_ping(self, device: Device) -> _Classification:
         """
-        Classify *device* and apply any short-circuit side-effects.
+        Return ``(pingable, dns_failed)`` after running per-device side-effects.
 
         Three filters apply: skip when a higher-priority source
         owns the device; claim ``.local`` cache hits for mDNS so
@@ -165,26 +126,31 @@ class PingSource:
         subnet; flip OFFLINE without probing when DNS already
         failed (no point hammering the resolver).
         """
+        pingable: list[Device] = []
+        dns_failed: list[Device] = []
         monitor = self._monitor
-        if not device.address or not shared.should_ping(monitor, device):
-            return _Classification.INELIGIBLE
-        if is_local_hostname(device.address) and (
-            cached := monitor.get_cached_addresses(device.address)
-        ):
-            monitor.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-            # Forward every cached IP so the dashboard shows all
-            # of them; ``apply_ip_addresses`` picks the IPv4
-            # primary for ICMP / OTA targeting.
-            monitor.apply_ip_addresses(device.name, cached)
-            return _Classification.MDNS_CLAIMED
-        if monitor.state.dns_cache.has_cached_failure(device.address):
-            # DNS-failure cache entry: don't hand the bare hostname
-            # to icmplib (it would hammer the system resolver every
-            # sweep). Apply OFFLINE under the ``ping`` source so a
-            # future successful resolve can flip the device back.
-            monitor.apply(device.name, DeviceState.OFFLINE, "ping")
-            return _Classification.DNS_FAILED
-        return _Classification.PING
+        for device in monitor._get_devices():
+            if not device.address or not shared.should_ping(monitor, device):
+                continue
+            if is_local_hostname(device.address) and (
+                cached := monitor.get_cached_addresses(device.address)
+            ):
+                monitor.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
+                # Forward every cached IP so the dashboard shows all
+                # of them; ``apply_ip_addresses`` picks the IPv4
+                # primary for ICMP / OTA targeting.
+                monitor.apply_ip_addresses(device.name, cached)
+                continue
+            if monitor.state.dns_cache.has_cached_failure(device.address):
+                # Don't hand the bare hostname to icmplib (it would
+                # hammer the system resolver every sweep). Apply
+                # OFFLINE under the ``ping`` source so a future
+                # successful resolve can flip the device back.
+                monitor.apply(device.name, DeviceState.OFFLINE, "ping")
+                dns_failed.append(device)
+                continue
+            pingable.append(device)
+        return pingable, dns_failed
 
     async def _resolve_and_ping(self, device: Device) -> None:
         """Resolve *device.address* through the DNS cache and ICMP it."""

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import enum
 import logging
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,14 @@ if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _Classification(enum.Enum):
+    INELIGIBLE = enum.auto()
+    MDNS_CLAIMED = enum.auto()
+    DNS_FAILED = enum.auto()
+    PING = enum.auto()
+
 
 _PING_INTERVAL = 60  # seconds between ping sweeps
 # Bootstrap delay gives the mDNS browser a head start so the
@@ -44,10 +53,11 @@ class PingSource:
         # still triggers the next idle.
         self._wake = asyncio.Event()
         self._concurrency = asyncio.Semaphore(_PING_BATCH_SIZE)
-        # Tuple of ``(name, address)`` from the last DEBUG-logged
-        # sweep; suppresses re-logging the identical line every
-        # 60s when the target set hasn't changed. New devices,
-        # mDNS claims, and removals re-surface the line.
+        # Tuple of ``(name, address)`` for every device that the
+        # classifier handed to either bucket on the last DEBUG sweep.
+        # Spanning both buckets keeps the signature stable across the
+        # DNS-failure-cache flicker (120s TTL vs 60s sweep), so the
+        # line only re-emits on real membership change.
         self._last_logged_targets: tuple[tuple[str, str], ...] = ()
         # 0→1 multiplexed into the same wake event so a subscriber
         # arriving mid-idle gets fresh ICMP without waiting out the
@@ -84,32 +94,70 @@ class PingSource:
     async def _ping_sweep(self) -> None:
         if icmp_ping is None:
             return
-        devices_to_ping = self._select_ping_targets()
-        if not devices_to_ping:
+        pingable, dns_failed = self._select_ping_targets()
+        if not pingable and not dns_failed:
             return
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            signature = tuple((d.name, d.address) for d in devices_to_ping)
+            # Signature spans both buckets so a device whose 120s
+            # DNS-failure cache TTL flips it between ``pingable`` and
+            # ``dns_failed`` every 60s sweep doesn't re-emit the log
+            # line each cycle. New devices, mDNS claims, and removals
+            # still resurface it.
+            all_targets = sorted(pingable + dns_failed, key=lambda d: d.name)
+            signature = tuple((d.name, d.address) for d in all_targets)
             if signature != self._last_logged_targets:
                 self._last_logged_targets = signature
-                _LOGGER.debug(
-                    "Pinging %d devices: %s",
-                    len(devices_to_ping),
-                    ", ".join(f"{d.name} ({d.address})" for d in devices_to_ping),
-                )
+                self._log_targets(pingable, dns_failed)
         # ``self._concurrency`` semaphore caps in-flight ICMP at
         # ``_PING_BATCH_SIZE``; no need to pre-chunk the gather.
         await asyncio.gather(
-            *(self._resolve_and_ping(device) for device in devices_to_ping),
+            *(self._resolve_and_ping(device) for device in pingable),
             return_exceptions=True,
         )
 
-    def _select_ping_targets(self) -> list[Device]:
-        """Filter the device list down to actual ping candidates."""
-        return [d for d in self._monitor._get_devices() if self._classify_for_ping(d)]
+    def _select_ping_targets(self) -> tuple[list[Device], list[Device]]:
+        """Return ``(pingable, dns_failed)`` after running classifier side-effects."""
+        pingable: list[Device] = []
+        dns_failed: list[Device] = []
+        for device in self._monitor._get_devices():
+            match self._classify_for_ping(device):
+                case _Classification.PING:
+                    pingable.append(device)
+                case _Classification.DNS_FAILED:
+                    dns_failed.append(device)
+                case _:
+                    continue
+        return pingable, dns_failed
 
-    def _classify_for_ping(self, device: Device) -> bool:
+    @staticmethod
+    def _log_targets(pingable: list[Device], dns_failed: list[Device]) -> None:
+        """Emit the per-membership-change DEBUG line for the next sweep."""
+        if dns_failed:
+            skipped = ", ".join(f"{d.name} ({d.address})" for d in dns_failed)
+            if pingable:
+                _LOGGER.debug(
+                    "Pinging %d devices: %s; skipping %d (cached DNS failure): %s",
+                    len(pingable),
+                    ", ".join(f"{d.name} ({d.address})" for d in pingable),
+                    len(dns_failed),
+                    skipped,
+                )
+            else:
+                _LOGGER.debug(
+                    "Skipping %d devices (cached DNS failure): %s",
+                    len(dns_failed),
+                    skipped,
+                )
+        else:
+            _LOGGER.debug(
+                "Pinging %d devices: %s",
+                len(pingable),
+                ", ".join(f"{d.name} ({d.address})" for d in pingable),
+            )
+
+    def _classify_for_ping(self, device: Device) -> _Classification:
         """
-        Return True iff *device* needs an ICMP probe; apply any short-circuit side-effects.
+        Classify *device* and apply any short-circuit side-effects.
 
         Three filters apply: skip when a higher-priority source
         owns the device; claim ``.local`` cache hits for mDNS so
@@ -119,7 +167,7 @@ class PingSource:
         """
         monitor = self._monitor
         if not device.address or not shared.should_ping(monitor, device):
-            return False
+            return _Classification.INELIGIBLE
         if is_local_hostname(device.address) and (
             cached := monitor.get_cached_addresses(device.address)
         ):
@@ -128,18 +176,15 @@ class PingSource:
             # of them; ``apply_ip_addresses`` picks the IPv4
             # primary for ICMP / OTA targeting.
             monitor.apply_ip_addresses(device.name, cached)
-            return False
+            return _Classification.MDNS_CLAIMED
         if monitor.state.dns_cache.has_cached_failure(device.address):
             # DNS-failure cache entry: don't hand the bare hostname
             # to icmplib (it would hammer the system resolver every
             # sweep). Apply OFFLINE under the ``ping`` source so a
             # future successful resolve can flip the device back.
-            _LOGGER.debug(
-                "Skipping ping for %s (%s): cached DNS failure", device.name, device.address
-            )
             monitor.apply(device.name, DeviceState.OFFLINE, "ping")
-            return False
-        return True
+            return _Classification.DNS_FAILED
+        return _Classification.PING
 
     async def _resolve_and_ping(self, device: Device) -> None:
         """Resolve *device.address* through the DNS cache and ICMP it."""

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _format_devices(devices: list[Device]) -> str:
+    """Render *devices* as ``"name (address), …"`` for log messages."""
+    return ", ".join(f"{d.name} ({d.address})" for d in devices)
+
+
 _PING_INTERVAL = 60  # seconds between ping sweeps
 # Bootstrap delay gives the mDNS browser a head start so the
 # common case (everything announces) skips a redundant ping the
@@ -97,18 +103,18 @@ class PingSource:
             signature = tuple(sorted((d.name, d.address) for d in pingable + dns_failed))
             if signature != self._last_logged_targets:
                 self._last_logged_targets = signature
-                pingable_str = ", ".join(f"{d.name} ({d.address})" for d in pingable) or "(none)"
                 if dns_failed:
-                    skipped_str = ", ".join(f"{d.name} ({d.address})" for d in dns_failed)
                     _LOGGER.debug(
                         "Pinging %d devices: %s; skipping %d (cached DNS failure): %s",
                         len(pingable),
-                        pingable_str,
+                        _format_devices(pingable) or "(none)",
                         len(dns_failed),
-                        skipped_str,
+                        _format_devices(dns_failed),
                     )
                 else:
-                    _LOGGER.debug("Pinging %d devices: %s", len(pingable), pingable_str)
+                    _LOGGER.debug(
+                        "Pinging %d devices: %s", len(pingable), _format_devices(pingable)
+                    )
         # ``self._concurrency`` semaphore caps in-flight ICMP at
         # ``_PING_BATCH_SIZE``; no need to pre-chunk the gather.
         await asyncio.gather(
@@ -117,15 +123,7 @@ class PingSource:
         )
 
     def _select_ping_targets(self) -> tuple[list[Device], list[Device]]:
-        """
-        Return ``(pingable, dns_failed)`` after running per-device side-effects.
-
-        Three filters apply: skip when a higher-priority source
-        owns the device; claim ``.local`` cache hits for mDNS so
-        the bare-hostname DNS fallback can't resolve them off-
-        subnet; flip OFFLINE without probing when DNS already
-        failed (no point hammering the resolver).
-        """
+        """Return ``(pingable, dns_failed)`` and apply per-device side-effects."""
         pingable: list[Device] = []
         dns_failed: list[Device] = []
         monitor = self._monitor

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1437,6 +1437,59 @@ async def test_repeat_sweep_with_unchanged_targets_logs_once(
 
 
 @pytest.mark.asyncio
+async def test_dns_failure_flicker_does_not_re_emit_log(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A device flipping between pingable and dns-failed each sweep logs once.
+
+    Production trigger: DNS cache TTL (120s) > ping interval (60s) makes a
+    permanently-DNS-failing device alternate every sweep between the
+    pingable bucket (cache just expired, resolve will fail again) and the
+    dns_failed bucket (fresh cache entry). The "Pinging N devices" line
+    must not re-emit on this transient bucket flip.
+    """
+    flaky = _device(name="zom", address="zom.local", state=DeviceState.UNKNOWN)
+    stable = _device(name="ok", address="ok.example.com", state=DeviceState.UNKNOWN)
+    monitor, _callbacks = _make_monitor([flaky, stable])
+
+    async def _icmp(_target: str, **_kw: Any) -> Any:
+        return MagicMock(is_alive=True, min_rtt=1.0)
+
+    monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
+    monitor.get_cached_addresses = MagicMock(return_value=None)
+    # ``zom`` alternates True/False every classify call, ``ok`` is always
+    # resolvable. ``side_effect`` is a list — pytest will replay it in
+    # order across however many calls the loop makes.
+    cache_calls = {"n": 0}
+
+    def _has_cached_failure(host: str) -> bool:
+        if host != "zom.local":
+            return False
+        cache_calls["n"] += 1
+        return cache_calls["n"] % 2 == 0
+
+    monitor.state.dns_cache.has_cached_failure = MagicMock(side_effect=_has_cached_failure)
+    _shrink_ping_intervals(monkeypatch)
+
+    with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
+        await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
+        try:
+            await _let_ping_loop_run_briefly(monitor)
+        finally:
+            await _stop_and_drain(monitor)
+
+    membership_logs = [
+        r for r in caplog.records if "Pinging" in r.message or "Skipping" in r.message
+    ]
+    assert len(membership_logs) == 1
+    # The flaky device made it into at least one classifier call, so the
+    # cache_calls counter is non-zero — confirms the flicker actually fired.
+    assert cache_calls["n"] >= 2
+
+
+@pytest.mark.asyncio
 async def test_start_skips_devices_without_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1441,14 +1441,7 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A device flipping between pingable and dns-failed each sweep logs once.
-
-    Production trigger: DNS cache TTL (120s) > ping interval (60s) makes a
-    permanently-DNS-failing device alternate every sweep between the
-    pingable bucket (cache just expired, resolve will fail again) and the
-    dns_failed bucket (fresh cache entry). The "Pinging N devices" line
-    must not re-emit on this transient bucket flip.
-    """
+    """A device flipping between pingable and dns-failed each sweep logs once."""
     flaky = _device(name="zom", address="zom.local", state=DeviceState.UNKNOWN)
     stable = _device(name="ok", address="ok.example.com", state=DeviceState.UNKNOWN)
     monitor, _callbacks = _make_monitor([flaky, stable])
@@ -1459,9 +1452,6 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
     monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
     monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
     monitor.get_cached_addresses = MagicMock(return_value=None)
-    # ``zom`` alternates True/False every classify call, ``ok`` is always
-    # resolvable. ``side_effect`` is a list — pytest will replay it in
-    # order across however many calls the loop makes.
     cache_calls = {"n": 0}
 
     def _has_cached_failure(host: str) -> bool:
@@ -1484,8 +1474,6 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
         r for r in caplog.records if "Pinging" in r.message or "Skipping" in r.message
     ]
     assert len(membership_logs) == 1
-    # The flaky device made it into at least one classifier call, so the
-    # cache_calls counter is non-zero — confirms the flicker actually fired.
     assert cache_calls["n"] >= 2
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #864. That PR deduplicated the
`Pinging N devices: ...` line when the target set is stable, but a
permanently-DNS-failing device still re-emits it every sweep. The
DNS-failure cache TTL (120s) is longer than the ping interval
(60s), so the device alternates each sweep between the pingable
bucket (cache just expired, resolve will fail again on this sweep)
and the dns_failed bucket (fresh cache entry). The signature
flipped on every cycle and the line re-emitted every minute. The
per-sweep `Skipping ping for X: cached DNS failure` debug fired on
the same cadence.

Field log captured the pattern in steady state, with `zom.local`
permanently failing DNS:

```
17:39:49 Pinging 4 devices: acfloat, apollo, wiznet, zwave
17:40:49 Pinging 5 devices: acfloat, apollo, wiznet, zom, zwave
17:41:53 Skipping ping for zom (zom.local): cached DNS failure
17:41:53 Pinging 4 devices: acfloat, apollo, wiznet, zwave
17:42:53 Pinging 5 devices: acfloat, apollo, wiznet, zom, zwave
17:43:56 Skipping ping for zom (zom.local): cached DNS failure
17:43:56 Pinging 4 devices: acfloat, apollo, wiznet, zwave
```

- **`ping.py`**: `_classify_for_ping` now returns a
  `_Classification` enum (`INELIGIBLE` / `MDNS_CLAIMED` /
  `DNS_FAILED` / `PING`); `_select_ping_targets` returns
  `(pingable, dns_failed)`. The dedup signature is the
  `(name, address)` tuple of the union, so a TTL-driven bucket flip
  doesn't change it. The per-sweep
  `Skipping ping for X: cached DNS failure` log is gone; its
  contents merge into the membership-change line as a
  `; skipping N (cached DNS failure): ...` clause when DNS-failed
  devices exist.

Test added: `test_dns_failure_flicker_does_not_re_emit_log` drives
a fake DNS cache whose `has_cached_failure` flips True/False every
classify call for one device and confirms exactly one
membership-change log lands across the run. The existing
`Pinging N devices` / `cached DNS failure` / dedup tests still
pass; the consolidated message still contains the
`cached DNS failure` substring the older assertion looks for.

**Related issue or feature (if applicable):**

- fixes (no issue filed; reported in-session, follow-up to #864)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
