### PR TITLE
Decouple YAML save reply from full scanner reload

### DIFF
--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -135,41 +135,41 @@ class BuildSizeRefresher:
         except Exception:
             _LOGGER.exception("Initial build-size fleet sweep failed")
         while True:
-            await self._worker.wait()
-            # One snapshot per drain cycle, not per item, so the
-            # per-device cached-signal lookup is O(1) on a hash
-            # rather than O(N) on a fresh fleet-wide copy.
-            metadata = self._get_metadata_snapshot()
-            while self._worker.pending:
-                configuration = self._worker.pending.pop()
-                entry = metadata.get(configuration, {})
-                cached = BuildDirSignal(
-                    dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),
-                    info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
-                )
-                try:
-                    result = await loop.run_in_executor(
-                        None,
-                        refresh_build_size_if_stale,
-                        configuration,
-                        cached,
+            async with self._worker.drain():
+                # One snapshot per drain cycle, not per item, so the
+                # per-device cached-signal lookup is O(1) on a hash
+                # rather than O(N) on a fresh fleet-wide copy.
+                metadata = self._get_metadata_snapshot()
+                while self._worker.pending:
+                    configuration = self._worker.pending.pop()
+                    entry = metadata.get(configuration, {})
+                    cached = BuildDirSignal(
+                        dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),
+                        info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
                     )
-                except Exception:
-                    _LOGGER.exception("Build-size refresh failed for %s", configuration)
-                    continue
-                if result is None:
-                    continue  # cache hit / no artifacts — nothing to publish
-                self._persist_size(configuration, result)
-                # Reflect the persisted signal into the local
-                # snapshot so a re-queue of the same configuration
-                # within this drain cycle sees the fresh cache.
-                metadata[configuration] = {
-                    **metadata.get(configuration, {}),
-                    "build_size_bytes": result.size_bytes,
-                    "build_size_dir_mtime": result.signal.dir_mtime,
-                    "build_size_info_mtime": result.signal.info_mtime,
-                }
-                try:
-                    await self._on_refreshed(configuration)
-                except Exception:
-                    _LOGGER.exception("on_refreshed callback failed for %s", configuration)
+                    try:
+                        result = await loop.run_in_executor(
+                            None,
+                            refresh_build_size_if_stale,
+                            configuration,
+                            cached,
+                        )
+                    except Exception:
+                        _LOGGER.exception("Build-size refresh failed for %s", configuration)
+                        continue
+                    if result is None:
+                        continue  # cache hit / no artifacts — nothing to publish
+                    self._persist_size(configuration, result)
+                    # Reflect the persisted signal into the local
+                    # snapshot so a re-queue of the same configuration
+                    # within this drain cycle sees the fresh cache.
+                    metadata[configuration] = {
+                        **metadata.get(configuration, {}),
+                        "build_size_bytes": result.size_bytes,
+                        "build_size_dir_mtime": result.signal.dir_mtime,
+                        "build_size_info_mtime": result.signal.info_mtime,
+                    }
+                    try:
+                        await self._on_refreshed(configuration)
+                    except Exception:
+                        _LOGGER.exception("on_refreshed callback failed for %s", configuration)

--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -53,16 +53,20 @@ _LOGGER = logging.getLogger(__name__)
 RefreshedCallback = Callable[[str], Awaitable[Any]]
 
 
-class BuildSizeRefresher:
+class BuildSizeRefresher(WakeWorker[str]):
     """
     One persistent worker that drains build-size refresh requests serially.
 
-    The owner pushes work via :meth:`request` (sync, side-effect-only)
-    or :meth:`enqueue_stale_fleet` (async, runs the phase-A sweep
-    and pushes any divergent configurations). The single worker
-    task wakes whenever the pending set is non-empty, walks one
-    device at a time, and notifies the owner via the
-    ``on_refreshed`` callback after each successful change.
+    Drains ``set.pop()``-style so mid-walk requests for an
+    already-running configuration land in the same drain cycle.
+    On startup runs :meth:`enqueue_stale_fleet` to pick up
+    CLI-compile drift across the whole catalog.
+
+    Mid-walk ``stop()`` is fine for cancellation but the
+    underlying executor thread keeps running until the walk
+    finishes; ``DeviceBuilder.stop()`` calls
+    ``loop.shutdown_default_executor()`` so the residual thread
+    drains cleanly at process shutdown.
     """
 
     def __init__(
@@ -72,38 +76,11 @@ class BuildSizeRefresher:
         persist_size: Callable[[str, BuildSizeRefreshResult], None],
         on_refreshed: RefreshedCallback,
     ) -> None:
+        super().__init__()
         self._get_filenames = get_filenames
         self._get_metadata_snapshot = get_metadata_snapshot
         self._persist_size = persist_size
         self._on_refreshed = on_refreshed
-        self._worker: WakeWorker[str] = WakeWorker()
-
-    def request(self, configuration: str) -> None:
-        """Queue a refresh and wake the worker.
-
-        Worker drains ``set.pop()``-style so mid-walk requests
-        for an already-running configuration land in the same
-        set and get a fresh walk right after the current one
-        finishes; duplicates coalesce.
-
-        A subtlety worth knowing: if the worker is mid-walk
-        inside ``loop.run_in_executor(None, ...)`` when ``stop()``
-        fires, cancelling the task only abandons the *await* — the
-        underlying executor thread keeps running until the walk
-        finishes (Python doesn't expose a way to interrupt a
-        running thread). ``DeviceBuilder.stop()`` calls
-        ``loop.shutdown_default_executor()`` which waits on the
-        residual thread, so process shutdown still drains cleanly.
-        """
-        self._worker.request(configuration)
-
-    def start(self) -> None:
-        """Spawn the worker task. Idempotent."""
-        self._worker.start(self._run, name="BuildSizeRefresher")
-
-    async def stop(self) -> None:
-        """Cancel the worker and wait for it to exit cleanly."""
-        await self._worker.stop()
 
     async def enqueue_stale_fleet(self) -> None:
         """
@@ -127,49 +104,48 @@ class BuildSizeRefresher:
         for configuration in stale:
             self.request(configuration)
 
-    async def _run(self) -> None:
-        """Phase-A sweep on startup, then drain the pending set on every wake."""
-        loop = asyncio.get_running_loop()
+    async def _on_start(self) -> None:
         try:
             await self.enqueue_stale_fleet()
         except Exception:
             _LOGGER.exception("Initial build-size fleet sweep failed")
-        while True:
-            async with self._worker.drain():
-                # One snapshot per drain cycle, not per item, so the
-                # per-device cached-signal lookup is O(1) on a hash
-                # rather than O(N) on a fresh fleet-wide copy.
-                metadata = self._get_metadata_snapshot()
-                while self._worker.pending:
-                    configuration = self._worker.pending.pop()
-                    entry = metadata.get(configuration, {})
-                    cached = BuildDirSignal(
-                        dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),
-                        info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
-                    )
-                    try:
-                        result = await loop.run_in_executor(
-                            None,
-                            refresh_build_size_if_stale,
-                            configuration,
-                            cached,
-                        )
-                    except Exception:
-                        _LOGGER.exception("Build-size refresh failed for %s", configuration)
-                        continue
-                    if result is None:
-                        continue  # cache hit / no artifacts — nothing to publish
-                    self._persist_size(configuration, result)
-                    # Reflect the persisted signal into the local
-                    # snapshot so a re-queue of the same configuration
-                    # within this drain cycle sees the fresh cache.
-                    metadata[configuration] = {
-                        **metadata.get(configuration, {}),
-                        "build_size_bytes": result.size_bytes,
-                        "build_size_dir_mtime": result.signal.dir_mtime,
-                        "build_size_info_mtime": result.signal.info_mtime,
-                    }
-                    try:
-                        await self._on_refreshed(configuration)
-                    except Exception:
-                        _LOGGER.exception("on_refreshed callback failed for %s", configuration)
+
+    async def _drain(self) -> None:
+        loop = asyncio.get_running_loop()
+        # One snapshot per drain cycle, not per item, so the
+        # per-device cached-signal lookup is O(1) on a hash
+        # rather than O(N) on a fresh fleet-wide copy.
+        metadata = self._get_metadata_snapshot()
+        while self.pending:
+            configuration = self.pending.pop()
+            entry = metadata.get(configuration, {})
+            cached = BuildDirSignal(
+                dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),
+                info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
+            )
+            try:
+                result = await loop.run_in_executor(
+                    None,
+                    refresh_build_size_if_stale,
+                    configuration,
+                    cached,
+                )
+            except Exception:
+                _LOGGER.exception("Build-size refresh failed for %s", configuration)
+                continue
+            if result is None:
+                continue  # cache hit / no artifacts — nothing to publish
+            self._persist_size(configuration, result)
+            # Reflect the persisted signal into the local snapshot so
+            # a re-queue of the same configuration within this drain
+            # cycle sees the fresh cache.
+            metadata[configuration] = {
+                **metadata.get(configuration, {}),
+                "build_size_bytes": result.size_bytes,
+                "build_size_dir_mtime": result.signal.dir_mtime,
+                "build_size_info_mtime": result.signal.info_mtime,
+            }
+            try:
+                await self._on_refreshed(configuration)
+            except Exception:
+                _LOGGER.exception("on_refreshed callback failed for %s", configuration)

--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -22,7 +22,7 @@ Design constraints driving the class shape:
 
 - **Errors must not kill the worker.** A bad walk on one
   configuration logs and continues with the next; the worker
-  sleeps on ``self._wake`` until the next request lands.
+  sleeps on the wake event until the next request lands.
 """
 
 from __future__ import annotations
@@ -39,6 +39,7 @@ from ..helpers.build_size import (
     find_stale_build_dirs,
     refresh_build_size_if_stale,
 )
+from ._wake_worker import WakeWorker
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,66 +76,34 @@ class BuildSizeRefresher:
         self._get_metadata_snapshot = get_metadata_snapshot
         self._persist_size = persist_size
         self._on_refreshed = on_refreshed
-        self._pending: set[str] = set()
-        self._wake = asyncio.Event()
-        self._worker_task: asyncio.Task[None] | None = None
+        self._worker: WakeWorker[str] = WakeWorker()
 
     def request(self, configuration: str) -> None:
-        """
-        Queue a refresh and wake the worker.
+        """Queue a refresh and wake the worker.
 
-        Cheap, sync, side-effect-only — safe to call from any
-        event-loop callback. Repeated requests for the same
-        configuration coalesce because the queue is a ``set``,
-        and a refresh that's already queued doesn't add a second
-        slot. The worker picks the request up on its next
-        iteration; mid-walk requests for an already-running
-        configuration land in the same set and get a fresh walk
-        right after the current one finishes.
-        """
-        self._pending.add(configuration)
-        self._wake.set()
-
-    def start(self) -> None:
-        """Spawn the worker task. Idempotent — a second call is a no-op."""
-        if self._worker_task is not None and not self._worker_task.done():
-            return
-        self._worker_task = asyncio.create_task(self._worker())
-
-    async def stop(self) -> None:
-        """Cancel the worker and wait for it to exit cleanly.
-
-        ``CancelledError`` is the expected exit and gets
-        suppressed silently. Anything else is unexpected — a
-        per-iteration ``except`` in the worker missed something —
-        and gets logged so the failure isn't invisible during a
-        clean controller shutdown.
+        Worker drains ``set.pop()``-style so mid-walk requests
+        for an already-running configuration land in the same
+        set and get a fresh walk right after the current one
+        finishes; duplicates coalesce.
 
         A subtlety worth knowing: if the worker is mid-walk
         inside ``loop.run_in_executor(None, ...)`` when ``stop()``
         fires, cancelling the task only abandons the *await* — the
         underlying executor thread keeps running until the walk
         finishes (Python doesn't expose a way to interrupt a
-        running thread). For build-size refresh the work is just
-        a directory walk + one sidecar write per device, so the
-        thread completes on its own within a few seconds at
-        worst; ``DeviceBuilder.stop()`` then calls
+        running thread). ``DeviceBuilder.stop()`` calls
         ``loop.shutdown_default_executor()`` which waits on the
