### PR TITLE
Share test factories for Device, PeerLinkSession, e2e bundle

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -831,25 +831,8 @@ def make_state_monitor_with_callbacks(
     return monitor, callbacks
 
 
-# ---------------------------------------------------------------------------
-# Shared ``Device`` factory
-#
-# ~16 test files were each carrying a near-identical ``_device`` /
-# ``_make_device`` helper that builds a ``Device(name=..., friendly_name=...,
-# configuration=f"{name}.yaml", address=f"{name}.local", state=UNKNOWN)``
-# with one or two field overrides. Centralising the defaults here means a
-# new ``Device`` field doesn't need a touch in every per-file helper.
-# ---------------------------------------------------------------------------
-
-
 def make_device(name: str = "kitchen", **overrides: Any) -> Device:
-    """Build a ``Device`` with the defaults the test suite expects.
-
-    ``friendly_name``, ``configuration`` and ``address`` are
-    derived from *name* unless overridden. ``state`` defaults to
-    ``DeviceState.UNKNOWN``. Any other field passes straight
-    through to the :class:`Device` constructor.
-    """
+    """Build a ``Device`` deriving friendly_name / configuration / address from *name*."""
     base: dict[str, Any] = {
         "name": name,
         "friendly_name": name.title(),
@@ -861,28 +844,12 @@ def make_device(name: str = "kitchen", **overrides: Any) -> Device:
     return Device(**base)
 
 
-# ---------------------------------------------------------------------------
-# Peer-link session stub
-#
-# Three remote-build receiver-side test files (``test_remote_build_job_fanout``,
-# ``test_remote_build_submit_job``, ``test_remote_build_artifacts_download``)
-# were each carrying their own ``_make_session`` helper that builds a
-# ``MagicMock`` with ``dashboard_id`` set and ``send_app_frame`` (plus
-# sometimes ``terminate``) wired as ``AsyncMock``. Hoist into one factory.
-# ---------------------------------------------------------------------------
-
-
 def make_peer_link_session(
     *,
     dashboard_id: str = "alpha",
     with_terminate: bool = True,
 ) -> Any:
-    """Stub ``PeerLinkSession`` capturing ``send_app_frame`` payloads.
-
-    ``with_terminate=False`` skips wiring the ``terminate``
-    ``AsyncMock`` for tests that only exercise the
-    happy-path send loop.
-    """
+    """Stub ``PeerLinkSession`` with ``send_app_frame`` (and optionally terminate) as AsyncMock."""
     session = MagicMock()
     session.dashboard_id = dashboard_id
     session.send_app_frame = AsyncMock(return_value=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -829,3 +829,63 @@ def make_state_monitor_with_callbacks(
         on_mac_address_change=callbacks.on_mac_address_change,
     )
     return monitor, callbacks
+
+
+# ---------------------------------------------------------------------------
+# Shared ``Device`` factory
+#
+# ~16 test files were each carrying a near-identical ``_device`` /
+# ``_make_device`` helper that builds a ``Device(name=..., friendly_name=...,
+# configuration=f"{name}.yaml", address=f"{name}.local", state=UNKNOWN)``
+# with one or two field overrides. Centralising the defaults here means a
+# new ``Device`` field doesn't need a touch in every per-file helper.
+# ---------------------------------------------------------------------------
+
+
+def make_device(name: str = "kitchen", **overrides: Any) -> Device:
+    """Build a ``Device`` with the defaults the test suite expects.
+
+    ``friendly_name``, ``configuration`` and ``address`` are
+    derived from *name* unless overridden. ``state`` defaults to
+    ``DeviceState.UNKNOWN``. Any other field passes straight
+    through to the :class:`Device` constructor.
+    """
+    base: dict[str, Any] = {
+        "name": name,
+        "friendly_name": name.title(),
+        "configuration": f"{name}.yaml",
+        "address": f"{name}.local",
+        "state": DeviceState.UNKNOWN,
+    }
+    base.update(overrides)
+    return Device(**base)
+
+
+# ---------------------------------------------------------------------------
+# Peer-link session stub
+#
+# Three remote-build receiver-side test files (``test_remote_build_job_fanout``,
+# ``test_remote_build_submit_job``, ``test_remote_build_artifacts_download``)
+# were each carrying their own ``_make_session`` helper that builds a
+# ``MagicMock`` with ``dashboard_id`` set and ``send_app_frame`` (plus
+# sometimes ``terminate``) wired as ``AsyncMock``. Hoist into one factory.
+# ---------------------------------------------------------------------------
+
+
+def make_peer_link_session(
+    *,
+    dashboard_id: str = "alpha",
+    with_terminate: bool = True,
+) -> Any:
+    """Stub ``PeerLinkSession`` capturing ``send_app_frame`` payloads.
+
+    ``with_terminate=False`` skips wiring the ``terminate``
+    ``AsyncMock`` for tests that only exercise the
+    happy-path send loop.
+    """
+    session = MagicMock()
+    session.dashboard_id = dashboard_id
+    session.send_app_frame = AsyncMock(return_value=True)
+    if with_terminate:
+        session.terminate = AsyncMock()
+    return session

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -46,6 +46,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 from tests._storage_fixtures import write_storage_json
+from tests.conftest import make_device
 
 from .conftest import (
     CaptureDevicesEventsFactory,
@@ -56,11 +57,9 @@ from .conftest import (
 
 
 def _device(name: str, *, ip: str = "", ip_addresses: list[str] | None = None) -> Device:
-    return Device(
+    """Local wrapper around ``make_device`` defaulting to ONLINE for these IP-list tests."""
+    return make_device(
         name=name,
-        friendly_name=name.title(),
-        configuration=f"{name}.yaml",
-        address=f"{name}.local",
         state=DeviceState.ONLINE,
         ip=ip,
         ip_addresses=list(ip_addresses) if ip_addresses else [],

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -57,7 +57,6 @@ from .conftest import (
 
 
 def _device(name: str, *, ip: str = "", ip_addresses: list[str] | None = None) -> Device:
-    """Local wrapper around ``make_device`` defaulting to ONLINE for these IP-list tests."""
     return make_device(
         name=name,
         state=DeviceState.ONLINE,

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -36,19 +36,14 @@ from esphome_device_builder.models import (
     DeviceState,
     EventType,
 )
+from tests.conftest import make_device
 
 from .conftest import CaptureDevicesEventsFactory, MakeControllerFactory
 
 
 def _device(name: str, *, state: DeviceState = DeviceState.ONLINE) -> Device:
-    """Bare-minimum ``Device`` for listing assertions."""
-    return Device(
-        name=name,
-        friendly_name=name.title(),
-        configuration=f"{name}.yaml",
-        address=f"{name}.local",
-        state=state,
-    )
+    """Local wrapper around ``make_device`` defaulting to ONLINE for these listing tests."""
+    return make_device(name=name, state=state)
 
 
 def _adoptable(name: str = "kitchen-1a2b3c") -> AdoptableDevice:

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -42,7 +42,6 @@ from .conftest import CaptureDevicesEventsFactory, MakeControllerFactory
 
 
 def _device(name: str, *, state: DeviceState = DeviceState.ONLINE) -> Device:
-    """Local wrapper around ``make_device`` defaulting to ONLINE for these listing tests."""
     return make_device(name=name, state=state)
 
 

--- a/tests/controllers/devices/test_search_yaml.py
+++ b/tests/controllers/devices/test_search_yaml.py
@@ -31,18 +31,17 @@ import pytest
 
 from esphome_device_builder.controllers.devices._yaml_search import MAX_CONTEXT_LINES
 from esphome_device_builder.models import Device, DeviceState
+from tests.conftest import make_device
 
 if TYPE_CHECKING:
     from .conftest import MakeControllerFactory
 
 
 def _device(name: str, *, friendly: str | None = None) -> Device:
-    """Bare-minimum ``Device`` for search-result assertions."""
-    return Device(
+    """Local wrapper around ``make_device`` defaulting to ONLINE for these search-result tests."""
+    return make_device(
         name=name,
         friendly_name=friendly or name.title(),
-        configuration=f"{name}.yaml",
-        address=f"{name}.local",
         state=DeviceState.ONLINE,
     )
 

--- a/tests/controllers/devices/test_search_yaml.py
+++ b/tests/controllers/devices/test_search_yaml.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
 
 
 def _device(name: str, *, friendly: str | None = None) -> Device:
-    """Local wrapper around ``make_device`` defaulting to ONLINE for these search-result tests."""
     return make_device(
         name=name,
         friendly_name=friendly or name.title(),

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -84,7 +84,6 @@ class _ReloadingScanner(RecordingScanner):
 
 
 def _make_device(filename: str = "kitchen.yaml", labels: list[str] | None = None) -> Device:
-    """Local wrapper taking ``configuration`` as ``filename`` for this file."""
     name = configuration_stem(filename)
     return make_device(
         name=name,

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -36,6 +36,7 @@ from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.device_yaml import configuration_stem
 from esphome_device_builder.models import Device, ErrorCode, Label
 from tests._recording_scanner import RecordingScanner
+from tests.conftest import make_device
 
 from .conftest import MakeControllerFactory
 
@@ -83,17 +84,13 @@ class _ReloadingScanner(RecordingScanner):
 
 
 def _make_device(filename: str = "kitchen.yaml", labels: list[str] | None = None) -> Device:
-    """Minimal Device fixture for these tests.
-
-    The set_labels handler doesn't read most fields off the device —
-    just ``configuration`` for the find-by-config lookup post-reload
-    and ``labels`` for the assertion. The rest carry safe defaults.
-    """
+    """Local wrapper taking ``configuration`` as ``filename`` for this file."""
     name = configuration_stem(filename)
-    return Device(
+    return make_device(
         name=name,
         friendly_name=name,
         configuration=filename,
+        address="",
         labels=list(labels or []),
     )
 

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -21,7 +21,6 @@ from tests.controllers.devices.conftest import RecordingStateMonitor
 
 
 def _device(**overrides: Any) -> Device:
-    """Local wrapper around ``make_device`` defaulting ``loaded_integrations`` for this file."""
     overrides.setdefault("loaded_integrations", ["api"])
     return make_device(**overrides)
 

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -16,20 +16,14 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices.helpers import _build_address_cache_args
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import Device, FirmwareJob, JobType
+from tests.conftest import make_device
 from tests.controllers.devices.conftest import RecordingStateMonitor
 
 
 def _device(**overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-        "address": "kitchen.local",
-        "ip": "",
-        "loaded_integrations": ["api"],
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` defaulting ``loaded_integrations`` for this file."""
+    overrides.setdefault("loaded_integrations", ["api"])
+    return make_device(**overrides)
 
 
 _TEST_HOSTS = ("kitchen.local", "esp.example.com")

--- a/tests/controllers/firmware/test_bulk_order.py
+++ b/tests/controllers/firmware/test_bulk_order.py
@@ -6,6 +6,7 @@ import pytest
 
 from esphome_device_builder.controllers.firmware.bulk import _esphome_version_sort_key
 from esphome_device_builder.models import Device, JobType
+from tests.conftest import make_device
 from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
@@ -25,11 +26,13 @@ def _device(
     has_pending_changes: bool = False,
     update_available: bool = False,
 ) -> Device:
+    """Local wrapper around ``make_device`` deriving ``name`` from *configuration*."""
     name = configuration.removesuffix(".yaml")
-    return Device(
+    return make_device(
         name=name,
         friendly_name=name,
         configuration=configuration,
+        address="",
         current_version=current_version,
         deployed_version=deployed_version,
         has_pending_changes=has_pending_changes,

--- a/tests/controllers/firmware/test_bulk_order.py
+++ b/tests/controllers/firmware/test_bulk_order.py
@@ -26,7 +26,6 @@ def _device(
     has_pending_changes: bool = False,
     update_available: bool = False,
 ) -> Device:
-    """Local wrapper around ``make_device`` deriving ``name`` from *configuration*."""
     name = configuration.removesuffix(".yaml")
     return make_device(
         name=name,

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -49,7 +49,6 @@ from tests.conftest import make_device
 
 
 def _device(name: str = "kitchen", **overrides: Any) -> Device:
-    """Local wrapper around ``make_device`` defaulting ``current_version`` for this file."""
     overrides.setdefault("current_version", "2026.5.0")
     return make_device(name=name, **overrides)
 

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -39,28 +39,19 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import (
     Device,
-    DeviceState,
     EventType,
     FirmwareJob,
     JobStatus,
     JobType,
 )
 from tests._recording_scanner import RecordingScanner
+from tests.conftest import make_device
 
 
 def _device(name: str = "kitchen", **overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": name,
-        "friendly_name": name.title(),
-        "configuration": f"{name}.yaml",
-        "address": f"{name}.local",
-        "current_version": "2026.5.0",
-        "deployed_version": "",
-        "state": DeviceState.UNKNOWN,
-        "has_pending_changes": True,
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` defaulting ``current_version`` for this file."""
+    overrides.setdefault("current_version", "2026.5.0")
+    return make_device(name=name, **overrides)
 
 
 # ----------------------------------------------------------------------

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -377,25 +377,12 @@ def make_remote_peer_job(
 
 
 def make_real_bundle(*, configuration_filename: str = "kitchen.yaml") -> bytes:
-    """Build a minimal-but-valid esphome bundle the upstream extractor accepts.
+    """
+    Build a minimal-but-valid esphome bundle the upstream extractor accepts.
 
-    Upstream :func:`esphome.bundle.extract_bundle` needs:
-
-    * A ``manifest.json`` member with
-      ``{"manifest_version": 1, "config_filename": "..."}``.
-    * The referenced ``config_filename`` member, with non-empty
-      content.
-
-    Nothing else; :func:`_validate_tar_members` rejects symlinks,
-    absolute paths, path traversal, and oversized archives, all
-    of which we naturally avoid by emitting two regular file
-    members at the top level.
-
-    Deliberately not going through :class:`BundleBuilder`: that
-    class drives ``BundleBuilder.discover_files`` off real
-    ``CORE.config_dir`` + ``CORE.config_path`` state, which would
-    couple the e2e tests to a real config-dir layout when all
-    they want is the wire-format contract.
+    Emits a ``manifest.json`` + the referenced YAML member; skips
+    :class:`BundleBuilder` so the test doesn't need a real
+    ``CORE.config_dir`` / ``CORE.config_path`` setup.
     """
     manifest = {
         "manifest_version": 1,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,6 +34,9 @@ application messages."
 from __future__ import annotations
 
 import asyncio
+import io
+import json
+import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -371,6 +374,45 @@ def make_remote_peer_job(
         remote_job_id=remote_job_id,
         error=error,
     )
+
+
+def make_real_bundle(*, configuration_filename: str = "kitchen.yaml") -> bytes:
+    """Build a minimal-but-valid esphome bundle the upstream extractor accepts.
+
+    Upstream :func:`esphome.bundle.extract_bundle` needs:
+
+    * A ``manifest.json`` member with
+      ``{"manifest_version": 1, "config_filename": "..."}``.
+    * The referenced ``config_filename`` member, with non-empty
+      content.
+
+    Nothing else; :func:`_validate_tar_members` rejects symlinks,
+    absolute paths, path traversal, and oversized archives, all
+    of which we naturally avoid by emitting two regular file
+    members at the top level.
+
+    Deliberately not going through :class:`BundleBuilder`: that
+    class drives ``BundleBuilder.discover_files`` off real
+    ``CORE.config_dir`` + ``CORE.config_path`` state, which would
+    couple the e2e tests to a real config-dir layout when all
+    they want is the wire-format contract.
+    """
+    manifest = {
+        "manifest_version": 1,
+        "config_filename": configuration_filename,
+    }
+    yaml_body = b"esphome:\n  name: kitchen\n"
+    members: list[tuple[str, bytes]] = [
+        ("manifest.json", json.dumps(manifest).encode("utf-8")),
+        (configuration_filename, yaml_body),
+    ]
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in members:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
 
 
 async def make_and_seed_remote_peer_job(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -51,9 +51,7 @@ on the offloader side."
 from __future__ import annotations
 
 import asyncio
-import io
 import json
-import tarfile
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -88,33 +86,7 @@ from esphome_device_builder.models import (
 
 from .._storage_fixtures import write_storage_json
 from ..conftest import capture_events, wire_firmware_remote_peer_api_mocks
-from .conftest import PairedInstances
-
-
-def _build_real_bundle(*, configuration_filename: str = "kitchen.yaml") -> bytes:
-    """Build a minimal-but-valid esphome bundle the upstream extractor accepts.
-
-    Mirror of ``test_submit_job._build_real_bundle`` — kept local
-    so this test file is self-contained. Upstream
-    ``esphome.bundle.extract_bundle`` only needs a manifest plus
-    the referenced ``config_filename`` member.
-    """
-    manifest = {
-        "manifest_version": 1,
-        "config_filename": configuration_filename,
-    }
-    yaml_body = b"esphome:\n  name: kitchen\n"
-    members: list[tuple[str, bytes]] = [
-        ("manifest.json", json.dumps(manifest).encode("utf-8")),
-        (configuration_filename, yaml_body),
-    ]
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for name, data in members:
-            info = tarfile.TarInfo(name=name)
-            info.size = len(data)
-            tar.addfile(info, io.BytesIO(data))
-    return buf.getvalue()
+from .conftest import PairedInstances, make_real_bundle
 
 
 def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[FirmwareJob]:
@@ -386,7 +358,7 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
 
     # 1. submit_job with a real bundle.
     handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
-    bundle_bytes = _build_real_bundle()
+    bundle_bytes = make_real_bundle()
     ack = await handle.client.submit_job(
         job_id="off-job-1",
         configuration_filename="kitchen.yaml",
@@ -508,7 +480,7 @@ async def test_remote_compile_materialises_for_local_firmware_download(
         job_id="off-compile-1",
         configuration_filename="kitchen.yaml",
         target="compile",
-        bundle_bytes=_build_real_bundle(),
+        bundle_bytes=make_real_bundle(),
     )
     assert ack["accepted"] is True
     receiver_job = created_jobs[0]
@@ -675,7 +647,7 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
     handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
-    bundle_bytes = _build_real_bundle()
+    bundle_bytes = make_real_bundle()
 
     for cycle in range(2):
         job_tag = f"off-job-{cycle}"
@@ -735,7 +707,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
     handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
-    bundle_bytes = _build_real_bundle()
+    bundle_bytes = make_real_bundle()
 
     # Cycle 1: fail.
     ack = await handle.client.submit_job(
@@ -801,7 +773,7 @@ async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
         job_id="off-clean-1",
         configuration_filename="kitchen.yaml",
         target="clean",
-        bundle_bytes=_build_real_bundle(),
+        bundle_bytes=make_real_bundle(),
     )
 
     # Receiver accepted the clean target on the same wire path

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -50,9 +50,6 @@ covered separately by tests on :func:`build_yaml_bundle`.
 
 from __future__ import annotations
 
-import io
-import json
-import tarfile
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -68,49 +65,7 @@ from esphome_device_builder.models import (
 )
 
 from ..conftest import capture_events
-from .conftest import PairedInstances
-
-
-def _build_real_bundle(*, configuration_filename: str = "kitchen.yaml") -> bytes:
-    """Build a minimal-but-valid esphome bundle the upstream extractor accepts.
-
-    Upstream :func:`esphome.bundle.extract_bundle` needs:
-
-    * A ``manifest.json`` member with
-      ``{"manifest_version": 1, "config_filename": "..."}``.
-    * The referenced ``config_filename`` member, with non-empty
-      content.
-
-    Nothing else — :func:`_validate_tar_members` rejects symlinks
-    / absolute paths / path traversal / oversized archives, all
-    of which we naturally avoid by emitting two regular file
-    members at the top level.
-
-    Deliberately not going through :class:`BundleBuilder`: that
-    class drives ``BundleBuilder.discover_files`` off real
-    ``CORE.config_dir`` + ``CORE.config_path`` state, which
-    would couple this test to a real config-dir layout when all
-    we want is the wire-format contract. The minimal bundle
-    here exercises the same upstream extract code as a
-    BundleBuilder-emitted one for the path that the receiver-
-    side gap lives in.
-    """
-    manifest = {
-        "manifest_version": 1,
-        "config_filename": configuration_filename,
-    }
-    yaml_body = b"esphome:\n  name: kitchen\n"
-    members: list[tuple[str, bytes]] = [
-        ("manifest.json", json.dumps(manifest).encode("utf-8")),
-        (configuration_filename, yaml_body),
-    ]
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for name, data in members:
-            info = tarfile.TarInfo(name=name)
-            info.size = len(data)
-            tar.addfile(info, io.BytesIO(data))
-    return buf.getvalue()
+from .conftest import PairedInstances, make_real_bundle
 
 
 def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[FirmwareJob]:
@@ -196,7 +151,7 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
     await paired_instances.wait_until_session_opened()
     created_jobs = _wire_receiver_firmware_recorder(paired_instances)
 
-    bundle_bytes = _build_real_bundle()
+    bundle_bytes = make_real_bundle()
     handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-job-1",
@@ -249,7 +204,7 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     await instances.wait_until_session_opened()
     created_jobs = _wire_receiver_firmware_recorder(instances)
 
-    bundle_bytes = _build_real_bundle()
+    bundle_bytes = make_real_bundle()
     handle = instances.offloader.state.peer_link_clients[instances.pin_sha256]
     ack = await handle.client.submit_job(
         job_id="off-job-678",
@@ -320,7 +275,7 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
         job_id="off-job-1",
         configuration_filename="kitchen.yaml",
         target="compile",
-        bundle_bytes=_build_real_bundle(),
+        bundle_bytes=make_real_bundle(),
     )
     assert ack["accepted"] is True
     assert len(created_jobs) == 1
@@ -386,7 +341,7 @@ async def test_submit_job_round_trip_carries_display_strings_to_receiver_job(
         job_id="off-job-display",
         configuration_filename="kitchen.yaml",
         target="compile",
-        bundle_bytes=_build_real_bundle(),
+        bundle_bytes=make_real_bundle(),
         device_name="kitchen",
         device_friendly_name="AC Float Monitor 32",
     )

--- a/tests/test_device_index.py
+++ b/tests/test_device_index.py
@@ -29,7 +29,6 @@ from .conftest import make_device
 
 
 def _device(name: str, configuration: str, *, friendly_name: str | None = None) -> Device:
-    """Local wrapper around ``make_device`` for these path-keyed index tests."""
     return make_device(
         name=name,
         friendly_name=friendly_name or name.title(),

--- a/tests/test_device_index.py
+++ b/tests/test_device_index.py
@@ -25,12 +25,16 @@ import pytest
 from esphome_device_builder.controllers._device_scanner import _DeviceIndex
 from esphome_device_builder.models import Device
 
+from .conftest import make_device
+
 
 def _device(name: str, configuration: str, *, friendly_name: str | None = None) -> Device:
-    return Device(
+    """Local wrapper around ``make_device`` for these path-keyed index tests."""
+    return make_device(
         name=name,
         friendly_name=friendly_name or name.title(),
         configuration=configuration,
+        address="",
     )
 
 

--- a/tests/test_device_state_event.py
+++ b/tests/test_device_state_event.py
@@ -10,9 +10,9 @@ other source) flipped a device online — exactly the bug from the
 
 from __future__ import annotations
 
-from esphome_device_builder.models import Device, DeviceState, EventType
+from esphome_device_builder.models import DeviceState, EventType
 
-from .conftest import make_devices_controller_with_bus
+from .conftest import make_device, make_devices_controller_with_bus
 
 
 def test_state_change_event_uses_flat_configuration_state_payload() -> None:
@@ -22,7 +22,7 @@ def test_state_change_event_uses_flat_configuration_state_payload() -> None:
     expects ``{configuration, state}``, not ``{device: …}``. A regression
     that swaps them back makes every state transition no-op the UI.
     """
-    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    device = make_device(address="")
     ctrl, captured = make_devices_controller_with_bus([device])
 
     ctrl._on_state_change("kitchen", DeviceState.ONLINE, "ping")
@@ -41,7 +41,7 @@ def test_state_change_state_value_is_serialised_string() -> None:
     encoding (or fail). Pin to ``.value`` so the wire format stays a
     plain string.
     """
-    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    device = make_device(address="")
     ctrl, captured = make_devices_controller_with_bus([device])
 
     ctrl._on_state_change("kitchen", DeviceState.OFFLINE, "ping")

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -24,7 +24,7 @@ from esphome_device_builder.controllers.config import (
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import make_devices_controller_with_bus
+from .conftest import make_device, make_devices_controller_with_bus
 
 
 @pytest.fixture
@@ -216,15 +216,9 @@ async def test_async_resolve_handles_timeout(fake_resolver) -> None:
 
 
 def _device(**overrides):  # type: ignore[no-untyped-def]
-    base = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-        "address": "esp.example.com",
-        "state": DeviceState.UNKNOWN,
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` defaulting ``address`` for this file's DNS tests."""
+    overrides.setdefault("address", "esp.example.com")
+    return make_device(**overrides)
 
 
 async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -216,7 +216,6 @@ async def test_async_resolve_handles_timeout(fake_resolver) -> None:
 
 
 def _device(**overrides):  # type: ignore[no-untyped-def]
-    """Local wrapper around ``make_device`` defaulting ``address`` for this file's DNS tests."""
     overrides.setdefault("address", "esp.example.com")
     return make_device(**overrides)
 

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -18,7 +18,6 @@ from .conftest import make_device, make_state_monitor_with_callbacks
 
 
 def _device(name: str) -> Device:
-    """Local wrapper around ``make_device`` keeping ``friendly_name == name`` for this file."""
     return make_device(name=name, friendly_name=name)
 
 

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -12,19 +12,14 @@ from __future__ import annotations
 from esphome.zeroconf import DashboardImportDiscovery, DiscoveredImport
 from zeroconf.asyncio import AsyncServiceInfo
 
-from esphome_device_builder.models import AdoptableDevice, Device, DeviceState
+from esphome_device_builder.models import AdoptableDevice, Device
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_device, make_state_monitor_with_callbacks
 
 
 def _device(name: str) -> Device:
-    return Device(
-        name=name,
-        friendly_name=name,
-        configuration=f"{name}.yaml",
-        address=f"{name}.local",
-        state=DeviceState.UNKNOWN,
-    )
+    """Local wrapper around ``make_device`` keeping ``friendly_name == name`` for this file."""
+    return make_device(name=name, friendly_name=name)
 
 
 def _discovered(device_name: str = "kitchen-1a2b3c") -> DiscoveredImport:

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -17,30 +17,20 @@ Three states matter for the apply path:
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
-from esphome_device_builder.models import Device, DeviceState, EventType
+from esphome_device_builder.models import EventType
 
-from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
-
-
-def _device(**overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-        "address": "kitchen.local",
-        "state": DeviceState.UNKNOWN,
-    }
-    base.update(overrides)
-    return Device(**base)
+from .conftest import (
+    make_device,
+    make_devices_controller_with_bus,
+    make_state_monitor_with_callbacks,
+)
 
 
 def test_apply_api_encryption_first_observation_fires_callback() -> None:
     """A first encryption value reaches the controller."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256") is True
     assert callbacks.calls == [
         ("on_api_encryption_change", "kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
@@ -54,14 +44,14 @@ def test_apply_api_encryption_empty_string_is_a_real_observation() -> None:
     callback firing at least once to know we have ground truth from
     mDNS at all.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_api_encryption("kitchen", "") is True
     assert callbacks.calls == [("on_api_encryption_change", "kitchen", "")]
 
 
 def test_apply_api_encryption_dedupes_same_value() -> None:
     """Repeated identical observations don't churn the controller."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
     monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
     assert callbacks.calls == [
@@ -71,7 +61,7 @@ def test_apply_api_encryption_dedupes_same_value() -> None:
 
 def test_apply_api_encryption_fires_on_change() -> None:
     """Encrypted → plaintext (or vice versa) re-fires the callback."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_api_encryption("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
     monitor.apply_api_encryption("kitchen", "")
     assert callbacks.calls == [
@@ -87,14 +77,14 @@ def test_apply_api_encryption_unknown_device_is_ignored() -> None:
     trigger a DEVICE_UPDATED on a configured device that happens to
     share a similar name slot.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_api_encryption("not-a-device", "anything") is False
     assert callbacks.calls == []
 
 
 def test_apply_api_encryption_dedupes_repeated_empty() -> None:
     """The empty-string state is dedup'd just like a non-empty one."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_api_encryption("kitchen", "")
     monitor.apply_api_encryption("kitchen", "")
     assert callbacks.calls == [("on_api_encryption_change", "kitchen", "")]
@@ -108,7 +98,7 @@ def test_apply_api_encryption_dedupes_repeated_empty() -> None:
 @pytest.mark.asyncio
 async def test_on_api_encryption_change_updates_device_and_fires_event() -> None:
     """Callback writes the value onto the in-memory device + fires DEVICE_UPDATED."""
-    device = _device(api_encryption_active=None)
+    device = make_device(api_encryption_active=None)
     controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
@@ -127,7 +117,7 @@ async def test_on_api_encryption_change_records_empty_string() -> None:
     from ``active`` to ``mismatch``/``pending`` when paired with a
     plaintext device).
     """
-    device = _device(api_encryption_active=None)
+    device = make_device(api_encryption_active=None)
     controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "")
@@ -151,7 +141,7 @@ async def test_on_api_encryption_change_skips_when_same() -> None:
     next test pins the promote-on-mismatch path that requires
     falling through this check.
     """
-    device = _device(
+    device = make_device(
         api_encrypted=True,
         api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256",
     )
@@ -175,7 +165,7 @@ async def test_on_api_encryption_change_promotes_api_encrypted_when_yaml_missed_
     (HA integration, table-row menu, "Show API key" gate) see
     the truth.
     """
-    device = _device(api_encrypted=False, api_encryption_active=None)
+    device = make_device(api_encrypted=False, api_encryption_active=None)
     controller, captured = make_devices_controller_with_bus([device])
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
@@ -200,7 +190,7 @@ async def test_on_api_encryption_change_promotion_fires_even_when_active_unchang
     "skip when same" short-circuit can't apply when the YAML
     side disagrees with the wire side.
     """
-    device = _device(
+    device = make_device(
         api_encrypted=False,
         api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256",
     )
@@ -224,7 +214,7 @@ async def test_on_api_encryption_change_empty_does_not_clear_api_encrypted() -> 
     state machine already encodes that distinction; the
     backend must not flatten it by clearing the flag.
     """
-    device = _device(
+    device = make_device(
         api_encrypted=True,
         api_encryption_active="Noise_NNpsk0_25519_ChaChaPoly_SHA256",
     )

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -17,23 +17,19 @@ from unittest.mock import MagicMock
 import pytest
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.models import Device, DeviceState, EventType
+from esphome_device_builder.models import Device, EventType
 
-from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
+from .conftest import (
+    make_device,
+    make_devices_controller_with_bus,
+    make_state_monitor_with_callbacks,
+)
 
 
 def _device(**overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-        "address": "kitchen.local",
-        "current_version": "2026.5.0",
-        "deployed_version": "",
-        "state": DeviceState.UNKNOWN,
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` defaulting ``current_version`` for this file."""
+    overrides.setdefault("current_version", "2026.5.0")
+    return make_device(**overrides)
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -27,7 +27,6 @@ from .conftest import (
 
 
 def _device(**overrides: Any) -> Device:
-    """Local wrapper around ``make_device`` defaulting ``current_version`` for this file."""
     overrides.setdefault("current_version", "2026.5.0")
     return make_device(**overrides)
 

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -265,7 +265,6 @@ def _record_scheduled(coros: list[object]) -> Callable[[object], object]:
 
 
 def _device_kitchen(**overrides: Any) -> Device:
-    """Local wrapper around ``make_device`` omitting ``address`` for _on_* callback tests."""
     return make_device(address="", **overrides)
 
 

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -24,29 +24,18 @@ from collections.abc import Callable
 from typing import Any
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.models import Device, DeviceState, EventType
+from esphome_device_builder.models import Device, EventType
 
 from .conftest import (
+    make_device,
     make_devices_controller_with_bus,
     make_state_monitor_with_callbacks,
 )
 
 
-def _device(**overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-        "address": "kitchen.local",
-        "state": DeviceState.UNKNOWN,
-    }
-    base.update(overrides)
-    return Device(**base)
-
-
 def test_apply_mac_address_first_observation_fires_callback() -> None:
     """A MAC we haven't seen before reaches the controller in canonical form."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_mac_address("kitchen", "94c9601f8cf1") is True
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
@@ -57,7 +46,7 @@ def test_apply_mac_address_dedupes_same_value() -> None:
     Devices broadcast the same TXT every announce; the dedupe keeps
     DEVICE_UPDATED quiet on a healthy fleet.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
@@ -69,7 +58,7 @@ def test_apply_mac_address_fires_on_change() -> None:
     Realistic when an unflashed YAML gets pointed at a different
     physical board mid-test.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     monitor.apply_mac_address("kitchen", "aabbccddeeff")
     assert callbacks.calls == [
@@ -87,14 +76,14 @@ def test_apply_mac_address_ignores_empty_string() -> None:
     so callers that read the dict via ``.get("mac") or ""`` don't
     blank out a previously-known MAC.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_mac_address("kitchen", "") is False
     assert callbacks.calls == []
 
 
 def test_apply_mac_address_unknown_device_is_no_op() -> None:
     """A stray announcement for an unconfigured name does nothing."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_mac_address("not-configured", "94c9601f8cf1") is False
     assert callbacks.calls == []
 
@@ -108,7 +97,7 @@ def test_apply_mac_address_no_op_when_callback_unwired() -> None:
     cleanly without dereferencing the ``None`` callback.
     """
     monitor = DeviceStateMonitor(
-        get_devices=lambda: [_device()],
+        get_devices=lambda: [make_device()],
         on_state_change=lambda *_: None,
         on_ip_change=lambda *_: None,
     )
@@ -127,14 +116,14 @@ def test_apply_mac_address_no_op_when_callback_unwired() -> None:
 
 def test_apply_mac_address_normalizes_lowercase_to_canonical() -> None:
     """Lowercase 12-hex-char wire form (today's broadcast shape) → uppercase colon-form."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94c9601f8cf1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_normalizes_uppercase_compact() -> None:
     """Uppercase 12-hex-char input also lands as canonical."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94C9601F8CF1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
@@ -147,28 +136,28 @@ def test_apply_mac_address_already_canonical_is_idempotent() -> None:
     on the device, and a re-broadcast feeds back through the same
     normalize path.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94:C9:60:1F:8C:F1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_strips_lowercase_colon_separators() -> None:
     """Lowercase colon-separated MAC normalizes to uppercase canonical."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94:c9:60:1f:8c:f1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_strips_dash_separators() -> None:
     """Windows-style ``94-C9-60-...`` normalizes the same way."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94-C9-60-1F-8C-F1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
 
 def test_apply_mac_address_strips_dot_separators() -> None:
     """Cisco-style ``94c9.601f.8cf1`` normalizes the same way."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     monitor.apply_mac_address("kitchen", "94c9.601f.8cf1")
     assert callbacks.calls == [("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")]
 
@@ -181,7 +170,7 @@ def test_apply_mac_address_normalized_dedupes_against_stored() -> None:
     to switch case style. The dedupe is keyed off the canonical
     form so equivalence holds across surface formats.
     """
-    devices = [_device(mac_address="94:C9:60:1F:8C:F1")]
+    devices = [make_device(mac_address="94:C9:60:1F:8C:F1")]
     monitor, callbacks = make_state_monitor_with_callbacks(devices)
     # Wire form (lowercase 12-hex) — what the firmware actually broadcasts.
     assert monitor.apply_mac_address("kitchen", "94c9601f8cf1") is False
@@ -192,14 +181,14 @@ def test_apply_mac_address_normalized_dedupes_against_stored() -> None:
 
 def test_apply_mac_address_rejects_non_hex_input() -> None:
     """Garbage TXT content is dropped, not stored."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     assert monitor.apply_mac_address("kitchen", "not-a-mac") is False
     assert callbacks.calls == []
 
 
 def test_apply_mac_address_rejects_wrong_length() -> None:
     """Too-short / too-long values are dropped (not silently truncated)."""
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     # 11 chars
     assert monitor.apply_mac_address("kitchen", "94c9601f8cf") is False
     # 13 chars
@@ -215,7 +204,7 @@ def test_apply_mac_address_rejects_correct_length_non_hex() -> None:
     a corrupt TXT can't pollute the sidecar with a value that
     looks the right shape but doesn't decode to a real MAC.
     """
-    monitor, callbacks = make_state_monitor_with_callbacks([_device()])
+    monitor, callbacks = make_state_monitor_with_callbacks([make_device()])
     # 12 chars, but the 'Z' isn't valid hex.
     assert monitor.apply_mac_address("kitchen", "94c9601f8cZZ") is False
     assert callbacks.calls == []
@@ -230,7 +219,7 @@ def test_apply_mac_address_refires_after_device_rebuild() -> None:
     the device's own field, so the next mDNS announcement should
     repopulate without short-circuiting on a stale cache.
     """
-    devices = [_device(mac_address="94:C9:60:1F:8C:F1")]
+    devices = [make_device(mac_address="94:C9:60:1F:8C:F1")]
     monitor, callbacks = make_state_monitor_with_callbacks(devices)
 
     # Steady state: the device already has the canonical MAC, so a
@@ -276,13 +265,8 @@ def _record_scheduled(coros: list[object]) -> Callable[[object], object]:
 
 
 def _device_kitchen(**overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` omitting ``address`` for _on_* callback tests."""
+    return make_device(address="", **overrides)
 
 
 def test_on_mac_address_change_updates_device_and_fires_event() -> None:

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -25,17 +25,12 @@ from esphome_device_builder.controllers._device_state_monitor import (
 from esphome_device_builder.controllers._device_state_monitor import mdns as mdns_module
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_device, make_state_monitor_with_callbacks
 
 
 def _device(name: str) -> Device:
-    return Device(
-        name=name,
-        friendly_name=name,
-        configuration=f"{name}.yaml",
-        address=f"{name}.local",
-        state=DeviceState.UNKNOWN,
-    )
+    """Local wrapper around ``make_device`` keeping ``friendly_name == name`` for this file."""
+    return make_device(name=name, friendly_name=name)
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -29,7 +29,6 @@ from .conftest import make_device, make_state_monitor_with_callbacks
 
 
 def _device(name: str) -> Device:
-    """Local wrapper around ``make_device`` keeping ``friendly_name == name`` for this file."""
     return make_device(name=name, friendly_name=name)
 
 

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -28,7 +28,6 @@ from .conftest import (
 
 
 def _device(**overrides: Any) -> Device:
-    """Local wrapper around ``make_device`` defaulting ``current_version`` for this file."""
     overrides.setdefault("current_version", "2026.5.0")
     return make_device(**overrides)
 

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -18,23 +18,19 @@ import pytest
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.controllers.devices import DevicesController
-from esphome_device_builder.models import Device, DeviceState, EventType
+from esphome_device_builder.models import Device, EventType
 
-from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
+from .conftest import (
+    make_device,
+    make_devices_controller_with_bus,
+    make_state_monitor_with_callbacks,
+)
 
 
 def _device(**overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": "kitchen.yaml",
-        "address": "kitchen.local",
-        "current_version": "2026.5.0",
-        "deployed_version": "",
-        "state": DeviceState.UNKNOWN,
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` defaulting ``current_version`` for this file."""
+    overrides.setdefault("current_version", "2026.5.0")
+    return make_device(**overrides)
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -35,7 +35,6 @@ def _device(
     loaded_integrations: list[str] | None = None,
     state: DeviceState = DeviceState.UNKNOWN,
 ) -> Device:
-    """Local wrapper around ``make_device`` keeping ``friendly_name == name`` for this file."""
     return make_device(
         name=name,
         friendly_name=name,

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -25,7 +25,7 @@ import pytest
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor, shared
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import make_state_monitor_with_callbacks
+from .conftest import make_device, make_state_monitor_with_callbacks
 
 
 def _device(
@@ -35,10 +35,10 @@ def _device(
     loaded_integrations: list[str] | None = None,
     state: DeviceState = DeviceState.UNKNOWN,
 ) -> Device:
-    return Device(
+    """Local wrapper around ``make_device`` keeping ``friendly_name == name`` for this file."""
+    return make_device(
         name=name,
         friendly_name=name,
-        configuration=f"{name}.yaml",
         address=address,
         loaded_integrations=loaded_integrations or [],
         state=state,

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -25,7 +25,7 @@ import json
 import tarfile
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -58,18 +58,11 @@ from esphome_device_builder.models import (
     JobStatus,
 )
 
+from .conftest import make_peer_link_session as _make_session
+
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_session(*, dashboard_id: str = "alpha") -> Any:
-    """Stub ``PeerLinkSession`` capturing send_app_frame + terminate calls."""
-    session = MagicMock()
-    session.dashboard_id = dashboard_id
-    session.send_app_frame = AsyncMock(return_value=True)
-    session.terminate = AsyncMock()
-    return session
 
 
 def _make_firmware_with_job(

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -31,13 +31,12 @@ from esphome_device_builder.models import (
     JobType,
 )
 
+from .conftest import make_peer_link_session
+
 
 def _make_session(*, dashboard_id: str = "alpha") -> Any:
-    """Stub ``PeerLinkSession`` capturing send_app_frame payloads."""
-    session = MagicMock()
-    session.dashboard_id = dashboard_id
-    session.send_app_frame = AsyncMock(return_value=True)
-    return session
+    """Local wrapper around ``make_peer_link_session`` without a ``terminate`` mock."""
+    return make_peer_link_session(dashboard_id=dashboard_id, with_terminate=False)
 
 
 def _make_remote_job(

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -35,7 +35,6 @@ from .conftest import make_peer_link_session
 
 
 def _make_session(*, dashboard_id: str = "alpha") -> Any:
-    """Local wrapper around ``make_peer_link_session`` without a ``terminate`` mock."""
     return make_peer_link_session(dashboard_id=dashboard_id, with_terminate=False)
 
 

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -40,16 +40,13 @@ from esphome_device_builder.models import (
     SubmitJobFrameData,
 )
 
-from .conftest import make_submit_job_frames, make_tar_bundle
-
-
-def _make_session(*, dashboard_id: str = "alpha") -> Any:
-    """Stub ``PeerLinkSession`` capturing send_app_frame + terminate calls."""
-    session = MagicMock()
-    session.dashboard_id = dashboard_id
-    session.send_app_frame = AsyncMock(return_value=True)
-    session.terminate = AsyncMock()
-    return session
+from .conftest import (
+    make_peer_link_session as _make_session,
+)
+from .conftest import (
+    make_submit_job_frames,
+    make_tar_bundle,
+)
 
 
 def _make_firmware_controller() -> Any:

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -26,7 +26,6 @@ from .conftest import (
 
 
 def _device(configuration: str, **overrides: Any) -> Device:
-    """Local wrapper around ``make_device`` taking ``configuration`` positionally."""
     return make_device(configuration=configuration, **overrides)
 
 

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -18,19 +18,16 @@ from unittest.mock import MagicMock
 
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import make_devices_controller_with_bus, make_state_monitor_with_callbacks
+from .conftest import (
+    make_device,
+    make_devices_controller_with_bus,
+    make_state_monitor_with_callbacks,
+)
 
 
 def _device(configuration: str, **overrides: Any) -> Device:
-    base: dict[str, Any] = {
-        "name": "kitchen",
-        "friendly_name": "Kitchen",
-        "configuration": configuration,
-        "address": "kitchen.local",
-        "state": DeviceState.UNKNOWN,
-    }
-    base.update(overrides)
-    return Device(**base)
+    """Local wrapper around ``make_device`` taking ``configuration`` positionally."""
+    return make_device(configuration=configuration, **overrides)
 
 
 def _close_coro(coro: Any) -> Any:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -39,30 +39,13 @@ from esphome_device_builder.controllers._reachability_tracker import Reachabilit
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import RecordingMonitorCallbacks
+from .conftest import make_device as _device
 
 # The service-type strings the production code uses; pinned here so
 # tests calling the captured dispatch use the exact same constants
 # the code under test does.
 ESPHOMELIB_SERVICE_TYPE = "_esphomelib._tcp.local."
 HTTP_SERVICE_TYPE = "_http._tcp.local."
-
-
-def _device(
-    *,
-    name: str = "kitchen",
-    address: str = "kitchen.local",
-    state: DeviceState = DeviceState.UNKNOWN,
-    **overrides: Any,
-) -> Device:
-    """Build a Device with sensible defaults — only the fields the monitor reads."""
-    return Device(
-        name=name,
-        friendly_name=name.title(),
-        configuration=f"{name}.yaml",
-        address=address,
-        state=state,
-        **overrides,
-    )
 
 
 def _make_monitor(

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -54,15 +54,7 @@ from esphome_device_builder.controllers._reachability_tracker import (
 )
 from esphome_device_builder.models import Device, DeviceState
 
-
-def _make_device(name: str = "kitchen", state: DeviceState = DeviceState.UNKNOWN) -> Device:
-    return Device(
-        name=name,
-        friendly_name=name.title(),
-        configuration=f"{name}.yaml",
-        address=f"{name}.local",
-        state=state,
-    )
+from .conftest import make_device as _make_device
 
 
 def _flip_state(devices: list[Device]) -> Any:


### PR DESCRIPTION
# What does this implement/fix?

Hoist three repeated test-fixture shapes into the shared conftests so a new field on `Device`, `PeerLinkSession`, or the e2e bundle layout doesn't need a touch in every per-file helper.

- `tests/conftest.py` gains `make_device(name="kitchen", **overrides)` replacing 16 per-file `_device` / `_make_device` helpers (mDNS suites, devices-controller tests, firmware-controller tests, scanner, DNS cache, importable discovery, state-monitor reachability/lifecycle/fanout). Where a file genuinely needs a non-default default (e.g. `current_version="2026.5.0"`, `address="esp.example.com"`, `loaded_integrations=["api"]`), it keeps a two-line wrapper that delegates with `overrides.setdefault(...)` so per-call overrides still win.
- `tests/conftest.py` also gains `make_peer_link_session(*, dashboard_id="alpha", with_terminate=True)` replacing the three near-identical `_make_session` stubs in `test_remote_build_job_fanout.py`, `test_remote_build_submit_job.py`, and `test_remote_build_artifacts_download.py`.
- `tests/e2e/conftest.py` gains `make_real_bundle(*, configuration_filename="kitchen.yaml")` replacing the duplicated `_build_real_bundle` helpers in `tests/e2e/test_submit_job.py` and `tests/e2e/test_install_round_trip.py`. Both files drop the now-unused `io` / `tarfile` imports.

Net diff is -78 lines across 27 files. No production code touched; full suite still passes (3438 passed, 26 skipped).

**Related issue or feature (if applicable):**

- N/A; pure test-suite DRY pass.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
