### PR TITLE
Quote sdkconfig_options string values that re-parse as non-string

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -201,7 +201,21 @@ def _coerce_string_map_values(
         value = fields.get(entry.key)
         if not isinstance(value, dict):
             continue
-        fields[entry.key] = {k: str(v) if not isinstance(v, str) else v for k, v in value.items()}
+        fields[entry.key] = {k: _coerce_map_scalar_to_string(v) for k, v in value.items()}
+
+
+def _coerce_map_scalar_to_string(value: Any) -> str:
+    """Convert a MAP-value scalar to its YAML-string form."""
+    if isinstance(value, str):
+        return value
+    # ``str(True)`` is ``"True"`` which YAML 1.1 re-parses as bool;
+    # canonicalise to the lowercase form so the downstream quoter
+    # recognises and quotes it.
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    return str(value)
 
 
 def _append_block(existing: str, block: str) -> str:
@@ -264,22 +278,33 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
 
 def _format_yaml_value(value: Any) -> str:
     """Format a Python value for YAML output."""
+    if value is None:
+        return "null"
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        if value in ("true", "false", "null", "yes", "no", "on", "off", "%", "~", ""):
-            return f'"{value}"'
-        if value.startswith("!") or ":" in value or "#" in value:
-            return f'"{value}"'
-        # Quote strings YAML would re-parse as a non-string scalar
-        # (``"100"`` -> int, ``"3.14"`` -> float, ``"2024-01-01"`` ->
-        # date). Without this, ``sdkconfig_options`` entries whose
-        # value is a numeric-looking string get parsed back as int and
-        # ESPHome's ``cv.string_strict`` rejects them (issue #901).
-        if _yaml_reparses_as_non_string(value):
-            return f'"{value}"'
-        return value
+        return f'"{value}"' if _string_needs_quoting(value) else value
     return str(value)
+
+
+_YAML_RESERVED_KEYWORDS = frozenset({"true", "false", "null", "yes", "no", "on", "off"})
+
+
+def _string_needs_quoting(value: str) -> bool:
+    """Return True when *value* needs YAML quoting to round-trip as a string."""
+    # YAML 1.1 recognises every case variant of the reserved words
+    # (``true``/``True``/``TRUE`` etc.) as bool/null, so ``str(True)``
+    # from a JSON bool would otherwise re-parse as ``True``. ``%`` is
+    # a YAML directive indicator; ``~`` and empty string are YAML null
+    # shorthands; ``!`` opens a tag; ``:`` opens a mapping value;
+    # ``#`` opens a comment. Anything that survives those checks then
+    # gets the (cheap pre-filtered) ``yaml.safe_load`` round-trip test
+    # for numeric-looking strings — the original #901 case.
+    if value.lower() in _YAML_RESERVED_KEYWORDS or value in ("%", "~", ""):
+        return True
+    if value.startswith("!") or ":" in value or "#" in value:
+        return True
+    return _yaml_reparses_as_non_string(value)
 
 
 # YAML 1.1 plain scalars can only re-parse as a non-string when the

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+import yaml
+
+from ...models import ConfigEntryType
 from .scalar import ESPHOME_YAML_INDENT
 
 if TYPE_CHECKING:
@@ -115,6 +118,7 @@ def generate_component_yaml(
       (no name) or can't be referenced from automations (no id).
     """
     fields = dict(fields)
+    _coerce_string_map_values(component, fields)
     category = component.category
     comp_id = component.id
 
@@ -173,6 +177,31 @@ def generate_component_yaml(
         lines.extend(_emit_field(key, value, indent))
 
     return "\n".join(lines)
+
+
+def _coerce_string_map_values(
+    component: ComponentCatalogEntry,
+    fields: dict[str, Any],
+) -> None:
+    """
+    Stringify dict values for MAP fields whose value template is STRING.
+
+    ``sdkconfig_options`` validates as ``Dict[str, str]`` on the
+    ESPHome side; a frontend that sends JSON number ``100`` for the
+    value would otherwise emit ``CONFIG_FOO: 100`` and trip
+    ``cv.string_strict`` (issue #901).
+    """
+    for entry in component.config_entries:
+        if entry.type != ConfigEntryType.MAP:
+            continue
+        if not entry.config_entries:
+            continue
+        if entry.config_entries[0].type != ConfigEntryType.STRING:
+            continue
+        value = fields.get(entry.key)
+        if not isinstance(value, dict):
+            continue
+        fields[entry.key] = {k: str(v) if not isinstance(v, str) else v for k, v in value.items()}
 
 
 def _append_block(existing: str, block: str) -> str:
@@ -242,8 +271,24 @@ def _format_yaml_value(value: Any) -> str:
             return f'"{value}"'
         if value.startswith("!") or ":" in value or "#" in value:
             return f'"{value}"'
+        # Quote strings YAML would re-parse as a non-string scalar
+        # (``"100"`` -> int, ``"3.14"`` -> float, ``"2024-01-01"`` ->
+        # date). Without this, ``sdkconfig_options`` entries whose
+        # value is a numeric-looking string get parsed back as int and
+        # ESPHome's ``cv.string_strict`` rejects them (issue #901).
+        if _yaml_reparses_as_non_string(value):
+            return f'"{value}"'
         return value
     return str(value)
+
+
+def _yaml_reparses_as_non_string(value: str) -> bool:
+    """Return True when ``yaml.safe_load(value)`` is not a string."""
+    try:
+        parsed = yaml.safe_load(value)
+    except yaml.YAMLError:
+        return False
+    return parsed is not None and not isinstance(parsed, str)
 
 
 def _format_flow_yaml_value(value: Any) -> str:

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -267,7 +267,7 @@ def _format_yaml_value(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        if value in ("true", "false", "null", "yes", "no", "on", "off", "%"):
+        if value in ("true", "false", "null", "yes", "no", "on", "off", "%", "~", ""):
             return f'"{value}"'
         if value.startswith("!") or ":" in value or "#" in value:
             return f'"{value}"'

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -282,8 +282,22 @@ def _format_yaml_value(value: Any) -> str:
     return str(value)
 
 
+# YAML 1.1 plain scalars can only re-parse as a non-string when the
+# first character is a digit, sign, or ``.`` (covers int / float /
+# hex / binary / ``.inf`` / ``.nan`` / dates / timestamps). Every
+# other plain leading character resolves to a string, so the cheap
+# membership test rules out the ``yaml.safe_load`` call for typical
+# values like ``"GPIO4"`` or ``"Bedroom Light"`` — without the
+# pre-filter the parser ran on every emitted string field and
+# regressed ``merge_component_yaml`` by ~600µs per emission
+# (CodSpeed flagged this on #908).
+_YAML_AMBIGUOUS_FIRST = frozenset("0123456789-+.")
+
+
 def _yaml_reparses_as_non_string(value: str) -> bool:
     """Return True when ``yaml.safe_load(value)`` is not a string."""
+    if not value or value[0] not in _YAML_AMBIGUOUS_FIRST:
+        return False
     try:
         parsed = yaml.safe_load(value)
     except yaml.YAMLError:

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from ...models import ConfigEntryType
+from ...models.common import ConfigEntryType
 from .scalar import ESPHOME_YAML_INDENT
 
 if TYPE_CHECKING:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1307,12 +1307,48 @@ def test_generate_component_yaml_coerce_skips_map_with_non_string_template() -> 
 
 
 def test_generate_component_yaml_coerce_skips_map_value_that_isnt_a_dict() -> None:
-    """A MAP key whose value is not a dict (None / missing) is left alone."""
+    """A MAP field whose value is None emits as ``null`` (coerce no-ops)."""
     component = _component_with_string_map("sdkconfig_options")
     # ``None`` would land here when the frontend submits the field
-    # with an empty payload; the coerce step must not blow up.
+    # with an empty payload; the coerce step must not blow up and the
+    # emitter renders YAML ``null`` rather than Python's ``None``.
     out = generate_component_yaml(component, {"sdkconfig_options": None})
-    assert "  sdkconfig_options: null" in out or "  sdkconfig_options: None" in out
+    assert "  sdkconfig_options: null" in out
+
+
+@pytest.mark.parametrize(
+    ("py_value", "expected"),
+    [(True, '"true"'), (False, '"false"'), (None, '"null"')],
+    ids=["bool-true", "bool-false", "none"],
+)
+def test_generate_component_yaml_quotes_map_bool_and_none_values(
+    py_value: Any, expected: str
+) -> None:
+    """A MAP string-typed value sent as JSON ``true`` / ``false`` / ``null``.
+
+    Coerce canonicalises to the lowercase YAML keyword, which the
+    emitter then quotes — so the round-tripped value stays a string
+    rather than landing as a YAML bool / null and tripping
+    ``cv.string_strict`` (same class of bug as #901, raised in PR
+    review).
+    """
+    component = _component_with_string_map("sdkconfig_options")
+    out = generate_component_yaml(component, {"sdkconfig_options": {"K": py_value}})
+    assert f"    K: {expected}" in out
+
+
+@pytest.mark.parametrize("variant", ["True", "TRUE", "False", "FALSE", "Null", "NULL"])
+def test_generate_component_yaml_quotes_case_variant_keyword_strings(variant: str) -> None:
+    """``"True"`` / ``"FALSE"`` etc. round-trip as bool/null on YAML 1.1.
+
+    The base allowlist only carried the lowercase forms; PyYAML
+    recognises every case variant the spec lists, so a Python string
+    ``"True"`` (e.g. ``str(True)``) re-parsed to ``True``. Quote any
+    case variant so the value survives as a string.
+    """
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"v": variant})
+    assert f'  v: "{variant}"' in out
 
 
 def test_generate_component_yaml_quotes_unparseable_string_starting_with_digit() -> None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1251,6 +1251,82 @@ def test_generate_component_yaml_leaves_plain_map_string_value_unquoted() -> Non
     assert '"y"' not in out
 
 
+def test_generate_component_yaml_coerce_skips_non_map_entry() -> None:
+    """Non-MAP entries pass through the coerce step untouched."""
+    component = ComponentCatalogEntry(
+        id="myc",
+        name="myc",
+        description="",
+        category=ComponentCategory.MISC,
+        config_entries=[
+            ConfigEntry(key="label", type=ConfigEntryType.STRING, label="Label"),
+        ],
+    )
+    out = generate_component_yaml(component, {"label": "kitchen"})
+    assert "  label: kitchen" in out
+
+
+def test_generate_component_yaml_coerce_skips_map_without_value_template() -> None:
+    """A MAP entry without an inner ``config_entries[0]`` is left alone."""
+    component = ComponentCatalogEntry(
+        id="myc",
+        name="myc",
+        description="",
+        category=ComponentCategory.MISC,
+        config_entries=[
+            ConfigEntry(key="opts", type=ConfigEntryType.MAP, label="Opts"),
+        ],
+    )
+    out = generate_component_yaml(component, {"opts": {"k": 1}})
+    assert "    k: 1" in out
+
+
+def test_generate_component_yaml_coerce_skips_map_with_non_string_template() -> None:
+    """A MAP whose value template is INTEGER preserves the int value."""
+    component = ComponentCatalogEntry(
+        id="myc",
+        name="myc",
+        description="",
+        category=ComponentCategory.MISC,
+        config_entries=[
+            ConfigEntry(
+                key="opts",
+                type=ConfigEntryType.MAP,
+                label="Opts",
+                config_entries=[
+                    ConfigEntry(key="value", type=ConfigEntryType.INTEGER, label="Value"),
+                ],
+            ),
+        ],
+    )
+    out = generate_component_yaml(component, {"opts": {"k": 7}})
+    assert "    k: 7" in out
+    assert '"7"' not in out
+
+
+def test_generate_component_yaml_coerce_skips_map_value_that_isnt_a_dict() -> None:
+    """A MAP key whose value is not a dict (None / missing) is left alone."""
+    component = _component_with_string_map("sdkconfig_options")
+    # ``None`` would land here when the frontend submits the field
+    # with an empty payload; the coerce step must not blow up.
+    out = generate_component_yaml(component, {"sdkconfig_options": None})
+    assert "  sdkconfig_options: null" in out or "  sdkconfig_options: None" in out
+
+
+def test_generate_component_yaml_quotes_unparseable_string_starting_with_digit() -> None:
+    r"""A digit-led string yaml can't parse (``"0\t"``) falls through unquoted.
+
+    Exercises the ``yaml.YAMLError`` branch in
+    ``_yaml_reparses_as_non_string`` — the pre-filter lets the value
+    through, the parser raises, and the helper returns False so the
+    string emits without quotes.
+    """
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"v": "0\t"})
+    # The value rendered bare — no extra quotes from the reparse check.
+    assert '  v: "' not in out
+
+
 # ---------------------------------------------------------------------------
 # _splice_into_domain_block — defensive guards
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -44,6 +44,7 @@ from esphome_device_builder.helpers.yaml import (
     rewrite_yaml_scalar,
     upsert_yaml_leaf_under_top_block,
 )
+from esphome_device_builder.models.common import ConfigEntry, ConfigEntryType
 from esphome_device_builder.models.components import (
     ComponentCatalogEntry,
     ComponentCategory,
@@ -1067,6 +1068,20 @@ def test_generate_component_yaml_emits_numeric_value_via_str(value: int | float)
     assert f'"{value}"' not in out
 
 
+@pytest.mark.parametrize(
+    "value",
+    ["100", "-5", "+5", "3.14", "0xFF", "0b101", ".inf", ".nan", "2024-01-01"],
+    ids=["int", "neg-int", "pos-int", "float", "hex", "binary", "inf", "nan", "date"],
+)
+def test_generate_component_yaml_quotes_strings_that_reparse_as_non_string(
+    value: str,
+) -> None:
+    """Strings whose YAML re-parse isn't a string get quoted (issue #901)."""
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"v": value})
+    assert f'  v: "{value}"' in out
+
+
 # ---------------------------------------------------------------------------
 # generate_component_yaml — nested fields (_emit_field branches)
 # ---------------------------------------------------------------------------
@@ -1187,6 +1202,53 @@ def test_generate_component_yaml_quotes_flow_string_with_flow_indicator() -> Non
     component = _component(component_id="myc", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"items": ["a,b", "c"]})
     assert '  items: ["a,b", c]' in out
