### PR TITLE
firmware: collapse CR-overwritten progress lines at storage time

### DIFF
--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -316,7 +316,7 @@ def _fire_job_progress(job: FirmwareJob, bus: EventBus, progress: int) -> None:
 
 
 def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
-    """
+    r"""
     Append *line* to ``job.output`` and fire local follower events.
 
     Shared bookkeeping for "one line of build output arrived" —
@@ -326,7 +326,11 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
 
     Steps:
 
-    1. Buffer the line on ``job.output``.
+    1. Buffer the line on ``job.output``. CR-terminated chunks
+       overwrite the previous entry instead of accumulating, so
+       a ninja-driven ESP-IDF build's ~1200 "[N/total] …\r"
+       updates don't fill the retention tail with overwritten
+       progress lines (#898).
     2. Trim down to ``_INFLIGHT_TRIM_KEEP`` if the in-flight
        cap is hit, so a chatty build doesn't grow ``output``
        without bound between terminal-event trims.
@@ -346,7 +350,15 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     ``failed`` status from the receiver instead of having to
     scrape stderr).
     """
-    job.output.append(line)
+    # Collapse CR-overwritten progress lines at storage time: a
+    # CR-terminated last entry followed by a non-bare-``\n`` chunk
+    # gets replaced rather than retained. ``JOB_OUTPUT`` still fires
+    # per chunk (live followers unchanged); only ``job.output``
+    # (historical replay) is collapsed.
+    if job.output and job.output[-1].endswith("\r") and line != "\n":
+        job.output[-1] = line
+    else:
+        job.output.append(line)
     if len(job.output) > _MAX_OUTPUT_LINES_INFLIGHT:
         _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -777,3 +777,73 @@ async def test_compile_repeats_error_pattern_short_circuits_check(
 
     assert job.status == JobStatus.FAILED
     assert job.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_compile_cr_progress_lines_collapsed_in_storage(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    r"""``\r``-terminated progress chunks are collapsed at storage time.
+
+    ESP-IDF / ninja builds emit a few thousand "[N/total] Compiling
+    …\r" / "Linking …\r" updates that each overwrite the previous
+    on-screen line. Without storage-side collapse, ``job.output``
+    retains every chunk — the retained 2000-line tail fills with
+    overwritten progress lines so a real error close to the end of
+    the build falls outside the window during historical replay.
+
+    This test pins the collapse rule:
+
+    - Sequence of CR-terminated progress chunks for the same line
+      slot ends with only the *last* chunk stored.
+    - Live ``JOB_OUTPUT`` events still fire once per input chunk so
+      followers' progress indicators animate; only ``job.output``
+      (the historical-replay source) is collapsed.
+    - A regular ``\n``-terminated log line after a CR-terminated
+      chunk replaces it — matches the frontend's visual-line
+      semantics, where a non-``\n`` follow-up pops the progress
+      line.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    # Emit three CR-terminated progress chunks, then a real log line.
+    # ``PYTHONUNBUFFERED=1`` is set in production by ``_execute_job``
+    # so each ``write`` lands as a separate read on our pipe. Use
+    # ``stdout.buffer.write`` so Windows text-mode translation
+    # doesn't turn the trailing ``\n`` into ``\r\n`` on us.
+    _fake_esphome(
+        controller,
+        "import sys\n"
+        "sys.stdout.buffer.write(b'[1/3] Compiling a.o\\r')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.stdout.buffer.write(b'[2/3] Compiling b.o\\r')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.stdout.buffer.write(b'[3/3] Compiling c.o\\r')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.stdout.buffer.write(b'INFO Compile finished.\\n')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.exit(0)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+    captured = await _run_until_terminal(controller)
+
+    assert job.status == JobStatus.COMPLETED
+
+    # Live followers see every chunk — the wire protocol isn't
+    # affected by storage-side collapse.
+    live_lines = [d["line"] for d in captured["job_output"]]
+    assert "[1/3] Compiling a.o\r" in live_lines
+    assert "[2/3] Compiling b.o\r" in live_lines
+    assert "[3/3] Compiling c.o\r" in live_lines
+    assert "INFO Compile finished.\n" in live_lines
+
+    # ``job.output`` retains only the final state. The three CR
+    # chunks collapse into the last one, then the trailing
+    # ``\n``-terminated log line pops it (mirroring the frontend's
+    # "non-``\n`` follow-up replaces the CR line" rule).
+    assert "[1/3] Compiling a.o\r" not in job.output
+    assert "[2/3] Compiling b.o\r" not in job.output
+    assert "[3/3] Compiling c.o\r" not in job.output
+    assert job.output[-1] == "INFO Compile finished.\n"


### PR DESCRIPTION
# What does this implement/fix?

`job.output` retained every CR-terminated progress chunk
(`[1229/1233] Generating binary image...\r`, `Compiling …\r`,
`Linking …\r`) even though each was immediately overwritten on
screen by the next. For ninja-driven ESP-IDF builds that's the
majority of the line count — ~1200+ chunks that never appear on
screen but were stored in full and replayed in full during
historical follow.

Fold the CR-overwrite rule into `_ingest_output_line` (shared by
the local-subprocess streaming loop and the remote-source
listener): when the last stored chunk ends in `\r` and the new
chunk isn't a bare `\n`, replace the last entry instead of
appending. The collapse is storage-only — `JOB_OUTPUT` still
fires per chunk so live followers' progress indicators animate
unchanged; only `job.output` (the historical-replay source) is
collapsed.

Net effect on a long ESP-IDF build: the retained 2000-line tail
now holds real per-step output instead of overwritten progress
lines, so a real error 30 s before completion stays inside the
window. Independent of the frontend rAF-batching fix proposed in
device-builder-frontend#348 — both should land.

**Related issue or feature (if applicable):**

- fixes #898

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.