### PR TITLE
Fix MQTT broker-resolve log spam for packages-based configs

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import yaml
 
+from ..helpers.device_yaml import load_device_yaml
 from ..helpers.yaml import FastestSafeLoader
 from ..models import Device
 from ._device_mqtt_monitor import (
@@ -52,6 +53,18 @@ class DeviceMqttCoordinator:
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._monitors: dict[tuple[str, int], DeviceMqttMonitor] = {}
+        # Cached broker per device, keyed on the YAML's mtime so the
+        # expensive ``load_device_yaml`` fallback (resolves
+        # ``packages:`` / ``!include``) only runs again when the file
+        # actually changes. Unchanged YAMLs return their cached
+        # broker on every poll.
+        self._broker_cache: dict[str, tuple[float, MqttBrokerConfig | None]] = {}
+        # Device filenames we've already logged a broker-unresolvable
+        # WARNING for. Subsequent polls drop to DEBUG so a single
+        # mis-configured device doesn't spam the log every 5 s.
+        # Cleared when the broker resolves or the device stops
+        # declaring ``mqtt:``.
+        self._unresolved_logged: set[str] = set()
 
     @property
     def active_brokers(self) -> int:
@@ -98,23 +111,17 @@ class DeviceMqttCoordinator:
     def _collect_brokers(self) -> list[MqttBrokerConfig]:
         secrets_map = _load_secrets(self._config_dir)
         seen: dict[tuple[str, int], MqttBrokerConfig] = {}
+        seen_devices: set[str] = set()
         for device in self._get_devices():
             if not device.uses_mqtt:
                 continue
+            seen_devices.add(device.configuration)
             yaml_path = self._config_dir / device.configuration
-            try:
-                yaml_content = yaml_path.read_text(encoding="utf-8")
-            except OSError:
-                _LOGGER.debug("Could not read %s for MQTT broker config", device.configuration)
-                continue
-            broker = parse_mqtt_block(yaml_content, secrets_map)
+            broker = self._resolve_broker(yaml_path, secrets_map)
             if broker is None:
-                _LOGGER.warning(
-                    "Device %s declares mqtt: but broker could not be resolved "
-                    "(missing secret or invalid config)",
-                    device.configuration,
-                )
+                self._log_broker_unresolved(device.configuration)
                 continue
+            self._unresolved_logged.discard(device.configuration)
             existing = seen.get(broker.key)
             if existing is None:
                 seen[broker.key] = broker
@@ -126,7 +133,59 @@ class DeviceMqttCoordinator:
                     broker.host,
                     broker.port,
                 )
+        # Forget per-device tracking for devices that no longer
+        # declare ``mqtt:`` so the next time they do, the WARNING
+        # surfaces again instead of being silently suppressed.
+        self._unresolved_logged &= seen_devices
+        self._broker_cache = {k: v for k, v in self._broker_cache.items() if k in seen_devices}
         return list(seen.values())
