### PR TITLE
automations: fix api.actions: splice indent under empty api: block

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -781,9 +781,17 @@ def _locate_singleton_block(
         stripped = lines[idx].rstrip("\n\r")
         if not stripped:
             continue
-        if stripped[0].isalpha() and not stripped.startswith(" "):
-            end = idx
-            break
+        if not stripped.startswith(" "):
+            # Alphabetic column-0 keys always terminate the block.
+            # Column-0 comments terminate it only while nothing
+            # indented has been seen yet — they're section banners
+            # introducing the next block, not mid-block notes — and
+            # otherwise we'd both poison ``indent`` with ``""`` and
+            # splice past them into the next section.
+            if stripped[0].isalpha() or not captured:
+                end = idx
+                break
+            continue
         if not captured:
             indent = " " * (len(stripped) - len(stripped.lstrip(" ")))
             captured = True

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -782,13 +782,15 @@ def _locate_singleton_block(
         if not stripped:
             continue
         if not stripped.startswith(" "):
-            # Alphabetic column-0 keys always terminate the block.
-            # Column-0 comments terminate it only while nothing
-            # indented has been seen yet — they're section banners
-            # introducing the next block, not mid-block notes — and
-            # otherwise we'd both poison ``indent`` with ``""`` and
-            # splice past them into the next section.
-            if stripped[0].isalpha() or not captured:
+            if stripped[0].isalpha():
+                end = idx
+                break
+            # Column-0 comment ends the block only when the next
+            # non-blank line is also column-0 (a section banner
+            # between two top-level blocks). A comment sitting
+            # between a parent key and an indented child below is
+            # a no-op — keep scanning.
+            if _next_non_blank_at_col_zero(lines, idx + 1):
                 end = idx
                 break
             continue
@@ -796,6 +798,16 @@ def _locate_singleton_block(
             indent = " " * (len(stripped) - len(stripped.lstrip(" ")))
             captured = True
     return start, end, indent
+
+
+def _next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
+    """Return True iff the next non-blank line at *start* or later sits at column 0."""
+    for idx in range(start, len(lines)):
+        stripped = lines[idx].rstrip("\n\r")
+        if not stripped:
+            continue
+        return not stripped.startswith(" ")
+    return False
 
 
 def _build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -637,6 +637,35 @@ def test_upsert_api_action_drops_action_key_smuggled_in_trigger_params() -> None
     assert "also_ignored" not in new_text
 
 
+def test_upsert_api_action_inserts_under_empty_api_with_section_banner_below() -> None:
+    """An empty ``api:`` block followed by a column-0 banner gets canonical indent.
+
+    The block locator used to absorb the next section's ``# Foo``
+    banner into the api span and read ``child_indent`` off it,
+    yielding ``""`` — the new ``actions:`` key then landed at
+    column 0 *below* the banner instead of column 2 directly under
+    ``api:``.
+    """
+    text = "esphome:\n  name: x\napi:\n\n# BLE proxy\nesp32_ble_tracker:\n  setup_priority: -500\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id=None, actions=[]),
+        location=ApiActionLocation(action_name="test"),
+    )
+    assert "  actions:\n" in new_text
+    assert "    - action: test\n" in new_text
+    # actions: lands directly under api:, above the section banner.
+    api_idx = new_text.index("api:")
+    actions_idx = new_text.index("  actions:")
+    banner_idx = new_text.index("# BLE proxy")
+    assert api_idx < actions_idx < banner_idx
+    # The banner still introduces esp32_ble_tracker:, not actions:.
+    assert "# BLE proxy\nesp32_ble_tracker:" in new_text
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["test"]
+
+
 def test_upsert_api_action_appends_when_actions_has_trailing_blank() -> None:
     """A trailing blank line below the last item doesn't push the new item past it."""
     text = (

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -638,14 +638,7 @@ def test_upsert_api_action_drops_action_key_smuggled_in_trigger_params() -> None
 
 
 def test_upsert_api_action_inserts_under_empty_api_with_section_banner_below() -> None:
-    """An empty ``api:`` block followed by a column-0 banner gets canonical indent.
-
-    The block locator used to absorb the next section's ``# Foo``
-    banner into the api span and read ``child_indent`` off it,
-    yielding ``""`` — the new ``actions:`` key then landed at
-    column 0 *below* the banner instead of column 2 directly under
-    ``api:``.
-    """
+    """An empty ``api:`` block followed by a column-0 banner gets canonical indent."""
     text = "esphome:\n  name: x\napi:\n\n# BLE proxy\nesp32_ble_tracker:\n  setup_priority: -500\n"
     new_text, _diff = render_upsert(
         text,
@@ -654,16 +647,34 @@ def test_upsert_api_action_inserts_under_empty_api_with_section_banner_below() -
     )
     assert "  actions:\n" in new_text
     assert "    - action: test\n" in new_text
-    # actions: lands directly under api:, above the section banner.
     api_idx = new_text.index("api:")
     actions_idx = new_text.index("  actions:")
     banner_idx = new_text.index("# BLE proxy")
     assert api_idx < actions_idx < banner_idx
-    # The banner still introduces esp32_ble_tracker:, not actions:.
     assert "# BLE proxy\nesp32_ble_tracker:" in new_text
     parsed = parse_device_yaml(new_text)
     api_entries = [p for p in parsed if p.location.kind == "api_action"]
     assert [e.location.action_name for e in api_entries] == ["test"]
+
+
+def test_upsert_api_action_appends_when_column_zero_comment_precedes_actions() -> None:
+    """A column-0 comment between ``api:`` and an indented ``actions:`` child is a no-op."""
+    text = (
+        "esphome:\n  name: x\n"
+        "api:\n"
+        "# note\n"
+        "  actions:\n"
+        "    - action: existing\n      then:\n        - delay: 1s\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id=None, actions=[]),
+        location=ApiActionLocation(action_name="new_one"),
+    )
+    assert new_text.count("actions:") == 1
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["existing", "new_one"]
 
 
 def test_upsert_api_action_appends_when_actions_has_trailing_blank() -> None:

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -677,6 +677,35 @@ def test_upsert_api_action_appends_when_column_zero_comment_precedes_actions() -
     assert [e.location.action_name for e in api_entries] == ["existing", "new_one"]
 
 
+def test_upsert_api_action_handles_blank_then_section_banner_after_empty_api() -> None:
+    """A blank line between the empty ``api:`` block and a column-0 banner is skipped."""
+    text = "esphome:\n  name: x\napi:\n# banner\n\nwifi:\n  ssid: x\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id=None, actions=[]),
+        location=ApiActionLocation(action_name="test"),
+    )
+    assert "  actions:\n" in new_text
+    assert "    - action: test\n" in new_text
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["test"]
+
+
+def test_upsert_api_action_handles_trailing_column_zero_comment_at_eof() -> None:
+    """A column-0 comment as the last non-blank line stays inside the ``api:`` span."""
+    text = "esphome:\n  name: x\napi:\n# trailing\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id=None, actions=[]),
+        location=ApiActionLocation(action_name="test"),
+    )
+    assert "  actions:\n" in new_text
+    parsed = parse_device_yaml(new_text)
+    api_entries = [p for p in parsed if p.location.kind == "api_action"]
+    assert [e.location.action_name for e in api_entries] == ["test"]
+
+
 def test_upsert_api_action_appends_when_actions_has_trailing_blank() -> None:
     """A trailing blank line below the last item doesn't push the new item past it."""
     text = (


### PR DESCRIPTION
# What does this implement/fix?

Fix a YAML splice bug in `automations/upsert` for `api.actions:` (introduced in #907). When the `api:` block had no children, `_locate_singleton_block` absorbed a following column-0 comment (e.g. a `# BLE proxy` section banner) into the api span and used it to derive `child_indent` — which evaluated to `""`. The new `actions:` key then landed at column 0 *below* the banner, breaking the api block's structure and stranding the comment from the next section.

- End the singleton-block span at column-0 comments while the block is still empty, so the canonical `"  "` default child indent applies.
- The splice now walks back past the trailing blank line and inserts `actions:` directly under `api:`, above the section banner.
- Non-empty blocks with mid-mapping column-0 comments retain their previous behaviour (the comment is treated as a no-op continuation, matching YAML semantics).
- Regression test pins the empty-`api:` + section-banner shape.

**Related issue or feature (if applicable):**

- follow-up to #907

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
