### PR TITLE
Redirect feature requests away from the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,13 +8,18 @@ body:
       value: |
         Thanks for trying the new dashboard! 🙏
 
+        **Looking to request a feature?** This template is for bug reports only. Feature ideas belong in the
+        [esphome org-level Discussions board](https://github.com/orgs/esphome/discussions);
+        planned / in-progress work is tracked on the
+        [Device Builder project board](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22).
+
         Before filing, please confirm:
         - **Not an ESPHome core problem** — compile errors / device behaviour /
           component bugs belong in the [esphome repo](https://github.com/esphome/esphome/issues/new/choose).
         - **Not already tracked** — check
           [open issues](https://github.com/esphome/device-builder-dashboard-backend/issues)
           and the
-          [project backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22).
+          [project backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22).
         - **Not better suited to chat** — quick questions and feedback land
           faster in the
           [Discord channel](https://discord.gg/Rf2jWGVjaK).


### PR DESCRIPTION
# What does this implement/fix?

Add a callout at the top of the bug-report issue template steering users who came to file a feature request to the esphome org-level Discussions board and the Device Builder project board, before they fill in bug-shaped fields. The bug report itself is unchanged.

**Related issue or feature (if applicable):**

-

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.