### PR TITLE
Share follow-race controller helper in firmware conftest

### DIFF
--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -314,3 +314,16 @@ def capture_enqueue_order() -> Iterator[CaptureEnqueueOrderFactory]:
     for controller, original_queue, original_bus in swaps:
         controller.state.queue = original_queue
         controller._db.bus = original_bus
+
+
+def make_follow_race_controller(
+    factory: FirmwareControllerFactory, *jobs: FirmwareJob
+) -> FirmwareController:
+    """Build a ``follow_job(s)``-shaped controller via the shared factory.
+
+    ``follow_job`` / ``follow_jobs`` read ``self.state.jobs`` and
+    ``self._db.bus`` only; ``with_real_bus=True`` swaps in the real
+    ``EventBus`` so listener-attach + fire semantics match production,
+    and ``with_settings=False`` skips the unused config-dir wiring.
+    """
+    return factory(*jobs, with_real_bus=True, with_settings=False)

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -21,26 +21,11 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware.constants import _MAX_OUTPUT_LINES_INFLIGHT
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
 from ...conftest import FakeWebSocketClient
-from .conftest import FirmwareControllerFactory
-
-
-def _make_controller_with_job(
-    factory: FirmwareControllerFactory, job: FirmwareJob
-) -> FirmwareController:
-    """Build a controller shell that ``follow_job`` can drive end-to-end.
-
-    ``follow_job`` reads ``self.state.jobs`` and ``self._db.bus`` only —
-    everything else is unused for this path. ``with_real_bus=True``
-    swaps in the real ``EventBus`` so the listener-attach + fire
-    semantics match production; ``with_settings=False`` skips the
-    config-dir wiring this path doesn't read.
-    """
-    return factory(job, with_real_bus=True, with_settings=False)
+from .conftest import FirmwareControllerFactory, make_follow_race_controller
 
 
 async def test_terminal_job_replays_full_history_and_returns(
@@ -55,7 +40,7 @@ async def test_terminal_job_replays_full_history_and_returns(
         output=["line a\n", "line b\n", "line c\n"],
         exit_code=0,
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
 
     await controller.follow_job(job_id="abc", client=client, message_id="m1")
@@ -85,7 +70,7 @@ async def test_history_lines_arrive_before_live_lines_in_order(
         status=JobStatus.RUNNING,
         output=["history-1\n", "history-2\n"],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -134,7 +119,7 @@ async def test_live_events_for_other_jobs_are_filtered_out(
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -183,7 +168,7 @@ async def test_streaming_loop_cannot_append_between_snapshot_and_subscribe(
         status=JobStatus.RUNNING,
         output=["pre-snapshot\n"],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -230,7 +215,7 @@ async def test_slow_follower_drops_lines_above_queue_cap(
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     bus = controller._db.bus
 
     # Park send_event so the drain stays blocked on the very first
@@ -299,7 +284,7 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full(
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     bus = controller._db.bus
 
     block = asyncio.Event()
@@ -363,7 +348,7 @@ async def test_cancelled_terminal_event_returns_with_status(
         status=JobStatus.RUNNING,
         output=["pre-cancel\n"],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -405,7 +390,7 @@ async def test_failed_terminal_event_carries_job_error_text(
         status=JobStatus.RUNNING,
         output=["compiling main.cpp\n"],
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -450,7 +435,7 @@ async def test_send_initial_replays_error_for_already_terminal_failed_job(
         exit_code=1,
         error="Process exited 1",
     )
-    controller = _make_controller_with_job(firmware_controller_factory, job)
+    controller = make_follow_race_controller(firmware_controller_factory, job)
     client = FakeWebSocketClient(yield_per_event=True)
 
     await controller.follow_job(job_id="abc", client=client, message_id="m1")

--- a/tests/controllers/firmware/test_follow_jobs_race.py
+++ b/tests/controllers/firmware/test_follow_jobs_race.py
@@ -15,25 +15,10 @@ import asyncio
 from contextlib import suppress
 from typing import Any
 
-from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType, StreamEvent
 
 from ...conftest import FakeWebSocketClient
-from .conftest import FirmwareControllerFactory
-
-
-def _make_controller(
-    factory: FirmwareControllerFactory, jobs: list[FirmwareJob]
-) -> FirmwareController:
-    """Build a ``follow_jobs``-shaped controller via the shared factory.
-
-    ``follow_jobs`` reads ``self.state.jobs`` and ``self._db.bus`` only;
-    ``with_real_bus=True`` swaps in the real ``EventBus`` so the
-    listener-attach + fire semantics match production, and
-    ``with_settings=False`` skips the config-dir wiring this path
-    doesn't read.
-    """
-    return factory(*jobs, with_real_bus=True, with_settings=False)
+from .conftest import FirmwareControllerFactory, make_follow_race_controller
 
 
 async def test_follow_jobs_replays_snapshot_then_live_events_in_order(
@@ -61,7 +46,7 @@ async def test_follow_jobs_replays_snapshot_then_live_events_in_order(
         status=JobStatus.RUNNING,
         output=[],
     )
-    controller = _make_controller(firmware_controller_factory, [job_a, job_b])
+    controller = make_follow_race_controller(firmware_controller_factory, job_a, job_b)
     client = FakeWebSocketClient(yield_per_event=True)
     bus = controller._db.bus
 
@@ -143,7 +128,7 @@ async def test_follow_jobs_snapshot_does_not_duplicate_with_concurrent_mutation(
         status=JobStatus.RUNNING,
         output=["b-pre-snapshot\n"],
     )
-    controller = _make_controller(firmware_controller_factory, [job_a, job_b])
+    controller = make_follow_race_controller(firmware_controller_factory, job_a, job_b)
     bus = controller._db.bus
 
     block = asyncio.Event()
@@ -204,7 +189,7 @@ async def test_follow_jobs_unsubscribes_on_cancellation(
     a leak here would silently grow the listener set on every
     reconnect.
     """
-    controller = _make_controller(firmware_controller_factory, [])
+    controller = make_follow_race_controller(firmware_controller_factory)
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
@@ -239,7 +224,7 @@ async def test_follow_jobs_forwards_job_progress_events(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """A ``JOB_PROGRESS`` event lands as a ``job_progress`` push (not a lifecycle)."""
-    controller = _make_controller(firmware_controller_factory, [])
+    controller = make_follow_race_controller(firmware_controller_factory)
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
@@ -268,7 +253,7 @@ async def test_follow_jobs_drops_lifecycle_event_with_no_job_payload(
     but the handler defends against a malformed payload by skipping it
     instead of crashing the stream — guard the early-return path here.
     """
-    controller = _make_controller(firmware_controller_factory, [])
+    controller = make_follow_race_controller(firmware_controller_factory)
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 
@@ -303,7 +288,7 @@ async def test_follow_jobs_lifecycle_payload_passthrough_for_dict_job(
     however, can hand back a plain dict — the handler's ``hasattr``
     check falls through and uses the dict as-is.
     """
-    controller = _make_controller(firmware_controller_factory, [])
+    controller = make_follow_race_controller(firmware_controller_factory)
     bus = controller._db.bus
     client = FakeWebSocketClient(yield_per_event=True)
 


### PR DESCRIPTION
# What does this implement/fix?

`tests/controllers/firmware/test_follow_job_race.py` and `tests/controllers/firmware/test_follow_jobs_race.py` each carried a near-identical thin wrapper around the shared `FirmwareControllerFactory` that only forwarded `with_real_bus=True, with_settings=False`. Hoist into `make_follow_race_controller(*jobs)` in `tests/controllers/firmware/conftest.py` (the narrowest conftest covering both callers, per #879's preference for subdirectory > root).

The unified helper takes `*jobs` variadic so both shapes work:
- `test_follow_job_race`: `make_follow_race_controller(factory, job)` (singular).
- `test_follow_jobs_race`: `make_follow_race_controller(factory, job_a, job_b)` (plural) or `make_follow_race_controller(factory)` (none).

15 call sites migrated; net -17 lines; no behaviour change.

**Related issue or feature (if applicable):**

- N/A; pure test-suite DRY pass.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