-        residual thread, so process shutdown still drains
-        cleanly. We accept this over a bespoke cancellation
-        channel into the walk, because process shutdown is the
-        only ``stop()`` caller and the trailing write is harmless.
+        residual thread, so process shutdown still drains cleanly.
         """
-        if self._worker_task is None:
-            return
-        self._worker_task.cancel()
-        try:
-            await self._worker_task
-        except asyncio.CancelledError:
-            pass
-        except Exception:
-            _LOGGER.exception("Build-size worker failed during shutdown")
-        self._worker_task = None
+        self._worker.request(configuration)
+
+    def start(self) -> None:
+        """Spawn the worker task. Idempotent."""
+        self._worker.start(self._run, name="BuildSizeRefresher")
+
+    async def stop(self) -> None:
+        """Cancel the worker and wait for it to exit cleanly."""
+        await self._worker.stop()
 
     async def enqueue_stale_fleet(self) -> None:
         """
@@ -158,41 +127,21 @@ class BuildSizeRefresher:
         for configuration in stale:
             self.request(configuration)
 
-    async def _worker(self) -> None:
-        """
-        Long-lived loop: drain the pending set when woken.
-
-        On first iteration, runs the phase-A fleet sweep so the
-        backend picks up CLI-compile drift across the whole
-        catalog without the controller having to fire a separate
-        startup task. Subsequent iterations sleep on ``self._wake``
-        until there's work, clear the event, then walk the queue
-        one configuration at a time until it's empty, then sleep
-        again. ``set.pop()`` is arbitrary-order — fine here, every
-        queued device gets walked. New requests that arrive
-        mid-iteration land in the same set and get processed
-        before the next sleep.
-
-        Per-iteration ``try`` swallows configuration-specific
-        errors so one bad walk can't kill the worker (typical
-        cause: a permission error or a vanishing path during the
-        walk). Cancellation propagates through the ``await`` and
-        breaks the outer ``while True:`` cleanly.
-        """
+    async def _run(self) -> None:
+        """Phase-A sweep on startup, then drain the pending set on every wake."""
         loop = asyncio.get_running_loop()
         try:
             await self.enqueue_stale_fleet()
         except Exception:
             _LOGGER.exception("Initial build-size fleet sweep failed")
         while True:
-            await self._wake.wait()
-            self._wake.clear()
+            await self._worker.wait()
             # One snapshot per drain cycle, not per item, so the
             # per-device cached-signal lookup is O(1) on a hash
             # rather than O(N) on a fresh fleet-wide copy.
             metadata = self._get_metadata_snapshot()
