### PR TITLE
Prefer upstream esphome.const placeholder wifi constants

### DIFF
--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -17,11 +17,17 @@ from pathlib import Path
 from esphome import yaml_util
 from esphome.core import EsphomeError
 
-# Bootstrap placeholder strings — hoisted from
-# ``controllers/config.py`` so the writer and the reader share a
-# single definition.
-PLACEHOLDER_WIFI_SSID = "REPLACE_WITH_YOUR_WIFI_NETWORK"
-PLACEHOLDER_WIFI_PASSWORD = "REPLACE_WITH_YOUR_WIFI_PASSWORD"  # noqa: S105 — obvious placeholder, not a real credential
+# Bootstrap placeholder strings. Upstream now exports these from
+# ``esphome.const``; fall back to local literals on older releases
+# that predate the promotion.
+try:
+    from esphome.const import (
+        PLACEHOLDER_WIFI_PASSWORD,
+        PLACEHOLDER_WIFI_SSID,
+    )
+except ImportError:
+    PLACEHOLDER_WIFI_SSID = "REPLACE_WITH_YOUR_WIFI_NETWORK"
+    PLACEHOLDER_WIFI_PASSWORD = "REPLACE_WITH_YOUR_WIFI_PASSWORD"  # noqa: S105
 
 # Values that count as "not user-configured" for ``wifi_ssid``:
 # missing key, empty string, or the bootstrap placeholder. Stored


### PR DESCRIPTION
# What does this implement/fix?

Re-export `PLACEHOLDER_WIFI_SSID` / `PLACEHOLDER_WIFI_PASSWORD`
from `esphome.const` when available, falling back to the local
literals on older esphome releases that predate the promotion.

Upstream esphome/esphome#16444 lifts these two constants into
`esphome.const` and refuses to compile a config whose resolved
`wifi.ssid` (or `wifi.ap.ssid`) is the placeholder. That refusal
needs to match the dashboard's bootstrap byte-for-byte; sourcing
the strings from upstream once it ships closes the room for
drift. Until that lands in a pinned esphome release, the
`try`/`except ImportError` keeps the literals available so the
dashboard works against current and prior esphome versions
unchanged.

No behavior change today. Once the esphome pin clears the release
that lands #16444, the fallback branch can be deleted.

**Related issue or feature (if applicable):**

- Upstream companion: esphome/esphome#16444

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
