### PR TITLE
automations: fix parse error on !lambda-tagged scalars

### DIFF
--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -23,6 +23,7 @@ from io import StringIO
 from typing import Any
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import TaggedScalar
 from ruamel.yaml.scalarstring import LiteralScalarString
 
 from ...helpers.api import CommandError
@@ -498,18 +499,17 @@ def _render_value(value: Any) -> Any:
 
     Lambda block scalars (``|`` or ``!lambda`` tagged) become the
     ``{"_lambda": "<source>"}`` sentinel; ruamel maps and lists
-    become plain dicts/lists, recursively.
+    become plain dicts/lists, recursively. Tagged scalars from
+    ruamel are not JSON-serialisable on their own, so any
+    unrecognised tag falls back to its plain string value.
     """
     if isinstance(value, LiteralScalarString):
         return {"_lambda": str(value)}
-    # Tagged ``!lambda`` scalars come through ruamel as a regular
-    # string carrying a ``.yaml_tag`` attribute; the LiteralScalar
-    # branch above handles the common case of an unmarked ``|``
-    # block, which ESPHome treats as a lambda when the schema's
-    # ``templatable`` flag is set.
-    tag = getattr(value, "yaml_tag", None)
-    if tag and getattr(tag, "value", "") == "!lambda":
-        return {"_lambda": str(value)}
+    if isinstance(value, TaggedScalar):
+        tag = getattr(value.tag, "value", "") if value.tag is not None else ""
+        if tag == "!lambda":
+            return {"_lambda": str(value)}
+        return str(value)
     if isinstance(value, dict):
         return {k: _render_value(v) for k, v in value.items()}
     if isinstance(value, list):

--- a/tests/fixtures/automation_yamls/lambda_tagged_scalars.yaml
+++ b/tests/fixtures/automation_yamls/lambda_tagged_scalars.yaml
@@ -1,0 +1,14 @@
+esphome:
+  name: x
+
+script:
+  - id: warmtepomp_turn_off_sequence
+    then:
+      - delay: !lambda return 0;
+
+interval:
+  - interval: 5s
+    then:
+      - lambda: !lambda |
+          // body
+          return;

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -15,7 +15,6 @@ from unittest.mock import patch
 
 import pytest
 from ruamel.yaml.scalarstring import LiteralScalarString
-from ruamel.yaml.tag import Tag
 
 from esphome_device_builder.controllers.automations import catalog
 from esphome_device_builder.controllers.automations.controller import (
@@ -328,14 +327,17 @@ def test_render_value_passes_lists_through_recursively() -> None:
 
 
 def test_render_value_handles_tagged_lambda_scalar() -> None:
-    """A ruamel scalar with a ``!lambda`` tag surfaces as the lambda sentinel."""
+    """A ruamel ``!lambda``-tagged plain scalar surfaces as the lambda sentinel."""
+    yaml = make_yaml()
+    data = yaml.load('a: !lambda ESP_LOGI("x");\n')
+    assert _render_value(data["a"]) == {"_lambda": 'ESP_LOGI("x");'}
 
-    class _Tagged(str):
-        pass
 
-    tagged = _Tagged('ESP_LOGI("x");')
-    tagged.yaml_tag = Tag(suffix="!lambda")  # type: ignore[attr-defined]
-    assert _render_value(tagged) == {"_lambda": 'ESP_LOGI("x");'}
+def test_render_value_falls_back_to_str_for_unknown_tagged_scalar() -> None:
+    """A non-``!lambda`` tagged scalar surfaces as its plain string value."""
+    yaml = make_yaml()
+    data = yaml.load("a: !custom hello\n")
+    assert _render_value(data["a"]) == "hello"
 
 
 def test_render_params_wraps_non_dict_under_value_key() -> None:

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import orjson
 import pytest
 
 from esphome_device_builder.controllers.automations.parsing import parse_device_yaml
@@ -301,6 +302,28 @@ def test_parse_lambda_action_surfaces_lambda_sentinel() -> None:
     assert isinstance(body, dict)
     assert "_lambda" in body
     assert "ESP_LOGI" in body["_lambda"]
+
+
+def test_parse_tagged_lambda_scalars_render_as_sentinel() -> None:
+    """!lambda-tagged scalars (plain + ``|`` block) parse to the sentinel and are JSON-safe."""
+    parsed = parse_device_yaml(_load("lambda_tagged_scalars.yaml"))
+    by_kind = {p.location.kind: p for p in parsed}
+
+    # Script: ``- delay: !lambda return 0;`` → params={"id": {"_lambda": "return 0;"}}.
+    script_actions = by_kind["script"].automation.actions
+    assert [a.action_id for a in script_actions] == ["delay"]
+    assert script_actions[0].params == {"id": {"_lambda": "return 0;"}}
+
+    # Interval: ``- lambda: !lambda |`` block → params={"id": {"_lambda": "<body>"}}.
+    interval_actions = by_kind["interval"].automation.actions
+    assert [a.action_id for a in interval_actions] == ["lambda"]
+    interval_body = interval_actions[0].params.get("id") or interval_actions[0].params
+    assert isinstance(interval_body, dict)
+    assert interval_body.get("_lambda", "").strip().endswith("return;")
+
+    # The whole response round-trips through orjson — TaggedScalar
+    # would have raised "Type is not JSON serializable" here.
+    orjson.dumps([p.to_dict() for p in parsed])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Opening an existing automation in the editor failed with `internal_error: Command failed: automations/parse` for any device YAML that uses `!lambda`-tagged scalars (e.g. `delay: !lambda return 0;` or a `lambda: !lambda |` block). The `automations/parse` handler ran fine, but the response carried a ruamel `TaggedScalar` object straight into `orjson.dumps`, which raised `TypeError: Type is not JSON serializable: TaggedScalar`.

Root cause: `_render_value` in `controllers/automations/parsing.py` checked for a `.yaml_tag` attribute, but ruamel 0.18+ surfaces tagged scalars as `TaggedScalar` instances with the tag at `.tag.value`. The check never matched, so tagged scalars fell through unchanged.

- detect `TaggedScalar` in `_render_value` and route `!lambda` through the existing `{"_lambda": ...}` sentinel
- fall back to the plain string value for any other tag so the parse response stays JSON-serialisable
- add a fixture + regression test covering a `!lambda` plain scalar and a `!lambda |` block, asserting the full payload round-trips through `orjson.dumps`
- replace the synthetic-stand-in branch test with one driven by a real ruamel-produced `TaggedScalar`, plus a fallback-to-string case for an unknown tag

**Related issue or feature (if applicable):**

n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