+
+
+# ---------------------------------------------------------------------------
+# generate_component_yaml — MAP fields with string value templates
+# ---------------------------------------------------------------------------
+
+
+def _component_with_string_map(key: str) -> ComponentCatalogEntry:
+    """Component with one MAP entry whose value template is STRING."""
+    return ComponentCatalogEntry(
+        id="myc",
+        name="myc",
+        description="",
+        category=ComponentCategory.MISC,
+        config_entries=[
+            ConfigEntry(
+                key=key,
+                type=ConfigEntryType.MAP,
+                label="Map",
+                config_entries=[
+                    ConfigEntry(key="value", type=ConfigEntryType.STRING, label="Value"),
+                ],
+            ),
+        ],
+    )
+
+
+def test_generate_component_yaml_quotes_map_string_value_that_looks_numeric() -> None:
+    """A MAP string-typed value sent as ``"100"`` lands quoted (issue #901)."""
+    component = _component_with_string_map("sdkconfig_options")
+    out = generate_component_yaml(component, {"sdkconfig_options": {"CONFIG_FOO": "100"}})
+    assert '    CONFIG_FOO: "100"' in out
+
+
+def test_generate_component_yaml_coerces_map_numeric_value_to_quoted_string() -> None:
+    """A MAP string-typed value sent as JSON number ``100`` lands as ``"100"``."""
+    component = _component_with_string_map("sdkconfig_options")
+    out = generate_component_yaml(component, {"sdkconfig_options": {"CONFIG_FOO": 100}})
+    assert '    CONFIG_FOO: "100"' in out
+
+
+def test_generate_component_yaml_leaves_plain_map_string_value_unquoted() -> None:
+    """A MAP string value that round-trips as itself stays unquoted."""
+    component = _component_with_string_map("sdkconfig_options")
+    out = generate_component_yaml(component, {"sdkconfig_options": {"CONFIG_FOO": "y"}})
+    assert "    CONFIG_FOO: y" in out
+    assert '"y"' not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1003,7 +1003,7 @@ def test_generate_component_yaml_emits_bool_false_lowercase() -> None:
     assert "  enabled: false" in out
 
 
