### PR TITLE
Carve pytest conftests out of the 800-line cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,28 @@ the official ESPHome container and Home Assistant add-on.
   A PR that touches a module *already over* 800 lines should
   not make it worse. New top-level modules start under the cap.
 
+  **Exception: pytest conftests.** Pytest's conftest is the
+  single import surface (`from .conftest import ...`) for
+  shared test fixtures and factories, and the cap's three
+  motivations apply weakly here: conftest is intentionally a
+  grab-bag (the "cross-concern coupling" the cap targets is the
+  whole point of the file), edits touch one fixture at a time
+  rather than the file as a whole, and the obvious split into
+  per-helper modules forces every test file to track which
+  helper lives where without buying anything. The 800-line cap
+  does not apply to conftest files.
+
+  When hoisting a duplicated test helper, prefer the *narrowest*
+  conftest that covers every caller; only widen to
+  `tests/conftest.py` when the callers genuinely span the whole
+  suite. Create a new subdirectory conftest (and the matching
+  test subdirectory, if needed) when a helper is shared by a
+  cohesive group of tests but not the rest of the suite. The
+  existing subdirectory conftests
+  (`tests/controllers/devices/conftest.py`,
+  `tests/controllers/firmware/conftest.py`, `tests/e2e/conftest.py`)
+  are the canonical shape.
+
 ## Commit / PR conventions
 
 - **No `Co-Authored-By: Claude` trailer.** Project preference.


### PR DESCRIPTION
# What does this implement/fix?

Documents that pytest conftests are exempt from the 800-line soft cap, and adds a preference for the narrowest conftest (subdirectory > root) when hoisting shared test helpers. Surfaced by Copilot's review on #878 when `tests/conftest.py` crossed 877 lines after the DRY pass that hoisted `make_device` / `make_peer_link_session` / `close_scheduled_coro` etc.

The carve-out's reasoning:

- Conftest is the single import surface (`from .conftest import ...`) for shared fixtures and factories. Splitting it into per-helper modules forces every test file to track which helper lives where without solving anything.
- The cap's three motivations apply weakly: conftest is intentionally a grab-bag (the "cross-concern coupling" the cap targets is the whole point), edits touch one fixture at a time rather than the file as a whole, and the obvious split is strictly worse for discoverability.

Preferred shape going forward: hoist into the narrowest conftest that covers every caller. Create a subdirectory conftest (and the matching test subdirectory if needed) when a helper is shared by a cohesive group of tests but not the rest of the suite. Only widen to `tests/conftest.py` when callers genuinely span the whole suite. `tests/controllers/devices/conftest.py`, `tests/controllers/firmware/conftest.py`, and `tests/e2e/conftest.py` are the canonical shape.

**Related issue or feature (if applicable):**

- N/A; follow-up to Copilot's review on #878.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
