### PR TITLE
Fix mypy assignment on rebound res in _delete_light_effect

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -511,16 +511,16 @@ def _delete_light_effect(
                 toLine=to_line,
                 replacement=replacement,
             )
-        res = remove_inline_handler(
+        removed = remove_inline_handler(
             yaml_text,
             component_domain="light",
             component_id=location.component_id,
             handler_key="effects",
         )
-        if res is None:  # pragma: no cover — instance found above
+        if removed is None:  # pragma: no cover — instance found above
             msg = f"effects: not found on light id={location.component_id!r}"
             raise CommandError(ErrorCode.NOT_FOUND, msg)
-        new_text, from_line, to_line = res
+        new_text, from_line, to_line = removed
         return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement="")
     msg = f"Light id={location.component_id!r} not found"
     raise CommandError(ErrorCode.NOT_FOUND, msg)


### PR DESCRIPTION
# What does this implement/fix?

`Lint + smoke checks` is red on `main` from two mypy errors in `_delete_light_effect`. `upsert_inline_handler` recently grew a 4th return value, but the same function still falls back to `remove_inline_handler` (still a 3-tuple) — both calls bind to a single `res` local, so mypy locks the type to the first binding and rejects the second.

- Rename the second binding in `_delete_light_effect` from `res` to `removed` so each call site gets its own type.
- No behaviour change; runtime control flow is unchanged.

**Related issue or feature (if applicable):**

- fixes the [`Lint + smoke checks` failure on `fe5f2eb5`](https://github.com/esphome/device-builder/actions/runs/26147461239/job/76906298889)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