-            while self._pending:
-                configuration = self._pending.pop()
+            while self._worker.pending:
+                configuration = self._worker.pending.pop()
                 entry = metadata.get(configuration, {})
                 cached = BuildDirSignal(
                     dir_mtime=coerce_sidecar_int(entry.get("build_size_dir_mtime")),

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -361,13 +361,13 @@ class DeviceScanner:
     async def _run(self) -> None:
         """Drain pending reloads whenever the wake fires."""
         while True:
-            await self._worker.wait()
-            pending, self._worker.pending = self._worker.pending, set()
-            for filename in pending:
-                try:
-                    await self.reload(filename)
-                except Exception:
-                    _LOGGER.exception("Background reload of %s failed", filename)
+            async with self._worker.drain():
+                pending, self._worker.pending = self._worker.pending, set()
+                for filename in pending:
+                    try:
+                        await self.reload(filename)
+                    except Exception:
+                        _LOGGER.exception("Background reload of %s failed", filename)
 
     async def _do_scan(self) -> None:
         loop = asyncio.get_running_loop()

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -21,6 +21,7 @@ from esphome import util
 
 from ..helpers.device_yaml import load_device_from_storage
 from ..models import Device
+from ._wake_worker import WakeWorker
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -252,6 +253,7 @@ class DeviceScanner:
         self._on_change = on_change
         self._index = _DeviceIndex()
         self._lock = asyncio.Lock()
+        self._worker: WakeWorker[str] = WakeWorker()
 
     @property
     def devices(self) -> list[Device]:
@@ -288,6 +290,18 @@ class DeviceScanner:
         """Refresh the device cache from disk, emitting per-file change events."""
         async with self._lock:
             await self._do_scan()
+
+    def start(self) -> None:
+        """Spawn the background reload worker. Idempotent."""
+        self._worker.start(self._run, name="DeviceScanner")
+
+    async def stop(self) -> None:
+        """Cancel the worker and await its exit."""
+        await self._worker.stop()
+
+    def request(self, filename: str) -> None:
+        """Queue a reload of *filename* and wake the worker."""
+        self._worker.request(filename)
 
     async def reload(self, filename: str) -> bool:
         """
@@ -343,6 +357,17 @@ class DeviceScanner:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Drain pending reloads whenever the wake fires."""
+        while True:
+            await self._worker.wait()
+            pending, self._worker.pending = self._worker.pending, set()
+            for filename in pending:
+                try:
+                    await self.reload(filename)
+                except Exception:
+                    _LOGGER.exception("Background reload of %s failed", filename)
 
     async def _do_scan(self) -> None:
         loop = asyncio.get_running_loop()

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -234,12 +234,15 @@ class _DeviceIndex:
             del self._devices_by_name[device.name]
 
 
-class DeviceScanner:
+class DeviceScanner(WakeWorker[str]):
     """
     Disk-backed device cache.
 
     ``scan()`` is safe to call concurrently — overlapping calls coalesce
     via an internal lock. Use ``devices`` to read the current snapshot.
+    The :class:`WakeWorker` base drives a background reload worker:
+    :meth:`request` queues a filename, :meth:`start` / :meth:`stop`
+    manage the task, :meth:`wait_idle` parks until the drain finishes.
     """
 
     def __init__(
@@ -248,12 +251,12 @@ class DeviceScanner:
         get_metadata: MetadataResolver,
         on_change: ScanCallback,
     ) -> None:
+        super().__init__()
         self._config_dir = config_dir
         self._get_metadata = get_metadata
         self._on_change = on_change
         self._index = _DeviceIndex()
         self._lock = asyncio.Lock()
-        self._worker: WakeWorker[str] = WakeWorker()
 
     @property
     def devices(self) -> list[Device]:
@@ -290,18 +293,6 @@ class DeviceScanner:
         """Refresh the device cache from disk, emitting per-file change events."""
         async with self._lock:
             await self._do_scan()
-
-    def start(self) -> None:
-        """Spawn the background reload worker. Idempotent."""
-        self._worker.start(self._run, name="DeviceScanner")
-
-    async def stop(self) -> None:
-        """Cancel the worker and await its exit."""
-        await self._worker.stop()
-
-    def request(self, filename: str) -> None:
-        """Queue a reload of *filename* and wake the worker."""
-        self._worker.request(filename)
 
     async def reload(self, filename: str) -> bool:
         """
@@ -358,16 +349,14 @@ class DeviceScanner:
     # Internals
     # ------------------------------------------------------------------
 
-    async def _run(self) -> None:
-        """Drain pending reloads whenever the wake fires."""
-        while True:
-            async with self._worker.drain():
-                pending, self._worker.pending = self._worker.pending, set()
-                for filename in pending:
-                    try:
-                        await self.reload(filename)
-                    except Exception:
-                        _LOGGER.exception("Background reload of %s failed", filename)
+    async def _drain(self) -> None:
+        """Reload every filename currently queued."""
+        pending, self.pending = self.pending, set()
+        for filename in pending:
+            try:
+                await self.reload(filename)
+            except Exception:
+                _LOGGER.exception("Background reload of %s failed", filename)
 
     async def _do_scan(self) -> None:
         loop = asyncio.get_running_loop()

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -354,9 +354,19 @@ class DeviceScanner(WakeWorker[str]):
         pending, self.pending = self.pending, set()
         for filename in pending:
             try:
-                await self.reload(filename)
+                reloaded = await self.reload(filename)
             except Exception:
                 _LOGGER.exception("Background reload of %s failed", filename)
+                continue
+            if not reloaded:
+                # Tracked at request time but gone by drain time
+                # (concurrent delete / atomic-save mid-flight).
+                # Debug-level: the drain doesn't fail, but the
+                # vanished save is otherwise invisible.
+                _LOGGER.debug(
+                    "Background reload skipped: %s is no longer tracked",
+                    filename,
+                )
 
     async def _do_scan(self) -> None:
         loop = asyncio.get_running_loop()

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -35,8 +35,16 @@ class WakeWorker[T]:
 
     def start(self) -> None:
         """Spawn the worker. Idempotent."""
-        if self._task is not None and not self._task.done():
+        prior = self._task
+        if prior is not None and not prior.done():
             return
+        if prior is not None and not prior.cancelled():
+            # Retrieve any unhandled exception so it doesn't surface
+            # as "Task exception was never retrieved" at GC time and
+            # so the failure mode is visible in logs.
+            exc = prior.exception()
+            if exc is not None:
+                _LOGGER.error("Worker %s crashed; restarting", prior.get_name(), exc_info=exc)
         self._task = asyncio.create_task(self._run_loop(), name=type(self).__name__)
 
     async def stop(self) -> None:
@@ -77,7 +85,18 @@ class WakeWorker[T]:
         await self._on_start()
         while True:
             async with self._drain_cycle():
-                await self._drain()
+                try:
+                    await self._drain()
+                except Exception:
+                    # Unexpected raise from a subclass ``_drain``
+                    # body. Log and continue so a programming bug
+                    # in one drain iteration doesn't kill the
+                    # worker — that would leave every ``wait_idle``
+                    # waiter parked forever until ``stop`` runs.
+                    _LOGGER.exception(
+                        "Worker %s drain raised; continuing",
+                        type(self).__name__,
+                    )
 
     @asynccontextmanager
     async def _drain_cycle(self) -> AsyncIterator[None]:

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -39,16 +39,12 @@ class WakeWorker[T]:
         if prior is not None and not prior.done():
             return
         if prior is not None and not prior.cancelled():
-            # Retrieve any unhandled exception so it doesn't surface
-            # as "Task exception was never retrieved" at GC time and
-            # so the failure mode is visible in logs.
+            # Retrieve any unhandled exception so it doesn't GC as
+            # "Task exception was never retrieved."
             exc = prior.exception()
             if exc is not None:
                 _LOGGER.error("Worker %s crashed; restarting", prior.get_name(), exc_info=exc)
-        # Clear idle so a ``wait_idle`` issued right after ``start``
-        # parks until at least ``_on_start`` + the first drain
-        # finishes. ``_run_loop`` re-sets it when ``_on_start``
-        # queues no work.
+        # ``wait_idle`` right after ``start`` parks past ``_on_start``.
         self._idle.clear()
         self._task = asyncio.create_task(self._run_loop(), name=type(self).__name__)
 
@@ -81,22 +77,8 @@ class WakeWorker[T]:
     async def _drain(self) -> None:
         """Process the current pending set. Subclasses must override.
 
-        Two patterns are supported:
-
-        * **Swap-empty**: ``pending, self.pending = self.pending,
-          set()`` once at the top, then iterate the local copy
-          with per-item ``try`` / ``except``. ``DeviceScanner``
-          uses this.
-        * **Pop-as-you-go**: ``while self.pending:
-          item = self.pending.pop()``. Lets mid-drain ``request``
-          calls land in the same cycle. ``BuildSizeRefresher``
-          uses this.
-
-        Either way, the base does not require ``_drain`` to
-        complete: a raise leaves whatever is still in
-        ``self.pending`` for the next cycle, and
-        :meth:`_drain_cycle` re-arms ``_wake`` so the worker
-        comes back instead of deadlocking.
+        A raise leaves whatever is still in :attr:`pending` for
+        the next cycle — :meth:`_drain_cycle` re-arms the wake.
         """
         raise NotImplementedError
 
@@ -106,9 +88,7 @@ class WakeWorker[T]:
 
     async def _run_loop(self) -> None:
         await self._on_start()
-        # ``start`` cleared idle so ``wait_idle`` parks past
-        # ``_on_start``; if the hook queued no work, re-set so
-        # waiters return without an artificial first-drain wait.
+        # Re-set the idle ``start`` cleared if ``_on_start`` queued no work.
         if not self.pending:
             self._idle.set()
         while True:
@@ -116,33 +96,18 @@ class WakeWorker[T]:
                 try:
                     await self._drain()
                 except Exception:
-                    # Unexpected raise from a subclass ``_drain``
-                    # body. Log and continue so a programming bug
-                    # in one drain iteration doesn't kill the
-                    # worker — that would leave every ``wait_idle``
-                    # waiter parked forever until ``stop`` runs.
-                    _LOGGER.exception(
-                        "Worker %s drain raised; continuing",
-                        type(self).__name__,
-                    )
+                    _LOGGER.exception("Worker %s drain raised; continuing", type(self).__name__)
 
     @asynccontextmanager
     async def _drain_cycle(self) -> AsyncIterator[None]:
-        """Wait for a wake; settle idle/wake on exit based on pending.
-
-        Re-arms ``_wake`` when items remain so the next iteration
-        still drains them — without this a ``_drain`` that raises
-        mid-pending would deadlock (``_wake`` was cleared on
-        entry, never re-armed, and any ``wait_idle`` waiter would
-        be stranded). ``Event.set()`` is idempotent so the normal
-        case (concurrent ``request`` already set ``_wake``) is a
-        no-op.
-        """
+        """Wait for a wake; mark idle on empty exit, re-arm wake on non-empty."""
         await self._wake.wait()
         self._wake.clear()
         try:
             yield
         finally:
+            # Re-arm wake on non-empty so a ``_drain`` that raises
+            # mid-pending isn't stranded; ``Event.set()`` is idempotent.
             if not self.pending:
                 self._idle.set()
             else:

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
 from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
@@ -13,19 +14,26 @@ _LOGGER = logging.getLogger(__name__)
 class WakeWorker[T]:
     """Sync-request + asyncio.Event-driven background worker scaffold.
 
-    Owner writes the drain loop and calls :meth:`wait` to park
-    between iterations. The base owns the pending set, the wake
-    event, and the start/stop lifecycle.
+    The base owns the pending set, the wake event, and the
+    start/stop lifecycle. Owners wrap their per-iteration work in
+    ``async with worker.drain():`` so :meth:`wait_idle` can await
+    a full drain cycle without polling internal state.
     """
 
     def __init__(self) -> None:
         self.pending: set[T] = set()
         self._wake = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
+        # Set when the worker is parked with pending empty;
+        # cleared by ``request`` so callers can ``await wait_idle``
+        # to block until their request has actually been processed.
+        self._idle = asyncio.Event()
+        self._idle.set()
 
     def request(self, item: T) -> None:
         """Push *item* onto :attr:`pending` and wake the loop."""
         self.pending.add(item)
+        self._idle.clear()
         self._wake.set()
 
     def start(
@@ -40,7 +48,12 @@ class WakeWorker[T]:
         self._task = asyncio.create_task(run(), name=name or "WakeWorker")
 
     async def stop(self) -> None:
-        """Cancel and await the worker. Idempotent."""
+        """Cancel and await the worker. Idempotent.
+
+        Sets the idle event on the way out so any
+        :meth:`wait_idle` waiter parked through shutdown resumes
+        rather than hanging.
+        """
         task = self._task
         if task is None:
             return
@@ -52,8 +65,23 @@ class WakeWorker[T]:
         except Exception:
             _LOGGER.exception("Worker %s failed during shutdown", task.get_name())
         self._task = None
+        self._idle.set()
 
-    async def wait(self) -> None:
-        """Park until the wake fires, then clear it."""
+    @asynccontextmanager
+    async def drain(self) -> AsyncIterator[None]:
+        """Park until a request lands; mark idle when the body exits.
+
+        Pairs the wake-receive with the idle-set in one structured
+        block so the run loop cannot leave :meth:`wait_idle` hung.
+        """
         await self._wake.wait()
         self._wake.clear()
+        try:
+            yield
+        finally:
+            if not self.pending:
+                self._idle.set()
+
+    async def wait_idle(self) -> None:
+        """Park until pending is empty and no drain is in progress."""
+        await self._idle.wait()

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -1,0 +1,59 @@
+"""Pending-set + wake-event + task lifecycle for background workers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WakeWorker[T]:
+    """Sync-request + asyncio.Event-driven background worker scaffold.
+
+    Owner writes the drain loop and calls :meth:`wait` to park
+    between iterations. The base owns the pending set, the wake
+    event, and the start/stop lifecycle.
+    """
+
+    def __init__(self) -> None:
+        self.pending: set[T] = set()
+        self._wake = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    def request(self, item: T) -> None:
+        """Push *item* onto :attr:`pending` and wake the loop."""
+        self.pending.add(item)
+        self._wake.set()
+
+    def start(
+        self,
+        run: Callable[[], Coroutine[Any, Any, None]],
+        *,
+        name: str | None = None,
+    ) -> None:
+        """Spawn the worker. Idempotent."""
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(run(), name=name or "WakeWorker")
+
+    async def stop(self) -> None:
+        """Cancel and await the worker. Idempotent."""
+        task = self._task
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            _LOGGER.exception("Worker %s failed during shutdown", task.get_name())
+        self._task = None
+
+    async def wait(self) -> None:
+        """Park until the wake fires, then clear it."""
+        await self._wake.wait()
+        self._wake.clear()

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -45,6 +45,11 @@ class WakeWorker[T]:
             exc = prior.exception()
             if exc is not None:
                 _LOGGER.error("Worker %s crashed; restarting", prior.get_name(), exc_info=exc)
+        # Clear idle so a ``wait_idle`` issued right after ``start``
+        # parks until at least ``_on_start`` + the first drain
+        # finishes. ``_run_loop`` re-sets it when ``_on_start``
+        # queues no work.
+        self._idle.clear()
         self._task = asyncio.create_task(self._run_loop(), name=type(self).__name__)
 
     async def stop(self) -> None:
@@ -74,7 +79,25 @@ class WakeWorker[T]:
         """One-shot hook called before the drain loop; default no-op."""
 
     async def _drain(self) -> None:
-        """Process the current pending set. Subclasses must override."""
+        """Process the current pending set. Subclasses must override.
+
+        Two patterns are supported:
+
+        * **Swap-empty**: ``pending, self.pending = self.pending,
+          set()`` once at the top, then iterate the local copy
+          with per-item ``try`` / ``except``. ``DeviceScanner``
+          uses this.
+        * **Pop-as-you-go**: ``while self.pending:
+          item = self.pending.pop()``. Lets mid-drain ``request``
+          calls land in the same cycle. ``BuildSizeRefresher``
+          uses this.
+
+        Either way, the base does not require ``_drain`` to
+        complete: a raise leaves whatever is still in
+        ``self.pending`` for the next cycle, and
+        :meth:`_drain_cycle` re-arms ``_wake`` so the worker
+        comes back instead of deadlocking.
+        """
         raise NotImplementedError
 
     # ------------------------------------------------------------------
@@ -83,6 +106,11 @@ class WakeWorker[T]:
 
     async def _run_loop(self) -> None:
         await self._on_start()
+        # ``start`` cleared idle so ``wait_idle`` parks past
+        # ``_on_start``; if the hook queued no work, re-set so
+        # waiters return without an artificial first-drain wait.
+        if not self.pending:
+            self._idle.set()
         while True:
             async with self._drain_cycle():
                 try:
@@ -100,7 +128,16 @@ class WakeWorker[T]:
 
     @asynccontextmanager
     async def _drain_cycle(self) -> AsyncIterator[None]:
-        """Wait for a wake; mark idle on exit when pending is empty."""
+        """Wait for a wake; settle idle/wake on exit based on pending.
+
+        Re-arms ``_wake`` when items remain so the next iteration
+        still drains them — without this a ``_drain`` that raises
+        mid-pending would deadlock (``_wake`` was cleared on
+        entry, never re-armed, and any ``wait_idle`` waiter would
+        be stranded). ``Event.set()`` is idempotent so the normal
+        case (concurrent ``request`` already set ``_wake``) is a
+        no-op.
+        """
         await self._wake.wait()
         self._wake.clear()
         try:
@@ -108,3 +145,5 @@ class WakeWorker[T]:
         finally:
             if not self.pending:
                 self._idle.set()
+            else:
+                self._wake.set()

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -28,7 +28,11 @@ class WakeWorker[T]:
         self._idle.set()
 
     def request(self, item: T) -> None:
-        """Push *item* onto :attr:`pending` and wake the loop."""
+        """Push *item* onto :attr:`pending` and wake the loop.
+
+        Requires :meth:`start` to be in effect for progress;
+        otherwise :meth:`wait_idle` will park until ``stop``.
+        """
         self.pending.add(item)
         self._idle.clear()
         self._wake.set()
@@ -87,7 +91,10 @@ class WakeWorker[T]:
     # ------------------------------------------------------------------
 
     async def _run_loop(self) -> None:
-        await self._on_start()
+        try:
+            await self._on_start()
+        except Exception:
+            _LOGGER.exception("Worker %s _on_start raised; continuing", type(self).__name__)
         # Re-set the idle ``start`` cleared if ``_on_start`` queued no work.
         if not self.pending:
             self._idle.set()

--- a/esphome_device_builder/controllers/_wake_worker.py
+++ b/esphome_device_builder/controllers/_wake_worker.py
@@ -4,29 +4,26 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class WakeWorker[T]:
-    """Sync-request + asyncio.Event-driven background worker scaffold.
+    """Sync-request + asyncio.Event-driven background worker base.
 
-    The base owns the pending set, the wake event, and the
-    start/stop lifecycle. Owners wrap their per-iteration work in
-    ``async with worker.drain():`` so :meth:`wait_idle` can await
-    a full drain cycle without polling internal state.
+    Subclasses implement :meth:`_drain` (called per wake) and
+    optionally :meth:`_on_start` (one-shot, before the loop).
+    The base owns the pending set, the wake event, the idle event,
+    the start/stop lifecycle, and the drain context manager that
+    pairs a wake-receive with an idle-set on exit.
     """
 
     def __init__(self) -> None:
         self.pending: set[T] = set()
         self._wake = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
-        # Set when the worker is parked with pending empty;
-        # cleared by ``request`` so callers can ``await wait_idle``
-        # to block until their request has actually been processed.
         self._idle = asyncio.Event()
         self._idle.set()
 
@@ -36,24 +33,14 @@ class WakeWorker[T]:
         self._idle.clear()
         self._wake.set()
 
-    def start(
-        self,
-        run: Callable[[], Coroutine[Any, Any, None]],
-        *,
-        name: str | None = None,
-    ) -> None:
+    def start(self) -> None:
         """Spawn the worker. Idempotent."""
         if self._task is not None and not self._task.done():
             return
-        self._task = asyncio.create_task(run(), name=name or "WakeWorker")
+        self._task = asyncio.create_task(self._run_loop(), name=type(self).__name__)
 
     async def stop(self) -> None:
-        """Cancel and await the worker. Idempotent.
-
-        Sets the idle event on the way out so any
-        :meth:`wait_idle` waiter parked through shutdown resumes
-        rather than hanging.
-        """
+        """Cancel and await the worker; unblock any :meth:`wait_idle` waiter."""
         task = self._task
         if task is None:
             return
@@ -67,13 +54,34 @@ class WakeWorker[T]:
         self._task = None
         self._idle.set()
 
-    @asynccontextmanager
-    async def drain(self) -> AsyncIterator[None]:
-        """Park until a request lands; mark idle when the body exits.
+    async def wait_idle(self) -> None:
+        """Park until pending is empty and no drain is in progress."""
+        await self._idle.wait()
 
-        Pairs the wake-receive with the idle-set in one structured
-        block so the run loop cannot leave :meth:`wait_idle` hung.
-        """
+    # ------------------------------------------------------------------
+    # Subclass hooks
+    # ------------------------------------------------------------------
+
+    async def _on_start(self) -> None:
+        """One-shot hook called before the drain loop; default no-op."""
+
+    async def _drain(self) -> None:
+        """Process the current pending set. Subclasses must override."""
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _run_loop(self) -> None:
+        await self._on_start()
+        while True:
+            async with self._drain_cycle():
+                await self._drain()
+
+    @asynccontextmanager
+    async def _drain_cycle(self) -> AsyncIterator[None]:
+        """Wait for a wake; mark idle on exit when pending is empty."""
         await self._wake.wait()
         self._wake.clear()
         try:
@@ -81,7 +89,3 @@ class WakeWorker[T]:
         finally:
             if not self.pending:
                 self._idle.set()
-
-    async def wait_idle(self) -> None:
-        """Park until pending is empty and no drain is in progress."""
-        await self._idle.wait()

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -225,6 +225,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         await self._metadata_store.async_load()
         await loop.run_in_executor(None, self._load_ignored_devices)
         await self._scanner.scan()
+        self._scanner.start()
         _LOGGER.info("Devices controller started — %d devices loaded", len(self._scanner.devices))
         await self._state_monitor.start()
         await self._mqtt_coordinator.reconcile()
@@ -242,6 +243,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         if self._unsub_job_completed is not None:
             self._unsub_job_completed()
             self._unsub_job_completed = None
+        await self._scanner.stop()
         await self._build_size.stop()
         await self._mqtt_coordinator.stop()
         await self._state_monitor.stop()
@@ -775,9 +777,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         await loop.run_in_executor(None, atomic_write_file, path, content)
 
     async def _persist_yaml_mutation(self, configuration: str, content: str) -> None:
-        """Atomic write + scan + StorageJSON regen for in-place YAML mutators."""
+        """Atomic write + queue background reload + StorageJSON regen."""
         await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
-        await self._scanner.scan()
+        self._scanner.request(configuration)
         # Mirrors the upstream dashboard's
         # ``async_schedule_storage_json_update``; without it
         # ``loaded_integrations`` stays at its pre-write state.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -777,7 +777,12 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         await loop.run_in_executor(None, atomic_write_file, path, content)
 
     async def _persist_yaml_mutation(self, configuration: str, content: str) -> None:
-        """Atomic write + queue background reload + StorageJSON regen."""
+        """Atomic write + fire-and-forget background reload + StorageJSON regen.
+
+        Returns once the bytes are on disk; the scanner reload
+        runs on its worker, so callers don't see the post-reload
+        device row before the next event tick.
+        """
         await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
         self._scanner.request(configuration)
         # Mirrors the upstream dashboard's

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -61,6 +61,15 @@ class RecordingScanner:
         self.calls.append(("reload", filename))
         return self._reload_returns
 
+    def request(self, filename: str) -> None:
+        self.calls.append(("request", filename))
+
+    async def start(self) -> None:
+        self.calls.append(("start",))
+
+    async def stop(self) -> None:
+        self.calls.append(("stop",))
+
     def get_by_name(self, name: str) -> list[object]:
         self.calls.append(("get_by_name", name))
         # Fresh list snapshot — mirrors production semantics so

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -64,7 +64,7 @@ class RecordingScanner:
     def request(self, filename: str) -> None:
         self.calls.append(("request", filename))
 
-    async def start(self) -> None:
+    def start(self) -> None:
         self.calls.append(("start",))
 
     async def stop(self) -> None:

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -15,24 +15,29 @@ from typing import Any
 
 
 class RecordingScanner:
-    """Test fake for ``DeviceScanner`` capturing scan/reload calls.
+    """Test fake for ``DeviceScanner`` capturing recorded method calls.
 
     Mirrors every public method on the production ``DeviceScanner``
-    (``scan`` / ``reload`` / ``get_by_name`` / ``devices`` /
-    ``by_path``). Calls to ``scan`` / ``reload`` / ``get_by_name``
-    land in ``self.calls`` as ``(method_name, *args)``; tests
-    assert on the list directly instead of scattering
-    ``MagicMock.assert_awaited_*`` lines.
+    (``scan`` / ``reload`` / ``request`` / ``start`` / ``stop`` /
+    ``get_by_name`` / ``devices`` / ``by_path``). Calls to the
+    recordable ones land in ``self.calls`` as
+    ``(method_name, *args)``; tests assert on the list directly
+    instead of scattering ``MagicMock.assert_awaited_*`` lines.
+
+    Signatures match production exactly — ``start`` is sync,
+    ``stop`` is async, ``request`` is sync. A future rename or a
+    sync/async change on the real class surfaces immediately
+    against this fake.
 
     Why a typed fake rather than ``MagicMock``: a typo
     (``scann.assert_awaited_once``) silently passes against a
     ``MagicMock`` because it spawns a fresh attribute on access; a
     refactor renaming a real method (``reload`` → ``refresh_one``)
     similarly breaks the contract without breaking the assertion.
-    Mirroring the *full* public surface (rather than just
-    ``scan`` + ``reload``) means a controller path that touches
-    ``get_by_name`` or ``by_path`` won't blow up against the fake
-    just because no earlier test exercised it.
+    Mirroring the *full* public surface means a controller path
+    that touches ``get_by_name``, ``by_path`` or the wake-worker
+    methods (``request`` / ``start`` / ``stop``) won't blow up
+    against the fake just because no earlier test exercised it.
 
     ``reload_returns`` controls the truthy return — production's
     ``reload`` returns ``False`` when the file isn't tracked, which

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -842,7 +842,7 @@ async def test_edit_friendly_name_end_to_end_through_real_scanner(
         # ``_persist_yaml_mutation`` queues a background reload on
         # the scanner's worker; ``wait_idle`` parks until the
         # drain (and the reload it contains) actually completes.
-        await real_scanner._worker.wait_idle()
+        await real_scanner.wait_idle()
     finally:
         await real_scanner.stop()
 

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -19,7 +19,6 @@ What we pin:
 
 from __future__ import annotations
 
-import asyncio
 import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -841,14 +840,9 @@ async def test_edit_friendly_name_end_to_end_through_real_scanner(
             configuration="brandnew.yaml", new_friendly_name="The BRAND NEW"
         )
         # ``_persist_yaml_mutation`` queues a background reload on
-        # the scanner's worker; poll on the user-observable state
-        # (the reloaded device's friendly_name) so the assertion
-        # doesn't race the worker's drain.
-        for _ in range(100):
-            [device] = real_scanner.devices
-            if device.friendly_name == expected_friendly:
-                break
-            await asyncio.sleep(0.01)
+        # the scanner's worker; ``wait_idle`` parks until the
+        # drain (and the reload it contains) actually completes.
+        await real_scanner._worker.wait_idle()
     finally:
         await real_scanner.stop()
 

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -19,6 +19,7 @@ What we pin:
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -72,7 +73,7 @@ async def test_edit_friendly_name_rewrites_literal_leaf_and_scans(
     # Other leaves untouched.
     assert "  name: kitchen\n" in new_yaml
     assert '    key: "AAABBB=="' in new_yaml
-    assert ctrl._scanner.calls == [("scan",)]
+    assert ctrl._scanner.calls == [("request", "kitchen.yaml")]
 
 
 async def test_edit_friendly_name_schedules_storage_regenerate(
@@ -834,9 +835,24 @@ async def test_edit_friendly_name_end_to_end_through_real_scanner(
     # stem when the YAML doesn't carry an esphome.name.
     assert seeded.configuration == "brandnew.yaml"
 
-    result = await ctrl.edit_friendly_name(
-        configuration="brandnew.yaml", new_friendly_name="The BRAND NEW"
-    )
+    real_scanner.start()
+    try:
+        result = await ctrl.edit_friendly_name(
+            configuration="brandnew.yaml", new_friendly_name="The BRAND NEW"
+        )
+        # ``_persist_yaml_mutation`` queues a background reload on
+        # the scanner's worker; spin the loop until it drains so
+        # ``scanner.devices`` reflects the post-edit YAML.
+        for _ in range(50):
+            if (
+                not real_scanner._worker.pending
+                and not real_scanner._worker._wake.is_set()
+                and not real_scanner._lock.locked()
+            ):
+                break
+            await asyncio.sleep(0)
+    finally:
+        await real_scanner.stop()
 
     assert result == {"configuration": "brandnew.yaml", "rewritten": True}
     [updated] = real_scanner.devices

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -841,16 +841,14 @@ async def test_edit_friendly_name_end_to_end_through_real_scanner(
             configuration="brandnew.yaml", new_friendly_name="The BRAND NEW"
         )
         # ``_persist_yaml_mutation`` queues a background reload on
-        # the scanner's worker; spin the loop until it drains so
-        # ``scanner.devices`` reflects the post-edit YAML.
-        for _ in range(50):
-            if (
-                not real_scanner._worker.pending
-                and not real_scanner._worker._wake.is_set()
-                and not real_scanner._lock.locked()
-            ):
+        # the scanner's worker; poll on the user-observable state
+        # (the reloaded device's friendly_name) so the assertion
+        # doesn't race the worker's drain.
+        for _ in range(100):
+            [device] = real_scanner.devices
+            if device.friendly_name == expected_friendly:
                 break
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.01)
     finally:
         await real_scanner.stop()
 

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -228,46 +228,40 @@ async def test_update_config_schedules_storage_regenerate(
 
 
 @pytest.mark.asyncio
-async def test_update_config_writes_before_scanner_runs(
-    tmp_path: Path, make_controller: MakeControllerFactory
+async def test_update_config_writes_before_requesting_reload(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The disk write completes before the scanner's reload is requested.
+    """``request()`` fires only after the atomic disk write returns.
 
-    The background worker reads the YAML it reloads; if the
-    request fired before the bytes landed, the worker would
-    pick up the stale on-disk version and dispatch
-    DEVICE_UPDATED with the old metadata. Pin the ordering by
-    reading the file inside a request-time hook — once
-    ``request()`` runs, the new content must already be on disk.
-
-    Read goes through ``asyncio.to_thread`` so blockbuster's
-    event-loop guard doesn't fault on the synchronous ``read_text``
-    on CI.
-
-    Regenerate-after-request is implicit: ``update_config`` calls
-    ``request()`` before ``_schedule_storage_regenerate``, so any
-    ordering of regen-vs-write follows from this request check
-    by virtue of the linear async control flow.
+    Reordering the two would make the scanner's worker pick up
+    the stale on-disk bytes and dispatch DEVICE_UPDATED with the
+    old metadata. Trace both calls and pin the order so a refactor
+    that swapped them would surface.
     """
     controller = make_controller(tmp_path)
     _stub_regenerate(controller)
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: stale\n", encoding="utf-8")
-
     new_content = "esphome:\n  name: fresh\n"
-    seen_during_request: list[str] = []
+    order: list[str] = []
+    real_write = controller._write_yaml_atomic_async
 
-    def _record_request(filename: str) -> None:
-        # Synchronous like production; ``asyncio.to_thread`` is the
-        # blockbuster-safe way to read inside an event-loop callback.
-        seen_during_request.append(yaml_path.read_text(encoding="utf-8"))
-        assert filename == "kitchen.yaml"
+    async def _trace_write(path: Path, content: str) -> None:
+        await real_write(path, content)
+        order.append("write")
 
-    controller._scanner.request = _record_request  # type: ignore[method-assign]
+    def _trace_request(filename: str) -> None:
+        order.append(f"request:{filename}")
+
+    monkeypatch.setattr(controller, "_write_yaml_atomic_async", _trace_write)
+    monkeypatch.setattr(controller._scanner, "request", _trace_request)
 
     await controller.update_config(configuration="kitchen.yaml", content=new_content)
 
-    assert seen_during_request == [new_content]
+    assert order == ["write", "request:kitchen.yaml"]
+    assert yaml_path.read_text(encoding="utf-8") == new_content
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -26,9 +26,7 @@ Coverage targets:
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -186,19 +184,22 @@ async def test_update_config_writes_utf8_unicode_intact(
 async def test_update_config_triggers_scan(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Each successful write awakens the scanner so the device list refreshes.
+    """Each successful write queues a targeted reload on the scanner.
 
-    Without the post-write scan, a freshly-added YAML wouldn't
-    show up in the device list until the next background scan tick
-    (up to 60s on the file-poll cadence). The dashboard's
-    "save and immediately see the device" UX depends on this.
+    Save acks on the disk write alone; the reload runs in the
+    background via :meth:`DeviceScanner.request` and fires
+    DEVICE_UPDATED through the on-change pipeline when the worker
+    drains the pending set. Pin the request call so a refactor
+    that dropped it would surface — the editor's "save and
+    immediately see the device" UX depends on the worker getting
+    poked.
     """
     controller = make_controller(tmp_path)
     _stub_regenerate(controller)
 
     await controller.update_config(configuration="new.yaml", content="esphome:\n  name: new\n")
 
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("request", "new.yaml")]
 
 
 @pytest.mark.asyncio
@@ -230,22 +231,23 @@ async def test_update_config_schedules_storage_regenerate(
 async def test_update_config_writes_before_scanner_runs(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """The disk write completes before ``scanner.scan()`` fires.
+    """The disk write completes before the scanner's reload is requested.
 
-    Scanner reads the YAML it scans; if scan ran first, it would
-    see the stale on-disk version and dispatch DEVICE_UPDATED with
-    the old metadata. Pin the ordering by reading the file
-    inside the scan callback — once scan() runs, the new content
-    must already be on disk.
+    The background worker reads the YAML it reloads; if the
+    request fired before the bytes landed, the worker would
+    pick up the stale on-disk version and dispatch
+    DEVICE_UPDATED with the old metadata. Pin the ordering by
+    reading the file inside a request-time hook — once
+    ``request()`` runs, the new content must already be on disk.
 
     Read goes through ``asyncio.to_thread`` so blockbuster's
     event-loop guard doesn't fault on the synchronous ``read_text``
     on CI.
 
-    Regenerate-after-scan is implicit: ``update_config`` awaits
-    ``scan()`` before calling ``_schedule_storage_regenerate``,
-    so any ordering of regen-vs-write follows from this scan
-    check by virtue of the linear async control flow.
+    Regenerate-after-request is implicit: ``update_config`` calls
+    ``request()`` before ``_schedule_storage_regenerate``, so any
+    ordering of regen-vs-write follows from this request check
+    by virtue of the linear async control flow.
     """
     controller = make_controller(tmp_path)
     _stub_regenerate(controller)
@@ -253,16 +255,19 @@ async def test_update_config_writes_before_scanner_runs(
     yaml_path.write_text("esphome:\n  name: stale\n", encoding="utf-8")
 
     new_content = "esphome:\n  name: fresh\n"
-    seen_during_scan: list[str] = []
+    seen_during_request: list[str] = []
 
-    async def _record_scan() -> None:
-        seen_during_scan.append(await asyncio.to_thread(yaml_path.read_text, "utf-8"))
+    def _record_request(filename: str) -> None:
+        # Synchronous like production; ``asyncio.to_thread`` is the
+        # blockbuster-safe way to read inside an event-loop callback.
+        seen_during_request.append(yaml_path.read_text(encoding="utf-8"))
+        assert filename == "kitchen.yaml"
 
-    controller._scanner.scan = AsyncMock(side_effect=_record_scan)
+    controller._scanner.request = _record_request  # type: ignore[method-assign]
 
     await controller.update_config(configuration="kitchen.yaml", content=new_content)
 
-    assert seen_during_scan == [new_content]
+    assert seen_during_request == [new_content]
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/test_build_size_refresher.py
+++ b/tests/controllers/test_build_size_refresher.py
@@ -84,8 +84,8 @@ async def test_request_adds_to_pending_set_and_wakes_event(tmp_path: Path) -> No
     refresher.request("kitchen.yaml")
     refresher.request("kitchen.yaml")  # dedupe
     refresher.request("bedroom.yaml")
-    assert refresher._pending == {"kitchen.yaml", "bedroom.yaml"}
-    assert refresher._wake.is_set()
+    assert refresher._worker.pending == {"kitchen.yaml", "bedroom.yaml"}
+    assert refresher._worker._wake.is_set()
 
 
 @pytest.mark.asyncio
@@ -93,9 +93,9 @@ async def test_start_is_idempotent(tmp_path: Path) -> None:
     """A second ``start`` while the worker is alive is a no-op."""
     refresher, _, _ = _make(tmp_path)
     refresher.start()
-    first_task = refresher._worker_task
+    first_task = refresher._worker._task
     refresher.start()
-    assert refresher._worker_task is first_task
+    assert refresher._worker._task is first_task
     await refresher.stop()
 
 
@@ -104,7 +104,7 @@ async def test_stop_with_no_running_worker_is_noop(tmp_path: Path) -> None:
     """``stop`` on a never-started refresher must not raise."""
     refresher, _, _ = _make(tmp_path)
     await refresher.stop()  # no exception
-    assert refresher._worker_task is None
+    assert refresher._worker._task is None
 
 
 # ----------------------------------------------------------------------
@@ -140,7 +140,7 @@ async def test_worker_drains_pending_and_fires_on_refreshed(tmp_path: Path) -> N
         await refresher.stop()
 
     assert refreshed == ["kitchen.yaml"]
-    assert refresher._pending == set()
+    assert refresher._worker.pending == set()
 
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_enqueue_stale_fleet_pushes_divergent_filenames(tmp_path: Path) ->
     ):
         await refresher.enqueue_stale_fleet()
 
-    assert refresher._pending == {"a.yaml", "c.yaml"}
+    assert refresher._worker.pending == {"a.yaml", "c.yaml"}
 
 
 @pytest.mark.asyncio
@@ -330,7 +330,7 @@ async def test_enqueue_stale_fleet_empty_filenames_skips_executor(tmp_path: Path
         await refresher.enqueue_stale_fleet()
 
     assert calls == []  # short-circuited before scheduling anything
-    assert refresher._pending == set()
+    assert refresher._worker.pending == set()
 
 
 # ----------------------------------------------------------------------
@@ -399,7 +399,7 @@ async def test_stop_logs_unexpected_worker_exception(tmp_path: Path, caplog: Any
     The worker's outer ``while True:`` doesn't catch errors raised
     *outside* the per-iteration ``try`` (e.g. an executor that
     explodes before reaching the per-iteration handler). Those
-    propagate through ``await self._worker_task`` during ``stop``;
+    propagate through the wake worker's task await during ``stop``;
     we log so the failure isn't invisible during a clean
     shutdown.
     """
@@ -416,11 +416,13 @@ async def test_stop_logs_unexpected_worker_exception(tmp_path: Path, caplog: Any
             raise RuntimeError("worker exploded") from None
 
     caplog.set_level(logging.ERROR)
-    with patch.object(BuildSizeRefresher, "_worker", _failing_worker):
+    with patch.object(BuildSizeRefresher, "_run", _failing_worker):
         refresher.start()
         # Yield once so the worker actually starts awaiting; without
         # this, ``stop`` cancels before the task entered the try.
         await asyncio.sleep(0)
         await refresher.stop()
 
-    assert any("Build-size worker failed during shutdown" in r.message for r in caplog.records)
+    assert any(
+        "Worker BuildSizeRefresher failed during shutdown" in r.message for r in caplog.records
+    )

--- a/tests/controllers/test_build_size_refresher.py
+++ b/tests/controllers/test_build_size_refresher.py
@@ -84,8 +84,8 @@ async def test_request_adds_to_pending_set_and_wakes_event(tmp_path: Path) -> No
     refresher.request("kitchen.yaml")
     refresher.request("kitchen.yaml")  # dedupe
     refresher.request("bedroom.yaml")
-    assert refresher._worker.pending == {"kitchen.yaml", "bedroom.yaml"}
-    assert refresher._worker._wake.is_set()
+    assert refresher.pending == {"kitchen.yaml", "bedroom.yaml"}
+    assert refresher._wake.is_set()
 
 
 @pytest.mark.asyncio
@@ -93,9 +93,9 @@ async def test_start_is_idempotent(tmp_path: Path) -> None:
     """A second ``start`` while the worker is alive is a no-op."""
     refresher, _, _ = _make(tmp_path)
     refresher.start()
-    first_task = refresher._worker._task
+    first_task = refresher._task
     refresher.start()
-    assert refresher._worker._task is first_task
+    assert refresher._task is first_task
     await refresher.stop()
 
 
@@ -104,7 +104,7 @@ async def test_stop_with_no_running_worker_is_noop(tmp_path: Path) -> None:
     """``stop`` on a never-started refresher must not raise."""
     refresher, _, _ = _make(tmp_path)
     await refresher.stop()  # no exception
-    assert refresher._worker._task is None
+    assert refresher._task is None
 
 
 # ----------------------------------------------------------------------
@@ -140,7 +140,7 @@ async def test_worker_drains_pending_and_fires_on_refreshed(tmp_path: Path) -> N
         await refresher.stop()
 
     assert refreshed == ["kitchen.yaml"]
-    assert refresher._worker.pending == set()
+    assert refresher.pending == set()
 
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_enqueue_stale_fleet_pushes_divergent_filenames(tmp_path: Path) ->
     ):
         await refresher.enqueue_stale_fleet()
 
-    assert refresher._worker.pending == {"a.yaml", "c.yaml"}
+    assert refresher.pending == {"a.yaml", "c.yaml"}
 
 
 @pytest.mark.asyncio
@@ -330,7 +330,7 @@ async def test_enqueue_stale_fleet_empty_filenames_skips_executor(tmp_path: Path
         await refresher.enqueue_stale_fleet()
 
     assert calls == []  # short-circuited before scheduling anything
-    assert refresher._worker.pending == set()
+    assert refresher.pending == set()
 
 
 # ----------------------------------------------------------------------
@@ -416,7 +416,7 @@ async def test_stop_logs_unexpected_worker_exception(tmp_path: Path, caplog: Any
             raise RuntimeError("worker exploded") from None
 
     caplog.set_level(logging.ERROR)
-    with patch.object(BuildSizeRefresher, "_run", _failing_worker):
+    with patch.object(BuildSizeRefresher, "_run_loop", _failing_worker):
         refresher.start()
         # Yield once so the worker actually starts awaiting; without
         # this, ``stop`` cancels before the task entered the try.

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -21,12 +21,85 @@ async def test_request_populates_pending_and_sets_wake() -> None:
     assert worker._wake.is_set()
 
 
-async def test_wait_clears_event() -> None:
-    """``wait`` returns when the wake fires and leaves the event cleared."""
+async def test_drain_clears_wake_and_sets_idle_on_exit() -> None:
+    """``drain`` clears the wake on entry and idle-sets on exit when pending is empty."""
     worker: WakeWorker[str] = WakeWorker()
     worker.request("a")
-    await worker.wait()
-    assert not worker._wake.is_set()
+    async with worker.drain():
+        # Wake is cleared on entry.
+        assert not worker._wake.is_set()
+        # Drain body consumes pending (mirrors the owner's swap).
+        worker.pending.clear()
+    # Pending empty at exit → idle set.
+    assert worker._idle.is_set()
+
+
+async def test_wait_idle_blocks_until_drain_completes() -> None:
+    """``wait_idle`` parks until the run loop finishes draining the pending set."""
+    worker: WakeWorker[str] = WakeWorker()
+    drained: list[str] = []
+
+    async def _loop() -> None:
+        while True:
+            async with worker.drain():
+                drained.extend(worker.pending)
+                worker.pending.clear()
+
+    worker.start(_loop, name="t")
+    try:
+        worker.request("a")
+        worker.request("b")
+        await worker.wait_idle()
+    finally:
+        await worker.stop()
+    assert set(drained) == {"a", "b"}
+
+
+async def test_wait_idle_returns_after_stop() -> None:
+    """``stop`` unblocks any ``wait_idle`` parked through shutdown."""
+    worker: WakeWorker[str] = WakeWorker()
+
+    async def _wedged_loop() -> None:
+        # Park forever — wait_idle would otherwise hang because no
+        # drain ever fires. ``stop`` must still unblock it.
+        await asyncio.Event().wait()
+
+    worker.start(_wedged_loop, name="t")
+    worker.request("never-drained")
+    waiter = asyncio.create_task(worker.wait_idle())
+    await asyncio.sleep(0.01)
+    assert not waiter.done()
+    await worker.stop()
+    await asyncio.wait_for(waiter, timeout=1.0)
+
+
+async def test_wait_idle_stays_clear_if_request_lands_mid_drain() -> None:
+    """A request fired during drain keeps idle clear until that request is drained."""
+    worker: WakeWorker[str] = WakeWorker()
+    drained: list[str] = []
+    second_request_done = asyncio.Event()
+
+    async def _loop() -> None:
+        while True:
+            async with worker.drain():
+                items = list(worker.pending)
+                worker.pending.clear()
+                drained.extend(items)
+                # On the first cycle, simulate a concurrent request
+                # landing mid-drain by firing it before the context
+                # manager exits. ``wait_idle`` must not return until
+                # the second request is also drained.
+                if items == ["a"] and not second_request_done.is_set():
+                    worker.request("b")
+                    second_request_done.set()
+
+    worker.start(_loop, name="t")
+    try:
+        worker.request("a")
+        await worker.wait_idle()
+    finally:
+        await worker.stop()
+    assert drained == ["a", "b"]
 
 
 async def test_start_spawns_and_is_idempotent() -> None:

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -1,0 +1,86 @@
+"""Tests for the shared :class:`WakeWorker` primitive."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.controllers._wake_worker import WakeWorker
+
+
+async def test_request_populates_pending_and_sets_wake() -> None:
+    """``request`` is sync, idempotent, signals the wake."""
+    worker: WakeWorker[str] = WakeWorker()
+    worker.request("a")
+    worker.request("a")
+    worker.request("b")
+    assert worker.pending == {"a", "b"}
+    assert worker._wake.is_set()
+
+
+async def test_wait_clears_event() -> None:
+    """``wait`` returns when the wake fires and leaves the event cleared."""
+    worker: WakeWorker[str] = WakeWorker()
+    worker.request("a")
+    await worker.wait()
+    assert not worker._wake.is_set()
+
+
+async def test_start_spawns_and_is_idempotent() -> None:
+    """``start`` is idempotent — second call returns the existing task."""
+    worker: WakeWorker[str] = WakeWorker()
+    parked = asyncio.Event()
+
+    async def _loop() -> None:
+        parked.set()
+        await asyncio.Event().wait()
+
+    worker.start(_loop, name="t")
+    first = worker._task
+    await parked.wait()
+    worker.start(_loop)
+    assert worker._task is first
+    await worker.stop()
+
+
+async def test_stop_cancels_and_clears_task() -> None:
+    """``stop`` cancels, awaits, and clears the task reference."""
+    worker: WakeWorker[str] = WakeWorker()
+
+    async def _loop() -> None:
+        await asyncio.Event().wait()
+
+    worker.start(_loop)
+    assert worker._task is not None
+    await worker.stop()
+    assert worker._task is None
+    await worker.stop()  # idempotent
+
+
+async def test_stop_with_no_running_worker_is_noop() -> None:
+    """``stop`` on a never-started worker returns cleanly."""
+    worker: WakeWorker[str] = WakeWorker()
+    await worker.stop()
+    assert worker._task is None
+
+
+@pytest.mark.asyncio
+async def test_stop_logs_unexpected_exception(caplog: Any) -> None:
+    """A non-cancel exception from the worker is logged during ``stop``."""
+    worker: WakeWorker[str] = WakeWorker()
+
+    async def _failing() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise RuntimeError("boom") from None
+
+    caplog.set_level(logging.ERROR)
+    worker.start(_failing, name="boomy")
+    await asyncio.sleep(0)
+    await worker.stop()
+
+    assert any("Worker boomy failed during shutdown" in r.message for r in caplog.records)

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -175,6 +175,82 @@ async def test_drain_exception_logged_and_loop_continues(
     assert any("drain raised" in r.message for r in caplog.records)
 
 
+async def test_drain_raising_with_items_pending_drains_remainder() -> None:
+    """``_drain`` raising mid-pending must not strand the unprocessed items.
+
+    Regression for the deadlock where ``_drain_cycle.__aexit__``
+    left ``_wake`` cleared and ``_idle`` cleared, parking the
+    next ``_wake.wait()`` forever and any ``wait_idle`` waiter.
+    """
+
+    class _MidPopFlaky(WakeWorker[str]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.processed: list[str] = []
+            self.raised_once = False
+
+        async def _drain(self) -> None:
+            # Pop-as-you-go pattern; raise on the first item
+            # while leaving the rest in pending.
+            item = self.pending.pop()
+            if not self.raised_once and item != "fine":
+                self.raised_once = True
+                raise RuntimeError("oops")
+            self.processed.append(item)
+
+    worker = _MidPopFlaky()
+    worker.start()
+    try:
+        worker.request("bad")
+        worker.request("fine")
+        await asyncio.wait_for(worker.wait_idle(), timeout=1.0)
+    finally:
+        await worker.stop()
+    # The "fine" item gets processed despite the earlier raise.
+    assert "fine" in worker.processed
+
+
+async def test_wait_idle_after_start_with_no_on_start_work() -> None:
+    """``wait_idle`` returns after ``start`` even if ``_on_start`` queued nothing."""
+
+    class _Quiet(WakeWorker[str]):
+        async def _drain(self) -> None:
+            self.pending.clear()
+
+    worker = _Quiet()
+    worker.start()
+    try:
+        # No request before wait_idle; _on_start did nothing.
+        # wait_idle must still return (the loop re-sets idle).
+        await asyncio.wait_for(worker.wait_idle(), timeout=1.0)
+    finally:
+        await worker.stop()
+
+
+async def test_wait_idle_after_start_waits_for_on_start_work() -> None:
+    """``wait_idle`` parks past ``_on_start`` queuing work via ``request``."""
+
+    class _SeedingStart(WakeWorker[str]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.processed: list[str] = []
+
+        async def _on_start(self) -> None:
+            self.request("seeded")
+
+        async def _drain(self) -> None:
+            self.processed.extend(sorted(self.pending))
+            self.pending.clear()
+
+    worker = _SeedingStart()
+    worker.start()
+    try:
+        await asyncio.wait_for(worker.wait_idle(), timeout=1.0)
+    finally:
+        await worker.stop()
+    assert worker.processed == ["seeded"]
+
+
 async def test_start_logs_and_replaces_crashed_task(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -35,6 +35,13 @@ class _WedgedWorker(WakeWorker[str]):
         await asyncio.Event().wait()
 
 
+async def test_default_drain_raises_not_implemented() -> None:
+    """The base ``_drain`` is abstract — calling it raises."""
+    worker: WakeWorker[str] = WakeWorker()
+    with pytest.raises(NotImplementedError):
+        await worker._drain()
+
+
 async def test_request_populates_pending_and_clears_idle() -> None:
     """``request`` is sync, deduplicates, clears idle, sets wake."""
     worker = _RecordingWorker()

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -1,4 +1,4 @@
-"""Tests for the shared :class:`WakeWorker` primitive."""
+"""Tests for the shared :class:`WakeWorker` base."""
 
 from __future__ import annotations
 
@@ -11,60 +11,95 @@ import pytest
 from esphome_device_builder.controllers._wake_worker import WakeWorker
 
 
-async def test_request_populates_pending_and_sets_wake() -> None:
-    """``request`` is sync, idempotent, signals the wake."""
-    worker: WakeWorker[str] = WakeWorker()
+class _RecordingWorker(WakeWorker[str]):
+    """Concrete worker that captures every drain into a list."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.drained: list[list[str]] = []
+        self.started = False
+
+    async def _on_start(self) -> None:
+        self.started = True
+
+    async def _drain(self) -> None:
+        items = sorted(self.pending)
+        self.pending.clear()
+        self.drained.append(items)
+
+
+class _WedgedWorker(WakeWorker[str]):
+    """Worker whose run loop never completes a drain."""
+
+    async def _drain(self) -> None:
+        # Hijack the entire loop so wait_idle would otherwise hang.
+        await asyncio.Event().wait()
+
+
+async def test_request_populates_pending_and_clears_idle() -> None:
+    """``request`` is sync, deduplicates, clears idle, sets wake."""
+    worker = _RecordingWorker()
     worker.request("a")
     worker.request("a")
     worker.request("b")
     assert worker.pending == {"a", "b"}
     assert worker._wake.is_set()
+    assert not worker._idle.is_set()
 
 
 async def test_drain_clears_wake_and_sets_idle_on_exit() -> None:
-    """``drain`` clears the wake on entry and idle-sets on exit when pending is empty."""
-    worker: WakeWorker[str] = WakeWorker()
+    """Drain context manager clears wake on entry, sets idle on empty-pending exit."""
+    worker = _RecordingWorker()
     worker.request("a")
-    async with worker.drain():
-        # Wake is cleared on entry.
+    async with worker._drain_cycle():
         assert not worker._wake.is_set()
-        # Drain body consumes pending (mirrors the owner's swap).
         worker.pending.clear()
-    # Pending empty at exit → idle set.
     assert worker._idle.is_set()
 
 
 async def test_wait_idle_blocks_until_drain_completes() -> None:
-    """``wait_idle`` parks until the run loop finishes draining the pending set."""
-    worker: WakeWorker[str] = WakeWorker()
-    drained: list[str] = []
-
-    async def _loop() -> None:
-        while True:
-            async with worker.drain():
-                drained.extend(worker.pending)
-                worker.pending.clear()
-
-    worker.start(_loop, name="t")
+    """``wait_idle`` returns only after the drain processes every request."""
+    worker = _RecordingWorker()
+    worker.start()
     try:
         worker.request("a")
         worker.request("b")
         await worker.wait_idle()
     finally:
         await worker.stop()
-    assert set(drained) == {"a", "b"}
+    assert worker.drained == [["a", "b"]]
+    assert worker.started
+
+
+async def test_wait_idle_stays_clear_if_request_lands_mid_drain() -> None:
+    """Mid-drain request keeps idle clear; both items end up drained."""
+
+    class _ChainingWorker(WakeWorker[str]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.drained: list[list[str]] = []
+
+        async def _drain(self) -> None:
+            items = sorted(self.pending)
+            self.pending.clear()
+            self.drained.append(items)
+            if items == ["a"]:
+                self.request("b")
+
+    worker = _ChainingWorker()
+    worker.start()
+    try:
+        worker.request("a")
+        await worker.wait_idle()
+    finally:
+        await worker.stop()
+    assert worker.drained == [["a"], ["b"]]
 
 
 async def test_wait_idle_returns_after_stop() -> None:
     """``stop`` unblocks any ``wait_idle`` parked through shutdown."""
-    worker: WakeWorker[str] = WakeWorker()
-
-    async def _wedged_loop() -> None:
-        # Park forever — wait_idle would otherwise hang because no
-        # drain ever fires. ``stop`` must still unblock it.
-        await asyncio.Event().wait()
-
-    worker.start(_wedged_loop, name="t")
+    worker = _WedgedWorker()
+    worker.start()
     worker.request("never-drained")
     waiter = asyncio.create_task(worker.wait_idle())
     await asyncio.sleep(0.01)
@@ -73,60 +108,22 @@ async def test_wait_idle_returns_after_stop() -> None:
     await asyncio.wait_for(waiter, timeout=1.0)
 
 
-async def test_wait_idle_stays_clear_if_request_lands_mid_drain() -> None:
-    """A request fired during drain keeps idle clear until that request is drained."""
-    worker: WakeWorker[str] = WakeWorker()
-    drained: list[str] = []
-    second_request_done = asyncio.Event()
-
-    async def _loop() -> None:
-        while True:
-            async with worker.drain():
-                items = list(worker.pending)
-                worker.pending.clear()
-                drained.extend(items)
-                # On the first cycle, simulate a concurrent request
-                # landing mid-drain by firing it before the context
-                # manager exits. ``wait_idle`` must not return until
-                # the second request is also drained.
-                if items == ["a"] and not second_request_done.is_set():
-                    worker.request("b")
-                    second_request_done.set()
-
-    worker.start(_loop, name="t")
+async def test_start_is_idempotent() -> None:
+    """A second ``start`` while the worker is alive is a no-op."""
+    worker = _RecordingWorker()
+    worker.start()
+    first = worker._task
     try:
-        worker.request("a")
-        await worker.wait_idle()
+        worker.start()
+        assert worker._task is first
     finally:
         await worker.stop()
-    assert drained == ["a", "b"]
-
-
-async def test_start_spawns_and_is_idempotent() -> None:
-    """``start`` is idempotent — second call returns the existing task."""
-    worker: WakeWorker[str] = WakeWorker()
-    parked = asyncio.Event()
-
-    async def _loop() -> None:
-        parked.set()
-        await asyncio.Event().wait()
-
-    worker.start(_loop, name="t")
-    first = worker._task
-    await parked.wait()
-    worker.start(_loop)
-    assert worker._task is first
-    await worker.stop()
 
 
 async def test_stop_cancels_and_clears_task() -> None:
-    """``stop`` cancels, awaits, and clears the task reference."""
-    worker: WakeWorker[str] = WakeWorker()
-
-    async def _loop() -> None:
-        await asyncio.Event().wait()
-
-    worker.start(_loop)
+    """``stop`` cancels, awaits, clears the task; idempotent."""
+    worker = _RecordingWorker()
+    worker.start()
     assert worker._task is not None
     await worker.stop()
     assert worker._task is None
@@ -135,7 +132,7 @@ async def test_stop_cancels_and_clears_task() -> None:
 
 async def test_stop_with_no_running_worker_is_noop() -> None:
     """``stop`` on a never-started worker returns cleanly."""
-    worker: WakeWorker[str] = WakeWorker()
+    worker = _RecordingWorker()
     await worker.stop()
     assert worker._task is None
 
@@ -143,17 +140,25 @@ async def test_stop_with_no_running_worker_is_noop() -> None:
 @pytest.mark.asyncio
 async def test_stop_logs_unexpected_exception(caplog: Any) -> None:
     """A non-cancel exception from the worker is logged during ``stop``."""
-    worker: WakeWorker[str] = WakeWorker()
+    entered_drain = asyncio.Event()
 
-    async def _failing() -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            raise RuntimeError("boom") from None
+    class _Exploding(WakeWorker[str]):
+        async def _drain(self) -> None:
+            entered_drain.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise RuntimeError("boom") from None
 
     caplog.set_level(logging.ERROR)
-    worker.start(_failing, name="boomy")
-    await asyncio.sleep(0)
+    worker = _Exploding()
+    worker.start()
+    # Request kicks the loop into _drain; without this the worker
+    # would be parked on _wake.wait and the cancellation wouldn't
+    # reach the RuntimeError branch inside _drain.
+    worker.request("x")
+    await entered_drain.wait()
     await worker.stop()
 
-    assert any("Worker boomy failed during shutdown" in r.message for r in caplog.records)
+    expected = f"Worker {_Exploding.__name__} failed during shutdown"
+    assert any(expected in r.message for r in caplog.records)

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
 
 import pytest
 
@@ -137,14 +136,75 @@ async def test_stop_with_no_running_worker_is_noop() -> None:
     assert worker._task is None
 
 
-@pytest.mark.asyncio
-async def test_stop_logs_unexpected_exception(caplog: Any) -> None:
-    """A non-cancel exception from the worker is logged during ``stop``."""
-    entered_drain = asyncio.Event()
+async def test_drain_exception_logged_and_loop_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unexpected raise from ``_drain`` is logged; the loop keeps draining."""
+
+    class _FlakyDrain(WakeWorker[str]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        async def _drain(self) -> None:
+            self.calls += 1
+            items = sorted(self.pending)
+            self.pending.clear()
+            if items == ["bad"]:
+                raise RuntimeError("oops")
+
+    caplog.set_level(logging.ERROR)
+    worker = _FlakyDrain()
+    worker.start()
+    try:
+        worker.request("bad")
+        await worker.wait_idle()
+        worker.request("good")
+        await worker.wait_idle()
+    finally:
+        await worker.stop()
+
+    assert worker.calls == 2
+    assert any("drain raised" in r.message for r in caplog.records)
+
+
+async def test_start_logs_and_replaces_crashed_task(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A second ``start`` after a crash logs the prior exception and restarts."""
+
+    class _Crashy(WakeWorker[str]):
+        # Override _run_loop directly so the crash bypasses the
+        # base's per-drain guard and the task ends with an
+        # exception that ``start`` has to deal with.
+        async def _run_loop(self) -> None:
+            raise RuntimeError("ka-boom")
+
+    caplog.set_level(logging.ERROR)
+    worker = _Crashy()
+    worker.start()
+    first = worker._task
+    # Let the task run and die.
+    for _ in range(5):
+        if first is not None and first.done():
+            break
+        await asyncio.sleep(0)
+    assert first is not None and first.done()
+    # Re-starting should retrieve the prior exception and spawn a fresh task.
+    worker.start()
+    assert worker._task is not first
+    await worker.stop()
+    assert any("crashed; restarting" in r.message for r in caplog.records)
+
+
+async def test_stop_logs_unexpected_exception(caplog: pytest.LogCaptureFixture) -> None:
+    """A non-cancel exception escaping ``_run_loop`` is logged during ``stop``."""
 
     class _Exploding(WakeWorker[str]):
-        async def _drain(self) -> None:
-            entered_drain.set()
+        # Override _run_loop so the raise bypasses the base's per-drain
+        # guard and the task ends with an exception that ``stop`` has
+        # to retrieve.
+        async def _run_loop(self) -> None:
             try:
                 await asyncio.Event().wait()
             except asyncio.CancelledError:
@@ -153,11 +213,7 @@ async def test_stop_logs_unexpected_exception(caplog: Any) -> None:
     caplog.set_level(logging.ERROR)
     worker = _Exploding()
     worker.start()
-    # Request kicks the loop into _drain; without this the worker
-    # would be parked on _wake.wait and the cancellation wouldn't
-    # reach the RuntimeError branch inside _drain.
-    worker.request("x")
-    await entered_drain.wait()
+    await asyncio.sleep(0)
     await worker.stop()
 
     expected = f"Worker {_Exploding.__name__} failed during shutdown"

--- a/tests/controllers/test_wake_worker.py
+++ b/tests/controllers/test_wake_worker.py
@@ -175,6 +175,35 @@ async def test_drain_exception_logged_and_loop_continues(
     assert any("drain raised" in r.message for r in caplog.records)
 
 
+async def test_on_start_exception_logged_and_loop_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An exception escaping ``_on_start`` is logged; the drain loop still runs."""
+
+    class _FlakyStart(WakeWorker[str]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.processed: list[str] = []
+
+        async def _on_start(self) -> None:
+            raise RuntimeError("on_start oops")
+
+        async def _drain(self) -> None:
+            self.processed.extend(sorted(self.pending))
+            self.pending.clear()
+
+    caplog.set_level(logging.ERROR)
+    worker = _FlakyStart()
+    worker.start()
+    try:
+        worker.request("after-broken-start")
+        await asyncio.wait_for(worker.wait_idle(), timeout=1.0)
+    finally:
+        await worker.stop()
+    assert worker.processed == ["after-broken-start"]
+    assert any("_on_start raised" in r.message for r in caplog.records)
+
+
 async def test_drain_raising_with_items_pending_drains_remainder() -> None:
     """``_drain`` raising mid-pending must not strand the unprocessed items.
 

--- a/tests/test_device_scanner_request.py
+++ b/tests/test_device_scanner_request.py
@@ -16,8 +16,6 @@ ordering / failure-mode coverage lives in
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -54,17 +52,6 @@ def _stub_load(path: Path, *_a: Any, **_kw: Any) -> Device:
     return Device(name=path.stem, friendly_name=path.stem, configuration=path.name)
 
 
-async def _wait_for(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
-    """Spin the loop until *predicate* returns True or *timeout* expires."""
-    deadline = asyncio.get_running_loop().time() + timeout
-    while asyncio.get_running_loop().time() < deadline:
-        if predicate():
-            return
-        await asyncio.sleep(0.005)
-    msg = "predicate did not become true within timeout"
-    raise AssertionError(msg)
-
-
 async def test_request_drains_one_file(tmp_path: Path) -> None:
     """``request()`` + a worker tick reloads the named file and fires UPDATED."""
     cfg = tmp_path / "configs"
@@ -80,7 +67,7 @@ async def test_request_drains_one_file(tmp_path: Path) -> None:
         scanner.start()
         try:
             scanner.request("kitchen.yaml")
-            await _wait_for(lambda: bool(events))
+            await scanner._worker.wait_idle()
         finally:
             await scanner.stop()
 
@@ -92,8 +79,8 @@ async def test_request_coalesces_duplicate_filenames(tmp_path: Path) -> None:
 
     A tight save-loop (the editor's keystroke-driven autosave is
     one realistic shape) must not pile up N reloads on the
-    worker. The set semantics of :attr:`_pending` carry this; pin
-    it so a refactor to a list / queue would surface.
+    worker. The set semantics of pending carry this; pin it so a
+    refactor to a list / queue would surface.
     """
     cfg = tmp_path / "configs"
     cfg.mkdir()
@@ -122,11 +109,7 @@ async def test_request_coalesces_duplicate_filenames(tmp_path: Path) -> None:
         scanner.request("kitchen.yaml")
         scanner.start()
         try:
-            await _wait_for(lambda: bool(reload_calls))
-            # Give the loop a chance to expose a duplicate reload
-            # if the coalesce property regressed.
-            for _ in range(5):
-                await asyncio.sleep(0.005)
+            await scanner._worker.wait_idle()
         finally:
             await scanner.stop()
 
@@ -155,7 +138,7 @@ async def test_request_before_start_drains_on_start(tmp_path: Path) -> None:
         scanner.request("kitchen.yaml")
         scanner.start()
         try:
-            await _wait_for(lambda: bool(events))
+            await scanner._worker.wait_idle()
         finally:
             await scanner.stop()
 
@@ -216,9 +199,9 @@ async def test_worker_survives_failing_reload(tmp_path: Path) -> None:
         scanner.start()
         try:
             scanner.request("kitchen.yaml")
-            await _wait_for(lambda: "kitchen.yaml" in reloaded)
+            await scanner._worker.wait_idle()
             scanner.request("bedroom.yaml")
-            await _wait_for(lambda: "bedroom.yaml" in reloaded)
+            await scanner._worker.wait_idle()
         finally:
             await scanner.stop()
 

--- a/tests/test_device_scanner_request.py
+++ b/tests/test_device_scanner_request.py
@@ -1,0 +1,221 @@
+"""
+Wake-driven reload worker tests for ``DeviceScanner``.
+
+The worker peels write-after-edit reloads off the WS hot path:
+:meth:`DeviceScanner.request` is the entry point for in-process
+mutators (``update_config`` / ``add_component`` / friendly-name
+edit). Callers fire-and-forget, the worker drains the pending
+set under :attr:`_lock`, and DEVICE_UPDATED reaches subscribers
+via the existing on_change pipeline.
+
+These tests pin the worker's contract — the broader scan
+ordering / failure-mode coverage lives in
+``test_device_scanner_branches.py`` and
+``test_device_scanner_order.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from esphome_device_builder.controllers._device_scanner import (
+    DeviceFileMetadata,
+    DeviceScanner,
+    ScanChange,
+)
+from esphome_device_builder.models import Device
+
+
+def _stub_metadata(_config_dir: Path, _filename: str) -> DeviceFileMetadata:
+    return DeviceFileMetadata(board_id="", ip="", expected_config_hash="")
+
+
+def _make_scanner(config_dir: Path) -> tuple[DeviceScanner, list[tuple[ScanChange, Device]]]:
+    events: list[tuple[ScanChange, Device]] = []
+    scanner = DeviceScanner(
+        config_dir=config_dir,
+        get_metadata=_stub_metadata,
+        on_change=lambda kind, device: events.append((kind, device)),
+    )
+    return scanner, events
+
+
+def _write_yaml(config_dir: Path, name: str) -> Path:
+    path = config_dir / f"{name}.yaml"
+    path.write_text(f"esphome:\n  name: {name}\n", encoding="utf-8")
+    return path
+
+
+def _stub_load(path: Path, *_a: Any, **_kw: Any) -> Device:
+    return Device(name=path.stem, friendly_name=path.stem, configuration=path.name)
+
+
+async def _drain(scanner: DeviceScanner) -> None:
+    """Spin the loop until the worker is parked again."""
+    for _ in range(50):
+        worker = scanner._worker
+        if not worker.pending and not worker._wake.is_set() and not scanner._lock.locked():
+            return
+        await asyncio.sleep(0)
+
+
+async def test_request_drains_one_file(tmp_path: Path) -> None:
+    """``request()`` + a worker tick reloads the named file and fires UPDATED."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=_stub_load,
+    ):
+        scanner, events = _make_scanner(cfg)
+        await scanner.scan()  # initial load so reload() can find the path
+        events.clear()
+        scanner.start()
+        try:
+            scanner.request("kitchen.yaml")
+            await _drain(scanner)
+        finally:
+            await scanner.stop()
+
+    assert [(kind, dev.name) for kind, dev in events] == [(ScanChange.UPDATED, "kitchen")]
+
+
+async def test_request_coalesces_duplicate_filenames(tmp_path: Path) -> None:
+    """Repeated requests for one file produce a single reload per wake.
+
+    A tight save-loop (the editor's keystroke-driven autosave is
+    one realistic shape) must not pile up N reloads on the
+    worker. The set semantics of :attr:`_pending` carry this; pin
+    it so a refactor to a list / queue would surface.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+
+    reload_calls: list[str] = []
+    real_reload = DeviceScanner.reload
+
+    async def _record(self: DeviceScanner, filename: str) -> bool:
+        reload_calls.append(filename)
+        return await real_reload(self, filename)
+
+    with (
+        patch(
+            "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+            side_effect=_stub_load,
+        ),
+        patch.object(DeviceScanner, "reload", _record),
+    ):
+        scanner, _ = _make_scanner(cfg)
+        await scanner.scan()
+        # Stage three requests before the worker starts so they
+        # all land in the same drain (set collapse, not race).
+        scanner.request("kitchen.yaml")
+        scanner.request("kitchen.yaml")
+        scanner.request("kitchen.yaml")
+        scanner.start()
+        try:
+            await _drain(scanner)
+        finally:
+            await scanner.stop()
+
+    assert reload_calls == ["kitchen.yaml"]
+
+
+async def test_request_before_start_drains_on_start(tmp_path: Path) -> None:
+    """A request fired before :meth:`start` waits in pending; the worker drains it.
+
+    The save handler can run before the controller's ``start()``
+    has spawned the worker (e.g. a test that creates the
+    controller and hits a WS command without calling
+    ``controller.start()`` first). Pending must survive across
+    the start boundary so no save is dropped.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=_stub_load,
+    ):
+        scanner, events = _make_scanner(cfg)
+        await scanner.scan()
+        events.clear()
+        scanner.request("kitchen.yaml")
+        scanner.start()
+        try:
+            await _drain(scanner)
+        finally:
+            await scanner.stop()
+
+    assert [(kind, dev.name) for kind, dev in events] == [(ScanChange.UPDATED, "kitchen")]
+
+
+async def test_start_is_idempotent(tmp_path: Path) -> None:
+    """Two ``start()`` calls don't double-spawn the worker."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    scanner, _ = _make_scanner(cfg)
+    scanner.start()
+    first_task = scanner._worker._task
+    try:
+        scanner.start()
+        assert scanner._worker._task is first_task
+    finally:
+        await scanner.stop()
+
+
+async def test_stop_cancels_idle_worker(tmp_path: Path) -> None:
+    """``stop()`` cancels and awaits the worker even when it's parked on wake."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    scanner, _ = _make_scanner(cfg)
+    scanner.start()
+    task = scanner._worker._task
+    assert task is not None
+    await scanner.stop()
+    assert task.done()
+    # Idempotent — a second stop call is a no-op.
+    await scanner.stop()
+
+
+async def test_worker_survives_failing_reload(tmp_path: Path) -> None:
+    """A reload that raises is logged and the worker continues on the next wake.
+
+    Real-world trigger: a YAML disappears between the save and
+    the worker's drain (concurrent delete, atomic-save mid-edit
+    where the temp file moved away). The save's request shouldn't
+    poison the worker for the next save.
+    """
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+    _write_yaml(cfg, "bedroom")
+
+    boom_count = 0
+
+    async def _boomy_reload(self: DeviceScanner, filename: str) -> bool:
+        nonlocal boom_count
+        if filename == "kitchen.yaml":
+            boom_count += 1
+            raise RuntimeError("simulated reload failure")
+        # bedroom path: just record without doing real work.
+        return True
+
+    with patch.object(DeviceScanner, "reload", _boomy_reload):
+        scanner, _ = _make_scanner(cfg)
+        scanner.start()
+        try:
+            scanner.request("kitchen.yaml")
+            await _drain(scanner)
+            scanner.request("bedroom.yaml")
+            await _drain(scanner)
+        finally:
+            await scanner.stop()
+
+    # Failing reload ran once and the worker survived to handle bedroom.
+    assert boom_count == 1

--- a/tests/test_device_scanner_request.py
+++ b/tests/test_device_scanner_request.py
@@ -67,7 +67,7 @@ async def test_request_drains_one_file(tmp_path: Path) -> None:
         scanner.start()
         try:
             scanner.request("kitchen.yaml")
-            await scanner._worker.wait_idle()
+            await scanner.wait_idle()
         finally:
             await scanner.stop()
 
@@ -109,7 +109,7 @@ async def test_request_coalesces_duplicate_filenames(tmp_path: Path) -> None:
         scanner.request("kitchen.yaml")
         scanner.start()
         try:
-            await scanner._worker.wait_idle()
+            await scanner.wait_idle()
         finally:
             await scanner.stop()
 
@@ -138,7 +138,7 @@ async def test_request_before_start_drains_on_start(tmp_path: Path) -> None:
         scanner.request("kitchen.yaml")
         scanner.start()
         try:
-            await scanner._worker.wait_idle()
+            await scanner.wait_idle()
         finally:
             await scanner.stop()
 
@@ -151,10 +151,10 @@ async def test_start_is_idempotent(tmp_path: Path) -> None:
     cfg.mkdir()
     scanner, _ = _make_scanner(cfg)
     scanner.start()
-    first_task = scanner._worker._task
+    first_task = scanner._task
     try:
         scanner.start()
-        assert scanner._worker._task is first_task
+        assert scanner._task is first_task
     finally:
         await scanner.stop()
 
@@ -165,7 +165,7 @@ async def test_stop_cancels_idle_worker(tmp_path: Path) -> None:
     cfg.mkdir()
     scanner, _ = _make_scanner(cfg)
     scanner.start()
-    task = scanner._worker._task
+    task = scanner._task
     assert task is not None
     await scanner.stop()
     assert task.done()
@@ -199,9 +199,9 @@ async def test_worker_survives_failing_reload(tmp_path: Path) -> None:
         scanner.start()
         try:
             scanner.request("kitchen.yaml")
-            await scanner._worker.wait_idle()
+            await scanner.wait_idle()
             scanner.request("bedroom.yaml")
-            await scanner._worker.wait_idle()
+            await scanner.wait_idle()
         finally:
             await scanner.stop()
 

--- a/tests/test_device_scanner_request.py
+++ b/tests/test_device_scanner_request.py
@@ -17,6 +17,7 @@ ordering / failure-mode coverage lives in
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -53,13 +54,15 @@ def _stub_load(path: Path, *_a: Any, **_kw: Any) -> Device:
     return Device(name=path.stem, friendly_name=path.stem, configuration=path.name)
 
 
-async def _drain(scanner: DeviceScanner) -> None:
-    """Spin the loop until the worker is parked again."""
-    for _ in range(50):
-        worker = scanner._worker
-        if not worker.pending and not worker._wake.is_set() and not scanner._lock.locked():
+async def _wait_for(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
+    """Spin the loop until *predicate* returns True or *timeout* expires."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
             return
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.005)
+    msg = "predicate did not become true within timeout"
+    raise AssertionError(msg)
 
 
 async def test_request_drains_one_file(tmp_path: Path) -> None:
@@ -77,7 +80,7 @@ async def test_request_drains_one_file(tmp_path: Path) -> None:
         scanner.start()
         try:
             scanner.request("kitchen.yaml")
-            await _drain(scanner)
+            await _wait_for(lambda: bool(events))
         finally:
             await scanner.stop()
 
@@ -119,7 +122,11 @@ async def test_request_coalesces_duplicate_filenames(tmp_path: Path) -> None:
         scanner.request("kitchen.yaml")
         scanner.start()
         try:
-            await _drain(scanner)
+            await _wait_for(lambda: bool(reload_calls))
+            # Give the loop a chance to expose a duplicate reload
+            # if the coalesce property regressed.
+            for _ in range(5):
+                await asyncio.sleep(0.005)
         finally:
             await scanner.stop()
 
@@ -148,7 +155,7 @@ async def test_request_before_start_drains_on_start(tmp_path: Path) -> None:
         scanner.request("kitchen.yaml")
         scanner.start()
         try:
-            await _drain(scanner)
+            await _wait_for(lambda: bool(events))
         finally:
             await scanner.stop()
 
@@ -196,14 +203,12 @@ async def test_worker_survives_failing_reload(tmp_path: Path) -> None:
     _write_yaml(cfg, "kitchen")
     _write_yaml(cfg, "bedroom")
 
-    boom_count = 0
+    reloaded: list[str] = []
 
     async def _boomy_reload(self: DeviceScanner, filename: str) -> bool:
-        nonlocal boom_count
+        reloaded.append(filename)
         if filename == "kitchen.yaml":
-            boom_count += 1
             raise RuntimeError("simulated reload failure")
-        # bedroom path: just record without doing real work.
         return True
 
     with patch.object(DeviceScanner, "reload", _boomy_reload):
@@ -211,11 +216,11 @@ async def test_worker_survives_failing_reload(tmp_path: Path) -> None:
         scanner.start()
         try:
             scanner.request("kitchen.yaml")
-            await _drain(scanner)
+            await _wait_for(lambda: "kitchen.yaml" in reloaded)
             scanner.request("bedroom.yaml")
-            await _drain(scanner)
+            await _wait_for(lambda: "bedroom.yaml" in reloaded)
         finally:
             await scanner.stop()
 
     # Failing reload ran once and the worker survived to handle bedroom.
-    assert boom_count == 1
+    assert reloaded == ["kitchen.yaml", "bedroom.yaml"]


### PR DESCRIPTION
# What does this implement/fix?

`devices/update_config` (the YAML editor's Save button) previously
awaited a full `scanner.scan()` on the WS hot path. For
~700-line configs, especially ones with `!include` / `packages:`,
the ESPHome YAML resolve inside `load_device_yaml` is hundreds of
ms of CPU on the worker thread, and the save-confirmation popup
waits for the whole round trip. (Reported in Discord by
MasterOfNone.)

This PR moves the post-save reload off the WS reply:

1. `DeviceScanner` gains a wake-driven background reload worker
   built on a new `WakeWorker[T]` primitive at
   `controllers/_wake_worker.py`. The worker drains a pending
   filename set when its `asyncio.Event` is set; reloads run
   under the existing scanner lock and fire `DEVICE_UPDATED` via
   the on-change pipeline.
2. `_persist_yaml_mutation` switches from `await scanner.scan()`
   to `scanner.request(configuration)`. The save reply acks on
   the atomic disk write alone, and the device row refresh
   reaches subscribed clients moments later via the existing
   event bus.
3. `BuildSizeRefresher` already had the same
   pending-set + wake-event + start/stop shape inlined; it now
   shares the new `WakeWorker` primitive too. Behaviour
   preserved (drain still uses `pop()`-style for the
   mid-walk-request semantics the original called out).

Drift-detection callers (`list_devices`, `start`, `delete`,
`archive`, `unarchive`, `create`, `clone`, the REST shim's
`poll()`) keep `await scanner.scan()`; they need the post-scan
view in their response. The scanner's internal lock serialises
them against the worker so semantics are preserved.

**Related issue or feature (if applicable):**

- fixes <none, Slack report from MasterOfNone, 2026-05-15>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

The wire shape of `devices/update_config` is unchanged; it still
returns `None`. The frontend already receives the post-save
device-row refresh via the existing `device_updated` event, so
the "save, then see the device update" UX continues to work; it
just arrives a fraction of a second after the popup instead of
being blocked behind the reload.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
