### PR TITLE
Retry ICMP on first sweep for UNKNOWN devices, not just ONLINE

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -175,16 +175,20 @@ class PingSource:
         # successful ping flips it back to ONLINE.
         monitor = self._monitor
         rtt_ms: float | None = None
-        # Only retry when the device was ONLINE going into this sweep.
-        # A first-shot miss on an already-OFFLINE/UNKNOWN device just
-        # confirms the state — no flap to prevent.
-        was_online = device.state == DeviceState.ONLINE
+        # Skip the retry only for already-OFFLINE devices: the miss
+        # just confirms the state, nothing to flap. ONLINE devices
+        # get the retry to absorb a transient drop; UNKNOWN devices
+        # get it too so the first classification on a lossy path
+        # (dashboard cold-start, every device starts UNKNOWN) doesn't
+        # immediately label a reachable device OFFLINE on a single
+        # dropped packet.
+        needs_retry = device.state is not DeviceState.OFFLINE
         try:
             result = await icmp_ping(target, count=1, timeout=3, privileged=False)
             is_alive = result.is_alive
-            if not is_alive and was_online:
-                # Retry with multiple packets before flapping an ONLINE
-                # device OFFLINE. A single dropped ICMP would otherwise
+            if not is_alive and needs_retry:
+                # Retry with multiple packets before flapping the
+                # indicator. A single dropped ICMP would otherwise
                 # flap on lossy paths (VPN, congested Wi-Fi).
                 result = await icmp_ping(target, count=3, interval=0.5, timeout=2, privileged=False)
                 is_alive = result.is_alive

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -302,11 +302,10 @@ async def test_ping_no_retry_when_first_probe_succeeds() -> None:
     fake_ping.assert_awaited_once()
 
 
-@pytest.mark.parametrize("starting_state", [DeviceState.OFFLINE, DeviceState.UNKNOWN])
 @pytest.mark.asyncio
-async def test_ping_no_retry_for_non_online_devices(starting_state: DeviceState) -> None:
-    """Retry is gated on ``was ONLINE``; non-ONLINE devices skip the retry on a missed probe."""
-    devices = [_make_device(state=starting_state)]
+async def test_ping_no_retry_when_already_offline() -> None:
+    """Already-OFFLINE devices skip the retry — the miss just confirms the state."""
+    devices = [_make_device(state=DeviceState.OFFLINE)]
     monitor = _make_monitor(devices, ReachabilityTracker())
 
     miss = MagicMock(is_alive=False, min_rtt=0.0)
@@ -319,6 +318,32 @@ async def test_ping_no_retry_for_non_online_devices(starting_state: DeviceState)
 
     fake_ping.assert_awaited_once()
     assert devices[0].state == DeviceState.OFFLINE
+
+
+@pytest.mark.asyncio
+async def test_ping_retry_absorbs_transient_miss_when_unknown() -> None:
+    """Cold-start UNKNOWN devices retry too; a single dropped packet can't flip OFFLINE.
+
+    Every device starts UNKNOWN at dashboard startup, so the
+    first ping sweep on a lossy path must retry before classifying
+    OFFLINE — otherwise the first sweep flaps the indicator on the
+    same packet-drop rate the ONLINE retry was added to absorb.
+    """
+    devices = [_make_device(state=DeviceState.UNKNOWN)]
+    monitor = _make_monitor(devices, ReachabilityTracker())
+
+    miss = MagicMock(is_alive=False, min_rtt=0.0)
+    hit = MagicMock(is_alive=True, min_rtt=7.5)
+    fake_ping = AsyncMock(side_effect=[miss, hit])
+    with patch(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        fake_ping,
+    ):
+        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+
+    assert fake_ping.await_count == 2
+    assert fake_ping.await_args_list[1].kwargs.get("count", 1) > 1
+    assert devices[0].state == DeviceState.ONLINE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

#877 added an ICMP retry before flapping an ONLINE device OFFLINE,
but gated it on `device.state == DeviceState.ONLINE`. Every device
starts in `DeviceState.UNKNOWN` at dashboard startup, so the first
ping sweep on a lossy path (VPN, congested Wi-Fi) still classified
the device OFFLINE on a single dropped packet because UNKNOWN
didn't qualify for the retry. The cold-start case the original PR
was meant to fix kept firing.

Widen the gate to retry whenever the device isn't already
`OFFLINE`. ONLINE keeps the retry (absorbs transient drops);
UNKNOWN now retries too (first classification on a lossy path is
confident); OFFLINE still skips the retry because the miss just
confirms the state and there's no flap to prevent.

New regression test `test_ping_retry_absorbs_transient_miss_when_unknown`
pins the cold-start case (UNKNOWN -> miss -> retry hit -> ONLINE).
The parametrized `OFFLINE | UNKNOWN -> no retry` test is replaced
with `test_ping_no_retry_when_already_offline`, which keeps the
OFFLINE half.

**Related issue or feature (if applicable):**

- follow-up to #877

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
