### PR TITLE
Enforce cross-origin allowlist on passwordless public site

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ managing automations, and pushing firmware updates.
 
 ## Try it
 
+> Running it behind a reverse proxy?
+> Skip ahead to [Behind a reverse proxy](#behind-a-reverse-proxy)
+> for the nginx / `--trusted-domains` setup.
+
 The dashboard ships as an **opt-in preview** in the official Home Assistant
 add-on and in [ESPHome Desktop](https://github.com/esphome/esphome-desktop).
 Pick the path that matches how you run ESPHome today:
@@ -104,6 +108,71 @@ the browser's default heuristic is fine when you're not rebuilding
 every few minutes.
 
 </details>
+
+## Behind a reverse proxy
+
+The dashboard rejects browser WebSocket handshakes whose
+`Origin` doesn't match the server's `Host` header. When a
+proxy fronts the dashboard under a different hostname (nginx,
+Caddy, Traefik, nginx-proxy-manager, ...), the browser sends
+`Origin: https://dashboard.example.com` but the upstream sees
+`Host: localhost:6052` — those don't match and the handshake
+gets 403'd. Same gate, same fix, regardless of whether the
+dashboard has a password set; it applies to every public-site
+deployment.
+
+Two ways to make it work:
+
+1. **Configure the proxy to forward the public Host** (cleanest):
+
+   ```nginx
+   location / {
+       proxy_pass http://localhost:6052;
+       proxy_http_version 1.1;
+       proxy_set_header Host $host;
+       proxy_set_header Upgrade $http_upgrade;
+       proxy_set_header Connection "upgrade";
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_read_timeout 86400s;  # keep WS connections alive
+   }
+   ```
+
+   With `proxy_set_header Host $host;`, the dashboard sees
+   `Host: dashboard.example.com` (the hostname the browser
+   asked for), `Origin` matches, and the handshake passes.
+
+2. **If the proxy rewrites Host** (default nginx, some
+   load-balancer setups), add the public hostname to
+   `--trusted-domains`:
+
+   ```bash
+   esphome-device-builder /config \
+     --trusted-domains dashboard.example.com,proxy.example.com
+   ```
+
+   Or via the env var (`$ESPHOME_TRUSTED_DOMAINS`, same name
+   the legacy dashboard used):
+
+   ```bash
+   ESPHOME_TRUSTED_DOMAINS=dashboard.example.com esphome-device-builder /config
+   ```
+
+   The list is comma-separated, case-insensitive, port-tolerant.
+   IPv6 addresses work bracketed or bare (`::1` and `[::1]`
+   both match). Use `*` as the only entry to disable the Host
+   restriction entirely (handy when the Host varies per request
+   — but then operator-supplied auth becomes the only gate).
+
+CLI tools and the Home Assistant integration omit `Origin`
+entirely, so they're never affected — the gate is browser-only.
+The HA Ingress site (the `--ingress-host` listener the
+supervisor proxies to) skips both checks because it's bound to
+the supervisor's internal docker network and the supervisor
+handles auth upstream.
+
+See [docs/ARCHITECTURE.md § Authentication](docs/ARCHITECTURE.md#authentication)
+for the deep dive on the trust model.
 
 ## Send builds to another dashboard
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -283,6 +283,8 @@ The allowlist drives two checks in the WS handshake (both opt-in; empty = strict
 
 Both gates apply only to requests that carry an `Origin` header. Browsers always set `Origin` for the WebSocket opening handshake, so DNS-rebinding attempts land inside the gate; non-browser clients (CLI tools, the HA integration, direct `websockets` clients) omit `Origin` and skip both gates. The in-band `auth` handshake does the work for those clients, and gating on `Origin` means an operator hardening against rebinding doesn't accidentally lock out their HA integration.
 
+The cross-origin gate applies to **every public-site deployment**, password-gated or not — a passwordless dashboard is still reachable only by the operator's own browser sessions, never by whatever malicious page they happen to visit. The same allowlist drives REST CORS in `helpers/json.py:cors_middleware`: `Access-Control-Allow-Origin` is reflected only when `Origin` matches `Host` or is in `--trusted-domains` (else omitted, so the browser blocks the calling JS from reading the response). The HA Ingress site (`trusted_site=True`) skips both gates because the supervisor handles auth upstream and the listener is bound to the supervisor's docker network.
+
 Match is case-insensitive and port-tolerant: `dashboard.example.com` accepts `Dashboard.Example.com:8443`. IPv6 may be entered with or without brackets (`::1` and `[::1]` both work). Use `*` as the only entry to opt out of the Host restriction while still permitting cross-origin handshakes (handy when the Host varies per request).
 
 ### Binding to a network interface name

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import ipaddress
 import logging
 import weakref
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse, urlsplit
 
 from aiohttp import WSCloseCode, WSMsgType, web
 from esphome.const import __version__ as esphome_version
@@ -22,6 +20,11 @@ from ..helpers.api import CommandError
 from ..helpers.auth import extract_bearer_token
 from ..helpers.event_bus import StreamBackpressureError
 from ..helpers.json import JSONDecodeError, dumps_str, loads
+from ..helpers.origin import (
+    host_in_allowlist,
+    origin_in_allowlist,
+    origin_matches_host,
+)
 from ..models import (
     CommandMessage,
     ErrorCode,
@@ -272,40 +275,34 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     settings = device_builder.settings
     trusted_site = bool(request.app.get("trusted_site", False))
 
-    # Reject cross-origin browser connections on the password-gated public
-    # site. CORS middleware doesn't apply to WebSockets, so without this a
-    # malicious page could open /ws against a victim's dashboard. Clients
-    # without an Origin header (CLI tools, HA integration) are unaffected.
-    if settings.using_password and not trusted_site:
+    # Reject cross-origin browser connections on the public site.
+    # CORS middleware doesn't apply to WebSockets, so without this a
+    # malicious page the operator browses could open /ws against the
+    # local dashboard — even a passwordless deployment is reachable
+    # only by the operator's own browser sessions, not by anything
+    # they happen to visit. Clients without an Origin header (CLI
+    # tools, HA integration) are unaffected — Origin is spec-
+    # mandated for browser WebSocket handshakes, so any browser-
+    # driven cross-origin attack lands inside the gate while
+    # non-browser auth (bearer / in-band) keeps working.
+    if not trusted_site:
         origin = request.headers.get("Origin")
-        # Both Origin / Host gates apply only to requests that
-        # carry an ``Origin`` header — browser-driven WebSocket
-        # connections always set it (spec-mandated for any WS
-        # opening handshake), so any DNS-rebinding attack lands
-        # here. CLI tools / HA integration / direct ``websockets``
-        # clients omit Origin and skip both checks; the existing
-        # bearer-token / in-band auth gate is doing the work for
-        # them. Without this gate, an operator who sets
-        # ``trusted_domains`` to harden against rebinding would
-        # also lock out their HA integration.
         if origin:
-            # Cross-origin acceptance gate: the Origin must equal
-            # Host OR the Origin's hostname must be in the
-            # operator-supplied trusted-domains allowlist. Without
-            # the allowlist branch, reverse-proxy deployments where
-            # Origin is ``https://dashboard.example.com`` but Host
-            # is the upstream ``localhost:6052`` lose dashboard
-            # access entirely.
-            if not _origin_matches_host(origin, request.host) and not _origin_in_allowlist(
+            # Cross-origin acceptance: Origin must equal Host OR
+            # Origin's hostname must be in the operator-supplied
+            # trusted-domains allowlist. Reverse-proxy deployments
+            # where Origin is ``https://dashboard.example.com`` but
+            # Host is the upstream ``localhost:6052`` need the
+            # allowlist branch.
+            if not origin_matches_host(origin, request.host) and not origin_in_allowlist(
                 origin, settings.trusted_domains
             ):
                 return web.Response(status=403, text="Cross-origin connection rejected")
             # Defense-in-depth Host allowlist. Empty list = not
             # configured = pass through. When set, the request's
             # Host must be one of the trusted domains — mitigates
-            # DNS-rebinding on top of the auth + per-IP rate limit
-            # chain.
-            if not _host_in_allowlist(request.host, settings.trusted_domains):
+            # DNS rebinding on top of the Origin equality check.
+            if not host_in_allowlist(request.host, settings.trusted_domains):
                 return web.Response(status=403, text="Host not in trusted-domains allowlist")
 
     ws = web.WebSocketResponse(heartbeat=_WS_HEARTBEAT_SECONDS)
@@ -423,112 +420,3 @@ def create_ws_routes() -> web.RouteTableDef:
         return await websocket_handler(request)
 
     return routes
-
-
-def _origin_matches_host(origin: str, request_host: str) -> bool:
-    """Return True when *origin*'s host:port matches the request's Host header."""
-    try:
-        parsed = urlparse(origin)
-    except ValueError:
-        return False
-    return bool(parsed.netloc) and parsed.netloc == request_host
-
-
-def _origin_in_allowlist(origin: str, allowlist: list[str]) -> bool:
-    """Return True when ``origin``'s hostname is in the allowlist.
-
-    Used by the cross-origin acceptance gate: reverse-proxy
-    deployments where Origin is ``https://dashboard.example.com``
-    but Host is ``localhost:6052`` (proxy upstream) need the
-    operator-supplied ``ESPHOME_TRUSTED_DOMAINS`` allowlist to
-    accept the cross-origin handshake.
-
-    The allowlist match is on the Origin URL's hostname (port and
-    scheme stripped), case-insensitive. A bare hostname entry like
-    ``dashboard.example.com`` matches an Origin of
-    ``https://Dashboard.Example.com`` regardless of port; an entry
-    of ``[::1]`` matches ``http://[::1]:6052``.
-
-    ``"*"`` matches anything (escape hatch for operators who set
-    the env var without a specific host list).
-    """
-    if not allowlist:
-        return False
-    if "*" in allowlist:
-        return True
-    try:
-        parsed = urlparse(origin)
-    except ValueError:
-        return False
-    hostname = (parsed.hostname or "").lower()
-    if not hostname:
-        return False
-    return any(_normalize_host(entry) == hostname for entry in allowlist)
-
-
-def _normalize_host(host: str) -> str:
-    """Lower-case ``host`` and strip the port + IPv6 brackets, if any.
-
-    HTTP ``Host`` headers carry IPv6 addresses bracket-wrapped
-    (``[::1]:6052``); naive ``split(":", 1)`` would chop the first
-    segment of the address. ``urlsplit("//" + host).hostname``
-    handles both shapes (IPv4 / hostname:port and ``[ipv6]:port``)
-    and returns the unbracketed lowercase hostname.
-
-    There's one edge case ``urlsplit`` mis-handles: a bare IPv6
-    address typed *without* brackets (operator's allowlist entry
-    of ``fe80::1`` rather than ``[fe80::1]``) — ``urlsplit``
-    parses the leading ``fe80`` as the host and ``:1`` as the
-    port. Short-circuit those via ``ipaddress.ip_address`` before
-    falling through to the URL-parser branch. Bracketed Host
-    headers go straight to ``urlsplit`` which handles them
-    correctly. Falls back to the input verbatim when ``urlsplit``
-    returns nothing usable (malformed Host header).
-    """
-    stripped = host.strip()
-    if not stripped.startswith("["):
-        try:
-            ipaddress.ip_address(stripped)
-        except ValueError:
-            pass
-        else:
-            return stripped.lower()
-    try:
-        hostname = urlsplit(f"//{stripped}").hostname
-    except ValueError:
-        hostname = None
-    if hostname is None:
-        return stripped.lower()
-    return hostname.lower()
-
-
-def _host_in_allowlist(request_host: str, allowlist: list[str]) -> bool:
-    """Return True when ``request_host`` is permitted by ``allowlist``.
-
-    ``allowlist`` is the operator-supplied ``--trusted-domains`` /
-    ``$ESPHOME_TRUSTED_DOMAINS`` list — empty means "no allowlist,
-    anything goes" and the caller skips the check entirely.
-
-    Both ``request_host`` and each allowlist entry go through
-    ``_normalize_host`` (lower-case, port stripped, IPv6 brackets
-    stripped). ``DashboardSettings.parse_args`` strips whitespace
-    and lower-cases the entries on load but does NOT canonicalise
-    bracket / port shape, so an entry of ``[::1]`` and a Host
-    header of ``[::1]:6052`` (or an un-bracketed ``::1``) all
-    end up normalised to ``::1`` here and compare equal.
-
-    The literal ``"*"`` is an explicit "match anything" escape hatch
-    for operators who want to record the config knob is set without
-    restricting hosts (handy for split-hostname proxy setups where
-    the Host header varies per request and the existing Origin/Host
-    equality + auth chain is doing the work).
-
-    Defense in depth on top of the existing Origin/Host equality
-    check + per-IP-rate-limited ``auth/login``.
-    """
-    if not allowlist:
-        return True
-    if "*" in allowlist:
-        return True
-    normalised = _normalize_host(request_host)
-    return any(_normalize_host(entry) == normalised for entry in allowlist)

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -276,8 +276,14 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     origin = request.headers.get("Origin")
     if not trusted_site and origin:
         if not request_origin_allowed(origin, request.host, settings.trusted_domains):
+            _LOGGER.debug(
+                "Rejecting WS handshake (cross-origin): origin=%s host=%s", origin, request.host
+            )
             return web.Response(status=403, text="Cross-origin connection rejected")
         if not host_in_allowlist(request.host, settings.trusted_domains):
+            _LOGGER.debug(
+                "Rejecting WS handshake (host not in trusted-domains): host=%s", request.host
+            )
             return web.Response(status=403, text="Host not in trusted-domains allowlist")
 
     ws = web.WebSocketResponse(heartbeat=_WS_HEARTBEAT_SECONDS)

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -271,23 +271,14 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     settings = device_builder.settings
     trusted_site = bool(request.app.get("trusted_site", False))
 
-    # Reject cross-origin browser connections on the public site.
-    # CORS middleware doesn't apply to WebSockets, so without this a
-    # malicious page the operator browses could open /ws against the
-    # local dashboard — even a passwordless deployment is reachable
-    # only by the operator's own browser sessions, not by anything
-    # they happen to visit. Clients without an Origin header (CLI
-    # tools, HA integration) are unaffected — Origin is spec-
-    # mandated for browser WebSocket handshakes, so any browser-
-    # driven cross-origin attack lands inside the gate while
-    # non-browser auth (bearer / in-band) keeps working.
-    if not trusted_site:
-        origin = request.headers.get("Origin")
-        if origin:
-            if not request_origin_allowed(origin, request.host, settings.trusted_domains):
-                return web.Response(status=403, text="Cross-origin connection rejected")
-            if not host_in_allowlist(request.host, settings.trusted_domains):
-                return web.Response(status=403, text="Host not in trusted-domains allowlist")
+    # Reject cross-origin browser handshakes — CORS middleware doesn't cover WS.
+    # Non-browser clients omit Origin and bypass the gate (auth is in-band).
+    origin = request.headers.get("Origin")
+    if not trusted_site and origin:
+        if not request_origin_allowed(origin, request.host, settings.trusted_domains):
+            return web.Response(status=403, text="Cross-origin connection rejected")
+        if not host_in_allowlist(request.host, settings.trusted_domains):
+            return web.Response(status=403, text="Host not in trusted-domains allowlist")
 
     ws = web.WebSocketResponse(heartbeat=_WS_HEARTBEAT_SECONDS)
     await ws.prepare(request)

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -20,11 +20,7 @@ from ..helpers.api import CommandError
 from ..helpers.auth import extract_bearer_token
 from ..helpers.event_bus import StreamBackpressureError
 from ..helpers.json import JSONDecodeError, dumps_str, loads
-from ..helpers.origin import (
-    host_in_allowlist,
-    origin_in_allowlist,
-    origin_matches_host,
-)
+from ..helpers.origin import host_in_allowlist, request_origin_allowed
 from ..models import (
     CommandMessage,
     ErrorCode,
@@ -288,20 +284,8 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
     if not trusted_site:
         origin = request.headers.get("Origin")
         if origin:
-            # Cross-origin acceptance: Origin must equal Host OR
-            # Origin's hostname must be in the operator-supplied
-            # trusted-domains allowlist. Reverse-proxy deployments
-            # where Origin is ``https://dashboard.example.com`` but
-            # Host is the upstream ``localhost:6052`` need the
-            # allowlist branch.
-            if not origin_matches_host(origin, request.host) and not origin_in_allowlist(
-                origin, settings.trusted_domains
-            ):
+            if not request_origin_allowed(origin, request.host, settings.trusted_domains):
                 return web.Response(status=403, text="Cross-origin connection rejected")
-            # Defense-in-depth Host allowlist. Empty list = not
-            # configured = pass through. When set, the request's
-            # Host must be one of the trusted domains — mitigates
-            # DNS rebinding on top of the Origin equality check.
             if not host_in_allowlist(request.host, settings.trusted_domains):
                 return web.Response(status=403, text="Host not in trusted-domains allowlist")
 

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -16,7 +16,7 @@ from typing import Any
 import orjson
 from aiohttp import web
 
-from .origin import origin_in_allowlist, origin_matches_host
+from .origin import request_origin_allowed
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,33 +111,27 @@ async def cors_middleware(request: web.Request, handler: Any) -> web.StreamRespo
     else:
         resp = await handler(request)
 
+    # Always advertise Vary: Origin — the response computation depends on
+    # Origin (reflected vs. omitted), so any shared cache MUST key on it
+    # or it'll serve the wrong variant to a peer with a different Origin.
+    resp.headers["Vary"] = "Origin"
+
     origin = request.headers.get("Origin")
     if not origin:
-        # No Origin → same-origin browser fetch or non-browser client.
-        # Neither needs CORS headers, so omit them entirely.
         return resp
 
-    trusted_site = bool(request.app.get("trusted_site", False))
-    if trusted_site:
-        # HA Ingress site is bound to the supervisor's docker network
-        # and trusts upstream auth — reflect Origin to keep the
-        # supervisor-proxied frontend working.
+    if request.app.get("trusted_site", False):
+        # HA Ingress site: supervisor handles the boundary upstream.
         allowed = True
     else:
         device_builder = request.app.get("device_builder")
         trusted_domains: list[str] = (
             device_builder.settings.trusted_domains if device_builder is not None else []
         )
-        allowed = origin_matches_host(origin, request.host) or origin_in_allowlist(
-            origin, trusted_domains
-        )
+        allowed = request_origin_allowed(origin, request.host, trusted_domains)
 
     if allowed:
         resp.headers["Access-Control-Allow-Origin"] = origin
-        # Vary so a shared cache doesn't serve the wrong Origin to a
-        # different cross-origin caller — without it, an
-        # allowlist-permitted response could leak to a peer.
-        resp.headers["Vary"] = "Origin"
         resp.headers["Access-Control-Allow-Methods"] = _CORS_METHODS
         resp.headers["Access-Control-Allow-Headers"] = _CORS_HEADERS
 

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -16,7 +16,12 @@ from typing import Any
 import orjson
 from aiohttp import web
 
+from .origin import origin_in_allowlist, origin_matches_host
+
 _LOGGER = logging.getLogger(__name__)
+
+_CORS_METHODS = "GET, POST, PUT, DELETE, OPTIONS"
+_CORS_HEADERS = "Content-Type, Authorization"
 
 # Re-export so callers can ``except JSONDecodeError`` without importing
 # orjson themselves. orjson's exception is a subclass of ValueError.
@@ -85,12 +90,55 @@ def json_response(data: Any, status: int = 200) -> web.Response:
 
 @web.middleware
 async def cors_middleware(request: web.Request, handler: Any) -> web.StreamResponse:
-    """Permissive CORS for local development."""
+    """Origin-allowlist CORS — reflect Origin only when allowed.
+
+    Same-origin (Origin matches Host) or in the operator's
+    ``trusted_domains`` allowlist passes the gate; everything else
+    has ``Access-Control-Allow-Origin`` omitted.
+
+    Sibling of the WS handshake gate in ``api/ws.py`` — both decide
+    cross-origin acceptance off the same predicate so they can't
+    drift. Cross-origin requests from non-allowlisted browsers still
+    reach the handler (and 401 / 403 / whatever the route returns),
+    but the response carries no ``Access-Control-Allow-Origin`` so
+    the browser blocks the calling JS from reading it. CLI tools /
+    HA integration omit Origin entirely and bypass the gate; their
+    requests are authenticated by the bearer-token / in-band auth
+    chain.
+    """
     if request.method == "OPTIONS":
         resp = web.Response()
     else:
         resp = await handler(request)
-    resp.headers["Access-Control-Allow-Origin"] = "*"
-    resp.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+
+    origin = request.headers.get("Origin")
+    if not origin:
+        # No Origin → same-origin browser fetch or non-browser client.
+        # Neither needs CORS headers, so omit them entirely.
+        return resp
+
+    trusted_site = bool(request.app.get("trusted_site", False))
+    if trusted_site:
+        # HA Ingress site is bound to the supervisor's docker network
+        # and trusts upstream auth — reflect Origin to keep the
+        # supervisor-proxied frontend working.
+        allowed = True
+    else:
+        device_builder = request.app.get("device_builder")
+        trusted_domains: list[str] = (
+            device_builder.settings.trusted_domains if device_builder is not None else []
+        )
+        allowed = origin_matches_host(origin, request.host) or origin_in_allowlist(
+            origin, trusted_domains
+        )
+
+    if allowed:
+        resp.headers["Access-Control-Allow-Origin"] = origin
+        # Vary so a shared cache doesn't serve the wrong Origin to a
+        # different cross-origin caller — without it, an
+        # allowlist-permitted response could leak to a peer.
+        resp.headers["Vary"] = "Origin"
+        resp.headers["Access-Control-Allow-Methods"] = _CORS_METHODS
+        resp.headers["Access-Control-Allow-Headers"] = _CORS_HEADERS
+
     return resp

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -105,6 +105,10 @@ async def cors_middleware(request: web.Request, handler: Any) -> web.StreamRespo
         resp.headers["Access-Control-Allow-Origin"] = origin
         resp.headers["Access-Control-Allow-Methods"] = _CORS_METHODS
         resp.headers["Access-Control-Allow-Headers"] = _CORS_HEADERS
+    elif origin:
+        _LOGGER.debug(
+            "CORS: omitting Access-Control-Allow-Origin: origin=%s host=%s", origin, request.host
+        )
     return resp
 
 

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -90,49 +90,31 @@ def json_response(data: Any, status: int = 200) -> web.Response:
 
 @web.middleware
 async def cors_middleware(request: web.Request, handler: Any) -> web.StreamResponse:
-    """Origin-allowlist CORS — reflect Origin only when allowed.
+    """Reflect Origin in CORS headers only when same-origin or in ``trusted_domains``.
 
-    Same-origin (Origin matches Host) or in the operator's
-    ``trusted_domains`` allowlist passes the gate; everything else
-    has ``Access-Control-Allow-Origin`` omitted.
-
-    Sibling of the WS handshake gate in ``api/ws.py`` — both decide
-    cross-origin acceptance off the same predicate so they can't
-    drift. Cross-origin requests from non-allowlisted browsers still
-    reach the handler (and 401 / 403 / whatever the route returns),
-    but the response carries no ``Access-Control-Allow-Origin`` so
-    the browser blocks the calling JS from reading it. CLI tools /
-    HA integration omit Origin entirely and bypass the gate; their
-    requests are authenticated by the bearer-token / in-band auth
-    chain.
+    Sibling of the WS handshake gate in ``api/ws.py`` — both share
+    ``request_origin_allowed`` so they can't drift.
     """
-    if request.method == "OPTIONS":
-        resp = web.Response()
-    else:
-        resp = await handler(request)
-
-    # Always advertise Vary: Origin — the response computation depends on
-    # Origin (reflected vs. omitted), so any shared cache MUST key on it
-    # or it'll serve the wrong variant to a peer with a different Origin.
+    resp = web.Response() if request.method == "OPTIONS" else await handler(request)
+    # Vary: Origin unconditionally — response shape depends on Origin, so a
+    # shared cache must key on it to avoid mis-serving a peer.
     resp.headers["Vary"] = "Origin"
 
     origin = request.headers.get("Origin")
-    if not origin:
-        return resp
-
-    if request.app.get("trusted_site", False):
-        # HA Ingress site: supervisor handles the boundary upstream.
-        allowed = True
-    else:
-        device_builder = request.app.get("device_builder")
-        trusted_domains: list[str] = (
-            device_builder.settings.trusted_domains if device_builder is not None else []
-        )
-        allowed = request_origin_allowed(origin, request.host, trusted_domains)
-
-    if allowed:
+    if origin and _cors_origin_allowed(request, origin):
         resp.headers["Access-Control-Allow-Origin"] = origin
         resp.headers["Access-Control-Allow-Methods"] = _CORS_METHODS
         resp.headers["Access-Control-Allow-Headers"] = _CORS_HEADERS
-
     return resp
+
+
+def _cors_origin_allowed(request: web.Request, origin: str) -> bool:
+    """Return True when CORS should reflect *origin* — same predicate as the WS gate."""
+    if request.app.get("trusted_site", False):
+        # HA Ingress: supervisor handles the boundary upstream.
+        return True
+    device_builder = request.app.get("device_builder")
+    trusted_domains: list[str] = (
+        device_builder.settings.trusted_domains if device_builder is not None else []
+    )
+    return request_origin_allowed(origin, request.host, trusted_domains)

--- a/esphome_device_builder/helpers/origin.py
+++ b/esphome_device_builder/helpers/origin.py
@@ -1,12 +1,4 @@
-"""Origin / Host header predicates shared by the WS handshake gate and CORS middleware.
-
-The WS handshake (``api/ws.py``) and the REST CORS middleware
-(``helpers/json.py``) both decide whether to accept a cross-origin
-browser request — they share these helpers so a tightening on one
-gate doesn't drift from the other. The functions are pure: input
-is the raw header strings + the operator-supplied
-``--trusted-domains`` allowlist, output is a bool.
-"""
+"""Origin / Host header predicates shared by the WS handshake and CORS middleware."""
 
 from __future__ import annotations
 
@@ -15,7 +7,7 @@ from urllib.parse import urlparse, urlsplit
 
 
 def origin_matches_host(origin: str, request_host: str) -> bool:
-    """Return True when *origin*'s host:port matches the request's Host header."""
+    """Return True when ``origin``'s ``host:port`` matches the request's ``Host``."""
     try:
         parsed = urlparse(origin)
     except ValueError:
@@ -24,24 +16,7 @@ def origin_matches_host(origin: str, request_host: str) -> bool:
 
 
 def origin_in_allowlist(origin: str, allowlist: list[str]) -> bool:
-    """
-    Return True when ``origin``'s hostname is in the allowlist.
-
-    Used by the cross-origin acceptance gate: reverse-proxy
-    deployments where Origin is ``https://dashboard.example.com``
-    but Host is ``localhost:6052`` (proxy upstream) need the
-    operator-supplied ``ESPHOME_TRUSTED_DOMAINS`` allowlist to
-    accept the cross-origin handshake.
-
-    The allowlist match is on the Origin URL's hostname (port and
-    scheme stripped), case-insensitive. A bare hostname entry like
-    ``dashboard.example.com`` matches an Origin of
-    ``https://Dashboard.Example.com`` regardless of port; an entry
-    of ``[::1]`` matches ``http://[::1]:6052``.
-
-    ``"*"`` matches anything (escape hatch for operators who set
-    the env var without a specific host list).
-    """
+    """Return True when ``origin``'s hostname is in ``allowlist`` (``"*"`` matches any)."""
     if not allowlist:
         return False
     if "*" in allowlist:
@@ -57,33 +32,8 @@ def origin_in_allowlist(origin: str, allowlist: list[str]) -> bool:
 
 
 def host_in_allowlist(request_host: str, allowlist: list[str]) -> bool:
-    """
-    Return True when ``request_host`` is permitted by ``allowlist``.
-
-    ``allowlist`` is the operator-supplied ``--trusted-domains`` /
-    ``$ESPHOME_TRUSTED_DOMAINS`` list — empty means "no allowlist,
-    anything goes" and the caller skips the check entirely.
-
-    Both ``request_host`` and each allowlist entry go through
-    ``normalize_host`` (lower-case, port stripped, IPv6 brackets
-    stripped). ``DashboardSettings.parse_args`` strips whitespace
-    and lower-cases the entries on load but does NOT canonicalise
-    bracket / port shape, so an entry of ``[::1]`` and a Host
-    header of ``[::1]:6052`` (or an un-bracketed ``::1``) all
-    end up normalised to ``::1`` here and compare equal.
-
-    The literal ``"*"`` is an explicit "match anything" escape hatch
-    for operators who want to record the config knob is set without
-    restricting hosts (handy for split-hostname proxy setups where
-    the Host header varies per request and the existing Origin/Host
-    equality + auth chain is doing the work).
-
-    Defense in depth on top of the existing Origin/Host equality
-    check + per-IP-rate-limited ``auth/login``.
-    """
-    if not allowlist:
-        return True
-    if "*" in allowlist:
+    """Return True when ``request_host`` is in ``allowlist``; empty list disables the check."""
+    if not allowlist or "*" in allowlist:
         return True
     normalised = normalize_host(request_host)
     return any(normalize_host(entry) == normalised for entry in allowlist)
@@ -91,23 +41,13 @@ def host_in_allowlist(request_host: str, allowlist: list[str]) -> bool:
 
 def normalize_host(host: str) -> str:
     """
-    Lower-case ``host`` and strip the port + IPv6 brackets, if any.
+    Lower-case ``host``, stripping the port and IPv6 brackets if any.
 
-    HTTP ``Host`` headers carry IPv6 addresses bracket-wrapped
-    (``[::1]:6052``); naive ``split(":", 1)`` would chop the first
-    segment of the address. ``urlsplit("//" + host).hostname``
-    handles both shapes (IPv4 / hostname:port and ``[ipv6]:port``)
-    and returns the unbracketed lowercase hostname.
-
-    There's one edge case ``urlsplit`` mis-handles: a bare IPv6
-    address typed *without* brackets (operator's allowlist entry
-    of ``fe80::1`` rather than ``[fe80::1]``) — ``urlsplit``
-    parses the leading ``fe80`` as the host and ``:1`` as the
-    port. Short-circuit those via ``ipaddress.ip_address`` before
-    falling through to the URL-parser branch. Bracketed Host
-    headers go straight to ``urlsplit`` which handles them
-    correctly. Falls back to the input verbatim when ``urlsplit``
-    returns nothing usable (malformed Host header).
+    Handles three shapes: ``hostname[:port]``, ``[ipv6]:port`` (bracketed,
+    standard Host-header form), and a bare un-bracketed IPv6 address
+    (``fe80::1``) — the last needs an ``ipaddress`` short-circuit because
+    ``urlsplit`` would parse ``fe80`` as the host and ``:1`` as the port.
+    Falls back to the input verbatim when ``urlsplit`` can't parse it.
     """
     stripped = host.strip()
     if not stripped.startswith("["):
@@ -127,5 +67,5 @@ def normalize_host(host: str) -> str:
 
 
 def request_origin_allowed(origin: str, request_host: str, trusted_domains: list[str]) -> bool:
-    """Combine ``origin_matches_host`` + ``origin_in_allowlist`` into one predicate."""
+    """Return True when ``origin`` is same-origin or its hostname is in ``trusted_domains``."""
     return origin_matches_host(origin, request_host) or origin_in_allowlist(origin, trusted_domains)

--- a/esphome_device_builder/helpers/origin.py
+++ b/esphome_device_builder/helpers/origin.py
@@ -1,0 +1,131 @@
+"""Origin / Host header predicates shared by the WS handshake gate and CORS middleware.
+
+The WS handshake (``api/ws.py``) and the REST CORS middleware
+(``helpers/json.py``) both decide whether to accept a cross-origin
+browser request — they share these helpers so a tightening on one
+gate doesn't drift from the other. The functions are pure: input
+is the raw header strings + the operator-supplied
+``--trusted-domains`` allowlist, output is a bool.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse, urlsplit
+
+
+def origin_matches_host(origin: str, request_host: str) -> bool:
+    """Return True when *origin*'s host:port matches the request's Host header."""
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+    return bool(parsed.netloc) and parsed.netloc == request_host
+
+
+def origin_in_allowlist(origin: str, allowlist: list[str]) -> bool:
+    """
+    Return True when ``origin``'s hostname is in the allowlist.
+
+    Used by the cross-origin acceptance gate: reverse-proxy
+    deployments where Origin is ``https://dashboard.example.com``
+    but Host is ``localhost:6052`` (proxy upstream) need the
+    operator-supplied ``ESPHOME_TRUSTED_DOMAINS`` allowlist to
+    accept the cross-origin handshake.
+
+    The allowlist match is on the Origin URL's hostname (port and
+    scheme stripped), case-insensitive. A bare hostname entry like
+    ``dashboard.example.com`` matches an Origin of
+    ``https://Dashboard.Example.com`` regardless of port; an entry
+    of ``[::1]`` matches ``http://[::1]:6052``.
+
+    ``"*"`` matches anything (escape hatch for operators who set
+    the env var without a specific host list).
+    """
+    if not allowlist:
+        return False
+    if "*" in allowlist:
+        return True
+    try:
+        parsed = urlparse(origin)
+    except ValueError:
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return False
+    return any(normalize_host(entry) == hostname for entry in allowlist)
+
+
+def host_in_allowlist(request_host: str, allowlist: list[str]) -> bool:
+    """
+    Return True when ``request_host`` is permitted by ``allowlist``.
+
+    ``allowlist`` is the operator-supplied ``--trusted-domains`` /
+    ``$ESPHOME_TRUSTED_DOMAINS`` list — empty means "no allowlist,
+    anything goes" and the caller skips the check entirely.
+
+    Both ``request_host`` and each allowlist entry go through
+    ``normalize_host`` (lower-case, port stripped, IPv6 brackets
+    stripped). ``DashboardSettings.parse_args`` strips whitespace
+    and lower-cases the entries on load but does NOT canonicalise
+    bracket / port shape, so an entry of ``[::1]`` and a Host
+    header of ``[::1]:6052`` (or an un-bracketed ``::1``) all
+    end up normalised to ``::1`` here and compare equal.
+
+    The literal ``"*"`` is an explicit "match anything" escape hatch
+    for operators who want to record the config knob is set without
+    restricting hosts (handy for split-hostname proxy setups where
+    the Host header varies per request and the existing Origin/Host
+    equality + auth chain is doing the work).
+
+    Defense in depth on top of the existing Origin/Host equality
+    check + per-IP-rate-limited ``auth/login``.
+    """
+    if not allowlist:
+        return True
+    if "*" in allowlist:
+        return True
+    normalised = normalize_host(request_host)
+    return any(normalize_host(entry) == normalised for entry in allowlist)
+
+
+def normalize_host(host: str) -> str:
+    """
+    Lower-case ``host`` and strip the port + IPv6 brackets, if any.
+
+    HTTP ``Host`` headers carry IPv6 addresses bracket-wrapped
+    (``[::1]:6052``); naive ``split(":", 1)`` would chop the first
+    segment of the address. ``urlsplit("//" + host).hostname``
+    handles both shapes (IPv4 / hostname:port and ``[ipv6]:port``)
+    and returns the unbracketed lowercase hostname.
+
+    There's one edge case ``urlsplit`` mis-handles: a bare IPv6
+    address typed *without* brackets (operator's allowlist entry
+    of ``fe80::1`` rather than ``[fe80::1]``) — ``urlsplit``
+    parses the leading ``fe80`` as the host and ``:1`` as the
+    port. Short-circuit those via ``ipaddress.ip_address`` before
+    falling through to the URL-parser branch. Bracketed Host
+    headers go straight to ``urlsplit`` which handles them
+    correctly. Falls back to the input verbatim when ``urlsplit``
+    returns nothing usable (malformed Host header).
+    """
+    stripped = host.strip()
+    if not stripped.startswith("["):
+        try:
+            ipaddress.ip_address(stripped)
+        except ValueError:
+            pass
+        else:
+            return stripped.lower()
+    try:
+        hostname = urlsplit(f"//{stripped}").hostname
+    except ValueError:
+        hostname = None
+    if hostname is None:
+        return stripped.lower()
+    return hostname.lower()
+
+
+def request_origin_allowed(origin: str, request_host: str, trusted_domains: list[str]) -> bool:
+    """Combine ``origin_matches_host`` + ``origin_in_allowlist`` into one predicate."""
+    return origin_matches_host(origin, request_host) or origin_in_allowlist(origin, trusted_domains)

--- a/esphome_device_builder/helpers/origin.py
+++ b/esphome_device_builder/helpers/origin.py
@@ -43,11 +43,9 @@ def normalize_host(host: str) -> str:
     """
     Lower-case ``host``, stripping the port and IPv6 brackets if any.
 
-    Handles three shapes: ``hostname[:port]``, ``[ipv6]:port`` (bracketed,
-    standard Host-header form), and a bare un-bracketed IPv6 address
-    (``fe80::1``) — the last needs an ``ipaddress`` short-circuit because
-    ``urlsplit`` would parse ``fe80`` as the host and ``:1`` as the port.
-    Falls back to the input verbatim when ``urlsplit`` can't parse it.
+    Bare un-bracketed IPv6 addresses (``fe80::1``) need the
+    ``ipaddress`` short-circuit because ``urlsplit`` would parse
+    ``fe80`` as the host and ``:1`` as the port.
     """
     stripped = host.strip()
     if not stripped.startswith("["):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -366,22 +366,22 @@ def test_rate_limiter_prune_keeps_locked_out_ips() -> None:
 # ---------------------------------------------------------------------------
 
 
-def testorigin_matches_host_accepts_same_origin() -> None:
+def test_origin_matches_host_accepts_same_origin() -> None:
     assert origin_matches_host("http://homeassistant.local:6052", "homeassistant.local:6052")
     assert origin_matches_host("https://esphome.example.com", "esphome.example.com")
 
 
-def testorigin_matches_host_rejects_cross_origin() -> None:
+def test_origin_matches_host_rejects_cross_origin() -> None:
     assert not origin_matches_host("https://attacker.com", "homeassistant.local:6052")
     assert not origin_matches_host("http://homeassistant.local:9999", "homeassistant.local:6052")
 
 
-def testorigin_matches_host_rejects_garbage() -> None:
+def test_origin_matches_host_rejects_garbage() -> None:
     assert not origin_matches_host("", "homeassistant.local:6052")
     assert not origin_matches_host("not-a-url", "homeassistant.local:6052")
 
 
-def testorigin_matches_host_rejects_invalid_ipv6_url() -> None:
+def test_origin_matches_host_rejects_invalid_ipv6_url() -> None:
     """An Origin with an unclosed IPv6 bracket makes ``urlparse`` raise.
 
     ``urlparse("http://[invalid")`` raises ``ValueError("Invalid

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.api.ws import WebSocketClient, _origin_matches_host
+from esphome_device_builder.api.ws import WebSocketClient
 from esphome_device_builder.controllers.auth import AuthController, AuthError
 from esphome_device_builder.controllers.config import DashboardSettings
 from esphome_device_builder.helpers.auth import (
@@ -30,6 +30,7 @@ from esphome_device_builder.helpers.auth import (
     hash_password,
     parse_basic_auth,
 )
+from esphome_device_builder.helpers.origin import origin_matches_host
 from esphome_device_builder.models import ErrorCode
 
 # ---------------------------------------------------------------------------
@@ -365,22 +366,22 @@ def test_rate_limiter_prune_keeps_locked_out_ips() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_origin_matches_host_accepts_same_origin() -> None:
-    assert _origin_matches_host("http://homeassistant.local:6052", "homeassistant.local:6052")
-    assert _origin_matches_host("https://esphome.example.com", "esphome.example.com")
+def testorigin_matches_host_accepts_same_origin() -> None:
+    assert origin_matches_host("http://homeassistant.local:6052", "homeassistant.local:6052")
+    assert origin_matches_host("https://esphome.example.com", "esphome.example.com")
 
 
-def test_origin_matches_host_rejects_cross_origin() -> None:
-    assert not _origin_matches_host("https://attacker.com", "homeassistant.local:6052")
-    assert not _origin_matches_host("http://homeassistant.local:9999", "homeassistant.local:6052")
+def testorigin_matches_host_rejects_cross_origin() -> None:
+    assert not origin_matches_host("https://attacker.com", "homeassistant.local:6052")
+    assert not origin_matches_host("http://homeassistant.local:9999", "homeassistant.local:6052")
 
 
-def test_origin_matches_host_rejects_garbage() -> None:
-    assert not _origin_matches_host("", "homeassistant.local:6052")
-    assert not _origin_matches_host("not-a-url", "homeassistant.local:6052")
+def testorigin_matches_host_rejects_garbage() -> None:
+    assert not origin_matches_host("", "homeassistant.local:6052")
+    assert not origin_matches_host("not-a-url", "homeassistant.local:6052")
 
 
-def test_origin_matches_host_rejects_invalid_ipv6_url() -> None:
+def testorigin_matches_host_rejects_invalid_ipv6_url() -> None:
     """An Origin with an unclosed IPv6 bracket makes ``urlparse`` raise.
 
     ``urlparse("http://[invalid")`` raises ``ValueError("Invalid
@@ -390,7 +391,7 @@ def test_origin_matches_host_rejects_invalid_ipv6_url() -> None:
     Origin header instead of returning the 403 the rest of the
     rejection branches produce.
     """
-    assert not _origin_matches_host("http://[invalid", "homeassistant.local:6052")
+    assert not origin_matches_host("http://[invalid", "homeassistant.local:6052")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -78,13 +78,7 @@ def _app_with_cors(
     trusted_domains: list[str] | None = None,
     trusted_site: bool = False,
 ) -> web.Application:
-    """Build an aiohttp app wired with ``cors_middleware``.
-
-    The middleware reads ``app["device_builder"].settings.trusted_domains``
-    and ``app["trusted_site"]`` to decide whether to reflect Origin,
-    so the test app provides a minimal stub that exposes those
-    knobs without spinning up a real ``DeviceBuilder``.
-    """
+    """Build a test app with ``cors_middleware`` + stubbed ``device_builder`` / ``trusted_site``."""
     settings = MagicMock()
     settings.trusted_domains = trusted_domains or []
     device_builder = MagicMock()
@@ -109,14 +103,15 @@ def _app_with_cors(
 async def test_cors_middleware_omits_origin_header_when_no_origin(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """No ``Origin`` header → no CORS headers (same-origin / non-browser client)."""
+    """No ``Origin`` → no ``Allow-Origin`` / methods / headers; ``Vary: Origin`` set."""
     client = await aiohttp_client(_app_with_cors())
     resp = await client.get("/hello")
 
     assert resp.status == 200
     assert "Access-Control-Allow-Origin" not in resp.headers
     assert "Access-Control-Allow-Methods" not in resp.headers
-    assert "Vary" not in resp.headers
+    # Vary: Origin is set unconditionally so shared caches don't mis-serve the variants.
+    assert resp.headers["Vary"] == "Origin"
     assert await resp.json() == {"ok": True}
 
 
@@ -139,13 +134,7 @@ async def test_cors_middleware_reflects_same_origin(
 async def test_cors_middleware_reflects_allowlisted_origin(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """Cross-origin Origin in ``trusted_domains`` → reflected.
-
-    Reverse-proxy deployment: the operator sets ``--trusted-domains``
-    to the proxy hostname so a same-origin browser request (from the
-    proxy's hostname's perspective) reaches the backend with an
-    ``Origin`` that doesn't match the upstream Host.
-    """
+    """Cross-origin Origin in ``trusted_domains`` is reflected (reverse-proxy case)."""
     client = await aiohttp_client(_app_with_cors(trusted_domains=["dashboard.example.com"]))
     origin = "https://dashboard.example.com"
     resp = await client.get("/hello", headers={"Origin": origin})
@@ -158,15 +147,7 @@ async def test_cors_middleware_reflects_allowlisted_origin(
 async def test_cors_middleware_omits_origin_header_for_disallowed_origin(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """Cross-origin Origin not in allowlist → response body served, no CORS headers.
-
-    Pin the new contract: previously the middleware unconditionally
-    set ``Access-Control-Allow-Origin: *``, which let a malicious
-    page in the operator's browser read sensitive responses
-    cross-origin. The new shape lets the request through (so non-
-    browser clients still get answered) but omits the CORS
-    headers so the browser blocks JS from reading the response.
-    """
+    """Disallowed cross-origin → handler runs, but ``Access-Control-Allow-Origin`` omitted."""
     client = await aiohttp_client(_app_with_cors())
     resp = await client.get("/hello", headers={"Origin": "https://evil.example.com"})
 
@@ -175,18 +156,15 @@ async def test_cors_middleware_omits_origin_header_for_disallowed_origin(
     # browser does with the response.
     assert resp.status == 200
     assert "Access-Control-Allow-Origin" not in resp.headers
+    # Vary still set so a shared cache doesn't mis-serve this no-ACAO response
+    # to a peer with an allowlisted Origin (or vice versa).
+    assert resp.headers["Vary"] == "Origin"
 
 
 async def test_cors_middleware_reflects_origin_unconditionally_on_trusted_site(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """``trusted_site=True`` (HA Ingress) reflects any Origin.
-
-    The ingress site is bound to the supervisor's docker network
-    and trusts upstream auth — Origin-allowlist enforcement
-    happens at the supervisor, not here. Reflect whatever Origin
-    the supervisor proxied through so the frontend works.
-    """
+    """``trusted_site=True`` (HA Ingress) reflects any Origin — supervisor handles the boundary."""
     client = await aiohttp_client(_app_with_cors(trusted_site=True))
     origin = "https://anything.example.com"
     resp = await client.get("/hello", headers={"Origin": origin})
@@ -199,14 +177,7 @@ async def test_cors_middleware_reflects_origin_unconditionally_on_trusted_site(
 async def test_cors_middleware_handles_options_preflight_without_invoking_handler(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """``OPTIONS`` requests return an empty 200 without calling the inner handler.
-
-    The preflight short-circuit predates the allowlist tightening
-    and stays the same: middleware answers itself so routes that
-    only register GET/POST don't 405 on preflight. CORS headers
-    still apply on top — reflected when the Origin is allowed,
-    omitted otherwise.
-    """
+    """``OPTIONS`` short-circuits to empty 200 without calling the handler; headers still attach."""
     handler_called: list[bool] = []
 
     async def _trap(_request: web.Request) -> web.Response:

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -9,6 +9,8 @@ cleanup doesn't silently regress legacy ``/json-config``.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
@@ -71,16 +73,26 @@ def test_dumps_str_non_str_keys_serialises_plain_str_keys() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _app_with_cors() -> web.Application:
-    """Build an aiohttp app wired with ``cors_middleware`` and a couple of route shapes.
+def _app_with_cors(
+    *,
+    trusted_domains: list[str] | None = None,
+    trusted_site: bool = False,
+) -> web.Application:
+    """Build an aiohttp app wired with ``cors_middleware``.
 
-    The middleware short-circuits ``OPTIONS`` (returning an empty
-    200 with the headers set) and forwards every other method to
-    the inner handler. Two routes are enough to exercise both —
-    a GET that returns a JSON body, and any non-GET (we use POST
-    here) that exercises the ``Access-Control-Allow-Methods`` line.
+    The middleware reads ``app["device_builder"].settings.trusted_domains``
+    and ``app["trusted_site"]`` to decide whether to reflect Origin,
+    so the test app provides a minimal stub that exposes those
+    knobs without spinning up a real ``DeviceBuilder``.
     """
+    settings = MagicMock()
+    settings.trusted_domains = trusted_domains or []
+    device_builder = MagicMock()
+    device_builder.settings = settings
+
     app = web.Application(middlewares=[cors_middleware])
+    app["device_builder"] = device_builder
+    app["trusted_site"] = trusted_site
 
     async def _hello(_request: web.Request) -> web.Response:
         return web.json_response({"ok": True})
@@ -94,29 +106,94 @@ def _app_with_cors() -> web.Application:
     return app
 
 
-async def test_cors_middleware_attaches_headers_to_get_response(
+async def test_cors_middleware_omits_origin_header_when_no_origin(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """A normal GET passes through and the response gains the CORS headers.
-
-    Pin all three header names + the wildcard origin so a
-    refactor that drops or narrows any of them surfaces here.
-    The ``Access-Control-Allow-Origin: *`` is deliberately
-    permissive — the dashboard's design assumption is that auth
-    happens at the WS / bearer layer, not via origin check; the
-    middleware is for development convenience (frontend dev
-    server on a different port).
-    """
+    """No ``Origin`` header → no CORS headers (same-origin / non-browser client)."""
     client = await aiohttp_client(_app_with_cors())
     resp = await client.get("/hello")
 
     assert resp.status == 200
-    assert resp.headers["Access-Control-Allow-Origin"] == "*"
+    assert "Access-Control-Allow-Origin" not in resp.headers
+    assert "Access-Control-Allow-Methods" not in resp.headers
+    assert "Vary" not in resp.headers
+    assert await resp.json() == {"ok": True}
+
+
+async def test_cors_middleware_reflects_same_origin(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """``Origin`` matching Host → reflected back, ``Vary: Origin`` set."""
+    client = await aiohttp_client(_app_with_cors())
+    host = f"{client.host}:{client.port}"
+    origin = f"http://{host}"
+    resp = await client.get("/hello", headers={"Origin": origin})
+
+    assert resp.status == 200
+    assert resp.headers["Access-Control-Allow-Origin"] == origin
+    assert resp.headers["Vary"] == "Origin"
     assert resp.headers["Access-Control-Allow-Methods"] == "GET, POST, PUT, DELETE, OPTIONS"
     assert resp.headers["Access-Control-Allow-Headers"] == "Content-Type, Authorization"
 
-    # Body still flows through unmolested.
-    assert await resp.json() == {"ok": True}
+
+async def test_cors_middleware_reflects_allowlisted_origin(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Cross-origin Origin in ``trusted_domains`` → reflected.
+
+    Reverse-proxy deployment: the operator sets ``--trusted-domains``
+    to the proxy hostname so a same-origin browser request (from the
+    proxy's hostname's perspective) reaches the backend with an
+    ``Origin`` that doesn't match the upstream Host.
+    """
+    client = await aiohttp_client(_app_with_cors(trusted_domains=["dashboard.example.com"]))
+    origin = "https://dashboard.example.com"
+    resp = await client.get("/hello", headers={"Origin": origin})
+
+    assert resp.status == 200
+    assert resp.headers["Access-Control-Allow-Origin"] == origin
+    assert resp.headers["Vary"] == "Origin"
+
+
+async def test_cors_middleware_omits_origin_header_for_disallowed_origin(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Cross-origin Origin not in allowlist → response body served, no CORS headers.
+
+    Pin the new contract: previously the middleware unconditionally
+    set ``Access-Control-Allow-Origin: *``, which let a malicious
+    page in the operator's browser read sensitive responses
+    cross-origin. The new shape lets the request through (so non-
+    browser clients still get answered) but omits the CORS
+    headers so the browser blocks JS from reading the response.
+    """
+    client = await aiohttp_client(_app_with_cors())
+    resp = await client.get("/hello", headers={"Origin": "https://evil.example.com"})
+
+    # Request still reaches the handler — the gating happens in the WS
+    # handler / auth middleware, not here. CORS just controls what the
+    # browser does with the response.
+    assert resp.status == 200
+    assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+async def test_cors_middleware_reflects_origin_unconditionally_on_trusted_site(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """``trusted_site=True`` (HA Ingress) reflects any Origin.
+
+    The ingress site is bound to the supervisor's docker network
+    and trusts upstream auth — Origin-allowlist enforcement
+    happens at the supervisor, not here. Reflect whatever Origin
+    the supervisor proxied through so the frontend works.
+    """
+    client = await aiohttp_client(_app_with_cors(trusted_site=True))
+    origin = "https://anything.example.com"
+    resp = await client.get("/hello", headers={"Origin": origin})
+
+    assert resp.status == 200
+    assert resp.headers["Access-Control-Allow-Origin"] == origin
+    assert resp.headers["Vary"] == "Origin"
 
 
 async def test_cors_middleware_handles_options_preflight_without_invoking_handler(
@@ -124,107 +201,66 @@ async def test_cors_middleware_handles_options_preflight_without_invoking_handle
 ) -> None:
     """``OPTIONS`` requests return an empty 200 without calling the inner handler.
 
-    The CORS preflight contract: browsers send ``OPTIONS`` to
-    check whether a non-simple cross-origin request is allowed.
-    The middleware MUST answer that itself — forwarding to the
-    inner handler would 405 (most aiohttp routes only register
-    GET/POST/etc., not OPTIONS) and the browser would block the
-    real request that follows. Pin both halves: status 200 +
-    headers present + body empty (the spec allows an empty 2xx
-    for preflight).
-
-    Track whether the handler was reached by registering an
-    ``OPTIONS`` route that records its invocation; the assertion
-    below proves it never fired despite a matching path.
+    The preflight short-circuit predates the allowlist tightening
+    and stays the same: middleware answers itself so routes that
+    only register GET/POST don't 405 on preflight. CORS headers
+    still apply on top — reflected when the Origin is allowed,
+    omitted otherwise.
     """
     handler_called: list[bool] = []
 
     async def _trap(_request: web.Request) -> web.Response:
         handler_called.append(True)
-        return web.Response(status=418)  # I'm a teapot — distinguishable
+        return web.Response(status=418)
 
-    app = web.Application(middlewares=[cors_middleware])
+    app = _app_with_cors()
     app.router.add_route("OPTIONS", "/preflight", _trap)
     client = await aiohttp_client(app)
 
-    resp = await client.options("/preflight")
+    host = f"{client.host}:{client.port}"
+    origin = f"http://{host}"
+    resp = await client.options("/preflight", headers={"Origin": origin})
 
     assert resp.status == 200
-    assert handler_called == [], (
-        "OPTIONS preflight must not reach the inner handler — the middleware's "
-        "early return is what makes preflight work for routes that don't "
-        "register OPTIONS explicitly"
-    )
-    # Headers attach the same way they do for normal responses.
-    assert resp.headers["Access-Control-Allow-Origin"] == "*"
+    assert handler_called == []
+    assert resp.headers["Access-Control-Allow-Origin"] == origin
     assert resp.headers["Access-Control-Allow-Methods"] == "GET, POST, PUT, DELETE, OPTIONS"
     assert resp.headers["Access-Control-Allow-Headers"] == "Content-Type, Authorization"
-    # Empty body — the middleware's ``web.Response()`` default.
     assert await resp.text() == ""
 
 
 async def test_cors_middleware_attaches_headers_to_non_get_methods(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """POST / PUT / DELETE responses also get the CORS headers.
-
-    Sanity-check that the middleware doesn't conditionally
-    attach headers (e.g. only on GET / OPTIONS) — every non-
-    OPTIONS method should pass through to the handler AND get
-    the post-handler header injection.
-    """
+    """POST / PUT / DELETE responses also get reflected CORS headers when allowed."""
     client = await aiohttp_client(_app_with_cors())
-    resp = await client.post("/echo", data="payload")
+    host = f"{client.host}:{client.port}"
+    origin = f"http://{host}"
+    resp = await client.post("/echo", data="payload", headers={"Origin": origin})
 
     assert resp.status == 200
     assert await resp.text() == "payload"
-    # Pin all three headers — a regression that conditionally
-    # attached only Origin (or only the GET-shaped subset)
-    # would still pass a single-header check.
-    assert resp.headers["Access-Control-Allow-Origin"] == "*"
-    assert resp.headers["Access-Control-Allow-Methods"] == "GET, POST, PUT, DELETE, OPTIONS"
-    assert resp.headers["Access-Control-Allow-Headers"] == "Content-Type, Authorization"
+    assert resp.headers["Access-Control-Allow-Origin"] == origin
+    assert resp.headers["Vary"] == "Origin"
 
 
 async def test_cors_middleware_attaches_headers_to_handler_error_response(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """A handler returning a non-2xx ``Response`` still gets CORS headers.
-
-    Pin the contract that the middleware's post-await header
-    injection runs on the handler's response object regardless
-    of its status code — a handler that returns
-    ``web.Response(status=500)`` (or 404 / 401 / etc.)
-    surfaces the error to the caller WITH the CORS headers
-    attached, so a browser-side ``fetch`` can read the status
-    and body cross-origin.
-
-    Note: a handler that *raises* ``web.HTTPException`` is a
-    different shape — aiohttp's exception handling builds the
-    response after the middleware's ``await`` raises, so those
-    responses bypass this middleware's header injection. That's
-    a known gap in the minimal middleware (no ``try/except``
-    wrap); pinning the *return*-error path here documents the
-    supported contract without locking the gap in as desired.
-    """
+    """Non-2xx handler responses still get reflected CORS headers when Origin is allowed."""
 
     async def _server_error(_request: web.Request) -> web.Response:
         return web.Response(status=500, text="boom")
 
-    app = web.Application(middlewares=[cors_middleware])
+    app = _app_with_cors()
     app.router.add_get("/error", _server_error)
     client = await aiohttp_client(app)
 
-    resp = await client.get("/error")
+    host = f"{client.host}:{client.port}"
+    origin = f"http://{host}"
+    resp = await client.get("/error", headers={"Origin": origin})
 
     assert resp.status == 500
     assert await resp.text() == "boom"
-    # Pin all three headers — a regression that made
-    # ``Access-Control-Allow-Headers`` conditional on a 2xx
-    # status code would silently break the
-    # browser's ability to read the error response cross-origin
-    # (preflight would still pass but the actual fetch would
-    # surface as a generic network error).
-    assert resp.headers["Access-Control-Allow-Origin"] == "*"
-    assert resp.headers["Access-Control-Allow-Methods"] == "GET, POST, PUT, DELETE, OPTIONS"
-    assert resp.headers["Access-Control-Allow-Headers"] == "Content-Type, Authorization"
+    assert resp.headers["Access-Control-Allow-Origin"] == origin
+    assert resp.headers["Vary"] == "Origin"

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -200,6 +200,19 @@ async def test_cors_middleware_handles_options_preflight_without_invoking_handle
     assert await resp.text() == ""
 
 
+async def test_cors_middleware_options_preflight_omits_acao_for_disallowed_origin(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """OPTIONS with a disallowed Origin still 200s but omits ``Access-Control-Allow-Origin``."""
+    client = await aiohttp_client(_app_with_cors())
+    resp = await client.options("/preflight", headers={"Origin": "https://evil.example.com"})
+
+    assert resp.status == 200
+    assert "Access-Control-Allow-Origin" not in resp.headers
+    assert resp.headers["Vary"] == "Origin"
+    assert await resp.text() == ""
+
+
 async def test_cors_middleware_attaches_headers_to_non_get_methods(
     aiohttp_client: AiohttpClient,
 ) -> None:

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -373,10 +373,6 @@ def _public_site_app(trusted_domains: list[str], *, using_password: bool = True)
     return app
 
 
-# Back-compat alias — most call sites only care about "public site, gate runs".
-_password_protected_app = _public_site_app
-
-
 async def test_handler_rejects_cross_origin_without_allowlist(
     aiohttp_client: AiohttpClient,
 ) -> None:
@@ -385,7 +381,7 @@ async def test_handler_rejects_cross_origin_without_allowlist(
     Pin the existing strict behaviour so a refactor of the
     Origin gate doesn't silently remove the protection.
     """
-    client = await aiohttp_client(_password_protected_app([]))
+    client = await aiohttp_client(_public_site_app([]))
     resp = await client.get("/ws", headers={"Origin": "https://evil.example.com"})
     assert resp.status == 403
     assert "Cross-origin" in await resp.text()
@@ -405,7 +401,7 @@ async def test_handler_accepts_cross_origin_when_origin_in_allowlist(
     # binds the test server there and the Host-allowlist check
     # runs after the Origin gate; without the IP entry, the test
     # would pass the Origin gate but trip the Host gate.
-    client = await aiohttp_client(_password_protected_app(["dashboard.example.com", "127.0.0.1"]))
+    client = await aiohttp_client(_public_site_app(["dashboard.example.com", "127.0.0.1"]))
     async with client.ws_connect("/ws", headers={"Origin": "https://dashboard.example.com"}) as ws:
         msg = await ws.receive(timeout=2.0)
         assert msg.type.name in ("TEXT", "BINARY")
@@ -422,7 +418,7 @@ async def test_handler_rejects_host_not_in_allowlist(
     catches it. We pass a matching ``Origin`` so the cross-origin
     gate doesn't short-circuit before the host-allowlist check.
     """
-    client = await aiohttp_client(_password_protected_app(["dashboard.example.com"]))
+    client = await aiohttp_client(_public_site_app(["dashboard.example.com"]))
     resp = await client.get(
         "/ws",
         headers={
@@ -438,7 +434,7 @@ async def test_handler_accepts_host_in_allowlist(
     aiohttp_client: AiohttpClient,
 ) -> None:
     """Host header in allowlist + same-origin → handshake succeeds."""
-    client = await aiohttp_client(_password_protected_app(["dashboard.example.com"]))
+    client = await aiohttp_client(_public_site_app(["dashboard.example.com"]))
     async with client.ws_connect(
         "/ws",
         headers={
@@ -505,7 +501,7 @@ async def test_handler_no_origin_skips_both_gates(
     ``trusted_domains`` to harden against rebinding accidentally
     locked their HA integration out.
     """
-    client = await aiohttp_client(_password_protected_app(["dashboard.example.com"]))
+    client = await aiohttp_client(_public_site_app(["dashboard.example.com"]))
     # No Origin header → CLI-style request. Host is the test
     # client's local IP:port, deliberately NOT in the allowlist.
     async with client.ws_connect("/ws") as ws:
@@ -516,15 +512,7 @@ async def test_handler_no_origin_skips_both_gates(
 async def test_handler_rejects_cross_origin_on_passwordless_public_site(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """Passwordless dashboards reject cross-origin handshakes too.
-
-    A passwordless dashboard is still reachable only by the operator's
-    own browsing sessions (and by CLI tools, which omit Origin). A
-    malicious page the operator browses must not be able to open
-    ``/ws`` and run privileged commands just because the operator
-    skipped the password — the previous skip-on-passwordless gate
-    was the canonical "looks fine, then someone visits evil.com" bug.
-    """
+    """Passwordless public site rejects cross-origin handshakes (no skip-on-passwordless gate)."""
     client = await aiohttp_client(_public_site_app([], using_password=False))
     resp = await client.get("/ws", headers={"Origin": "https://evil.example.com"})
     assert resp.status == 403
@@ -534,16 +522,11 @@ async def test_handler_rejects_cross_origin_on_passwordless_public_site(
 async def test_handler_accepts_same_origin_on_passwordless_public_site(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """Passwordless first-run access from the operator's browser still works.
+    """Passwordless same-origin handshake passes — pin the equality branch.
 
-    Same-origin (Origin's host:port == Host) is the canonical
-    "operator typed http://192.168.1.50:6052 in their browser"
-    path — has to keep working when the gate goes on by
-    default. ``aiohttp.ClientSession`` does NOT auto-set Origin
-    on ``ws_connect``, so pass it explicitly to actually
-    exercise the equality branch (otherwise the test would
-    pass via the no-Origin skip and not pin same-origin
-    acceptance).
+    ``aiohttp.ClientSession.ws_connect`` doesn't auto-set Origin,
+    so pass it explicitly; otherwise the test would pass via the
+    no-Origin skip and not exercise the same-origin acceptance.
     """
     client = await aiohttp_client(_public_site_app([], using_password=False))
     host = f"{client.host}:{client.port}"

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -536,13 +536,17 @@ async def test_handler_accepts_same_origin_on_passwordless_public_site(
 ) -> None:
     """Passwordless first-run access from the operator's browser still works.
 
-    Same-origin (Origin's host:port == Host) was always the
-    canonical "operator typed http://192.168.1.50:6052 in their
-    browser" path — it has to keep working when the gate goes
-    on by default. ``aiohttp_client`` binds the test server on
-    127.0.0.1, so the client's auto-set Origin matches Host.
+    Same-origin (Origin's host:port == Host) is the canonical
+    "operator typed http://192.168.1.50:6052 in their browser"
+    path — has to keep working when the gate goes on by
+    default. ``aiohttp.ClientSession`` does NOT auto-set Origin
+    on ``ws_connect``, so pass it explicitly to actually
+    exercise the equality branch (otherwise the test would
+    pass via the no-Origin skip and not pin same-origin
+    acceptance).
     """
     client = await aiohttp_client(_public_site_app([], using_password=False))
-    async with client.ws_connect("/ws") as ws:
+    host = f"{client.host}:{client.port}"
+    async with client.ws_connect("/ws", headers={"Origin": f"http://{host}"}) as ws:
         msg = await ws.receive(timeout=2.0)
         assert msg.type.name in ("TEXT", "BINARY")

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -13,8 +13,8 @@ checks in ``api/ws.py``:
 
 These tests exercise three layers:
 
-* The pure ``_normalize_host`` / ``_host_in_allowlist`` /
-  ``_origin_in_allowlist`` helpers.
+* The pure ``normalize_host`` / ``host_in_allowlist`` /
+  ``origin_in_allowlist`` helpers.
 * ``DashboardSettings.parse_args`` — CLI / env-var precedence,
   whitespace handling, the ``--trusted-domains ""`` explicit
   override path.
@@ -35,15 +35,15 @@ from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
 from esphome_device_builder.api import ws as ws_module
-from esphome_device_builder.api.ws import (
-    _host_in_allowlist,
-    _normalize_host,
-    _origin_in_allowlist,
-)
 from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.helpers.origin import (
+    host_in_allowlist,
+    normalize_host,
+    origin_in_allowlist,
+)
 
 # ---------------------------------------------------------------------------
-# _normalize_host
+# normalize_host
 # ---------------------------------------------------------------------------
 
 
@@ -71,16 +71,16 @@ def test_normalize_host_strips_port_and_brackets(raw: str, expected: str) -> Non
     plus port, ``[ipv6]`` plus port) and returns the unbracketed
     hostname; this test pins both branches.
     """
-    assert _normalize_host(raw) == expected
+    assert normalize_host(raw) == expected
 
 
 def test_normalize_host_falls_back_on_malformed() -> None:
     """``urlsplit`` of garbage may return empty hostname — fall back to lowercase."""
     # Empty string and lone colon both yield None from .hostname; the
     # fallback returns the lowercase input verbatim so the comparison
-    # in _host_in_allowlist still has something deterministic.
-    assert _normalize_host("") == ""
-    assert _normalize_host("WeirdInput") == "weirdinput"
+    # in host_in_allowlist still has something deterministic.
+    assert normalize_host("") == ""
+    assert normalize_host("WeirdInput") == "weirdinput"
 
 
 def test_normalize_host_falls_back_on_invalid_ipv6_url() -> None:
@@ -94,11 +94,11 @@ def test_normalize_host_falls_back_on_invalid_ipv6_url() -> None:
     the WS handshake instead of falling through to the
     allowlist's normal "doesn't match" rejection path.
     """
-    assert _normalize_host("[invalid") == "[invalid"
+    assert normalize_host("[invalid") == "[invalid"
 
 
 # ---------------------------------------------------------------------------
-# _host_in_allowlist
+# host_in_allowlist
 # ---------------------------------------------------------------------------
 
 
@@ -110,13 +110,13 @@ def test_host_in_allowlist_empty_means_pass_through() -> None:
     truthiness check (returning False on empty) doesn't break
     every default deployment.
     """
-    assert _host_in_allowlist("dashboard.local:6052", []) is True
+    assert host_in_allowlist("dashboard.local:6052", []) is True
 
 
 def test_host_in_allowlist_wildcard_match_anything() -> None:
     """``"*"`` is the explicit "match anything" escape hatch."""
-    assert _host_in_allowlist("anything.example.com", ["*"]) is True
-    assert _host_in_allowlist("[::1]:6052", ["*"]) is True
+    assert host_in_allowlist("anything.example.com", ["*"]) is True
+    assert host_in_allowlist("[::1]:6052", ["*"]) is True
 
 
 @pytest.mark.parametrize(
@@ -139,7 +139,7 @@ def test_host_in_allowlist_match(host: str, allowlist: list[str]) -> None:
     accepted shapes so a normaliser tweak that breaks any of
     them shows up in CI.
     """
-    assert _host_in_allowlist(host, allowlist) is True
+    assert host_in_allowlist(host, allowlist) is True
 
 
 @pytest.mark.parametrize(
@@ -158,11 +158,11 @@ def test_host_in_allowlist_reject_non_match(host: str, allowlist: list[str]) -> 
     the attacker domain, the allowlist (set to the operator's
     real domain) catches it.
     """
-    assert _host_in_allowlist(host, allowlist) is False
+    assert host_in_allowlist(host, allowlist) is False
 
 
 # ---------------------------------------------------------------------------
-# _origin_in_allowlist
+# origin_in_allowlist
 # ---------------------------------------------------------------------------
 
 
@@ -173,7 +173,7 @@ def test_origin_in_allowlist_empty_means_no_grant() -> None:
     acceptance. Empty allowlist falls through to the existing
     Origin-equals-Host hard reject.
     """
-    assert _origin_in_allowlist("https://dashboard.example.com", []) is False
+    assert origin_in_allowlist("https://dashboard.example.com", []) is False
 
 
 def test_origin_in_allowlist_wildcard_accepts_any() -> None:
@@ -184,7 +184,7 @@ def test_origin_in_allowlist_wildcard_accepts_any() -> None:
     network and just want the dashboard usable from any
     proxy hostname).
     """
-    assert _origin_in_allowlist("https://anything.example.com", ["*"]) is True
+    assert origin_in_allowlist("https://anything.example.com", ["*"]) is True
 
 
 @pytest.mark.parametrize(
@@ -199,18 +199,18 @@ def test_origin_in_allowlist_wildcard_accepts_any() -> None:
 )
 def test_origin_in_allowlist_match(origin: str, allowlist: list[str]) -> None:
     """Match is on the Origin URL's hostname (port + scheme stripped)."""
-    assert _origin_in_allowlist(origin, allowlist) is True
+    assert origin_in_allowlist(origin, allowlist) is True
 
 
 def test_origin_in_allowlist_rejects_unmatched() -> None:
     """An attacker domain that's not in the list stays rejected."""
-    assert _origin_in_allowlist("https://evil.example.com", ["dashboard.example.com"]) is False
+    assert origin_in_allowlist("https://evil.example.com", ["dashboard.example.com"]) is False
 
 
 def test_origin_in_allowlist_rejects_malformed() -> None:
     """Garbage Origin header -> reject."""
     # Empty hostname after parsing -> not a useful match candidate.
-    assert _origin_in_allowlist("not-a-url", ["dashboard.example.com"]) is False
+    assert origin_in_allowlist("not-a-url", ["dashboard.example.com"]) is False
 
 
 def test_origin_in_allowlist_rejects_invalid_ipv6_url() -> None:
@@ -222,7 +222,7 @@ def test_origin_in_allowlist_rejects_invalid_ipv6_url() -> None:
     so the allowlist check returns ``False`` instead of 500-ing
     the WS handshake on a malformed Origin header.
     """
-    assert _origin_in_allowlist("http://[invalid", ["dashboard.example.com"]) is False
+    assert origin_in_allowlist("http://[invalid", ["dashboard.example.com"]) is False
 
 
 # ---------------------------------------------------------------------------
@@ -352,18 +352,10 @@ def test_settings_explicit_empty_cli_overrides_env_var(tmp_path: object) -> None
 # ---------------------------------------------------------------------------
 
 
-def _password_protected_app(trusted_domains: list[str]) -> web.Application:
-    """Build a minimal aiohttp app wired to ``websocket_handler``.
-
-    Mirrors the pattern in ``test_websocket_heartbeat.py``: stub
-    settings + auth so ``websocket_handler``'s gating branches run
-    without spinning up the real DeviceBuilder. Password is set
-    (``using_password=True``) so the Origin/Host checks actually
-    execute — the gate is skipped on unauthenticated deployments
-    and on the trusted ingress site.
-    """
+def _public_site_app(trusted_domains: list[str], *, using_password: bool = True) -> web.Application:
+    """Build a minimal aiohttp app wired to ``websocket_handler`` on the public site."""
     settings = MagicMock()
-    settings.using_password = True
+    settings.using_password = using_password
     settings.trusted_domains = trusted_domains
     settings.port = 6052
     settings.on_ha_addon = False
@@ -379,6 +371,10 @@ def _password_protected_app(trusted_domains: list[str]) -> web.Application:
     ws_module.init_ws_app(app)
     app.router.add_routes(ws_module.create_ws_routes())
     return app
+
+
+# Back-compat alias — most call sites only care about "public site, gate runs".
+_password_protected_app = _public_site_app
 
 
 async def test_handler_rejects_cross_origin_without_allowlist(
@@ -517,34 +513,36 @@ async def test_handler_no_origin_skips_both_gates(
         assert msg.type.name in ("TEXT", "BINARY")
 
 
-async def test_handler_accepts_when_no_password(
+async def test_handler_rejects_cross_origin_on_passwordless_public_site(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """Unauthenticated public site bypasses gating.
+    """Passwordless dashboards reject cross-origin handshakes too.
 
-    The Origin / Host checks fire only when ``using_password``.
-    A dashboard running without auth is already in
-    "trust-the-LAN" mode; adding hostname checks would break
-    first-run access from another machine.
+    A passwordless dashboard is still reachable only by the operator's
+    own browsing sessions (and by CLI tools, which omit Origin). A
+    malicious page the operator browses must not be able to open
+    ``/ws`` and run privileged commands just because the operator
+    skipped the password — the previous skip-on-passwordless gate
+    was the canonical "looks fine, then someone visits evil.com" bug.
     """
-    settings = MagicMock()
-    settings.using_password = False
-    settings.trusted_domains = []
-    settings.port = 6052
-    settings.on_ha_addon = False
+    client = await aiohttp_client(_public_site_app([], using_password=False))
+    resp = await client.get("/ws", headers={"Origin": "https://evil.example.com"})
+    assert resp.status == 403
+    assert "Cross-origin" in await resp.text()
 
-    device_builder = MagicMock()
-    device_builder.settings = settings
-    device_builder.auth = MagicMock()
-    device_builder.auth.session_store = MagicMock()
 
-    app = web.Application()
-    app["device_builder"] = device_builder
-    app["trusted_site"] = False
-    ws_module.init_ws_app(app)
-    app.router.add_routes(ws_module.create_ws_routes())
+async def test_handler_accepts_same_origin_on_passwordless_public_site(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Passwordless first-run access from the operator's browser still works.
 
-    client = await aiohttp_client(app)
-    async with client.ws_connect("/ws", headers={"Origin": "https://evil.example.com"}) as ws:
+    Same-origin (Origin's host:port == Host) was always the
+    canonical "operator typed http://192.168.1.50:6052 in their
+    browser" path — it has to keep working when the gate goes
+    on by default. ``aiohttp_client`` binds the test server on
+    127.0.0.1, so the client's auto-set Origin matches Host.
+    """
+    client = await aiohttp_client(_public_site_app([], using_password=False))
+    async with client.ws_connect("/ws") as ws:
         msg = await ws.receive(timeout=2.0)
         assert msg.type.name in ("TEXT", "BINARY")


### PR DESCRIPTION
# What does this implement/fix?

Two paths on the public site previously trusted any browser origin
when no password was configured:

- `api/ws.py` skipped the Origin / Host gate entirely on
  passwordless deployments. A passwordless dashboard would
  accept a `/ws` handshake from `Origin: https://evil.com` and
  hand the caller a fully-authenticated session, because
  `pre_authenticated = not using_password` already covered the
  in-band auth path. Combined with the WS command surface, any
  page the operator browsed could read or mutate dashboard
  state.
- `helpers/json.py:cors_middleware` returned
  `Access-Control-Allow-Origin: *` unconditionally. Same shape:
  a passwordless dashboard's REST endpoints would let a malicious
  page read responses cross-origin.

Fix: enforce the existing Origin / Host allowlist regardless of
password state on the public site, and tighten the CORS
middleware to the same predicate.

- `api/ws.py`: the gate now runs whenever `not trusted_site`.
  Same-origin (Origin matches Host) and trusted-domains-allowlisted
  origins still pass; everything else gets 403. Non-browser
  clients (CLI tools, HA integration) omit Origin and skip the
  gate — unchanged.
- `helpers/json.py:cors_middleware`: reflects the request's
  Origin only when it matches Host or is in
  `--trusted-domains`. Otherwise omits `Access-Control-Allow-Origin`
  so the browser blocks the calling JS from reading the response.
  The HA Ingress site (`trusted_site=True`) keeps reflecting any
  Origin — the supervisor handles auth upstream and the
  listener is bound to its docker network.
- New `helpers/origin.py`: shared Origin / Host predicates so
  the WS handshake and REST middleware decide cross-origin
  acceptance off the same code path. Avoids the
  `api/ws.py` ↔ `helpers/json.py` cycle a direct import would
  create.

## Audience this protects

A malicious web page in the operator's own browser is the
canonical threat — JS in that page can `fetch()` / open a
`WebSocket` against the dashboard's URL, the request rides on
the operator's network identity, and pre-fix on passwordless it
returned a fully-authenticated session. The bind address doesn't
help; the browser is on the same host as the dashboard. Same
shape as the historical "localhost-bound dev service hijacked by
malicious page" class (Plex API, various dev servers).

| Deployment | Vulnerable pre-fix? | Notes |
|---|---|---|
| **ESPHome Desktop on `127.0.0.1`** | Yes | Localhost bind doesn't immunize — the operator's browser reaches `127.0.0.1` by definition; a malicious page in that browser does too. |
| **Standalone PyPI on `0.0.0.0`** (default) | Yes | Malicious page + LAN-resident attacker on the same network both reachable. |
| **Standalone PyPI on `127.0.0.1`** | Yes | Same as Desktop. |
| **HA Addon (ingress)** | No — untouched | `trusted_site=True` skips the gate; the supervisor handles auth upstream and the listener is bound to the supervisor's docker network. |

Standalone PyPI and Desktop both start without a password unless
the operator passes `--username/--password`, so passwordless
deployments aren't hypothetical — they're the default for those
audiences. The gate now catches the malicious-page class for
every public-site deployment, password-gated or not.

## Operator-visible change

Passwordless dashboards behind a reverse proxy that **rewrites
`Host`** now require `--trusted-domains` to be set, matching
what password-gated deployments already require. The common
nginx shape `proxy_set_header Host $host;` preserves Host and
keeps working with no config change; nginx's default Host
rewriting (`$proxy_host`) now needs the explicit allowlist
entry. README has the setup walk-through.

Same-origin first-run access (`http://192.168.1.50:6052`
directly from the operator's browser) keeps working — Origin
matches Host.

## Why this is a security fix (this one is)

Unlike #868 (which only changed what an *authenticated* caller
could do — and authenticated callers are already host-equivalent
via `external_components:`, see #869), this gate stands between
**unauthenticated** browser traffic and the dashboard. A malicious
page in the operator's own browser is the canonical example —
they didn't authenticate to the dashboard, but the browser sends
the request from the operator's network identity. That makes the
fix a real boundary tightening, not defense-in-depth.

**Related issue or feature (if applicable):**

- fixes <none — reported in-conversation>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