-@pytest.mark.parametrize("keyword", ["true", "false", "null", "yes", "no", "on", "off"])
+@pytest.mark.parametrize("keyword", ["true", "false", "null", "yes", "no", "on", "off", "~", ""])
 def test_generate_component_yaml_quotes_yaml_keyword_strings(keyword: str) -> None:
     """Strings whose value is a YAML 1.1 boolean keyword get quoted.
 
@@ -1012,7 +1012,9 @@ def test_generate_component_yaml_quotes_yaml_keyword_strings(keyword: str) -> No
     these as enum values for several components (e.g. light states),
     so the helper has to disambiguate. ``null`` / ``yes`` / ``no``
     follow the same logic; pin every keyword in the helper's
-    allowlist so a regression that drops one shows up here.
+    allowlist so a regression that drops one shows up here. ``~`` and
+    the empty string round-trip as YAML null, same class of bug as
+    #901 for any field validating as a strict string.
     """
     component = _component(component_id="myc", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"state": keyword})


### PR DESCRIPTION
# What does this implement/fix?

Adding a `sdkconfig_options` entry through the visual editor with an integer-looking value (e.g. `100`) produced YAML like `CONFIG_FOO: 100`, which ESPHome's `cv.string_strict` rejected since `sdkconfig_options` validates as `Dict[str, str]`. The emitter dropped the string-ness in two ways: a Python string `"100"` was written unquoted, and a JSON-number `100` from the form wasn't coerced back to a string.

Changes:

- `_format_yaml_value` now quotes any string whose `yaml.safe_load` round-trip is a non-string scalar (int, float, hex, binary, inf/nan, date).
- New `_coerce_string_map_values` step stringifies values for MAP entries whose value template is `STRING` before emission, so a JSON-number sent by the frontend still lands as a quoted YAML string.
- Tests pin the quoting for nine scalar shapes plus the three MAP code paths.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/901

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
