### PR TITLE
Share scheduled-coroutine helpers across mDNS test suites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -856,3 +856,22 @@ def make_peer_link_session(
     if with_terminate:
         session.terminate = AsyncMock()
     return session
+
+
+def close_scheduled_coro(coro: object) -> object:
+    """Close a coroutine handed to ``create_background_task`` so it doesn't leak un-awaited."""
+    if hasattr(coro, "close"):
+        coro.close()
+    return coro
+
+
+def record_scheduled_coros(coros: list[object]) -> Callable[[object], object]:
+    """Build a ``create_background_task`` side-effect that appends to *coros* and closes."""
+
+    def _impl(coro: object) -> object:
+        coros.append(coro)
+        if hasattr(coro, "close"):
+            coro.close()
+        return coro
+
+    return _impl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -870,8 +870,6 @@ def record_scheduled_coros(coros: list[object]) -> Callable[[object], object]:
 
     def _impl(coro: object) -> object:
         coros.append(coro)
-        if hasattr(coro, "close"):
-            coro.close()
-        return coro
+        return close_scheduled_coro(coro)
 
     return _impl

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -24,7 +24,11 @@ from esphome_device_builder.controllers.config import (
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.models import Device, DeviceState
 
-from .conftest import make_device, make_devices_controller_with_bus
+from .conftest import (
+    make_device,
+    make_devices_controller_with_bus,
+    record_scheduled_coros,
+)
 
 
 @pytest.fixture
@@ -593,29 +597,12 @@ def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore
     assert device.address == "kitchen.lan"
 
 
-def _record_scheduled(coros: list[object]) -> Callable[[object], object]:
-    """Build a ``create_background_task`` side-effect that records + closes coroutines.
-
-    Each scheduled coroutine lands in *coros* and is immediately
-    closed so it doesn't leak as ``RuntimeWarning: coroutine was
-    never awaited``.
-    """
-
-    def _impl(coro: object) -> object:
-        coros.append(coro)
-        if hasattr(coro, "close"):
-            coro.close()
-        return coro
-
-    return _impl
-
-
 def test_on_ip_change_persists_non_empty_value() -> None:
     """``_on_ip_change`` schedules a metadata write for non-empty IPs."""
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_ip_change("kitchen", "10.0.0.1", ["10.0.0.1", "fe80::1%en0"])
@@ -636,7 +623,7 @@ def test_on_ip_change_skips_persist_for_empty_value() -> None:
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_ip_change("kitchen", "", [])

--- a/tests/test_mdns_mac_address.py
+++ b/tests/test_mdns_mac_address.py
@@ -20,7 +20,6 @@ to keep the steady-state "same MAC every announce" cycle off-disk.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
@@ -30,6 +29,7 @@ from .conftest import (
     make_device,
     make_devices_controller_with_bus,
     make_state_monitor_with_callbacks,
+    record_scheduled_coros,
 )
 
 
@@ -245,25 +245,6 @@ def test_apply_mac_address_refires_after_device_rebuild() -> None:
 # ----------------------------------------------------------------------
 
 
-def _record_scheduled(coros: list[object]) -> Callable[[object], object]:
-    """Capture + close coroutines handed to ``create_background_task``.
-
-    The persist-async branches use ``create_background_task`` to push
-    the blocking sidecar write off the event-loop thread. The tests
-    don't have a running loop, so we just record the coroutine and
-    close it to avoid the "coroutine was never awaited" warning —
-    the call count is what verifies whether the I/O was scheduled.
-    """
-
-    def _impl(coro: object) -> object:
-        coros.append(coro)
-        if hasattr(coro, "close"):
-            coro.close()
-        return coro
-
-    return _impl
-
-
 def _device_kitchen(**overrides: Any) -> Device:
     return make_device(address="", **overrides)
 
@@ -273,7 +254,7 @@ def test_on_mac_address_change_updates_device_and_fires_event() -> None:
     device = _device_kitchen()
     scheduled: list[object] = []
     controller, captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F1")
@@ -287,7 +268,7 @@ def test_on_mac_address_change_persists_to_sidecar() -> None:
     device = _device_kitchen()
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F1")
@@ -307,7 +288,7 @@ def test_on_mac_address_change_skips_persist_when_unchanged() -> None:
     device = _device_kitchen(mac_address="94:C9:60:1F:8C:F1")
     scheduled: list[object] = []
     controller, captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F1")
@@ -320,7 +301,7 @@ def test_on_mac_address_change_unknown_device_is_noop() -> None:
     """Stray callback for an unconfigured name doesn't raise or fire events."""
     scheduled: list[object] = []
     controller, captured = make_devices_controller_with_bus(
-        [], create_background_task=_record_scheduled(scheduled)
+        [], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("ghost", "94:C9:60:1F:8C:F1")
@@ -342,7 +323,7 @@ def test_on_mac_address_change_derives_ethernet_mac_on_esp32() -> None:
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
@@ -360,7 +341,7 @@ def test_on_mac_address_change_derives_bluetooth_mac_on_esp32() -> None:
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
@@ -383,7 +364,7 @@ def test_on_mac_address_change_derives_ethernet_equal_primary_on_rp2040() -> Non
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
@@ -406,7 +387,7 @@ def test_on_mac_address_change_clears_derived_on_unknown_platform() -> None:
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
@@ -433,7 +414,7 @@ def test_on_mac_address_change_clears_stale_derived_macs_on_change() -> None:
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "94:C9:60:1F:8C:F0")
@@ -461,7 +442,7 @@ def test_on_mac_address_change_rederives_ethernet_and_bluetooth_when_primary_cha
     )
     scheduled: list[object] = []
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record_scheduled(scheduled)
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_mac_address_change("kitchen", "AA:BB:CC:DD:EE:F0")

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -21,9 +21,11 @@ from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.models import Device, EventType
 
 from .conftest import (
+    close_scheduled_coro,
     make_device,
     make_devices_controller_with_bus,
     make_state_monitor_with_callbacks,
+    record_scheduled_coros,
 )
 
 
@@ -156,19 +158,12 @@ def test_persist_storage_version_handles_missing_storage(monkeypatch: Any, tmp_p
 # ----------------------------------------------------------------------
 
 
-def _close_coro(coro: object) -> object:
-    """Close any scheduled coroutine to silence the un-awaited warning."""
-    if hasattr(coro, "close"):
-        coro.close()
-    return coro
-
-
 @pytest.mark.asyncio
 async def test_on_version_change_updates_device_and_fires_event(monkeypatch: Any) -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
     device = _device(deployed_version="2026.4.0")
     controller, captured = make_devices_controller_with_bus(
-        [device], create_background_task=_close_coro
+        [device], create_background_task=close_scheduled_coro
     )
 
     persisted: list[tuple[str, str]] = []
@@ -191,13 +186,8 @@ async def test_on_version_change_skips_when_same() -> None:
     """No-op when in-memory device already has the announced version."""
     device = _device(deployed_version="2026.5.0")
     scheduled: list[object] = []
-
-    def _record(coro: object) -> object:
-        scheduled.append(coro)
-        return _close_coro(coro)
-
     controller, captured = make_devices_controller_with_bus(
-        [device], create_background_task=_record
+        [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
     controller._on_version_change("kitchen", "2026.5.0")
@@ -211,7 +201,7 @@ async def test_on_version_change_marks_update_available_when_behind() -> None:
     """A device on an older version than the dashboard → ``update_available`` flips on."""
     device = _device(current_version="2026.5.0", deployed_version="2026.4.0")
     controller, _captured = make_devices_controller_with_bus(
-        [device], create_background_task=_close_coro
+        [device], create_background_task=close_scheduled_coro
     )
 
     # Simulate mDNS reporting an even older version than the previous

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -14,11 +14,11 @@ its sibling tracked the device.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
 
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import (
+    close_scheduled_coro,
     make_device,
     make_devices_controller_with_bus,
     make_state_monitor_with_callbacks,
@@ -27,19 +27,6 @@ from .conftest import (
 
 def _device(configuration: str, **overrides: Any) -> Device:
     return make_device(configuration=configuration, **overrides)
-
-
-def _close_coro(coro: Any) -> Any:
-    """Close any coroutine handed to ``create_background_task``.
-
-    Without this the test stub leaves ``_persist_device_ip_async`` /
-    ``_persist_storage_version_async`` coroutines un-awaited, which
-    triggers ``RuntimeWarning: coroutine was never awaited`` (some
-    pytest configs upgrade that to a failure).
-    """
-    if hasattr(coro, "close"):
-        coro.close()
-    return MagicMock()
 
 
 def test_state_change_fans_out_to_every_matching_device() -> None:
@@ -53,7 +40,7 @@ def test_state_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml")
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        create_background_task=_close_coro,
+        create_background_task=close_scheduled_coro,
     )
 
     controller._on_state_change("kitchen", DeviceState.ONLINE, "mdns")
@@ -70,7 +57,7 @@ def test_ip_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml", ip="")
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        create_background_task=_close_coro,
+        create_background_task=close_scheduled_coro,
     )
 
     controller._on_ip_change("kitchen", "10.0.0.5", ["10.0.0.5"])
@@ -91,7 +78,7 @@ def test_version_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml", current_version="2026.5.0", deployed_version="")
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        create_background_task=_close_coro,
+        create_background_task=close_scheduled_coro,
     )
 
     controller._on_version_change("kitchen", "2026.5.0")
@@ -114,7 +101,7 @@ def test_config_hash_change_fans_out_to_every_matching_device() -> None:
     )
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        create_background_task=_close_coro,
+        create_background_task=close_scheduled_coro,
     )
 
     controller._on_config_hash_change("kitchen", "abcd1234")
@@ -132,7 +119,7 @@ def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
     b = _device("kitchen (1).yaml", api_encryption_active=None)
     controller, captured = make_devices_controller_with_bus(
         [a, b],
-        create_background_task=_close_coro,
+        create_background_task=close_scheduled_coro,
     )
 
     controller._on_api_encryption_change("kitchen", "Noise_NNpsk0_25519_ChaChaPoly_SHA256")
@@ -148,7 +135,7 @@ def test_unrelated_devices_are_not_touched() -> None:
     garage = _device("garage.yaml", name="garage", address="garage.local")
     controller, captured = make_devices_controller_with_bus(
         [kitchen, garage],
-        create_background_task=_close_coro,
+        create_background_task=close_scheduled_coro,
     )
 
     controller._on_state_change("kitchen", DeviceState.ONLINE, "mdns")


### PR DESCRIPTION
# What does this implement/fix?

Follow-up DRY pass on top of #876. Four of the mDNS / DNS-cache test files were carrying near-identical `create_background_task` side-effect helpers — one shape that just closes the scheduled coroutine, and one that records it in a list first and then closes. Hoist both into `tests/conftest.py` as `close_scheduled_coro` and `record_scheduled_coros(list_)`.

Migrated call sites:
- `tests/test_dns_cache.py` — replaces local `_record_scheduled`.
- `tests/test_mdns_mac_address.py` — replaces local `_record_scheduled`.
- `tests/test_mdns_version.py` — replaces local `_close_coro` (and an inline `_record` wrapper).
- `tests/test_state_fanout_duplicate_names.py` — replaces local `_close_coro`.

Net -36 lines; no production code touched.

**Related issue or feature (if applicable):**

- N/A; pure test-suite DRY pass.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
