### PR TITLE
Retry ICMP once before flipping an ONLINE device OFFLINE

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -175,13 +175,17 @@ class PingSource:
         # successful ping flips it back to ONLINE.
         monitor = self._monitor
         rtt_ms: float | None = None
+        # Only retry when the device was ONLINE going into this sweep.
+        # A first-shot miss on an already-OFFLINE/UNKNOWN device just
+        # confirms the state — no flap to prevent.
+        was_online = device.state == DeviceState.ONLINE
         try:
             result = await icmp_ping(target, count=1, timeout=3, privileged=False)
             is_alive = result.is_alive
-            if not is_alive:
-                # Retry with multiple packets before declaring OFFLINE.
-                # A single dropped ICMP would otherwise flap the device
-                # every sweep on lossy paths (VPN, congested Wi-Fi).
+            if not is_alive and was_online:
+                # Retry with multiple packets before flapping an ONLINE
+                # device OFFLINE. A single dropped ICMP would otherwise
+                # flap on lossy paths (VPN, congested Wi-Fi).
                 result = await icmp_ping(target, count=3, interval=0.5, timeout=2, privileged=False)
                 is_alive = result.is_alive
             # ``Host.min_rtt`` is 0.0 on a failed ping which would

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -173,11 +173,23 @@ class PingSource:
         # ``PermissionError``, socket-open failures all mean
         # "we tried and couldn't reach this". A subsequent
         # successful ping flips it back to ONLINE.
+        #
+        # Retry-on-miss before declaring OFFLINE. A single dropped
+        # ICMP would otherwise flap the indicator every sweep on
+        # high-loss paths (VPN, congested Wi-Fi). Send one packet
+        # first to stay cheap on a clean LAN; only pay the multi-
+        # packet wall when that first probe misses. Mirrors the
+        # legacy dashboard's "any reply = alive" semantics —
+        # ``icmplib`` itself defaults to ``count=4`` for the same
+        # reason — while keeping the steady-state sweep fast.
         monitor = self._monitor
         rtt_ms: float | None = None
         try:
-            result = await icmp_ping(target, count=1, timeout=3, privileged=False)
+            result = await icmp_ping(target, count=1, timeout=2, privileged=False)
             is_alive = result.is_alive
+            if not is_alive:
+                result = await icmp_ping(target, count=3, interval=0.5, timeout=2, privileged=False)
+                is_alive = result.is_alive
             # ``Host.min_rtt`` is 0.0 on a failed ping which would
             # surface as "0 ms" in the drawer — gate the capture
             # on ``is_alive`` so failures stay null instead.

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -173,21 +173,15 @@ class PingSource:
         # ``PermissionError``, socket-open failures all mean
         # "we tried and couldn't reach this". A subsequent
         # successful ping flips it back to ONLINE.
-        #
-        # Retry-on-miss before declaring OFFLINE. A single dropped
-        # ICMP would otherwise flap the indicator every sweep on
-        # high-loss paths (VPN, congested Wi-Fi). Send one packet
-        # first to stay cheap on a clean LAN; only pay the multi-
-        # packet wall when that first probe misses. Mirrors the
-        # legacy dashboard's "any reply = alive" semantics —
-        # ``icmplib`` itself defaults to ``count=4`` for the same
-        # reason — while keeping the steady-state sweep fast.
         monitor = self._monitor
         rtt_ms: float | None = None
         try:
-            result = await icmp_ping(target, count=1, timeout=2, privileged=False)
+            result = await icmp_ping(target, count=1, timeout=3, privileged=False)
             is_alive = result.is_alive
             if not is_alive:
+                # Retry with multiple packets before declaring OFFLINE.
+                # A single dropped ICMP would otherwise flap the device
+                # every sweep on lossy paths (VPN, congested Wi-Fi).
                 result = await icmp_ping(target, count=3, interval=0.5, timeout=2, privileged=False)
                 is_alive = result.is_alive
             # ``Host.min_rtt`` is 0.0 on a failed ping which would

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -234,6 +234,81 @@ async def test_ping_failure_does_not_record_rtt() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ping_retry_absorbs_transient_miss() -> None:
+    """First-shot miss → retry-with-multiple-packets → ONLINE, not OFFLINE.
+
+    A single dropped ICMP packet on a lossy path (VPN, congested
+    Wi-Fi) used to flip the device OFFLINE every sweep. Pin the
+    retry: when the cheap ``count=1`` probe misses, we issue a
+    second multi-packet probe and use its result.
+    """
+    devices = [_make_device(state=DeviceState.ONLINE)]
+    tracker = ReachabilityTracker()
+    monitor = _make_monitor(devices, tracker)
+
+    miss = MagicMock(is_alive=False, min_rtt=0.0)
+    hit = MagicMock(is_alive=True, min_rtt=7.5)
+    fake_ping = AsyncMock(side_effect=[miss, hit])
+    with patch(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        fake_ping,
+    ):
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+
+    assert fake_ping.await_count == 2
+    # First call is the cheap single-shot.
+    assert fake_ping.await_args_list[0].kwargs.get("count") == 1
+    # Retry sends multiple packets so a transient drop doesn't
+    # flap the indicator.
+    assert fake_ping.await_args_list[1].kwargs.get("count", 1) > 1
+    assert devices[0].state == DeviceState.ONLINE
+    snap = tracker.snapshot(
+        "kitchen", state=DeviceState.ONLINE, active_source="ping", ip="10.0.0.42"
+    )
+    assert snap["ping_rtt_ms"] == 7.5
+
+
+@pytest.mark.asyncio
+async def test_ping_retry_still_offline_when_retry_also_misses() -> None:
+    """Both probes miss → OFFLINE. Retry doesn't mask a genuinely-gone device."""
+    devices = [_make_device(state=DeviceState.ONLINE)]
+    tracker = ReachabilityTracker()
+    monitor = _make_monitor(devices, tracker)
+
+    miss = MagicMock(is_alive=False, min_rtt=0.0)
+    fake_ping = AsyncMock(side_effect=[miss, miss])
+    with patch(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        fake_ping,
+    ):
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+
+    assert fake_ping.await_count == 2
+    assert devices[0].state == DeviceState.OFFLINE
+    snap = tracker.snapshot(
+        "kitchen", state=DeviceState.OFFLINE, active_source="ping", ip="10.0.0.42"
+    )
+    assert snap["ping_rtt_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_ping_no_retry_when_first_probe_succeeds() -> None:
+    """Healthy path stays a single packet; the retry is opt-in on miss."""
+    devices = [_make_device()]
+    monitor = _make_monitor(devices, ReachabilityTracker())
+
+    hit = MagicMock(is_alive=True, min_rtt=4.2)
+    fake_ping = AsyncMock(return_value=hit)
+    with patch(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        fake_ping,
+    ):
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+
+    fake_ping.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_mdns_removed_clears_tracker_for_device() -> None:
     """A ``Removed`` mDNS event wipes every channel's history for the device.
 

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -235,13 +235,7 @@ async def test_ping_failure_does_not_record_rtt() -> None:
 
 @pytest.mark.asyncio
 async def test_ping_retry_absorbs_transient_miss() -> None:
-    """First-shot miss → retry-with-multiple-packets → ONLINE, not OFFLINE.
-
-    A single dropped ICMP packet on a lossy path (VPN, congested
-    Wi-Fi) used to flip the device OFFLINE every sweep. Pin the
-    retry: when the cheap ``count=1`` probe misses, we issue a
-    second multi-packet probe and use its result.
-    """
+    """First-shot miss → retry with multiple packets → ONLINE, not OFFLINE."""
     devices = [_make_device(state=DeviceState.ONLINE)]
     tracker = ReachabilityTracker()
     monitor = _make_monitor(devices, tracker)

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -302,6 +302,25 @@ async def test_ping_no_retry_when_first_probe_succeeds() -> None:
     fake_ping.assert_awaited_once()
 
 
+@pytest.mark.parametrize("starting_state", [DeviceState.OFFLINE, DeviceState.UNKNOWN])
+@pytest.mark.asyncio
+async def test_ping_no_retry_for_non_online_devices(starting_state: DeviceState) -> None:
+    """Retry is gated on ``was ONLINE``; non-ONLINE devices skip the retry on a missed probe."""
+    devices = [_make_device(state=starting_state)]
+    monitor = _make_monitor(devices, ReachabilityTracker())
+
+    miss = MagicMock(is_alive=False, min_rtt=0.0)
+    fake_ping = AsyncMock(return_value=miss)
+    with patch(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        fake_ping,
+    ):
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+
+    fake_ping.assert_awaited_once()
+    assert devices[0].state == DeviceState.OFFLINE
+
+
 @pytest.mark.asyncio
 async def test_mdns_removed_clears_tracker_for_device() -> None:
     """A ``Removed`` mDNS event wipes every channel's history for the device.


### PR DESCRIPTION
# What does this implement/fix?

The ping sweep issued a single `count=1, timeout=3` ICMP probe and
flipped a device OFFLINE on any miss. On lossy paths (VPN,
congested Wi-Fi) a single dropped packet would flap an otherwise-
healthy device every 60-second sweep. A live test against an
ESPHome device over VPN showed **4/30 (13%) single-shot misses**
using icmplib's unprivileged-ICMP path — matching the user-
reported flapping on a fleet where the system `ping` itself only
dropped ~8% of packets.

This change retries before flapping an **ONLINE** device. The
cheap `count=1` probe runs first to keep the sweep fast on a clean
LAN; when it misses *and* the device was ONLINE going into this
sweep, we issue a `count=3, interval=0.5, timeout=2` follow-up.
Mirrors the legacy esphome dashboard's "any reply = alive"
semantics (icmplib's own default is `count=4`) without paying the
multi-packet wall on every healthy device.

The retry is gated on `device.state == ONLINE`: a first-shot miss
on an already-OFFLINE/UNKNOWN device just confirms the state, so
there's no flap to prevent and no reason to pay the extra wall.
Cold-start and steady-OFFLINE sweeps therefore stay single-packet,
which matters on large fleets where the retry would otherwise add
~2.5s of wall per OFFLINE device.

Verified end-to-end against the same live VPN device:
**0/30 false OFFLINE flips** with the retry, vs 4/30 before.
Four new regression tests pin retry-absorbs-miss, both-miss-still-
OFFLINE, no-retry-on-success, and no-retry-when-not-ONLINE
(parametrized over OFFLINE / UNKNOWN).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
