### PR TITLE
Cache editor/validate_yaml results per session content hash

### DIFF
--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -32,7 +32,9 @@ _VALIDATE_TIMEOUT = 30.0
 # content (typing-stops → linter at 600 ms → user clicks save).
 # Cache covers that hand-off; longer would risk staleness for
 # ``!include`` / ``external_components`` files mutated outside
-# the editor.
+# the editor. ``fnv1a_32`` keys the cache (non-cryptographic;
+# collision risk negligible for the ≤dozens of buffers an editor
+# session sees inside one TTL window).
 _VALIDATE_CACHE_TTL = 60.0
 
 
@@ -41,7 +43,7 @@ class _CachedValidation:
     """Snapshot of a validate_yaml result, with the inputs needed to reuse it."""
 
     content_hash: int
-    result: dict
+    result: dict[str, Any]
     at: float
 
     def is_fresh_for(self, content_hash: int) -> bool:

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -208,9 +208,8 @@ class EditorController:
         ``{start_line, start_col, end_line, end_col}`` (0-indexed).
 
         Results are cached per session by content hash for
-        ``_VALIDATE_CACHE_TTL`` seconds — the linter and the
-        save-time re-validate hit the same content back-to-back,
-        and ESPHome's full schema run is the dominant cost.
+        ``_VALIDATE_CACHE_TTL`` seconds; the linter and the
+        save-time re-validate hit the same content back-to-back.
         """
         session = self._sessions.setdefault(
             configuration, _EditorSession(configuration=configuration)

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from fnv_hash_fast import fnv1a_32
 
 from ..helpers.api import api_command
 from ..helpers.json import JSONDecodeError, dumps, loads
@@ -25,15 +28,35 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 _STARTUP_TIMEOUT = 15.0
 _VALIDATE_TIMEOUT = 30.0
+# Linter and save both call ``validate_yaml`` on identical
+# content (typing-stops → linter at 600 ms → user clicks save).
+# Cache covers that hand-off; longer would risk staleness for
+# ``!include`` / ``external_components`` files mutated outside
+# the editor.
+_VALIDATE_CACHE_TTL = 60.0
 
 
 @dataclass
 class _EditorSession:
-    """Per-configuration validator state: one warm subprocess plus a serialization lock."""
+    """Per-configuration validator state: warm subprocess, lock, and result cache."""
 
     configuration: str
     proc: asyncio.subprocess.Process | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    cached_hash: int = 0
+    cached_result: dict | None = None
+    cached_at: float = 0.0
+
+
+def _cached_result(session: _EditorSession, content_hash: int) -> dict | None:
+    """Return the cached result if it matches *content_hash* and is fresh."""
+    if (
+        session.cached_result is not None
+        and session.cached_hash == content_hash
+        and time.monotonic() - session.cached_at < _VALIDATE_CACHE_TTL
+    ):
+        return session.cached_result
+    return None
 
 
 class EditorController:
@@ -180,13 +203,29 @@ class EditorController:
         the same shape upstream ``vscode.py`` produces. Each error has a
         ``message`` and (for validation errors) a ``range`` with
         ``{start_line, start_col, end_line, end_col}`` (0-indexed).
+
+        Results are cached per session by content hash for
+        ``_VALIDATE_CACHE_TTL`` seconds — the linter and the
+        save-time re-validate hit the same content back-to-back,
+        and ESPHome's full schema run is the dominant cost.
         """
         session = self._sessions.setdefault(
             configuration, _EditorSession(configuration=configuration)
         )
+        content_hash = fnv1a_32(content.encode("utf-8"))
+        # Fast path: avoid the lock when the previous result is
+        # still fresh for the same content.
+        cached = _cached_result(session, content_hash)
+        if cached is not None:
+            return cached
         async with session.lock:
+            # Re-check under the lock so a concurrent linter+save
+            # for the same content only spawns one subprocess pass.
+            cached = _cached_result(session, content_hash)
+            if cached is not None:
+                return cached
             try:
