### PR TITLE
Deprecate --username and --password CLI flags

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -133,14 +133,19 @@ def main() -> None:
         "--username",
         default="",
         help=(
-            "Dashboard username (must be paired with --password; falls back to $ESPHOME_USERNAME)"
+            "Deprecated; use $ESPHOME_USERNAME instead. Dashboard username "
+            "(must be paired with --password). The flag will be removed in "
+            "a future release"
         ),
     )
     parser.add_argument(
         "--password",
         default="",
         help=(
-            "Dashboard password (must be paired with --username; falls back to $ESPHOME_PASSWORD)"
+            "Deprecated; use $ESPHOME_PASSWORD instead. Dashboard password "
+            "(must be paired with --username). The flag will be removed in "
+            "a future release; values passed on the command line are visible "
+            "to every other local user via process listings"
         ),
     )
     parser.add_argument("--ha-addon", action="store_true", help="Running as HA add-on")
@@ -244,6 +249,8 @@ def main() -> None:
 
     _setup_logging(args.log_level, args.log_file)
 
+    _warn_deprecated_credential_flags(args)
+
     # Deferred so ``--version`` / ``--help`` keep working in installs
     # that omit the optional ``[esphome]`` extra — both modules below
     # transitively import ``esphome`` at module load time.
@@ -339,6 +346,18 @@ def _validate_credentials(parser: argparse.ArgumentParser, args: argparse.Namesp
         )
 
 
+def _warn_deprecated_credential_flags(args: argparse.Namespace) -> None:
+    """Log a deprecation warning when --username / --password are used."""
+    if not (args.username or args.password):
+        return
+    logging.getLogger(_LOGGER_NAME).warning(
+        "DEPRECATION: --username / --password are deprecated and will be "
+        "removed in a future release. Use $ESPHOME_USERNAME / "
+        "$ESPHOME_PASSWORD env vars instead; command-line arguments are "
+        "visible to every other local user via process listings."
+    )
+
+
 def _warn_if_unprotected(settings: DashboardSettings) -> None:
     """Print a banner when starting without any authentication boundary."""
     if settings.using_password:
@@ -352,7 +371,7 @@ def _warn_if_unprotected(settings: DashboardSettings) -> None:
         "\n%s\n"
         " WARNING: Dashboard is running WITHOUT AUTHENTICATION.\n"
         " Anyone with network access to %s:%d can manage your devices.\n"
-        " Set --username and --password (or $ESPHOME_USERNAME / $ESPHOME_PASSWORD) to enable.\n"
+        " Set $ESPHOME_USERNAME / $ESPHOME_PASSWORD env vars to enable.\n"
         "%s",
         banner,
         settings.host,

--- a/tests/test_credentials_env.py
+++ b/tests/test_credentials_env.py
@@ -27,7 +27,10 @@ from unittest.mock import patch
 
 import pytest
 
-from esphome_device_builder.__main__ import _validate_credentials
+from esphome_device_builder.__main__ import (
+    _validate_credentials,
+    _warn_deprecated_credential_flags,
+)
 from esphome_device_builder.controllers.config import DashboardSettings
 
 
@@ -153,6 +156,41 @@ def test_validate_credentials_error_message_names_new_env_vars(
     # reintroduce the system-var collision footgun.
     assert "$USERNAME" not in err
     assert "$PASSWORD" not in err
+
+
+# ---------------------------------------------------------------------------
+# _warn_deprecated_credential_flags — log on --username / --password
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("username", "password"),
+    [
+        ("admin", "hunter2"),
+        ("admin", ""),
+        ("", "hunter2"),
+    ],
+)
+def test_warn_deprecated_credential_flags_logs_when_cli_used(
+    username: str,
+    password: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A CLI value on either flag triggers the deprecation log."""
+    args = argparse.Namespace(username=username, password=password)
+    with caplog.at_level("WARNING", logger="esphome_device_builder"):
+        _warn_deprecated_credential_flags(args)
+    assert any("DEPRECATION" in r.getMessage() for r in caplog.records)
+
+
+def test_warn_deprecated_credential_flags_silent_when_env_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning when neither CLI flag is set."""
+    args = argparse.Namespace(username="", password="")
+    with caplog.at_level("WARNING", logger="esphome_device_builder"):
+        _warn_deprecated_credential_flags(args)
+    assert caplog.records == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the docs review on #925; values passed via `--username` / `--password` end up in `ps` output, Task Manager, and `/proc/<pid>/cmdline`, so any other local user on the host can read the dashboard password. The env-var path (`ESPHOME_USERNAME` / `ESPHOME_PASSWORD`) has been the recommended way for a while and avoids the leak.

This marks both CLI flags as deprecated in the argparse help text and emits a DEPRECATION warning at startup when either is used; env-var users stay silent. The flags keep working for one more release cycle so operators migrating off the legacy dashboard CLI have time to switch over.

Verified locally that the warning fires via the CLI launcher when `--username` / `--password` are passed, stays silent when only the env vars are set, and that the broader test suite is still green (3639 passed).

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
