### PR TITLE
Drop top-level condition gate from AutomationTree

### DIFF
--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -46,15 +46,13 @@ def render_interval_item(tree: AutomationTree) -> str:
     item = CommentedMap()
     for key, value in tree.trigger_params.items():
         item[key] = encode_value(value)
-    if tree.conditions:
-        item["condition"] = emit_condition_seq(tree.conditions)
     item["then"] = emit_action_seq(tree.actions)
     return dump([item])
 
 
 def render_trigger_handler(tree: AutomationTree, *, key: str) -> str:
     """
-    Render a ``<trigger_key>:`` mapping with then / condition / params.
+    Render a ``<trigger_key>:`` mapping with then + trigger params.
 
     Canonicalises to the explicit ``then:`` form on every write so
     round-trips stay deterministic (the parser accepts both
@@ -63,8 +61,6 @@ def render_trigger_handler(tree: AutomationTree, *, key: str) -> str:
     body = CommentedMap()
     for param_key, value in tree.trigger_params.items():
         body[param_key] = encode_value(value)
-    if tree.conditions:
-        body["condition"] = emit_condition_seq(tree.conditions)
     body["then"] = emit_action_seq(tree.actions)
     wrapper = CommentedMap()
     wrapper[key] = body

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -150,7 +150,6 @@ def _parse_top_level_scripts(root: Any) -> list[ParsedAutomation]:
         tree = AutomationTree(
             trigger_id=None,
             trigger_params=_collect_block_params(item, action_list_keys={"then"}),
-            conditions=[],
             actions=_decompose_action_list(item.get("then")),
         )
         out.append(
@@ -183,7 +182,6 @@ def _parse_top_level_intervals(root: Any) -> list[ParsedAutomation]:
         tree = AutomationTree(
             trigger_id=None,
             trigger_params=_collect_block_params(item, action_list_keys={"then"}),
-            conditions=[],
             actions=_decompose_action_list(item.get("then")),
         )
         out.append(
@@ -273,7 +271,6 @@ def _parse_light_effects(root: Any) -> list[ParsedAutomation]:
             tree = AutomationTree(
                 trigger_id=None,
                 trigger_params={effect_id: _render_params(params)} if params else {effect_id: {}},
-                conditions=[],
                 actions=[],
             )
             out.append(
@@ -298,14 +295,12 @@ def _decompose_trigger_body(body: Any, *, trigger_id: str) -> AutomationTree:
     bare action (``on_press: action: ...``), explicit ``then:``.
     """
     trigger_params: dict[str, Any] = {}
-    conditions: list[ConditionNode] = []
     actions: list[ActionNode] = []
 
     if body is None:
         return AutomationTree(
             trigger_id=trigger_id,
             trigger_params={},
-            conditions=[],
             actions=[],
         )
 
@@ -313,9 +308,6 @@ def _decompose_trigger_body(body: Any, *, trigger_id: str) -> AutomationTree:
         actions = _decompose_action_list(body)
     elif isinstance(body, dict):
         trigger_params = _collect_block_params(body, action_list_keys={"then"})
-        cond_value = body.get("condition")
-        if cond_value is not None:
-            conditions = _decompose_condition_list(cond_value)
         if "then" in body:
             actions = _decompose_action_list(body["then"])
         else:
@@ -324,11 +316,7 @@ def _decompose_trigger_body(body: Any, *, trigger_id: str) -> AutomationTree:
             # ``_collect_block_params`` naively absorbed both; pull
             # the action keys back out by catalog lookup and rebuild
             # ``trigger_params`` without them.
-            action_body = {
-                k: v
-                for k, v in body.items()
-                if k != "condition" and catalog.action_by_id(k) is not None
-            }
+            action_body = {k: v for k, v in body.items() if catalog.action_by_id(k) is not None}
             if action_body:
                 actions = _decompose_action_list([action_body])
                 trigger_params = {k: v for k, v in trigger_params.items() if k not in action_body}
@@ -336,7 +324,6 @@ def _decompose_trigger_body(body: Any, *, trigger_id: str) -> AutomationTree:
     return AutomationTree(
         trigger_id=trigger_id,
         trigger_params=trigger_params,
-        conditions=conditions,
         actions=actions,
     )
 
@@ -439,10 +426,10 @@ def _collect_block_params(
     *,
     action_list_keys: set[str],
 ) -> dict[str, Any]:
-    """Collect non-then / non-condition keys as plain ``params`` values."""
+    """Collect non-action-list keys as plain ``params`` values."""
     out: dict[str, Any] = {}
     for key, value in block.items():
-        if key in action_list_keys or key == "condition":
+        if key in action_list_keys:
             continue
         out[key] = _render_value(value)
     return out

--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -214,12 +214,13 @@ class AutomationTree(DataClassORJSONMixin):
 
     ``trigger_id`` is ``None`` for top-level ``script:`` /
     ``interval:`` blocks — the block kind is implied by the
