### PR TITLE
Log remote-build materialise decisions at INFO

### DIFF
--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -141,18 +141,37 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
                 receiver_build_path=receiver_build_path,
                 offloader_build_path=build_path,
             )
-            # rmtree is best-effort: failures log + fall through, and
-            # the extract below overwrites every member named in the
-            # tarball, but stale files the tarball doesn't mention can
-            # survive a failed wipe.
-            if storage_should_clean(prior_storage, new_storage):
+            pioenvs_dir = build_path / ".pioenvs" / device_name
+            object_count_before = _count_pioenvs_objects(pioenvs_dir)
+            clean_reason = _storage_clean_reason(prior_storage, new_storage)
+            if clean_reason is not None:
+                _LOGGER.info(
+                    "remote-build materialise(%s): wiping offloader build dir "
+                    "(was %d .o files) -- %s",
+                    configuration,
+                    object_count_before,
+                    clean_reason,
+                )
+                # rmtree is best-effort: failures log + fall through, and
+                # the extract below overwrites every member named in the
+                # tarball, but stale files the tarball doesn't mention can
+                # survive a failed wipe.
                 try:
                     rmtree(build_path)
                 except OSError as exc:
                     _LOGGER.debug("materialise: pre-extract rmtree(%s) failed: %s", build_path, exc)
+            else:
+                _LOGGER.info(
+                    "remote-build materialise(%s): preserving offloader build dir "
+                    "(%d .o files; receiver esphome=%s, offloader esphome=%s)",
+                    configuration,
+                    object_count_before,
+                    new_storage.esphome_version,
+                    prior_storage.esphome_version if prior_storage is not None else "<none>",
+                )
             build_path.mkdir(parents=True, exist_ok=True)
             pio_path = build_path / PLATFORMIO_INI_MEMBER_NAME
-            with _preserve_platformio_ini_mtime_if_unchanged(pio_path):
+            with _preserve_platformio_ini_mtime_if_unchanged(pio_path, configuration=configuration):
                 _safe_extract_excluding(
                     tar,
                     build_path,
@@ -163,6 +182,13 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
                     },
                     initial_total_bytes=total_bytes,
                 )
