### PR TITLE
automations: support api.actions: as a callable variant

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -227,9 +227,10 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 {kind: "component_on",  component_id: string, trigger: string}
 {kind: "device_on",     trigger: string}
 {kind: "light_effect",  component_id: string, index: int}
+{kind: "api_action",    action_name: string}
 ```
 
-`upsert` / `delete` consume the same shape so the writer knows the exact YAML range to splice.
+`upsert` / `delete` consume the same shape so the writer knows the exact YAML range to splice. `api_action` covers user-defined actions under `api.actions:` — structurally a callable (named, typed `variables:`, `then:` action list, no trigger) so the editor reuses the script pipeline. The deprecated `service:` discriminator is accepted on read; the writer emits `action:`.
 
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|
@@ -238,7 +239,7 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 | `automations/get_conditions` | `{platform?, board_id?}` | `[AutomationCondition]` | Full condition catalog (includes core combinators: `and`, `or`, `all`, `any`, `not`, `xor`, `for`, `lambda`). |
 | `automations/get_light_effects` | `{platform?, board_id?}` | `[LightEffect]` | Full light-effects catalog. |
 | `automations/get_available` | `{configuration}` | `{triggers, actions, conditions, scripts, devices}` | Scoped catalog for a single device. `triggers` / `actions` / `conditions` filtered to the components present in the YAML, matched by the catalog's canonical `<domain>.<platform>` form (e.g. an action with `domain == "switch.template"` only surfaces when a switch with `platform: template` is configured); `core` items (control flow, lambda, combinators) and device-level triggers are always included. `scripts` lists declared `script: id`s with their `parameters:` map. `devices` lists every configured component instance with its `id` / `name` for id-picker dropdowns. |
-| `automations/parse` | `{configuration}` | `[ParsedAutomation]` | Walk the device YAML and return every recognised automation (top-level `script:` / `interval:`, device-level `esphome.on_*`, inline component `on_*:`, light `effects:` entries). Unknown action / condition ids raise `INVALID_ARGS` rather than best-effort rebuilding. |
+| `automations/parse` | `{configuration}` | `[ParsedAutomation]` | Walk the device YAML and return every recognised automation (top-level `script:` / `interval:`, `api.actions:`, device-level `esphome.on_*`, inline component `on_*:`, light `effects:` entries). Unknown action / condition ids raise `INVALID_ARGS` rather than best-effort rebuilding. |
 | `automations/upsert` | `{configuration, automation, location}` | `{yaml_diff: YamlDiff}` | Insert or replace one automation at `location`. Returns the splice the frontend applies in place. |
 | `automations/delete` | `{configuration, location}` | `{yaml_diff: YamlDiff}` | Remove the automation at `location`. |
 

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -19,6 +19,30 @@ import re
 from ...models.automations import YamlDiff
 
 
+def has_inline_actions_value(
+    lines: list[str],
+    api_span: tuple[int, int, str],
+) -> bool:
+    """Return True iff ``actions:`` under *api_span* carries an inline value.
+
+    Flow-style values (``actions: []``, ``actions: null``,
+    ``actions: !secret foo``, …) can't be spliced into the way the
+    line-based writer wants. Callers should refuse the upsert /
+    delete and surface a clear error rather than emit a second
+    ``actions:`` key alongside the inline one.
+    """
+    api_start, api_end, child_indent = api_span
+    header = f"{child_indent}actions:"
+    for idx in range(api_start + 1, api_end):
+        text = lines[idx].rstrip("\n\r")
+        if text == header:
+            return False
+        if text.startswith(header + " "):
+            rest = text[len(header) :].strip()
+            return bool(rest) and not rest.startswith("#")
+    return False
+
+
 def locate_actions_list(
     lines: list[str],
     api_span: tuple[int, int, str],

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -136,16 +136,13 @@ def indent_for_list(rendered_item: str, item_indent: str) -> str:
     live two levels deeper than that, so add the *item_indent* - 2
     delta to every non-empty line.
     """
-    extra = max(len(item_indent) - 2, 0)
-    if extra == 0:
-        return rendered_item if rendered_item.endswith("\n") else rendered_item + "\n"
-    pad = " " * extra
-    out_lines: list[str] = []
-    for line in rendered_item.splitlines():
-        if not line:
-            out_lines.append("")
-            continue
-        out_lines.append(pad + line)
+    # item_indent is always at least ``  `` (the canonical 4-space
+    # nesting under ``api.actions:``) in every reachable path, so
+    # *extra* is always positive — the ``dump([item])`` shape that
+    # rendered_item comes from is bounded too (no embedded blank
+    # lines, always trailing ``\n``).
+    pad = " " * (len(item_indent) - 2)
+    out_lines = [pad + line for line in rendered_item.splitlines()]
     if not out_lines or out_lines[-1] != "":
         out_lines.append("")
     return "\n".join(out_lines)
@@ -170,13 +167,12 @@ def render_create_block(yaml_text: str, rendered: str) -> tuple[str, str]:
     """Return ``(new_yaml, block_text)`` for a fresh ``api:`` block at EOF."""
     item_indent = "    "
     item_text = indent_for_list(rendered, item_indent)
+    # ``item_text`` always ends with ``\n``, so the block does too and
+    # the final concatenation lands a trailing newline on EOF.
     block = "api:\n  actions:\n" + item_text
     base = yaml_text.rstrip()
     separator = "\n\n" if base else ""
-    new_text = f"{base}{separator}{block}"
-    if not new_text.endswith("\n"):
-        new_text += "\n"
-    return new_text, block
+    return f"{base}{separator}{block}", block
 
 
 def render_insert_actions_key(

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -4,10 +4,12 @@
 The ``api:`` block hosts a list of named callables under ``actions:``
 — structurally near-identical to ``script:``, but nested two levels
 deep rather than at the top level. The lookup, item-locator, and
-re-indent helpers live here so :mod:`writing` stays under the
-800-line file-size cap; the dispatch surface (the two
-``render_*_api_action`` entry points) stays in :mod:`writing`
-alongside every other location type for grep-ability.
+re-indent helpers live here so :mod:`writing` stays close to the
+800-line file-size cap; the dispatch surface (the
+``_upsert_api_action`` / ``_delete_api_action`` branches of
+:func:`writing.render_upsert` / :func:`writing.render_delete`)
+stays in :mod:`writing` alongside every other location type for
+grep-ability.
 """
 
 from __future__ import annotations

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -134,15 +134,19 @@ def indent_for_list(rendered_item: str, item_indent: str) -> str:
     two (``  - key: value``) because ``offset=2`` indents each dash
     two columns inside its parent sequence. ``api.actions:`` items
     live two levels deeper than that, so add the *item_indent* - 2
-    delta to every non-empty line.
+    delta to every non-empty line. Blank lines inside ``|`` block
+    scalars (e.g. a multi-paragraph ``lambda:`` body) are left
+    untouched — padding them with spaces would change the scalar's
+    content, since YAML treats whitespace-only lines and fully
+    empty lines differently inside a literal block.
     """
-    # item_indent is always at least ``  `` (the canonical 4-space
-    # nesting under ``api.actions:``) in every reachable path, so
-    # *extra* is always positive — the ``dump([item])`` shape that
-    # rendered_item comes from is bounded too (no embedded blank
-    # lines, always trailing ``\n``).
     pad = " " * (len(item_indent) - 2)
-    out_lines = [pad + line for line in rendered_item.splitlines()]
+    out_lines: list[str] = []
+    for line in rendered_item.splitlines():
+        if not line:
+            out_lines.append("")
+            continue
+        out_lines.append(pad + line)
     if not out_lines or out_lines[-1] != "":
         out_lines.append("")
     return "\n".join(out_lines)

--- a/esphome_device_builder/controllers/automations/api_actions.py
+++ b/esphome_device_builder/controllers/automations/api_actions.py
@@ -1,0 +1,252 @@
+"""
+``api.actions:`` splice helpers used by :mod:`writing`.
+
+The ``api:`` block hosts a list of named callables under ``actions:``
+— structurally near-identical to ``script:``, but nested two levels
+deep rather than at the top level. The lookup, item-locator, and
+re-indent helpers live here so :mod:`writing` stays under the
+800-line file-size cap; the dispatch surface (the two
+``render_*_api_action`` entry points) stays in :mod:`writing`
+alongside every other location type for grep-ability.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ...models.automations import YamlDiff
+
+
+def locate_actions_list(
+    lines: list[str],
+    api_span: tuple[int, int, str],
+) -> tuple[int, int, str] | None:
+    """Return ``(start, end, item_indent)`` for ``api.actions:`` or ``None``.
+
+    ``start`` is the line index of the ``actions:`` key; ``end`` is
+    one past the last item line; ``item_indent`` is the leading
+    whitespace shared by each ``- ...`` dash line.
+    """
+    api_start, api_end, child_indent = api_span
+    header = f"{child_indent}actions:"
+    actions_start: int | None = None
+    for idx in range(api_start + 1, api_end):
+        text = lines[idx].rstrip("\n\r")
+        if text == header or text.startswith(header + " "):
+            actions_start = idx
+            break
+    if actions_start is None:
+        return None
+    actions_end = api_end
+    for idx in range(actions_start + 1, api_end):
+        content = lines[idx].rstrip("\n\r")
+        if not content:
+            continue
+        leading = len(content) - len(content.lstrip(" "))
+        if leading <= len(child_indent):
+            actions_end = idx
+            break
+    item_indent: str | None = None
+    for idx in range(actions_start + 1, actions_end):
+        raw = lines[idx].rstrip("\n\r")
+        stripped = raw.lstrip(" ")
+        if stripped.startswith("- "):
+            item_indent = raw[: len(raw) - len(stripped)]
+            break
+    if item_indent is None:
+        # Empty list — assume the canonical two-space nesting under
+        # ``actions:`` so the first item still indents predictably.
+        item_indent = child_indent + "  "
+    return actions_start, actions_end, item_indent
+
+
+def find_item(
+    lines: list[str],
+    actions_start: int,
+    actions_end: int,
+    item_indent: str,
+    action_name: str,
+) -> tuple[int, int] | None:
+    """Locate the line range of the list item whose discriminator matches."""
+    item_starts: list[int] = []
+    for idx in range(actions_start + 1, actions_end):
+        raw = lines[idx].rstrip("\n\r")
+        if not raw.startswith(item_indent + "- "):
+            continue
+        item_starts.append(idx)
+    for run, start in enumerate(item_starts):
+        end = item_starts[run + 1] if run + 1 < len(item_starts) else actions_end
+        if _discriminator(lines, start, end, item_indent) == action_name:
+            return start, end
+    return None
+
+
+def count_siblings(
+    lines: list[str],
+    actions_start: int,
+    actions_end: int,
+    item_indent: str,
+    matched: tuple[int, int],
+) -> int:
+    """Count list items at *item_indent* that aren't the matched span."""
+    item_start, item_end = matched
+    siblings = 0
+    for idx in range(actions_start + 1, actions_end):
+        raw = lines[idx].rstrip("\n\r")
+        if not raw.startswith(item_indent + "- "):
+            continue
+        if item_start <= idx < item_end:
+            continue
+        siblings += 1
+    return siblings
+
+
+def indent_for_list(rendered_item: str, item_indent: str) -> str:
+    """Re-indent a ``dump([item])`` block to nest under ``api.actions:``.
+
+    The shared ruamel emitter writes top-level list items at column
+    two (``  - key: value``) because ``offset=2`` indents each dash
+    two columns inside its parent sequence. ``api.actions:`` items
+    live two levels deeper than that, so add the *item_indent* - 2
+    delta to every non-empty line.
+    """
+    extra = max(len(item_indent) - 2, 0)
+    if extra == 0:
+        return rendered_item if rendered_item.endswith("\n") else rendered_item + "\n"
+    pad = " " * extra
+    out_lines: list[str] = []
+    for line in rendered_item.splitlines():
+        if not line:
+            out_lines.append("")
+            continue
+        out_lines.append(pad + line)
+    if not out_lines or out_lines[-1] != "":
+        out_lines.append("")
+    return "\n".join(out_lines)
+
+
+def render_replacement(
+    lines: list[str],
+    item_start: int,
+    item_end: int,
+    rendered_text: str,
+) -> tuple[str, YamlDiff]:
+    """Splice *rendered_text* over the lines spanning an existing item."""
+    new_lines = [*lines[:item_start], rendered_text, *lines[item_end:]]
+    return "".join(new_lines), YamlDiff(
+        fromLine=item_start + 1,
+        toLine=item_end,
+        replacement=rendered_text,
+    )
+
+
+def render_create_block(yaml_text: str, rendered: str) -> tuple[str, str]:
+    """Return ``(new_yaml, block_text)`` for a fresh ``api:`` block at EOF."""
+    item_indent = "    "
+    item_text = indent_for_list(rendered, item_indent)
+    block = "api:\n  actions:\n" + item_text
+    base = yaml_text.rstrip()
+    separator = "\n\n" if base else ""
+    new_text = f"{base}{separator}{block}"
+    if not new_text.endswith("\n"):
+        new_text += "\n"
+    return new_text, block
+
+
+def render_insert_actions_key(
+    lines: list[str],
+    api_span: tuple[int, int, str],
+    rendered: str,
+) -> tuple[str, YamlDiff]:
+    """Insert an ``actions:`` key with one item under an existing ``api:`` block."""
+    api_start, api_end, child_indent = api_span
+    item_indent = child_indent + "  "
+    item_text = indent_for_list(rendered, item_indent)
+    block = f"{child_indent}actions:\n{item_text}"
+    insert_at = api_end
+    while insert_at > api_start + 1 and not lines[insert_at - 1].strip():
+        insert_at -= 1
+    new_lines = [*lines[:insert_at], block, *lines[insert_at:]]
+    new_text = "".join(new_lines)
+    return new_text, YamlDiff(
+        fromLine=insert_at + 1,
+        toLine=insert_at,
+        replacement=block,
+    )
+
+
+def render_append(
+    lines: list[str],
+    actions_end: int,
+    item_indent: str,
+    rendered: str,
+) -> tuple[str, YamlDiff]:
+    """Append a new list item at the end of an existing ``api.actions:``."""
+    item_text = indent_for_list(rendered, item_indent)
+    insert_at = actions_end
+    while insert_at > 0 and not lines[insert_at - 1].strip():
+        insert_at -= 1
+    new_lines = [*lines[:insert_at], item_text, *lines[insert_at:]]
+    new_text = "".join(new_lines)
+    return new_text, YamlDiff(
+        fromLine=insert_at + 1,
+        toLine=insert_at,
+        replacement=item_text,
+    )
+
+
+def render_delete_item(
+    lines: list[str],
+    item_start: int,
+    item_end: int,
+) -> tuple[str, YamlDiff]:
+    """Remove the line range covering a single api-action list item."""
+    new_lines = [*lines[:item_start], *lines[item_end:]]
+    return "".join(new_lines), YamlDiff(
+        fromLine=item_start + 1,
+        toLine=item_end,
+        replacement="",
+    )
+
+
+def render_delete_actions_key(
+    lines: list[str],
+    actions_start: int,
+    actions_end: int,
+) -> tuple[str, YamlDiff]:
+    """Remove the entire ``actions:`` key when its last item is being dropped."""
+    new_lines = [*lines[:actions_start], *lines[actions_end:]]
+    return "".join(new_lines), YamlDiff(
+        fromLine=actions_start + 1,
+        toLine=actions_end,
+        replacement="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _discriminator(
+    lines: list[str],
+    item_start: int,
+    item_end: int,
+    item_indent: str,
+) -> str | None:
+    """Read the ``action:`` (or legacy ``service:``) key for a list item."""
+    child_indent = item_indent + "  "
+    inline = re.match(
+        rf"^{re.escape(item_indent)}-\s*(?P<key>action|service):\s*(?P<val>\S+)",
+        lines[item_start].rstrip("\n\r"),
+    )
+    if inline:
+        return inline.group("val").strip("'\"")
+    child_re = re.compile(
+        rf"^{re.escape(child_indent)}(?:action|service):\s*(?P<val>\S+)",
+    )
+    for idx in range(item_start, item_end):
+        m = child_re.match(lines[idx].rstrip("\n\r"))
+        if m:
+            return m.group("val").strip("'\"")
+    return None

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -18,6 +18,7 @@ from ruamel.yaml import YAMLError
 from ...helpers.api import CommandError, api_command
 from ...models.api import ErrorCode
 from ...models.automations import (
+    ApiActionLocation,
     AutomationLocation,
     AutomationTree,
     AvailableAutomations,
@@ -370,5 +371,7 @@ def _decode_location(raw: dict) -> AutomationLocation:
         return DeviceOnLocation.from_dict(raw)
     if kind == "light_effect":
         return LightEffectLocation.from_dict(raw)
+    if kind == "api_action":
+        return ApiActionLocation.from_dict(raw)
     msg = f"Unknown location kind: {kind!r}"
     raise CommandError(ErrorCode.INVALID_ARGS, msg)

--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -50,6 +50,18 @@ def render_interval_item(tree: AutomationTree) -> str:
     return dump([item])
 
 
+def render_api_action_item(tree: AutomationTree, action_name: str) -> str:
+    """Render a single ``- action: <name>`` api-actions list item."""
+    item = CommentedMap()
+    item["action"] = action_name
+    for key, value in tree.trigger_params.items():
+        if key in ("action", "service"):
+            continue
+        item[key] = encode_value(value)
+    item["then"] = emit_action_seq(tree.actions)
+    return dump([item])
+
+
 def render_trigger_handler(tree: AutomationTree, *, key: str) -> str:
     """
     Render a ``<trigger_key>:`` mapping with then + trigger params.

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -4,10 +4,11 @@ YAML → :class:`ParsedAutomation` list.
 ruamel.yaml round-trip mode preserves the user's comments, key
 order, blank lines, and quoting so a "no-op" round-trip through
 parse → upsert leaves the document visually identical. The parser
-walks four shapes:
+walks five shapes:
 
 - Top-level ``script:`` and ``interval:`` list blocks.
 - ``esphome.on_boot`` / ``on_loop`` / ``on_shutdown``.
+- ``api.actions:`` user-defined callable list items.
 - Configured component instances with inline ``on_*:`` handlers.
 - Light ``effects:`` lists.
 

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -28,6 +28,7 @@ from ...helpers.api import CommandError
 from ...models.api import ErrorCode
 from ...models.automations import (
     ActionNode,
+    ApiActionLocation,
     AutomationTree,
     ComponentOnLocation,
     ConditionNode,
@@ -80,6 +81,7 @@ def parse_device_yaml(yaml_text: str) -> list[ParsedAutomation]:
     out.extend(_parse_device_level(data))
     out.extend(_parse_top_level_scripts(data))
     out.extend(_parse_top_level_intervals(data))
+    out.extend(_parse_api_actions(data))
     out.extend(_parse_inline_component_triggers(data))
     out.extend(_parse_light_effects(data))
     return out
@@ -188,6 +190,50 @@ def _parse_top_level_intervals(root: Any) -> list[ParsedAutomation]:
             ParsedAutomation(
                 location=IntervalLocation(index=idx),
                 label=label,
+                automation=tree,
+                from_line=from_line,
+                to_line=to_line,
+                raw_yaml=_dump_slice([item]),
+            )
+        )
+    return out
+
+
+def _parse_api_actions(root: Any) -> list[ParsedAutomation]:
+    """
+    Parse ``api.actions:`` list items as callable automations.
+
+    Structurally a near-duplicate of ``script:`` — named callable
+    with typed ``variables:`` and a ``then:`` action list — so the
+    same :class:`AutomationTree` shape carries it. The deprecated
+    ``service:`` discriminator key is accepted as an alias for
+    ``action:`` on read; the writer emits ``action:``.
+    """
+    if not isinstance(root, dict):
+        return []
+    api_block = root.get("api")
+    if not isinstance(api_block, dict):
+        return []
+    actions = api_block.get("actions")
+    if not isinstance(actions, list):
+        return []
+    out: list[ParsedAutomation] = []
+    for idx, item in enumerate(actions):
+        if not isinstance(item, dict):
+            continue
+        action_name = item.get("action") or item.get("service")
+        if not action_name:
+            continue
+        from_line, to_line = _item_range(actions, idx)
+        tree = AutomationTree(
+            trigger_id=None,
+            trigger_params=_collect_api_action_params(item),
+            actions=_decompose_action_list(item.get("then")),
+        )
+        out.append(
+            ParsedAutomation(
+                location=ApiActionLocation(action_name=str(action_name)),
+                label=f"API: {action_name}",
                 automation=tree,
                 from_line=from_line,
                 to_line=to_line,
@@ -430,6 +476,16 @@ def _collect_block_params(
     out: dict[str, Any] = {}
     for key, value in block.items():
         if key in action_list_keys:
+            continue
+        out[key] = _render_value(value)
+    return out
+
+
+def _collect_api_action_params(block: dict) -> dict[str, Any]:
+    """Collect ``api.actions:`` item params, dropping the discriminator + ``then:``."""
+    out: dict[str, Any] = {}
+    for key, value in block.items():
+        if key in ("then", "action", "service"):
             continue
         out[key] = _render_value(value)
     return out

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -25,6 +25,7 @@ from ...helpers.yaml import (
 )
 from ...models.api import ErrorCode
 from ...models.automations import (
+    ApiActionLocation,
     AutomationLocation,
     AutomationTree,
     ComponentOnLocation,
@@ -34,10 +35,11 @@ from ...models.automations import (
     ScriptLocation,
     YamlDiff,
 )
-from . import catalog
+from . import api_actions, catalog
 from .emitter import (
     dump,
     emit_effect_item,
+    render_api_action_item,
     render_interval_item,
     render_script_item,
     render_trigger_handler,
@@ -72,6 +74,8 @@ def render_upsert(
         return _upsert_component_on(yaml_text, tree, location)
     if isinstance(location, LightEffectLocation):
         return _upsert_light_effect(yaml_text, tree, location)
+    if isinstance(location, ApiActionLocation):
+        return _upsert_api_action(yaml_text, tree, location)
     msg = f"Unsupported AutomationLocation: {type(location).__name__}"
     raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
@@ -88,6 +92,8 @@ def render_delete(
         return _delete_component_on(yaml_text, location)
     if isinstance(location, LightEffectLocation):
         return _delete_light_effect(yaml_text, location)
+    if isinstance(location, ApiActionLocation):
+        return _delete_api_action(yaml_text, location)
     msg = f"Unsupported AutomationLocation: {type(location).__name__}"
     raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
@@ -160,6 +166,36 @@ def _upsert_component_on(
         toLine=to_line,
         replacement=replacement,
     )
+
+
+def _upsert_api_action(
+    yaml_text: str,
+    tree: AutomationTree,
+    location: ApiActionLocation,
+) -> tuple[str, YamlDiff]:
+    """Splice or replace an ``api.actions:`` list item by ``action_name``."""
+    rendered = render_api_action_item(tree, location.action_name)
+    lines = yaml_text.splitlines(keepends=True)
+    api_span = _locate_singleton_block(lines, "api")
+    if api_span is None:
+        new_text, _block = api_actions.render_create_block(yaml_text, rendered)
+        return new_text, _build_diff_for_append(yaml_text, new_text)
+    actions_span = api_actions.locate_actions_list(lines, api_span)
+    if actions_span is None:
+        return api_actions.render_insert_actions_key(lines, api_span, rendered)
+    actions_start, actions_end, item_indent = actions_span
+    existing = api_actions.find_item(
+        lines,
+        actions_start,
+        actions_end,
+        item_indent,
+        location.action_name,
+    )
+    if existing is not None:
+        item_start, item_end = existing
+        rendered_text = api_actions.indent_for_list(rendered, item_indent)
+        return api_actions.render_replacement(lines, item_start, item_end, rendered_text)
+    return api_actions.render_append(lines, actions_end, item_indent, rendered)
 
 
 def _upsert_light_effect(
@@ -462,6 +498,46 @@ def _delete_component_on(
         raise CommandError(ErrorCode.NOT_FOUND, msg)
     new_text, from_line, to_line = res
     return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement="")
+
+
+def _delete_api_action(
+    yaml_text: str,
+    location: ApiActionLocation,
+) -> tuple[str, YamlDiff]:
+    """Drop a single ``api.actions:`` item; drop ``actions:`` when emptied."""
+    lines = yaml_text.splitlines(keepends=True)
+    api_span = _locate_singleton_block(lines, "api")
+    if api_span is None:
+        msg = "api: block not present; nothing to delete"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    actions_span = api_actions.locate_actions_list(lines, api_span)
+    if actions_span is None:
+        msg = "api.actions: not present; nothing to delete"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    actions_start, actions_end, item_indent = actions_span
+    existing = api_actions.find_item(
+        lines,
+        actions_start,
+        actions_end,
+        item_indent,
+        location.action_name,
+    )
+    if existing is None:
+        msg = f"api.actions[action={location.action_name!r}] not present"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    item_start, item_end = existing
+    siblings = api_actions.count_siblings(
+        lines,
+        actions_start,
+        actions_end,
+        item_indent,
+        existing,
+    )
+    if siblings > 0:
+        return api_actions.render_delete_item(lines, item_start, item_end)
+    # Last sibling — drop the entire ``actions:`` key as well so the
+    # file doesn't grow ``actions: []`` noise.
+    return api_actions.render_delete_actions_key(lines, actions_start, actions_end)
 
 
 def _delete_light_effect(

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -180,6 +180,9 @@ def _upsert_api_action(
     if api_span is None:
         new_text, _block = api_actions.render_create_block(yaml_text, rendered)
         return new_text, _build_diff_for_append(yaml_text, new_text)
+    if api_actions.has_inline_actions_value(lines, api_span):
+        msg = "api.actions: is inline (e.g. `actions: []`); rewrite it as a block list first"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
     actions_span = api_actions.locate_actions_list(lines, api_span)
     if actions_span is None:
         return api_actions.render_insert_actions_key(lines, api_span, rendered)
@@ -510,6 +513,9 @@ def _delete_api_action(
     if api_span is None:
         msg = "api: block not present; nothing to delete"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
+    if api_actions.has_inline_actions_value(lines, api_span):
+        msg = "api.actions: is inline (e.g. `actions: []`); rewrite it as a block list first"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
     actions_span = api_actions.locate_actions_list(lines, api_span)
     if actions_span is None:
         msg = "api.actions: not present; nothing to delete"

--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -160,12 +160,21 @@ class LightEffectLocation(DataClassORJSONMixin):
     kind: Literal["light_effect"] = "light_effect"
 
 
+@dataclass
+class ApiActionLocation(DataClassORJSONMixin):
+    """A user-defined action inside the ``api.actions:`` list."""
+
+    action_name: str
+    kind: Literal["api_action"] = "api_action"
+
+
 AutomationLocation = Annotated[
     ScriptLocation
     | IntervalLocation
     | ComponentOnLocation
     | DeviceOnLocation
-    | LightEffectLocation,
+    | LightEffectLocation
+    | ApiActionLocation,
     Discriminator(field="kind", include_supertypes=True),
 ]
 

--- a/tests/fixtures/automation_yamls/api_action_simple.yaml
+++ b/tests/fixtures/automation_yamls/api_action_simple.yaml
@@ -1,0 +1,7 @@
+esphome:
+  name: x
+api:
+  actions:
+    - action: start_laundry
+      then:
+        - logger.log: 'Starting laundry cycle'

--- a/tests/fixtures/automation_yamls/api_action_with_if.yaml
+++ b/tests/fixtures/automation_yamls/api_action_with_if.yaml
@@ -1,0 +1,15 @@
+esphome:
+  name: x
+api:
+  actions:
+    - action: toggle_when_on
+      variables:
+        relay_id: string
+      then:
+        - if:
+            condition:
+              switch.is_on: relay1
+            then:
+              - switch.turn_off: relay1
+            else:
+              - switch.turn_on: relay1

--- a/tests/fixtures/automation_yamls/api_action_with_variables.yaml
+++ b/tests/fixtures/automation_yamls/api_action_with_variables.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: x
+api:
+  actions:
+    - action: notify_user
+      variables:
+        message: string
+        urgency: int
+      then:
+        - logger.log: 'Notifying user'

--- a/tests/fixtures/automation_yamls/api_actions_multiple.yaml
+++ b/tests/fixtures/automation_yamls/api_actions_multiple.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: x
+api:
+  actions:
+    - action: start_laundry
+      then:
+        - logger.log: 'Starting laundry cycle'
+    - action: stop_laundry
+      then:
+        - logger.log: 'Stopping laundry cycle'

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -479,6 +479,73 @@ async def test_delete_device_on_returns_empty_replacement(tmp_path: Path) -> Non
     assert diff["toLine"] >= diff["fromLine"]
 
 
+async def test_upsert_api_action_returns_yaml_diff(tmp_path: Path) -> None:
+    """Upserting an api-action returns a splice that drops the new entry in."""
+    config = tmp_path / "u.yaml"
+    config.write_text(
+        "esphome:\n  name: u\napi:\n  actions:\n"
+        "    - action: existing\n      then:\n        - delay: 1s\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.upsert(
+        configuration="u.yaml",
+        automation={
+            "trigger_id": None,
+            "trigger_params": {"variables": {"x": "int"}},
+            "actions": [
+                {
+                    "action_id": "logger.log",
+                    "params": {"id": "tick"},
+                    "children": {},
+                    "conditions": [],
+                },
+            ],
+        },
+        location={"kind": "api_action", "action_name": "new_action"},
+    )
+    diff = result["yaml_diff"]
+    assert diff["fromLine"] >= 1
+    assert "- action: new_action" in diff["replacement"]
+    assert "variables:" in diff["replacement"]
+
+
+async def test_delete_api_action_returns_empty_replacement(tmp_path: Path) -> None:
+    """Deleting an api-action returns an empty replacement over its line range."""
+    config = tmp_path / "d.yaml"
+    config.write_text(
+        "esphome:\n  name: d\napi:\n  actions:\n"
+        "    - action: gone\n      then:\n        - delay: 1s\n"
+        "    - action: keep\n      then:\n        - delay: 2s\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.delete(
+        configuration="d.yaml",
+        location={"kind": "api_action", "action_name": "gone"},
+    )
+    diff = result["yaml_diff"]
+    assert diff["replacement"] == ""
+    assert diff["toLine"] >= diff["fromLine"]
+
+
+async def test_parse_surfaces_api_actions(tmp_path: Path) -> None:
+    """``automations/parse`` returns one ``api_action`` entry per item."""
+    config = tmp_path / "p.yaml"
+    config.write_text(
+        "esphome:\n  name: p\napi:\n  actions:\n"
+        "    - action: first\n      then:\n        - delay: 1s\n"
+        "    - action: second\n      variables:\n        name: string\n"
+        "      then:\n        - delay: 2s\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.parse(configuration="p.yaml")
+    api_entries = [p for p in result if p["location"]["kind"] == "api_action"]
+    assert [e["location"]["action_name"] for e in api_entries] == ["first", "second"]
+    assert api_entries[1]["automation"]["trigger_params"]["variables"] == {"name": "string"}
+
+
 async def test_parse_raises_on_unknown_action_id(tmp_path: Path) -> None:
     """Unknown action ids surface as ``CommandError(INVALID_ARGS)``."""
     config = tmp_path / "x.yaml"

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -212,6 +212,35 @@ def test_parse_api_action_accepts_legacy_service_key() -> None:
     assert parsed[0].location.action_name == "legacy_name"
 
 
+def test_parse_api_block_without_actions_returns_empty() -> None:
+    """An ``api:`` block without an ``actions:`` key yields no api_action entries.
+
+    The api block carries unrelated configuration (encryption, password,
+    port, ...) that's not an automation surface.
+    """
+    yaml = "esphome:\n  name: x\napi:\n  encryption:\n    key: 'aaaa'\n"
+    parsed = parse_device_yaml(yaml)
+    assert [p for p in parsed if p.location.kind == "api_action"] == []
+
+
+def test_parse_api_actions_skips_malformed_items() -> None:
+    """Items missing the discriminator or with a non-dict shape are silently skipped.
+
+    Defensive against mid-edit YAMLs where the user has typed a
+    partial item — surfacing an error would block the parse for
+    every other valid entry.
+    """
+    yaml = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "    - then:\n        - delay: 1s\n"  # no action: key
+        "    - action: good\n      then:\n        - delay: 2s\n"
+    )
+    parsed = parse_device_yaml(yaml)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["good"]
+
+
 # ---------------------------------------------------------------------------
 # Recursive / control-flow
 # ---------------------------------------------------------------------------

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -148,6 +148,71 @@ def test_parse_interval_block() -> None:
 
 
 # ---------------------------------------------------------------------------
+# api.actions
+# ---------------------------------------------------------------------------
+
+
+def test_parse_api_action_surfaces_action_name_and_then() -> None:
+    """A bare ``api.actions:`` item parses to one ``api_action`` entry."""
+    parsed = parse_device_yaml(_load("api_action_simple.yaml"))
+    assert len(parsed) == 1
+    item = parsed[0]
+    assert item.location.kind == "api_action"
+    assert item.location.action_name == "start_laundry"
+    assert item.label == "API: start_laundry"
+    tree = item.automation
+    assert tree.trigger_id is None
+    assert tree.trigger_params == {}
+    assert [a.action_id for a in tree.actions] == ["logger.log"]
+
+
+def test_parse_api_action_surfaces_variables_as_trigger_params() -> None:
+    """``variables:`` survives as a dict on ``trigger_params``."""
+    parsed = parse_device_yaml(_load("api_action_with_variables.yaml"))
+    assert len(parsed) == 1
+    tree = parsed[0].automation
+    # The discriminator key is implicit via location; only sibling
+    # fields (``variables:`` here) surface on trigger_params.
+    assert "action" not in tree.trigger_params
+    assert tree.trigger_params["variables"] == {"message": "string", "urgency": "int"}
+
+
+def test_parse_api_action_emits_one_entry_per_item() -> None:
+    """Multiple ``api.actions:`` siblings each yield their own ParsedAutomation."""
+    parsed = parse_device_yaml(_load("api_actions_multiple.yaml"))
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == [
+        "start_laundry",
+        "stop_laundry",
+    ]
+
+
+def test_parse_api_action_decomposes_nested_if() -> None:
+    """An api-action whose ``then:`` carries an ``if`` decomposes recursively."""
+    parsed = parse_device_yaml(_load("api_action_with_if.yaml"))
+    assert len(parsed) == 1
+    actions = parsed[0].automation.actions
+    assert len(actions) == 1
+    if_node = actions[0]
+    assert if_node.action_id == "if"
+    assert set(if_node.children) == {"then", "else"}
+
+
+def test_parse_api_action_accepts_legacy_service_key() -> None:
+    """The deprecated ``service:`` discriminator parses to the same shape."""
+    legacy = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "    - service: legacy_name\n"
+        "      then:\n        - delay: 1s\n"
+    )
+    parsed = parse_device_yaml(legacy)
+    assert len(parsed) == 1
+    assert parsed[0].location.kind == "api_action"
+    assert parsed[0].location.action_name == "legacy_name"
+
+
+# ---------------------------------------------------------------------------
 # Recursive / control-flow
 # ---------------------------------------------------------------------------
 

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -241,6 +241,24 @@ def test_parse_api_actions_skips_malformed_items() -> None:
     assert [e.location.action_name for e in api_entries] == ["good"]
 
 
+def test_parse_api_actions_skips_non_dict_list_items() -> None:
+    """A bare scalar item in ``actions:`` is silently skipped, not raised.
+
+    A mid-edit YAML can carry a stray ``- foo`` while the user is
+    typing — losing every following valid item to a parse error
+    would be hostile.
+    """
+    yaml = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "    - bogus_scalar\n"
+        "    - action: real\n      then:\n        - delay: 1s\n"
+    )
+    parsed = parse_device_yaml(yaml)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["real"]
+
+
 # ---------------------------------------------------------------------------
 # Recursive / control-flow
 # ---------------------------------------------------------------------------

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -393,6 +393,57 @@ def test_delete_api_action_raises_not_found_when_actions_key_missing() -> None:
     assert err.value.code == ErrorCode.NOT_FOUND
 
 
+def test_upsert_api_action_refuses_inline_actions_list() -> None:
+    """``actions: []`` (or any inline value) is rejected with INVALID_ARGS.
+
+    A line-based splice can't safely insert dash items below
+    ``actions: []`` without producing invalid YAML or doubling the
+    key. Surface a clear error so the user converts to a block list
+    explicitly.
+    """
+    text = "esphome:\n  name: x\napi:\n  actions: []\n"
+    with pytest.raises(CommandError) as err:
+        render_upsert(
+            text,
+            tree=AutomationTree(
+                trigger_id=None,
+                actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+            ),
+            location=ApiActionLocation(action_name="new"),
+        )
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_delete_api_action_refuses_inline_actions_list() -> None:
+    """Same INVALID_ARGS guard fires on the delete path."""
+    text = "esphome:\n  name: x\napi:\n  actions: null\n"
+    with pytest.raises(CommandError) as err:
+        render_delete(text, location=ApiActionLocation(action_name="anything"))
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_upsert_api_action_tolerates_actions_key_with_trailing_comment() -> None:
+    """``actions: # a note`` is still a block-style key; splice as normal."""
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:  # the user added a note here\n"
+        "    - action: existing\n      then:\n        - delay: 1s\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "2s"})],
+        ),
+        location=ApiActionLocation(action_name="newer"),
+    )
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["existing", "newer"]
+    # Comment survived intact.
+    assert "the user added a note here" in new_text
+
+
 def test_delete_api_action_raises_not_found_when_name_missing() -> None:
     """Deleting an unknown ``action_name`` raises NOT_FOUND."""
     text = _load("api_actions_multiple.yaml")

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -393,6 +393,36 @@ def test_delete_api_action_raises_not_found_when_name_missing() -> None:
     assert err.value.code == ErrorCode.NOT_FOUND
 
 
+def test_upsert_api_action_matches_when_discriminator_is_on_a_later_line() -> None:
+    """``action:`` doesn't have to be on the dash line — pick it up from a child line.
+
+    Round-trip from the dashboard always emits ``- action: <name>``
+    inline, but a hand-edited YAML may carry ``variables:`` or other
+    keys above ``action:``. The lookup must find the match either way.
+    """
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "    - variables:\n        msg: string\n"
+        "      action: notify\n"
+        "      then:\n        - delay: 1s\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "5s"})],
+        ),
+        location=ApiActionLocation(action_name="notify"),
+    )
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    # The replace path took effect (one entry, replaced delay value)
+    # rather than an append leaving two ``notify`` siblings.
+    assert [e.location.action_name for e in api_entries] == ["notify"]
+    assert [a.action_id for a in api_entries[0].automation.actions] == ["delay"]
+
+
 # ---------------------------------------------------------------------------
 # Comment / blank-line preservation
 # ---------------------------------------------------------------------------

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -26,6 +26,7 @@ from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models.api import ErrorCode
 from esphome_device_builder.models.automations import (
     ActionNode,
+    ApiActionLocation,
     AutomationTree,
     ComponentOnLocation,
     DeviceOnLocation,
@@ -242,6 +243,154 @@ def test_delete_light_effect_removes_one_list_item() -> None:
     # ``flicker`` is gone, ``pulse`` remains.
     assert "flicker" not in new_text
     assert "pulse" in new_text
+
+
+# ---------------------------------------------------------------------------
+# api.actions
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_api_action_preserves_action_name_and_variables() -> None:
+    """Parse → upsert with same tree → parse keeps the api-action stable."""
+    text = _load("api_action_with_variables.yaml")
+    parsed_first = parse_device_yaml(text)[0]
+    new_text, _diff = render_upsert(
+        text,
+        tree=parsed_first.automation,
+        location=parsed_first.location,
+    )
+    parsed_second = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed_second if p.location.kind == "api_action"]
+    assert len(api_entries) == 1
+    assert api_entries[0].location.action_name == "notify_user"
+    assert api_entries[0].automation.trigger_params["variables"] == {
+        "message": "string",
+        "urgency": "int",
+    }
+
+
+def test_upsert_api_action_creates_block_when_absent() -> None:
+    """A YAML with no ``api:`` block gains one when an api-action lands."""
+    text = "esphome:\n  name: x\n"
+    new_text, diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="my_action"),
+    )
+    assert "api:" in new_text
+    assert "actions:" in new_text
+    assert "- action: my_action" in new_text
+    assert "delay: 1s" in new_text
+    assert diff.replacement.strip() != ""
+
+
+def test_upsert_api_action_creates_actions_under_existing_api_block() -> None:
+    """An ``api:`` block without an ``actions:`` key gains the key + first item."""
+    text = "esphome:\n  name: x\napi:\n  encryption:\n    key: 'aaaa'\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="my_action"),
+    )
+    # The new actions key sits under the existing api block, and the
+    # encryption key it inherited is untouched.
+    assert "encryption:" in new_text
+    assert "key: 'aaaa'" in new_text
+    assert "actions:" in new_text
+    assert "- action: my_action" in new_text
+
+
+def test_upsert_api_action_appends_to_existing_list() -> None:
+    """Appending a new api-action leaves existing siblings byte-stable."""
+    text = _load("api_actions_multiple.yaml")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "5s"})],
+        ),
+        location=ApiActionLocation(action_name="pause_laundry"),
+    )
+    parsed = parse_device_yaml(new_text)
+    api_names = [p.location.action_name for p in parsed if p.location.kind == "api_action"]
+    assert api_names == ["start_laundry", "stop_laundry", "pause_laundry"]
+    # Sibling text is still present verbatim.
+    assert "Starting laundry cycle" in new_text
+    assert "Stopping laundry cycle" in new_text
+
+
+def test_upsert_api_action_replaces_matching_action_name() -> None:
+    """Upserting against an existing ``action_name`` replaces that item in place."""
+    text = _load("api_actions_multiple.yaml")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="stop_laundry"),
+    )
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["start_laundry", "stop_laundry"]
+    # The replaced item carries the new ``delay`` action, not the
+    # original logger.log.
+    stop = next(e for e in api_entries if e.location.action_name == "stop_laundry")
+    assert [a.action_id for a in stop.automation.actions] == ["delay"]
+    # The unrelated sibling stayed intact.
+    assert "Starting laundry cycle" in new_text
+
+
+def test_delete_api_action_drops_only_matching_item() -> None:
+    """Deleting one api-action leaves the other survivors untouched."""
+    text = _load("api_actions_multiple.yaml")
+    new_text, diff = render_delete(
+        text,
+        location=ApiActionLocation(action_name="start_laundry"),
+    )
+    parsed = parse_device_yaml(new_text)
+    api_names = [p.location.action_name for p in parsed if p.location.kind == "api_action"]
+    assert api_names == ["stop_laundry"]
+    assert "Starting laundry cycle" not in new_text
+    assert "Stopping laundry cycle" in new_text
+    assert diff.replacement == ""
+
+
+def test_delete_last_api_action_drops_the_actions_key() -> None:
+    """Deleting the final api-action leaves no ``actions: []`` noise."""
+    text = _load("api_action_simple.yaml")
+    new_text, _diff = render_delete(
+        text,
+        location=ApiActionLocation(action_name="start_laundry"),
+    )
+    assert "actions:" not in new_text
+    assert "start_laundry" not in new_text
+    # The ``api:`` block itself is preserved — encryption / password
+    # siblings (if present) wouldn't be touched. We don't have one
+    # here, so it's just the bare ``api:`` header.
+    assert "api:" in new_text
+
+
+def test_delete_api_action_raises_not_found_when_block_absent() -> None:
+    """Deleting from a YAML with no ``api:`` block raises NOT_FOUND."""
+    text = "esphome:\n  name: x\n"
+    with pytest.raises(CommandError) as err:
+        render_delete(text, location=ApiActionLocation(action_name="absent"))
+    assert err.value.code == ErrorCode.NOT_FOUND
+
+
+def test_delete_api_action_raises_not_found_when_name_missing() -> None:
+    """Deleting an unknown ``action_name`` raises NOT_FOUND."""
+    text = _load("api_actions_multiple.yaml")
+    with pytest.raises(CommandError) as err:
+        render_delete(text, location=ApiActionLocation(action_name="never_added"))
+    assert err.value.code == ErrorCode.NOT_FOUND
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -474,6 +474,40 @@ def test_upsert_api_action_skips_malformed_sibling_during_lookup() -> None:
     assert "delay: 9s" in new_text
 
 
+def test_upsert_api_action_preserves_blank_lines_in_lambda_block_scalar() -> None:
+    """A ``|``-style lambda body with an embedded blank line round-trips intact.
+
+    Padding the blank line with spaces would turn it into a
+    whitespace-only line — which YAML treats differently inside a
+    literal block scalar than a fully empty line, corrupting the
+    lambda's content. Pin that the writer keeps blank lines blank.
+    """
+    text = "esphome:\n  name: x\n"
+    body = 'ESP_LOGI("tag", "before");\n\nESP_LOGI("tag", "after");'
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[
+                ActionNode(action_id="lambda", params={"id": {"_lambda": body}}),
+            ],
+        ),
+        location=ApiActionLocation(action_name="logme"),
+    )
+    # The embedded blank line stays a fully-empty line (no leading
+    # whitespace).
+    assert "\n\n" in new_text
+    # Round-trip parses back to the same lambda body.
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert len(api_entries) == 1
+    params = api_entries[0].automation.actions[0].params
+    src = params["id"]["_lambda"] if "id" in params else params["_lambda"]
+    assert "before" in src
+    assert "after" in src
+    assert "\n\n" in src
+
+
 def test_upsert_api_action_tolerates_actions_key_with_trailing_comment() -> None:
     """``actions: # a note`` is still a block-style key; splice as normal."""
     text = (

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -422,6 +422,58 @@ def test_delete_api_action_refuses_inline_actions_list() -> None:
     assert err.value.code == ErrorCode.INVALID_ARGS
 
 
+def test_upsert_api_action_appends_into_empty_actions_with_sibling_key() -> None:
+    """``actions:`` with no items but a sibling key below gains its first item.
+
+    Hits the ``item_indent`` fallback in ``locate_actions_list`` —
+    there's no existing dash to derive the indent from, so the
+    canonical child + 2 nesting is used.
+    """
+    text = "esphome:\n  name: x\napi:\n  actions:\n  encryption:\n    key: 'aaaa'\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="first"),
+    )
+    # The new item landed under actions:, encryption: stayed intact.
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["first"]
+    assert "encryption:" in new_text
+    assert "key: 'aaaa'" in new_text
+
+
+def test_upsert_api_action_skips_malformed_sibling_during_lookup() -> None:
+    """A malformed sibling item (no ``action:`` key) doesn't derail the lookup.
+
+    Hits the ``_discriminator`` returns-None branch — ``find_item``
+    walks every list item, and items missing a discriminator are
+    silently skipped instead of crashing the upsert.
+    """
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "    - variables:\n        foo: int\n"  # no action: key at all
+        "    - action: real\n      then:\n        - delay: 1s\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "9s"})],
+        ),
+        location=ApiActionLocation(action_name="real"),
+    )
+    # The ``real`` action was replaced (not appended as a duplicate).
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["real"]
+    assert "delay: 9s" in new_text
+
+
 def test_upsert_api_action_tolerates_actions_key_with_trailing_comment() -> None:
     """``actions: # a note`` is still a block-style key; splice as normal."""
     text = (

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -385,12 +385,140 @@ def test_delete_api_action_raises_not_found_when_block_absent() -> None:
     assert err.value.code == ErrorCode.NOT_FOUND
 
 
+def test_delete_api_action_raises_not_found_when_actions_key_missing() -> None:
+    """An ``api:`` block without an ``actions:`` key is also NOT_FOUND."""
+    text = "esphome:\n  name: x\napi:\n  encryption:\n    key: 'aaaa'\n"
+    with pytest.raises(CommandError) as err:
+        render_delete(text, location=ApiActionLocation(action_name="absent"))
+    assert err.value.code == ErrorCode.NOT_FOUND
+
+
 def test_delete_api_action_raises_not_found_when_name_missing() -> None:
     """Deleting an unknown ``action_name`` raises NOT_FOUND."""
     text = _load("api_actions_multiple.yaml")
     with pytest.raises(CommandError) as err:
         render_delete(text, location=ApiActionLocation(action_name="never_added"))
     assert err.value.code == ErrorCode.NOT_FOUND
+
+
+def test_upsert_api_action_preserves_api_siblings_after_actions() -> None:
+    """An ``api:`` block with siblings (encryption, port, ...) keeps them intact.
+
+    Pins the actions-list locator's boundary scan — it has to stop
+    at ``encryption:`` (sibling at child indent) rather than
+    swallowing the rest of the api block. Without that the splice
+    point lands inside the wrong key.
+    """
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n"
+        "  actions:\n"
+        "    - action: existing\n      then:\n        - delay: 1s\n"
+        "\n"
+        "  encryption:\n    key: 'aaaa'\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "2s"})],
+        ),
+        location=ApiActionLocation(action_name="new_one"),
+    )
+    # Sibling encryption: survived.
+    assert "encryption:" in new_text
+    assert "key: 'aaaa'" in new_text
+    # Both api actions are present, encryption is still its own block.
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["existing", "new_one"]
+
+
+def test_upsert_api_action_creates_block_when_yaml_has_no_trailing_newline() -> None:
+    """A YAML missing its trailing newline still gets a well-formed new api block."""
+    text = "esphome:\n  name: x"  # no trailing newline
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="my_action"),
+    )
+    assert new_text.endswith("\n")
+    assert "- action: my_action" in new_text
+
+
+def test_upsert_api_action_inserts_actions_key_when_api_has_trailing_blanks() -> None:
+    """Trailing blank lines inside the ``api:`` block don't shift the insert point.
+
+    Pins the insert-point trim — the new ``actions:`` key has to land
+    above any trailing blank lines so subsequent top-level blocks
+    don't collide with it.
+    """
+    text = "esphome:\n  name: x\napi:\n  encryption:\n    key: 'aaaa'\n\n\nwifi:\n  ssid: x\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="my_action"),
+    )
+    # The api block's trailing structure should survive; the new
+    # actions key lands above the blank-line gap and wifi remains
+    # its own top-level block.
+    assert "wifi:" in new_text
+    assert "  actions:" in new_text
+    # Parser sees both the api action and otherwise valid YAML.
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["my_action"]
+
+
+def test_upsert_api_action_drops_action_key_smuggled_in_trigger_params() -> None:
+    """An explicit ``action`` key on the tree's trigger_params is ignored.
+
+    The discriminator lives on the location, not the tree. A
+    hand-built tree may still carry ``action: <name>`` in
+    trigger_params (e.g. round-tripped from a pre-rename shape);
+    the emitter must not write two ``action:`` lines per item.
+    """
+    text = "esphome:\n  name: x\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            trigger_params={"action": "ignored_name", "service": "also_ignored"},
+            actions=[ActionNode(action_id="delay", params={"id": "1s"})],
+        ),
+        location=ApiActionLocation(action_name="real_name"),
+    )
+    # Only the location-derived action_name is emitted.
+    assert "- action: real_name" in new_text
+    assert "ignored_name" not in new_text
+    assert "also_ignored" not in new_text
+
+
+def test_upsert_api_action_appends_when_actions_has_trailing_blank() -> None:
+    """A trailing blank line below the last item doesn't push the new item past it."""
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n  actions:\n"
+        "    - action: existing\n      then:\n        - delay: 1s\n"
+        "\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id=None,
+            actions=[ActionNode(action_id="delay", params={"id": "2s"})],
+        ),
+        location=ApiActionLocation(action_name="new_one"),
+    )
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["existing", "new_one"]
 
 
 def test_upsert_api_action_matches_when_discriminator_is_on_a_later_line() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Extends the merged automation editor backend to handle `api.actions:` — ESPHome's mechanism for exposing user-callable actions to Home Assistant. Structurally a near-duplicate of `script:` (named callable, typed `variables:`, `then:` action list, no trigger), so the existing script pipeline is reused via a new `ApiActionLocation` member of the `AutomationLocation` tagged union.

- New `ApiActionLocation(kind="api_action", action_name)` in `AutomationLocation`.
- Parser walks the top-level `api:` block's `actions:` list; one `ParsedAutomation` per item with `label = "API: <name>"`. Accepts the deprecated `service:` discriminator on read.
- Writer splices / replaces / appends list items by `action_name`; leaves siblings byte-stable. Deleting the last item drops the `actions:` key entirely so no `actions: []` noise lands. Creates the `api:` block (and the `actions:` key) when missing.
- Controller dispatch + WS payload decode wired through `automations/upsert` and `automations/delete`.
- Splice helpers live in a new `controllers/automations/api_actions.py` module to keep `writing.py` focused on dispatch.
- Docs + tests updated; fixtures cover simple, multi-sibling, `variables:`, nested `if`, and legacy `service:` shapes.

**Related issue or feature (if applicable):**

- closes esphome/device-builder#411

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: target-picker / nav-label work follows in a separate PR

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.