### PR TITLE
docs: README section on setting username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,78 @@ every few minutes.
 
 </details>
 
+## Username / password authentication
+
+The three install paths each handle network reach and the auth gate
+differently. The Home Assistant add-on runs ingress-only with no
+password under the new preview, so access goes through the HA
+sidebar and port `6052` stays unbound; ESPHome Desktop binds only
+to `127.0.0.1`, so there's nothing on the LAN to authenticate
+against in the first place; the standalone PyPI install binds
+`0.0.0.0:6052`, is LAN-reachable by default, and prints a startup
+banner warning that there is no auth gate until you configure one.
+
+Configuring a username and password is only wired up for the
+standalone install today. The HA add-on doesn't ship a knob for it
+(see below for the rationale, this is by design) and Desktop is
+localhost-only, so the knob doesn't add anything there. The backend
+itself accepts credentials anywhere it runs; it's the packaging
+around the HA add-on and Desktop that doesn't pass any in.
+
+### Home Assistant add-on
+
+When the **Use new Device Builder Preview** toggle is on, the add-on
+is reached through Home Assistant itself: you open it from the HA
+sidebar in your browser, and the Home Assistant Companion App opens
+it the same way. Both paths come in over Home Assistant Ingress, so
+the dashboard is already protected by your Home Assistant login;
+there's no separate username or password to configure for the
+add-on, and port `6052` stays unbound to keep the dashboard off the
+LAN by default.
+
+This is the supported way to use the add-on and we're not planning
+to add a "just expose the port directly" option for it. The classic
+dashboard let you opt in to binding port `6052` on the LAN and
+forwarded your Home Assistant username and password through the
+supervisor `/auth` endpoint to gate it; that endpoint has no rate
+limiting or lockout, so opting into the exposed port turned the
+dashboard into an open brute-force target against every account on
+the Home Assistant instance. We chose not to carry that risk
+forward (see
+[device-builder issue #85](https://github.com/esphome/device-builder/issues/85)).
+
+If you need port `6052` reachable on the LAN, please file a feature
+request describing the use case. For LAN access today, run the
+standalone PyPI install on the same network as your add-on with its
+own dashboard-managed password.
+
+### Standalone (PyPI)
+
+Set the credentials through environment variables before launching the
+dashboard:
+
+```bash
+export ESPHOME_USERNAME=admin
+export ESPHOME_PASSWORD='<pick a strong password>'
+esphome-device-builder ~/esphome-configs
+```
+
+Both values must be set together; setting only one fails the
+credential check at startup. The env var names are `ESPHOME_USERNAME`
+and `ESPHOME_PASSWORD`, not the legacy dashboard's bare `USERNAME` /
+`PASSWORD`, because the bare names collide with the OS-supplied
+`$USERNAME` on Windows and most login shells.
+
+The `--username` / `--password` CLI flags are still accepted for
+parity with the legacy dashboard's CLI, but please avoid
+`--password` in particular: command-line arguments show up in
+process listings (`ps` output on Linux / macOS, Task Manager on
+Windows, plus `/proc/<pid>/cmdline` on Linux unless `hidepid` is
+locked down), so another local user on the host can usually read
+the dashboard password. Use the env vars instead (or a `.env` /
+systemd `EnvironmentFile=` that's only readable by the dashboard's
+user).
+
 ## Behind a reverse proxy
 
 The dashboard rejects browser WebSocket handshakes whose


### PR DESCRIPTION
# What does this implement/fix?

Discord question came in about where to set username and password on the new Device Builder Preview, especially the HA add-on case where 6052 stops being exposed and there's no field in the UI. Adding a short README section to answer it and to set expectations for each install path.

For the HA add-on the README now opens user-first: you reach the dashboard from the HA sidebar in your browser and from the Home Assistant Companion App, both come in over Ingress, and that means your Home Assistant login already protects it; there's no separate username / password to configure, and port 6052 stays unbound by default. The rationale for not exposing 6052 directly is the supervisor `/auth` endpoint, which has no rate limiting or lockout, so binding the port would turn the dashboard into an open brute-force target against every account on the instance. Users who actually need LAN reachability on 6052 are pointed at filing a feature request describing the use case, with the standalone PyPI install as the workaround today.

The standalone section leads with `ESPHOME_USERNAME` / `ESPHOME_PASSWORD` env vars and notes that `--password` is observable in process listings (`ps`, Task Manager, `/proc/<pid>/cmdline`). Verified the standalone behaviour locally with curl before writing.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