+
+    def _resolve_broker(
+        self, yaml_path: Path, secrets_map: dict[str, Any]
+    ) -> MqttBrokerConfig | None:
+        """Resolve the broker for *yaml_path*, falling back to a full YAML resolve.
+
+        Fast path: raw-text parse of the device YAML — covers the
+        common case where ``mqtt:`` is at the top level of the file
+        itself. Slow path: ``load_device_yaml`` expands
+        ``packages:`` / ``!include`` so configs that pull the mqtt
+        block in from a shared package still resolve. The slow path
+        is cached per (file, mtime) so a steady-state poll doesn't
+        re-resolve packages every 5 s.
+        """
+        try:
+            yaml_content = yaml_path.read_text(encoding="utf-8")
+        except OSError:
+            _LOGGER.debug("Could not read %s for MQTT broker config", yaml_path.name)
+            return None
+        broker = parse_mqtt_block(yaml_content, secrets_map)
+        if broker is not None:
+            return broker
+        try:
+            mtime = yaml_path.stat().st_mtime
+        except OSError:
+            return None
+        cached = self._broker_cache.get(yaml_path.name)
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
+        resolved = load_device_yaml(yaml_path)
+        broker = _extract_broker_from_config(resolved)
+        self._broker_cache[yaml_path.name] = (mtime, broker)
+        return broker
+
+    def _log_broker_unresolved(self, configuration: str) -> None:
+        if configuration in self._unresolved_logged:
+            _LOGGER.debug(
+                "Device %s declares mqtt: but broker still could not be resolved",
+                configuration,
+            )
+            return
+        _LOGGER.warning(
+            "Device %s declares mqtt: but broker could not be resolved "
+            "(missing secret or invalid config)",
+            configuration,
+        )
+        self._unresolved_logged.add(configuration)
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +235,10 @@ def parse_mqtt_block(
     Returns ``None`` when the YAML has no ``mqtt:`` block, when the
     block has no resolvable ``broker:`` field, or when the YAML fails
     to parse. ``!secret xyz`` references are resolved via *secrets_map*.
+    Sees only the literal file contents — configs that bring the
+    ``mqtt:`` block in via ``packages:`` / ``!include`` won't match;
+    callers needing that resolution go through
+    :func:`load_device_yaml` and ``_extract_broker_from_config``.
     """
     secrets_map = secrets_map or {}
     try:
@@ -205,6 +268,39 @@ def parse_mqtt_block(
     password = _resolve(mqtt.get("password"), secrets_map) or None
 
     return MqttBrokerConfig(host=host, port=port, username=username, password=password)
+
+
+def _extract_broker_from_config(config: dict | None) -> MqttBrokerConfig | None:
+    """
+    Extract broker parameters from a fully-resolved ESPHome config.
+
+    Mirrors :func:`parse_mqtt_block` but operates on the dict
+    produced by :func:`load_device_yaml` — i.e. after ``!secret``,
+    ``!include`` and ``packages:`` have been resolved by ESPHome's
+    own loader. Returns ``None`` when *config* has no ``mqtt:`` key
+    or the block has no usable ``broker:``.
+    """
+    if not isinstance(config, dict):
+        return None
+    mqtt = config.get("mqtt")
+    if not isinstance(mqtt, dict):
+        return None
+    host = mqtt.get("broker")
+    if not host:
+        return None
+    port_raw = mqtt.get("port")
+    try:
+        port = int(port_raw) if port_raw else _DEFAULT_PORT
+    except (TypeError, ValueError):
+        port = _DEFAULT_PORT
+    username = mqtt.get("username") or None
+    password = mqtt.get("password") or None
+    return MqttBrokerConfig(
+        host=str(host),
+        port=port,
+        username=str(username) if username is not None else None,
+        password=str(password) if password is not None else None,
+    )
 
 
 def _load_secrets(config_dir: Path) -> dict[str, Any]:

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -53,12 +53,16 @@ class DeviceMqttCoordinator:
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._monitors: dict[tuple[str, int], DeviceMqttMonitor] = {}
-        # Cached broker per device, keyed on the YAML's mtime so the
-        # expensive ``load_device_yaml`` fallback (resolves
-        # ``packages:`` / ``!include``) only runs again when the file
-        # actually changes. Unchanged YAMLs return their cached
-        # broker on every poll.
-        self._broker_cache: dict[str, tuple[float, MqttBrokerConfig | None]] = {}
+        # Cached broker per device, keyed on the YAML's mtime and
+        # ``secrets.yaml``'s mtime so the expensive
+        # ``load_device_yaml`` fallback (resolves ``packages:`` /
+        # ``!include`` / ``!secret``) only runs again when something
+        # the resolve depends on actually changes. Only successful
+        # resolves are cached — ``None`` results are re-tried every
+        # poll so a user edit to a ``!include``d / package file
+        # (whose mtime we don't track) recovers without a process
+        # restart.
+        self._broker_cache: dict[str, tuple[tuple[float, float], MqttBrokerConfig]] = {}
         # Device filenames we've already logged a broker-unresolvable
         # WARNING for. Subsequent polls drop to DEBUG so a single
         # mis-configured device doesn't spam the log every 5 s.
@@ -148,10 +152,13 @@ class DeviceMqttCoordinator:
         Fast path: raw-text parse of the device YAML — covers the
         common case where ``mqtt:`` is at the top level of the file
         itself. Slow path: ``load_device_yaml`` expands
-        ``packages:`` / ``!include`` so configs that pull the mqtt
-        block in from a shared package still resolve. The slow path
-        is cached per (file, mtime) so a steady-state poll doesn't
-        re-resolve packages every 5 s.
+        ``packages:`` / ``!include`` / ``!secret`` so configs that
+        pull the mqtt block in from a shared package or read the
+        broker from ``secrets.yaml`` still resolve. The slow path is
+        cached per ``(yaml_mtime, secrets_mtime)`` so a steady-state
+        poll doesn't re-resolve packages every 5 s, and only
+        positive results are cached so a fix to a transitively-
+        included file recovers on the next poll without a restart.
         """
         try:
             yaml_content = yaml_path.read_text(encoding="utf-8")
@@ -162,15 +169,19 @@ class DeviceMqttCoordinator:
         if broker is not None:
             return broker
         try:
-            mtime = yaml_path.stat().st_mtime
+            yaml_mtime = yaml_path.stat().st_mtime
         except OSError:
             return None
+        cache_key = (yaml_mtime, _safe_mtime(self._config_dir / "secrets.yaml"))
         cached = self._broker_cache.get(yaml_path.name)
-        if cached is not None and cached[0] == mtime:
+        if cached is not None and cached[0] == cache_key:
             return cached[1]
         resolved = load_device_yaml(yaml_path)
         broker = _extract_broker_from_config(resolved)
-        self._broker_cache[yaml_path.name] = (mtime, broker)
+        if broker is not None:
+            self._broker_cache[yaml_path.name] = (cache_key, broker)
+        else:
+            self._broker_cache.pop(yaml_path.name, None)
         return broker
 
     def _log_broker_unresolved(self, configuration: str) -> None:
@@ -317,6 +328,14 @@ def _load_secrets(config_dir: Path) -> dict[str, Any]:
         _LOGGER.warning("Could not parse secrets.yaml — MQTT broker secrets unavailable")
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _safe_mtime(path: Path) -> float:
+    """Return *path*'s mtime, or ``0.0`` when the file is missing."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def _resolve(value: Any, secrets_map: dict[str, Any]) -> str | None:

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -106,6 +106,7 @@ class DeviceMqttCoordinator:
 
     def _collect_brokers(self) -> list[MqttBrokerConfig]:
         secrets_map = _load_secrets(self._config_dir)
+        secrets_mtime = _safe_mtime(self._config_dir / "secrets.yaml")
         seen: dict[tuple[str, int], MqttBrokerConfig] = {}
         seen_devices: set[str] = set()
         for device in self._get_devices():
@@ -115,12 +116,15 @@ class DeviceMqttCoordinator:
             yaml_path = self._config_dir / device.configuration
             try:
                 yaml_content = yaml_path.read_text(encoding="utf-8")
+                yaml_mtime = yaml_path.stat().st_mtime
             except OSError:
                 # Skip silently — the WARNING is reserved for
                 # present-but-unresolvable YAMLs, not deleted ones.
                 _LOGGER.debug("Could not read %s for MQTT broker config", device.configuration)
                 continue
-            broker = self._resolve_broker(yaml_path, yaml_content, secrets_map)
+            broker = self._resolve_broker(
+                yaml_path, yaml_content, yaml_mtime, secrets_mtime, secrets_map
+            )
             if broker is None:
                 self._log_broker_unresolved(device.configuration)
                 continue
@@ -142,17 +146,18 @@ class DeviceMqttCoordinator:
         return list(seen.values())
 
     def _resolve_broker(
-        self, yaml_path: Path, yaml_content: str, secrets_map: dict[str, Any]
+        self,
+        yaml_path: Path,
+        yaml_content: str,
+        yaml_mtime: float,
+        secrets_mtime: float,
+        secrets_map: dict[str, Any],
     ) -> MqttBrokerConfig | None:
         """Return the broker for *yaml_path*, or None if unresolvable."""
         broker = parse_mqtt_block(yaml_content, secrets_map)
         if broker is not None:
             return broker
-        try:
-            yaml_mtime = yaml_path.stat().st_mtime
-        except OSError:
-            return None
-        cache_key = (yaml_mtime, _safe_mtime(self._config_dir / "secrets.yaml"))
+        cache_key = (yaml_mtime, secrets_mtime)
         cached = self._broker_cache.get(yaml_path.name)
         if cached is not None and cached[0] == cache_key:
             return cached[1]
@@ -244,19 +249,14 @@ def parse_mqtt_block(
     mqtt = data.get("mqtt")
     if not isinstance(mqtt, dict):
         return None
-
-    host = _resolve(mqtt.get("broker"), secrets_map)
-    if not host:
-        return None
-    port_raw = _resolve(mqtt.get("port"), secrets_map)
-    try:
-        port = int(port_raw) if port_raw else _DEFAULT_PORT
-    except (TypeError, ValueError):
-        port = _DEFAULT_PORT
-    username = _resolve(mqtt.get("username"), secrets_map) or None
-    password = _resolve(mqtt.get("password"), secrets_map) or None
-
-    return MqttBrokerConfig(host=host, port=port, username=username, password=password)
+    return _broker_from_block(
+        {
+            "broker": _resolve(mqtt.get("broker"), secrets_map),
+            "port": _resolve(mqtt.get("port"), secrets_map),
+            "username": _resolve(mqtt.get("username"), secrets_map),
+            "password": _resolve(mqtt.get("password"), secrets_map),
+        }
+    )
 
 
 def _extract_broker_from_config(config: dict | None) -> MqttBrokerConfig | None:
@@ -266,6 +266,11 @@ def _extract_broker_from_config(config: dict | None) -> MqttBrokerConfig | None:
     mqtt = config.get("mqtt")
     if not isinstance(mqtt, dict):
         return None
+    return _broker_from_block(mqtt)
+
+
+def _broker_from_block(mqtt: dict) -> MqttBrokerConfig | None:
+    """Build an :class:`MqttBrokerConfig` from a resolved ``mqtt:`` block."""
     host = mqtt.get("broker")
     if not host:
         return None

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -53,15 +53,19 @@ class DeviceMqttCoordinator:
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._monitors: dict[tuple[str, int], DeviceMqttMonitor] = {}
-        # Cached broker per device, keyed on the YAML's mtime and
-        # ``secrets.yaml``'s mtime so the expensive
-        # ``load_device_yaml`` fallback (resolves ``packages:`` /
-        # ``!include`` / ``!secret``) only runs again when something
-        # the resolve depends on actually changes. Only successful
-        # resolves are cached — ``None`` results are re-tried every
-        # poll so a user edit to a ``!include``d / package file
-        # (whose mtime we don't track) recovers without a process
-        # restart.
+        # Cached broker per device, keyed on the device YAML's mtime
+        # and ``secrets.yaml``'s mtime — covers the common shared-
+        # dependency case for ``!secret``-driven broker fields. Only
+        # successful resolves are cached; ``None`` results are
+        # re-tried every poll so a fix to a previously-broken
+        # ``!include`` / package file recovers without a process
+        # restart. Changes to a ``packages:`` / ``!include`` file
+        # that previously resolved successfully are NOT picked up
+        # until the device YAML or ``secrets.yaml`` mtime changes —
+        # walking every transitively-included file on every poll
+        # isn't worth the I/O for the rare live-package-edit case;
+        # the user can touch the device YAML or restart the
+        # dashboard if they need an immediate refresh.
         self._broker_cache: dict[str, tuple[tuple[float, float], MqttBrokerConfig]] = {}
         # Device filenames we've already logged a broker-unresolvable
         # WARNING for. Subsequent polls drop to DEBUG so a single
@@ -121,7 +125,17 @@ class DeviceMqttCoordinator:
                 continue
             seen_devices.add(device.configuration)
             yaml_path = self._config_dir / device.configuration
-            broker = self._resolve_broker(yaml_path, secrets_map)
+            try:
+                yaml_content = yaml_path.read_text(encoding="utf-8")
+            except OSError:
+                # File deleted between the scanner snapshot and this
+                # poll — not user-actionable, skip silently. The
+                # broker-unresolvable WARNING is reserved for YAMLs
+                # that DO exist but whose ``mqtt:`` block can't be
+                # made sense of.
+                _LOGGER.debug("Could not read %s for MQTT broker config", device.configuration)
+                continue
+            broker = self._resolve_broker(yaml_path, yaml_content, secrets_map)
             if broker is None:
                 self._log_broker_unresolved(device.configuration)
                 continue
@@ -145,11 +159,11 @@ class DeviceMqttCoordinator:
         return list(seen.values())
 
     def _resolve_broker(
-        self, yaml_path: Path, secrets_map: dict[str, Any]
+        self, yaml_path: Path, yaml_content: str, secrets_map: dict[str, Any]
     ) -> MqttBrokerConfig | None:
         """Resolve the broker for *yaml_path*, falling back to a full YAML resolve.
 
-        Fast path: raw-text parse of the device YAML — covers the
+        Fast path: raw-text parse of *yaml_content* — covers the
         common case where ``mqtt:`` is at the top level of the file
         itself. Slow path: ``load_device_yaml`` expands
         ``packages:`` / ``!include`` / ``!secret`` so configs that
@@ -160,11 +174,6 @@ class DeviceMqttCoordinator:
         positive results are cached so a fix to a transitively-
         included file recovers on the next poll without a restart.
         """
-        try:
-            yaml_content = yaml_path.read_text(encoding="utf-8")
-        except OSError:
-            _LOGGER.debug("Could not read %s for MQTT broker config", yaml_path.name)
-            return None
         broker = parse_mqtt_block(yaml_content, secrets_map)
         if broker is not None:
             return broker

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -53,25 +53,13 @@ class DeviceMqttCoordinator:
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
         self._monitors: dict[tuple[str, int], DeviceMqttMonitor] = {}
-        # Cached broker per device, keyed on the device YAML's mtime
-        # and ``secrets.yaml``'s mtime — covers the common shared-
-        # dependency case for ``!secret``-driven broker fields. Only
-        # successful resolves are cached; ``None`` results are
-        # re-tried every poll so a fix to a previously-broken
-        # ``!include`` / package file recovers without a process
-        # restart. Changes to a ``packages:`` / ``!include`` file
-        # that previously resolved successfully are NOT picked up
-        # until the device YAML or ``secrets.yaml`` mtime changes —
-        # walking every transitively-included file on every poll
-        # isn't worth the I/O for the rare live-package-edit case;
-        # the user can touch the device YAML or restart the
-        # dashboard if they need an immediate refresh.
+        # Positive-only slow-path cache keyed on ``(yaml_mtime,
+        # secrets_mtime)``. Package / ``!include`` edits on a
+        # previously-cached device won't invalidate — user needs a
+        # device-YAML touch or dashboard restart for those.
         self._broker_cache: dict[str, tuple[tuple[float, float], MqttBrokerConfig]] = {}
-        # Device filenames we've already logged a broker-unresolvable
-        # WARNING for. Subsequent polls drop to DEBUG so a single
-        # mis-configured device doesn't spam the log every 5 s.
-        # Cleared when the broker resolves or the device stops
-        # declaring ``mqtt:``.
+        # Per-device dedupe for the broker-unresolvable WARNING —
+        # WARNING once, DEBUG on repeats.
         self._unresolved_logged: set[str] = set()
 
     @property
@@ -128,11 +116,8 @@ class DeviceMqttCoordinator:
             try:
                 yaml_content = yaml_path.read_text(encoding="utf-8")
             except OSError:
-                # File deleted between the scanner snapshot and this
-                # poll — not user-actionable, skip silently. The
-                # broker-unresolvable WARNING is reserved for YAMLs
-                # that DO exist but whose ``mqtt:`` block can't be
-                # made sense of.
+                # Skip silently — the WARNING is reserved for
+                # present-but-unresolvable YAMLs, not deleted ones.
                 _LOGGER.debug("Could not read %s for MQTT broker config", device.configuration)
                 continue
             broker = self._resolve_broker(yaml_path, yaml_content, secrets_map)
@@ -151,9 +136,7 @@ class DeviceMqttCoordinator:
                     broker.host,
                     broker.port,
                 )
-        # Forget per-device tracking for devices that no longer
-        # declare ``mqtt:`` so the next time they do, the WARNING
-        # surfaces again instead of being silently suppressed.
+        # Drop tracking for devices no longer declaring ``mqtt:``.
         self._unresolved_logged &= seen_devices
         self._broker_cache = {k: v for k, v in self._broker_cache.items() if k in seen_devices}
         return list(seen.values())
@@ -161,19 +144,7 @@ class DeviceMqttCoordinator:
     def _resolve_broker(
         self, yaml_path: Path, yaml_content: str, secrets_map: dict[str, Any]
     ) -> MqttBrokerConfig | None:
-        """Resolve the broker for *yaml_path*, falling back to a full YAML resolve.
-
-        Fast path: raw-text parse of *yaml_content* — covers the
-        common case where ``mqtt:`` is at the top level of the file
-        itself. Slow path: ``load_device_yaml`` expands
-        ``packages:`` / ``!include`` / ``!secret`` so configs that
-        pull the mqtt block in from a shared package or read the
-        broker from ``secrets.yaml`` still resolve. The slow path is
-        cached per ``(yaml_mtime, secrets_mtime)`` so a steady-state
-        poll doesn't re-resolve packages every 5 s, and only
-        positive results are cached so a fix to a transitively-
-        included file recovers on the next poll without a restart.
-        """
+        """Return the broker for *yaml_path*, or None if unresolvable."""
         broker = parse_mqtt_block(yaml_content, secrets_map)
         if broker is not None:
             return broker
@@ -255,10 +226,8 @@ def parse_mqtt_block(
     Returns ``None`` when the YAML has no ``mqtt:`` block, when the
     block has no resolvable ``broker:`` field, or when the YAML fails
     to parse. ``!secret xyz`` references are resolved via *secrets_map*.
-    Sees only the literal file contents — configs that bring the
-    ``mqtt:`` block in via ``packages:`` / ``!include`` won't match;
-    callers needing that resolution go through
-    :func:`load_device_yaml` and ``_extract_broker_from_config``.
+    Reads literal contents only — ``packages:`` / ``!include`` go
+    through :func:`load_device_yaml` + ``_extract_broker_from_config``.
     """
     secrets_map = secrets_map or {}
     try:
@@ -291,15 +260,7 @@ def parse_mqtt_block(
 
 
 def _extract_broker_from_config(config: dict | None) -> MqttBrokerConfig | None:
-    """
-    Extract broker parameters from a fully-resolved ESPHome config.
-
-    Mirrors :func:`parse_mqtt_block` but operates on the dict
-    produced by :func:`load_device_yaml` — i.e. after ``!secret``,
-    ``!include`` and ``packages:`` have been resolved by ESPHome's
-    own loader. Returns ``None`` when *config* has no ``mqtt:`` key
-    or the block has no usable ``broker:``.
-    """
+    """Extract broker parameters from a fully-resolved ESPHome config."""
     if not isinstance(config, dict):
         return None
     mqtt = config.get("mqtt")

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -21,6 +21,7 @@ import pytest
 from esphome_device_builder.controllers import _device_mqtt_monitor as monitor_module
 from esphome_device_builder.controllers._device_mqtt_coordinator import (
     DeviceMqttCoordinator,
+    _extract_broker_from_config,
     parse_mqtt_block,
 )
 from esphome_device_builder.controllers._device_mqtt_monitor import (
@@ -295,6 +296,131 @@ async def test_coordinator_resolves_secrets_from_secrets_yaml(
     assert coord.active_brokers == 1
     assert stub_monitor.instances[0].broker.host == "10.0.0.5"
     assert stub_monitor.instances[0].broker.password == "shh"
+
+
+async def test_coordinator_resolves_broker_pulled_in_via_packages(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    # Common real-world shape (issue #893): each device YAML defers
+    # the ``mqtt:`` block to a shared package, so the raw-text scan
+    # of the device file finds no top-level ``mqtt:``. The
+    # resolved-config fallback expands the package and the broker
+    # resolves normally.
+    (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.203\n")
+    (tmp_path / "alpha.yaml").write_text(
+        "esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n"
+    )
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert stub_monitor.instances[0].broker.host == "192.168.1.203"
+
+
+async def test_coordinator_warns_once_per_unresolved_device(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Truly unresolvable mqtt: block — neither the raw-text parse
+    # nor the resolved-config fallback can find a broker (the
+    # device claims ``uses_mqtt`` but no ``mqtt:`` is actually
+    # present anywhere).
+    (tmp_path / "alpha.yaml").write_text("esphome:\n  name: alpha\n")
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("DEBUG", logger=target):
+        await coord.reconcile()
+        await coord.reconcile()
+        await coord.reconcile()
+
+    warnings = [r for r in caplog.records if r.name == target and r.levelname == "WARNING"]
+    debugs = [
+        r
+        for r in caplog.records
+        if r.name == target
+        and r.levelname == "DEBUG"
+        and "still could not be resolved" in r.getMessage()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+    assert len(debugs) >= 2
+
+
+async def test_coordinator_re_warns_after_broker_recovers_and_breaks_again(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The dedupe must reset when the broker resolves successfully —
+    # a later regression should produce a fresh WARNING, not a
+    # silently-suppressed DEBUG.
+    alpha_path = tmp_path / "alpha.yaml"
+    alpha_path.write_text("esphome:\n  name: alpha\n")
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("WARNING", logger=target):
+        await coord.reconcile()  # unresolved → WARNING #1
+        await coord.reconcile()  # unresolved → DEBUG (suppressed)
+        alpha_path.write_text("esphome:\n  name: alpha\nmqtt:\n  broker: broker.local\n")
+        await coord.reconcile()  # resolved → flag cleared
+        alpha_path.write_text("esphome:\n  name: alpha\n")
+        await coord.reconcile()  # unresolved again → WARNING #2
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.name == target
+        and r.levelname == "WARNING"
+        and "could not be resolved" in r.getMessage()
+    ]
+    assert len(warnings) == 2
+
+
+def test_extract_broker_from_config_returns_none_for_non_dict() -> None:
+    assert _extract_broker_from_config(None) is None
+    assert _extract_broker_from_config({"mqtt": "not-a-dict"}) is None
+    assert _extract_broker_from_config({}) is None
+
+
+def test_extract_broker_from_config_reads_resolved_block() -> None:
+    # Shape after ESPHome's loader has run — secrets/includes already
+    # expanded, every field is a plain scalar. Mirrors what the user
+    # in issue #893 sees as ``esphome config`` output.
+    config = {
+        "mqtt": {
+            "broker": "192.168.1.203",
+            "port": 1883,
+            "username": "mquser",
+            "password": "topsecret",
+        }
+    }
+    broker = _extract_broker_from_config(config)
+    assert broker == MqttBrokerConfig(
+        host="192.168.1.203",
+        port=1883,
+        username="mquser",
+        password="topsecret",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -402,6 +402,63 @@ def test_extract_broker_from_config_returns_none_for_non_dict() -> None:
     assert _extract_broker_from_config({}) is None
 
 
+async def test_coordinator_recovers_when_negative_resolve_fixed_in_secrets(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    # Device pulls its broker from secrets.yaml. Initial state: the
+    # secret is missing, so resolution fails. The coordinator must
+    # NOT cache the failure — the next poll, after the user fills
+    # in secrets.yaml, should pick up the broker without a restart.
+    (tmp_path / "alpha.yaml").write_text(
+        "esphome:\n  name: alpha\nmqtt:\n  broker: !secret mqtt_host\n"
+    )
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+
+    await coord.reconcile()
+    assert coord.active_brokers == 0
+
+    (tmp_path / "secrets.yaml").write_text("mqtt_host: 192.168.1.42\n")
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert stub_monitor.instances[0].broker.host == "192.168.1.42"
+
+
+async def test_coordinator_skips_devices_with_missing_yaml(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    # ``uses_mqtt`` reflects the resolved-config view captured at
+    # scan time; the file may have been deleted between scans. The
+    # reconcile shouldn't crash — it just skips the device.
+    device = Device(
+        name="ghost",
+        friendly_name="ghost",
+        configuration="ghost.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+    await coord.reconcile()
+    assert coord.active_brokers == 0
+
+
+def test_extract_broker_from_config_handles_invalid_port() -> None:
+    config = {"mqtt": {"broker": "broker.local", "port": "not-a-number"}}
+    broker = _extract_broker_from_config(config)
+    assert broker is not None
+    assert broker.port == 1883
+
+
+def test_extract_broker_from_config_returns_none_when_broker_missing() -> None:
+    assert _extract_broker_from_config({"mqtt": {"username": "u"}}) is None
+
+
 def test_extract_broker_from_config_reads_resolved_block() -> None:
     # Shape after ESPHome's loader has run — secrets/includes already
     # expanded, every field is a plain scalar. Mirrors what the user

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -403,9 +403,10 @@ def test_extract_broker_from_config_returns_none_for_non_dict() -> None:
 async def test_coordinator_handles_stat_race_after_successful_read(
     tmp_path: Path,
     stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # Race: read_text succeeds, file disappears before stat().
-    (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.50\n")
+    # Race: read_text succeeds, file disappears before stat(). Skip
+    # silently — the WARNING is reserved for fixable configs.
     yaml_path = tmp_path / "alpha.yaml"
     yaml_path.write_text("esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n")
     device = Device(
@@ -423,10 +424,13 @@ async def test_coordinator_handles_stat_race_after_successful_read(
             raise OSError("simulated stat race")
         return real_stat(self, *args, **kwargs)
 
-    with patch.object(Path, "stat", _stat):
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with patch.object(Path, "stat", _stat), caplog.at_level("DEBUG", logger=target):
         await coord.reconcile()
 
     assert coord.active_brokers == 0
+    warnings = [r for r in caplog.records if r.name == target and r.levelname == "WARNING"]
+    assert warnings == [], [r.getMessage() for r in warnings]
 
 
 async def test_coordinator_caches_resolved_broker_across_polls(

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -15,6 +15,7 @@ import contextlib
 import json
 from pathlib import Path
 from typing import Any, ClassVar
+from unittest.mock import patch
 
 import pytest
 
@@ -403,6 +404,38 @@ def test_extract_broker_from_config_returns_none_for_non_dict() -> None:
     assert _extract_broker_from_config(None) is None
     assert _extract_broker_from_config({"mqtt": "not-a-dict"}) is None
     assert _extract_broker_from_config({}) is None
+
+
+async def test_coordinator_handles_stat_race_after_successful_read(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    # Narrow race: ``_collect_brokers`` reads the YAML successfully,
+    # the raw-text parse misses (mqtt block lives in a package), and
+    # the file is gone by the time ``_resolve_broker`` calls
+    # ``stat()``. Bail without crashing.
+    (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.50\n")
+    yaml_path = tmp_path / "alpha.yaml"
+    yaml_path.write_text("esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n")
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+
+    real_stat = Path.stat
+
+    def _stat(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if self == yaml_path:
+            raise OSError("simulated stat race")
+        return real_stat(self, *args, **kwargs)
+
+    with patch.object(Path, "stat", _stat):
+        await coord.reconcile()
+
+    assert coord.active_brokers == 0
 
 
 async def test_coordinator_caches_resolved_broker_across_polls(

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -18,6 +18,9 @@ from typing import Any, ClassVar
 
 import pytest
 
+from esphome_device_builder.controllers import (
+    _device_mqtt_coordinator as coordinator_module,
+)
 from esphome_device_builder.controllers import _device_mqtt_monitor as monitor_module
 from esphome_device_builder.controllers._device_mqtt_coordinator import (
     DeviceMqttCoordinator,
@@ -400,6 +403,44 @@ def test_extract_broker_from_config_returns_none_for_non_dict() -> None:
     assert _extract_broker_from_config(None) is None
     assert _extract_broker_from_config({"mqtt": "not-a-dict"}) is None
     assert _extract_broker_from_config({}) is None
+
+
+async def test_coordinator_caches_resolved_broker_across_polls(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The slow-path resolve (``load_device_yaml``) can ``git clone``
+    # remote packages and is way too expensive to run every 5 s.
+    # Once a broker resolves, subsequent polls must hit the cache
+    # until the YAML or secrets.yaml mtime changes.
+    (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.50\n")
+    (tmp_path / "alpha.yaml").write_text(
+        "esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n"
+    )
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+
+    calls = 0
+    real_loader = coordinator_module.load_device_yaml
+
+    def counting_loader(path: Path) -> dict | None:
+        nonlocal calls
+        calls += 1
+        return real_loader(path)
+
+    monkeypatch.setattr(coordinator_module, "load_device_yaml", counting_loader)
+
+    await coord.reconcile()
+    await coord.reconcile()
+    await coord.reconcile()
+    assert calls == 1
+    assert coord.active_brokers == 1
 
 
 async def test_coordinator_recovers_when_negative_resolve_fixed_in_secrets(

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -474,10 +474,13 @@ async def test_coordinator_recovers_when_negative_resolve_fixed_in_secrets(
 async def test_coordinator_skips_devices_with_missing_yaml(
     tmp_path: Path,
     stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # ``uses_mqtt`` reflects the resolved-config view captured at
     # scan time; the file may have been deleted between scans. The
-    # reconcile shouldn't crash — it just skips the device.
+    # reconcile shouldn't crash, shouldn't fire the broker-
+    # unresolvable WARNING (that message is reserved for YAMLs the
+    # user can actually fix), just skips the device silently.
     device = Device(
         name="ghost",
         friendly_name="ghost",
@@ -485,8 +488,12 @@ async def test_coordinator_skips_devices_with_missing_yaml(
         uses_mqtt=True,
     )
     coord = _make_coordinator(tmp_path, [device])
-    await coord.reconcile()
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("DEBUG", logger=target):
+        await coord.reconcile()
     assert coord.active_brokers == 0
+    warnings = [r for r in caplog.records if r.name == target and r.levelname == "WARNING"]
+    assert warnings == [], [r.getMessage() for r in warnings]
 
 
 def test_extract_broker_from_config_handles_invalid_port() -> None:

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -306,11 +306,8 @@ async def test_coordinator_resolves_broker_pulled_in_via_packages(
     tmp_path: Path,
     stub_monitor: type[_RecordingMonitor],
 ) -> None:
-    # Common real-world shape (issue #893): each device YAML defers
-    # the ``mqtt:`` block to a shared package, so the raw-text scan
-    # of the device file finds no top-level ``mqtt:``. The
-    # resolved-config fallback expands the package and the broker
-    # resolves normally.
+    # Issue #893: mqtt block lives in a shared package, not the
+    # device file. Resolved-config fallback expands and resolves it.
     (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.203\n")
     (tmp_path / "alpha.yaml").write_text(
         "esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n"
@@ -332,10 +329,8 @@ async def test_coordinator_warns_once_per_unresolved_device(
     stub_monitor: type[_RecordingMonitor],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # Truly unresolvable mqtt: block — neither the raw-text parse
-    # nor the resolved-config fallback can find a broker (the
-    # device claims ``uses_mqtt`` but no ``mqtt:`` is actually
-    # present anywhere).
+    # uses_mqtt set but no mqtt: present anywhere — neither path
+    # can resolve a broker.
     (tmp_path / "alpha.yaml").write_text("esphome:\n  name: alpha\n")
     device = Device(
         name="alpha",
@@ -368,9 +363,8 @@ async def test_coordinator_re_warns_after_broker_recovers_and_breaks_again(
     stub_monitor: type[_RecordingMonitor],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # The dedupe must reset when the broker resolves successfully —
-    # a later regression should produce a fresh WARNING, not a
-    # silently-suppressed DEBUG.
+    # Dedupe must reset on a successful resolve so a later
+    # regression surfaces a fresh WARNING, not a DEBUG.
     alpha_path = tmp_path / "alpha.yaml"
     alpha_path.write_text("esphome:\n  name: alpha\n")
     device = Device(
@@ -410,10 +404,7 @@ async def test_coordinator_handles_stat_race_after_successful_read(
     tmp_path: Path,
     stub_monitor: type[_RecordingMonitor],
 ) -> None:
-    # Narrow race: ``_collect_brokers`` reads the YAML successfully,
-    # the raw-text parse misses (mqtt block lives in a package), and
-    # the file is gone by the time ``_resolve_broker`` calls
-    # ``stat()``. Bail without crashing.
+    # Race: read_text succeeds, file disappears before stat().
     (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.50\n")
     yaml_path = tmp_path / "alpha.yaml"
     yaml_path.write_text("esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n")
@@ -443,10 +434,9 @@ async def test_coordinator_caches_resolved_broker_across_polls(
     stub_monitor: type[_RecordingMonitor],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The slow-path resolve (``load_device_yaml``) can ``git clone``
-    # remote packages and is way too expensive to run every 5 s.
-    # Once a broker resolves, subsequent polls must hit the cache
-    # until the YAML or secrets.yaml mtime changes.
+    # ``load_device_yaml`` can ``git clone`` remote packages —
+    # too expensive to run every 5 s. Once resolved, polls hit
+    # the cache until an mtime moves.
     (tmp_path / "common.yaml").write_text("mqtt:\n  broker: 192.168.1.50\n")
     (tmp_path / "alpha.yaml").write_text(
         "esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n"
@@ -480,10 +470,8 @@ async def test_coordinator_recovers_when_negative_resolve_fixed_in_secrets(
     tmp_path: Path,
     stub_monitor: type[_RecordingMonitor],
 ) -> None:
-    # Device pulls its broker from secrets.yaml. Initial state: the
-    # secret is missing, so resolution fails. The coordinator must
-    # NOT cache the failure — the next poll, after the user fills
-    # in secrets.yaml, should pick up the broker without a restart.
+    # Failure must not be cached — fix to secrets.yaml has to
+    # recover on the next poll without a restart.
     (tmp_path / "alpha.yaml").write_text(
         "esphome:\n  name: alpha\nmqtt:\n  broker: !secret mqtt_host\n"
     )
@@ -509,11 +497,8 @@ async def test_coordinator_skips_devices_with_missing_yaml(
     stub_monitor: type[_RecordingMonitor],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # ``uses_mqtt`` reflects the resolved-config view captured at
-    # scan time; the file may have been deleted between scans. The
-    # reconcile shouldn't crash, shouldn't fire the broker-
-    # unresolvable WARNING (that message is reserved for YAMLs the
-    # user can actually fix), just skips the device silently.
+    # YAML deleted between scans — skip silently, don't fire
+    # the broker-unresolvable WARNING (reserved for fixable YAMLs).
     device = Device(
         name="ghost",
         friendly_name="ghost",
@@ -541,9 +526,7 @@ def test_extract_broker_from_config_returns_none_when_broker_missing() -> None:
 
 
 def test_extract_broker_from_config_reads_resolved_block() -> None:
-    # Shape after ESPHome's loader has run — secrets/includes already
-    # expanded, every field is a plain scalar. Mirrors what the user
-    # in issue #893 sees as ``esphome config`` output.
+    # Post-resolver shape — every field a plain scalar.
     config = {
         "mqtt": {
             "broker": "192.168.1.203",


### PR DESCRIPTION
# What does this implement/fix?

Devices that bring their `mqtt:` block in via `packages:` / `!include` —
a common shape for fleets that share a broker — caused
`_device_mqtt_coordinator` to log
`Device <foo>.yaml declares mqtt: but broker could not be resolved`
as a WARNING every 5 s while the dashboard is open.

The flag side (`Device.uses_mqtt`) is computed from the *resolved*
config, so it sees mqtt blocks pulled in by packages. The
broker-extraction side called `parse_mqtt_block` on the *raw* YAML,
which doesn't see packages — so it returned `None` and the warning
fired on every poll.

Changes:

- Add a slow-path fallback in `_resolve_broker` that re-uses
  `load_device_yaml` (the same resolver that drives `uses_mqtt`)
  when the raw-text parse misses. Cached per `(filename, mtime)`
  so steady-state polls don't pay the package-resolve cost.
- De-dupe the unresolved-broker WARNING per device: log it once,
  drop subsequent polls to DEBUG until the broker resolves again
  or the device drops `mqtt:`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/893

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