+            _LOGGER.info(
+                "remote-build materialise(%s): %d .o files remain in %s/.pioenvs/%s/ after extract",
+                configuration,
+                _count_pioenvs_objects(pioenvs_dir),
+                build_path,
+                device_name,
+            )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
     if not (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file():
@@ -424,8 +450,33 @@ def _stage_offloader_validated_yaml(
     os.utime(path, (now, now))
 
 
+def _storage_clean_reason(old: StorageJSON | None, new: StorageJSON) -> str | None:
+    """Return a human-readable reason ``storage_should_clean`` would fire, or None."""
+    if not storage_should_clean(old, new):
+        return None
+    if old is None:
+        return "no prior offloader StorageJSON (first materialise)"
+    if old.src_version != new.src_version:
+        return f"src_version changed ({old.src_version} -> {new.src_version})"
+    if old.build_path != new.build_path:
+        return f"build_path changed ({old.build_path} -> {new.build_path})"
+    removed = old.loaded_integrations - new.loaded_integrations
+    if removed:
+        return f"loaded_integrations removed: {sorted(removed)}"
+    return "storage_should_clean returned True for an unknown reason"
+
+
+def _count_pioenvs_objects(pioenvs_dir: Path) -> int:
+    """Return the number of ``*.o`` files under *pioenvs_dir*; 0 if missing."""
+    if not pioenvs_dir.is_dir():
+        return 0
+    return sum(1 for _ in pioenvs_dir.rglob("*.o"))
+
+
 @contextmanager
-def _preserve_platformio_ini_mtime_if_unchanged(pio_path: Path) -> Iterator[None]:
+def _preserve_platformio_ini_mtime_if_unchanged(
+    pio_path: Path, *, configuration: str
+) -> Iterator[None]:
     """
     Hold *pio_path*'s mtime stable across an enclosed write when the bytes don't change.
 
@@ -445,11 +496,32 @@ def _preserve_platformio_ini_mtime_if_unchanged(pio_path: Path) -> Iterator[None
     yield
     if not pio_path.is_file():
         return
-    if prior_mtime_ns is not None and pio_path.read_bytes() == prior_bytes:
+    new_bytes = pio_path.read_bytes()
+    if prior_mtime_ns is not None and new_bytes == prior_bytes:
         os.utime(pio_path, ns=(prior_mtime_ns, prior_mtime_ns))
+        _LOGGER.info(
+            "remote-build materialise(%s): platformio.ini unchanged (%d bytes), "
+            "mtime preserved (SCons .o cache stays valid)",
+            configuration,
+            len(new_bytes),
+        )
     else:
         now_ns = time.time_ns()
         os.utime(pio_path, ns=(now_ns, now_ns))
+        if prior_mtime_ns is None:
+            _LOGGER.info(
+                "remote-build materialise(%s): platformio.ini first install (%d bytes)",
+                configuration,
+                len(new_bytes),
+            )
+        else:
+            _LOGGER.info(
+                "remote-build materialise(%s): platformio.ini changed "
+                "(%d -> %d bytes), mtime bumped (SCons will recompile every .o)",
+                configuration,
+                len(prior_bytes or b""),
+                len(new_bytes),
+            )
 
 
 def _force_idedata_cache_hit(*, platformio_ini: Path, cached_idedata: Path) -> None:

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from esphome.const import __version__ as _esphome_version
 from esphome.helpers import rmtree
 from esphome.storage_json import StorageJSON
 from esphome.writer import storage_should_clean
@@ -163,11 +164,13 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             else:
                 _LOGGER.info(
                     "remote-build materialise(%s): preserving offloader build dir "
-                    "(%d .o files; receiver esphome=%s, offloader esphome=%s)",
+                    "(%d .o files; receiver esphome=%s, prior_sidecar_esphome=%s, "
+                    "offloader esphome=%s)",
                     configuration,
                     object_count_before,
                     new_storage.esphome_version,
                     prior_storage.esphome_version if prior_storage is not None else "<none>",
+                    _esphome_version,
                 )
             build_path.mkdir(parents=True, exist_ok=True)
             pio_path = build_path / PLATFORMIO_INI_MEMBER_NAME

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import os
 import sys
 import tarfile
@@ -25,6 +26,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from esphome.const import __version__ as _offloader_esphome_version
 from esphome.core import CORE
 
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
@@ -585,6 +587,101 @@ def test_materialise_wipes_when_prior_storage_is_corrupt(
     _materialise_in_tmp(tarball, offloader_root)
 
     assert not stale.exists()
+
+
+# ---------------------------------------------------------------------------
+# INFO-level triage diagnostics (temporary; will be ripped out once the
+# remote→local rebuild reports are understood).
+# ---------------------------------------------------------------------------
+
+
+_MATERIALISE_LOGGER = "esphome_device_builder.helpers.remote_artifacts_materialise"
+
+
+def test_materialise_logs_preserve_decision_with_version_fields(
+    paired_roots: tuple[Path, Path],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The preserve-branch log carries receiver / prior_sidecar / offloader versions."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)
+    _materialise_in_tmp(tarball, offloader_root)
+
+    with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        _materialise_in_tmp(tarball, offloader_root)
+
+    preserve = [
+        r.getMessage() for r in caplog.records if "preserving offloader build dir" in r.getMessage()
+    ]
+    assert len(preserve) == 1, [r.getMessage() for r in caplog.records]
+    msg = preserve[0]
+    assert "receiver esphome=" in msg
+    assert "prior_sidecar_esphome=" in msg
+    assert f"offloader esphome={_offloader_esphome_version}" in msg
+
+
+def test_materialise_logs_wipe_decision_with_reason(
+    paired_roots: tuple[Path, Path],
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The wipe-branch log names the storage_should_clean reason that fired."""
+    receiver_root, offloader_root = paired_roots
+    first_tarball = _pack_in_tmp(receiver_root, loaded_integrations=["esp32", "dht"])
+    _materialise_in_tmp(first_tarball, offloader_root)
+
+    receiver_root_2 = tmp_path / "receiver2"
+    receiver_root_2.mkdir()
+    shrunk_tarball = _pack_in_tmp(receiver_root_2, loaded_integrations=["esp32"])
+
+    with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        _materialise_in_tmp(shrunk_tarball, offloader_root)
+
+    wipe = [
+        r.getMessage() for r in caplog.records if "wiping offloader build dir" in r.getMessage()
+    ]
+    assert len(wipe) == 1, [r.getMessage() for r in caplog.records]
+    assert "loaded_integrations removed:" in wipe[0]
+    assert "'dht'" in wipe[0]
+
+
+def test_materialise_logs_platformio_ini_unchanged(
+    paired_roots: tuple[Path, Path],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The platformio.ini-unchanged path logs ``mtime preserved``."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)
+    _materialise_in_tmp(tarball, offloader_root)
+
+    with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        _materialise_in_tmp(tarball, offloader_root)
+
+    pio_msgs = [r.getMessage() for r in caplog.records if "platformio.ini" in r.getMessage()]
+    assert len(pio_msgs) == 1, [r.getMessage() for r in caplog.records]
+    assert "unchanged" in pio_msgs[0]
+    assert "mtime preserved" in pio_msgs[0]
+
+
+def test_materialise_logs_post_extract_object_count(
+    paired_roots: tuple[Path, Path],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The post-extract summary line carries the surviving ``.o`` count."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)
+    first = _materialise_in_tmp(tarball, offloader_root)
+    pioenvs = first / ".pioenvs" / "kitchen" / "src"
+    pioenvs.mkdir(parents=True, exist_ok=True)
+    (pioenvs / "main.o").write_bytes(b"OBJ")
+    (pioenvs / "extra.o").write_bytes(b"OBJ2")
+
+    with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        _materialise_in_tmp(tarball, offloader_root)
+
+    summary = [r.getMessage() for r in caplog.records if ".o files remain in" in r.getMessage()]
+    assert len(summary) == 1, [r.getMessage() for r in caplog.records]
+    assert "2 .o files remain in" in summary[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -608,6 +608,7 @@ def test_materialise_logs_preserve_decision_with_version_fields(
     _materialise_in_tmp(tarball, offloader_root)
 
     with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        caplog.clear()
         _materialise_in_tmp(tarball, offloader_root)
 
     preserve = [
@@ -635,6 +636,7 @@ def test_materialise_logs_wipe_decision_with_reason(
     shrunk_tarball = _pack_in_tmp(receiver_root_2, loaded_integrations=["esp32"])
 
     with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        caplog.clear()
         _materialise_in_tmp(shrunk_tarball, offloader_root)
 
     wipe = [
@@ -655,6 +657,7 @@ def test_materialise_logs_platformio_ini_unchanged(
     _materialise_in_tmp(tarball, offloader_root)
 
     with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        caplog.clear()
         _materialise_in_tmp(tarball, offloader_root)
 
     pio_msgs = [r.getMessage() for r in caplog.records if "platformio.ini" in r.getMessage()]
@@ -677,6 +680,7 @@ def test_materialise_logs_post_extract_object_count(
     (pioenvs / "extra.o").write_bytes(b"OBJ2")
 
     with caplog.at_level(logging.INFO, logger=_MATERIALISE_LOGGER):
+        caplog.clear()
         _materialise_in_tmp(tarball, offloader_root)
 
     summary = [r.getMessage() for r in caplog.records if ".o files remain in" in r.getMessage()]


### PR DESCRIPTION
# What does this implement/fix?

Add INFO-level diagnostics inside the remote-build materialiser so a
user reporting "`remote → local` triggers a full rebuild" can be
triaged from their dashboard log without instrumenting a build. The
three signals the materialiser already decides internally but doesn't
surface today:

1. **Wipe decision.** The materialiser calls esphome's
   `storage_should_clean(prior, new)` to decide whether to `rmtree`
   the offloader's build dir before extracting the receiver's
   tarball. When it fires, the next local compile rebuilds from
   scratch. We now log either `preserving offloader build dir
   (N .o files; receiver esphome=X, offloader esphome=Y)` or
   `wiping offloader build dir (was N .o files) -- <reason>`,
   where `<reason>` is the actual `storage_should_clean` branch
   that hit (`build_path changed (... -> ...)`,
   `loaded_integrations removed: [...]`, etc.). The
   `loaded_integrations` line is the one that catches a
   receiver/offloader esphome-dev version skew; same YAML
   compiled against two different esphome checkouts can disagree
   on the loaded-components set and the offloader's local
   recompute then wipes.

2. **`platformio.ini` mtime path.** PR #880's preserve-on-unchanged
   context manager already branches on prior bytes vs new bytes;
   we now log which branch fired:
   `platformio.ini unchanged (N bytes), mtime preserved (SCons .o
   cache stays valid)` vs `platformio.ini changed (M -> N bytes),
   mtime bumped (SCons will recompile every .o)`. If a user reports
   a recompile and this line says "bumped", we know PIO's config
   genuinely differs across compiles and the recompile is correct.
   If it says "preserved" but the user still sees recompiles, the
   trigger is elsewhere (the wipe gate above, or something past
   the materialiser).

3. **Post-extract `.o` count.** Final line after every materialise:
   `N .o files remain in <path>/.pioenvs/<name>/ after extract`.
   The killer datum for a user filing a bug; they can read it
   straight off their log and we don't have to ask them to count
   files.

Concretely this is to triage a current MasterOfNone report that
`local → local → remote → remote → local` still triggers a rebuild
on the remote→local transition after PR #880 / #874 landed. The
three log lines above narrow it to one of: stale install,
`storage_should_clean` firing on the post-materialise local
compile, or a separate `platformio.ini` content change. The
issue is plausibly user-environment-specific (their two esphome
dev checkouts disagree on `loaded_integrations`) and we don't
want to keep speculating without seeing what their materialise
actually decided.

Beta-ship-and-rip: device-builder is in late beta, remote/offload
is early beta. Worth shipping the logging now to triage live
reports, and ripping the lines out (or downgrading to DEBUG) once
we either confirm the gap and fix it or confirm everything's
working as designed in the field.

No behaviour change. The added helpers (`_storage_clean_reason`,
`_count_pioenvs_objects`) are pure read-only inspection; the
mtime context manager grew a kwarg-only `configuration=` for the
log line and the new bytes-read was already happening at runtime
(moved into a local to avoid double-reading). Existing unit suite
still passes; mypy clean.

**Related issue or feature (if applicable):**

- fixes <none; in-conversation triage of a remote→local rebuild report>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