-    location. ``conditions`` is the optional "only run if" gate.
+    location. ESPHome's ``AUTOMATION_SCHEMA`` has no top-level
+    condition key; any conditional gating is expressed per-action
+    through ``if`` / ``wait_until`` / ``while``.
     """
 
     trigger_id: str | None = None
     trigger_params: dict[str, Any] = field(default_factory=dict)
-    conditions: list[ConditionNode] = field(default_factory=list)
     actions: list[ActionNode] = field(default_factory=list)
 
 

--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -214,9 +214,7 @@ class AutomationTree(DataClassORJSONMixin):
 
     ``trigger_id`` is ``None`` for top-level ``script:`` /
     ``interval:`` blocks — the block kind is implied by the
-    location. ESPHome's ``AUTOMATION_SCHEMA`` has no top-level
-    condition key; any conditional gating is expressed per-action
-    through ``if`` / ``wait_until`` / ``while``.
+    location.
     """
 
     trigger_id: str | None = None

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -29,8 +29,6 @@ from esphome_device_builder.controllers.automations.emitter import (
     emit_condition_seq,
     emit_effect_item,
     encode_value,
-    render_interval_item,
-    render_trigger_handler,
 )
 from esphome_device_builder.controllers.automations.parsing import (
     _decompose_action,
@@ -376,32 +374,6 @@ def test_dump_slice_round_trips_mapping() -> None:
 # ---------------------------------------------------------------------------
 # emitter.py
 # ---------------------------------------------------------------------------
-
-
-def test_render_interval_item_emits_condition_block() -> None:
-    """Interval with a condition gate emits ``condition:``."""
-    text = render_interval_item(
-        AutomationTree(
-            trigger_id=None,
-            trigger_params={"interval": "30s"},
-            conditions=[ConditionNode(condition_id="switch.is_on", params={"id": "r"})],
-            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
-        ),
-    )
-    assert "condition:" in text
-
-
-def test_render_trigger_handler_emits_condition_block() -> None:
-    """Trigger handler with a condition gate emits ``condition:``."""
-    text = render_trigger_handler(
-        AutomationTree(
-            trigger_id="on_boot",
-            conditions=[ConditionNode(condition_id="switch.is_on", params={"id": "r"})],
-            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
-        ),
-        key="on_boot",
-    )
-    assert "condition:" in text
 
 
 def test_emit_action_node_bare_action() -> None:
@@ -828,19 +800,6 @@ def test_instance_id_no_match_returns_none() -> None:
 def test_parse_top_level_list_root_returns_empty() -> None:
     """A YAML whose root is a list parses to an empty automations list."""
     assert parse_device_yaml("- one\n- two\n") == []
-
-
-def test_parse_trigger_body_with_condition_gate() -> None:
-    """``on_press: { condition: ..., then: ... }`` surfaces the condition gate."""
-    parsed = parse_device_yaml(
-        "binary_sensor:\n  - platform: gpio\n    id: btn\n    pin: GPIO0\n"
-        "    on_press:\n      condition:\n        switch.is_on: r\n"
-        "      then:\n        - switch.toggle: r\n",
-    )
-    assert len(parsed) == 1
-    tree = parsed[0].automation
-    assert [c.condition_id for c in tree.conditions] == ["switch.is_on"]
-    assert [a.action_id for a in tree.actions] == ["switch.toggle"]
 
 
 def test_parse_action_with_non_id_params() -> None:

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -340,7 +340,6 @@ async def test_upsert_device_on_boot_returns_yaml_diff(tmp_path: Path) -> None:
         automation={
             "trigger_id": "on_boot",
             "trigger_params": {},
-            "conditions": [],
             "actions": [
                 {
                     "action_id": "delay",
@@ -370,7 +369,6 @@ async def test_upsert_rejects_unknown_location_kind(tmp_path: Path) -> None:
             automation={
                 "trigger_id": "on_boot",
                 "trigger_params": {},
-                "conditions": [],
                 "actions": [],
             },
             location={"kind": "bogus", "id": "x"},


### PR DESCRIPTION
# What does this implement/fix?

Our `AutomationTree` model carried a top-level `conditions: ConditionNode[]` field, which the frontend rendered as an "Only run when" panel. ESPHome automations don't actually have a top-level condition — conditional gating is per-action through `if` / `wait_until` / `while` — so the panel implies a concept that can't round-trip to valid YAML.

- Drop `conditions: list[ConditionNode]` from `AutomationTree`
- Remove the trigger-body `condition:` lookup in `parsing._decompose_trigger_body` and the `condition` carveout in `_collect_block_params`
- Remove the `if tree.conditions: ...` branches in `emitter.render_interval_item` / `render_trigger_handler`
- Update tests + wire-shape payloads to match (per-action `ActionNode.conditions` stays — that's the real ESPHome concept)

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