-                return await asyncio.wait_for(
+                result = await asyncio.wait_for(
                     self._validate_locked(session, configuration, content),
                     timeout=_VALIDATE_TIMEOUT,
                 )
@@ -194,6 +233,10 @@ class EditorController:
                 # Subprocess wedged or died — kill it so the next call respawns.
                 await self._terminate_subprocess(session)
                 raise
+            session.cached_hash = content_hash
+            session.cached_result = result
+            session.cached_at = time.monotonic()
+            return result
 
     async def _validate_locked(
         self, session: _EditorSession, configuration: str, content: str

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -37,26 +37,27 @@ _VALIDATE_CACHE_TTL = 60.0
 
 
 @dataclass
+class _CachedValidation:
+    """Snapshot of a validate_yaml result, with the inputs needed to reuse it."""
+
+    content_hash: int
+    result: dict
+    at: float
+
+    def is_fresh_for(self, content_hash: int) -> bool:
+        return (
+            self.content_hash == content_hash and time.monotonic() - self.at < _VALIDATE_CACHE_TTL
+        )
+
+
+@dataclass
 class _EditorSession:
     """Per-configuration validator state: warm subprocess, lock, and result cache."""
 
     configuration: str
     proc: asyncio.subprocess.Process | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    cached_hash: int = 0
-    cached_result: dict | None = None
-    cached_at: float = 0.0
-
-
-def _cached_result(session: _EditorSession, content_hash: int) -> dict | None:
-    """Return the cached result if it matches *content_hash* and is fresh."""
-    if (
-        session.cached_result is not None
-        and session.cached_hash == content_hash
-        and time.monotonic() - session.cached_at < _VALIDATE_CACHE_TTL
-    ):
-        return session.cached_result
-    return None
+    cached: _CachedValidation | None = None
 
 
 class EditorController:
@@ -215,15 +216,15 @@ class EditorController:
         content_hash = fnv1a_32(content.encode("utf-8"))
         # Fast path: avoid the lock when the previous result is
         # still fresh for the same content.
-        cached = _cached_result(session, content_hash)
-        if cached is not None:
-            return cached
+        cached = session.cached
+        if cached is not None and cached.is_fresh_for(content_hash):
+            return cached.result
         async with session.lock:
             # Re-check under the lock so a concurrent linter+save
             # for the same content only spawns one subprocess pass.
-            cached = _cached_result(session, content_hash)
-            if cached is not None:
-                return cached
+            cached = session.cached
+            if cached is not None and cached.is_fresh_for(content_hash):
+                return cached.result
             try:
                 result = await asyncio.wait_for(
                     self._validate_locked(session, configuration, content),
@@ -233,9 +234,9 @@ class EditorController:
                 # Subprocess wedged or died — kill it so the next call respawns.
                 await self._terminate_subprocess(session)
                 raise
-            session.cached_hash = content_hash
-            session.cached_result = result
-            session.cached_at = time.monotonic()
+            session.cached = _CachedValidation(
+                content_hash=content_hash, result=result, at=time.monotonic()
+            )
             return result
 
     async def _validate_locked(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
   "aiohttp-asyncmdnsresolver>=0.1.1",
   "colorlog>=6.8.0",
   "cryptography>=42.0.2",
+  # Cheap non-cryptographic hash for the editor's
+  # validate-result cache (content → cached subprocess result).
+  "fnv-hash-fast>=1.0.0",
   "ifaddr>=0.2.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -901,3 +901,47 @@ async def test_validate_yaml_cache_is_per_configuration(tmp_path: Path) -> None:
 
     assert len(calls) == 2
     assert {c[0] for c in calls} == {"kitchen.yaml", "bedroom.yaml"}
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_inner_lock_recheck_coalesces_concurrent_calls(
+    tmp_path: Path,
+) -> None:
+    """Two concurrent calls for identical content share a single subprocess pass.
+
+    Both reach the fast-path check before any cache entry exists,
+    miss, then race for ``session.lock``. The winner runs
+    ``_validate_locked`` and stores the result; the loser
+    re-checks under the lock and returns the cached entry without
+    a second subprocess pass.
+    """
+    controller = _make_controller(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def _slow_validate(_session: Any, _configuration: str, _content: str) -> dict:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _slow_validate  # type: ignore[method-assign]
+
+    first = asyncio.create_task(
+        controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+    )
+    # Wait for the first call to enter ``_validate_locked`` so the
+    # second call lands in the fast-path miss + lock-wait window.
+    await started.wait()
+    second = asyncio.create_task(
+        controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+    )
+    # Hand the second task a tick to reach the lock acquire.
+    await asyncio.sleep(0)
+    release.set()
+    results = await asyncio.gather(first, second)
+
+    assert calls == 1
+    assert results[0] == results[1] == {"yaml_errors": [], "validation_errors": []}

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -36,6 +36,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from esphome_device_builder.controllers import editor as editor_module
 from esphome_device_builder.controllers.editor import (
     EditorController,
     _EditorSession,
@@ -799,3 +800,104 @@ async def test_validate_yaml_terminates_session_on_runtime_error(
         await controller.validate_yaml(configuration="kitchen.yaml", content="")
 
     terminated.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# validate_yaml — content-hash cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_caches_result_for_repeated_content(tmp_path: Path) -> None:
+    """A second call with identical content returns the cached result.
+
+    The linter and the save-time re-validate hit the same buffer
+    back-to-back; the cache turns the second one into a no-op
+    instead of paying for another ``esphome vscode`` round-trip.
+    """
+    controller = _make_controller(tmp_path)
+    calls: list[str] = []
+
+    async def _record(session: Any, configuration: str, content: str) -> dict:
+        calls.append(content)
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _record  # type: ignore[method-assign]
+
+    first = await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+    second = await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+
+    assert first == second == {"yaml_errors": [], "validation_errors": []}
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_cache_misses_on_different_content(tmp_path: Path) -> None:
+    """Distinct content bypasses the cache and re-validates."""
+    controller = _make_controller(tmp_path)
+    calls: list[str] = []
+
+    async def _record(session: Any, configuration: str, content: str) -> dict:
+        calls.append(content)
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _record  # type: ignore[method-assign]
+
+    await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+    await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen-2\n"
+    )
+
+    assert calls == ["esphome:\n  name: kitchen\n", "esphome:\n  name: kitchen-2\n"]
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_cache_expires_after_ttl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cache TTL bounds staleness of ``!include`` / external-component reads."""
+    controller = _make_controller(tmp_path)
+    calls: list[str] = []
+
+    async def _record(session: Any, configuration: str, content: str) -> dict:
+        calls.append(content)
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _record  # type: ignore[method-assign]
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(editor_module.time, "monotonic", lambda: fake_now["t"])
+
+    await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+    fake_now["t"] += editor_module._VALIDATE_CACHE_TTL + 1
+    await controller.validate_yaml(
+        configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
+    )
+
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_validate_yaml_cache_is_per_configuration(tmp_path: Path) -> None:
+    """Same content under a different configuration doesn't share the cache."""
+    controller = _make_controller(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    async def _record(session: Any, configuration: str, content: str) -> dict:
+        calls.append((configuration, content))
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _record  # type: ignore[method-assign]
+
+    await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n  name: same\n")
+    await controller.validate_yaml(configuration="bedroom.yaml", content="esphome:\n  name: same\n")
+
+    assert len(calls) == 2
+    assert {c[0] for c in calls} == {"kitchen.yaml", "bedroom.yaml"}

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -907,14 +907,7 @@ async def test_validate_yaml_cache_is_per_configuration(tmp_path: Path) -> None:
 async def test_validate_yaml_inner_lock_recheck_coalesces_concurrent_calls(
     tmp_path: Path,
 ) -> None:
-    """Two concurrent calls for identical content share a single subprocess pass.
-
-    Both reach the fast-path check before any cache entry exists,
-    miss, then race for ``session.lock``. The winner runs
-    ``_validate_locked`` and stores the result; the loser
-    re-checks under the lock and returns the cached entry without
-    a second subprocess pass.
-    """
+    """Two concurrent calls for identical content share a single subprocess pass."""
     controller = _make_controller(tmp_path)
     started = asyncio.Event()
     release = asyncio.Event()


### PR DESCRIPTION
# What does this implement/fix?

The editor's CodeMirror linter and `_saveYaml` both call
`editor/validate_yaml` against the same buffer back-to-back: the
linter at typing-stop+600ms, the save on click. On large configs
with `external_components` / `packages:` / `!include` the
`esphome vscode` subprocess takes several seconds per pass.
Visible on user reports as 7-9s click-to-popup latency on a
Celeron NUC (MasterOfNone, Slack 2026-05-16).

This PR caches `editor/validate_yaml` results on `_EditorSession`
keyed by content hash with a 60s TTL. The save-time re-validate
hits the linter's just-stored result instead of spinning up
another subprocess pass. Different content or expiry invalidates
and re-validates as before. Uses `fnv1a_32` from
`fnv-hash-fast` since this is a cache key, not a security
boundary.

The 60s TTL bounds staleness for `!include` / external-component
files mutated outside the editor; long enough to cover any
realistic linter-to-save hand-off, short enough that an external
change recovers on the next debounce tick.

**Related issue or feature (if applicable):**

- fixes <discord report from MasterOfNone, 2026-05-16>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#344

Backend cache makes the save-time `validate_yaml` cheap; the
frontend companion skips the WS round-trip entirely when the
linter's last result still matches the buffer. The two compose;
either alone is an improvement.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
