### PR TITLE
Resolve esphome meta substitutions from packages and !include

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -666,6 +666,7 @@ def extract_directly_referenced_integrations(
 
 def parse_esphome_meta(  # noqa: PLR0912
     yaml_content: str,
+    extra_substitutions: dict[str, str] | None = None,
 ) -> tuple[str | None, str | None, str | None, str | None]:
     """
     Parse the top-level ``esphome:`` block for ``(name, friendly_name, comment, area)``.
@@ -685,6 +686,13 @@ def parse_esphome_meta(  # noqa: PLR0912
 
     yields ``friendly_name = "Living Room Lamp"`` instead of the raw
     ``$friendly_name`` token. Unknown references are left untouched.
+
+    *extra_substitutions* is an optional fallback map of substitutions
+    contributed by ``packages:`` / ``!include`` blocks — typically the
+    ``substitutions`` key off the resolved config returned by
+    :func:`load_device_yaml`. The file's own ``substitutions:`` block
+    still wins on key conflicts, mirroring esphome's package merge
+    precedence (local config overrides package contributions).
     """
     name: str | None = None
     friendly_name: str | None = None
@@ -722,11 +730,19 @@ def parse_esphome_meta(  # noqa: PLR0912
             if sep:
                 substitutions[sub_key.strip()] = _parse_inline_value(sub_raw)
 
-    if substitutions:
-        name = _resolve_substitutions(name, substitutions)
-        friendly_name = _resolve_substitutions(friendly_name, substitutions)
-        comment = _resolve_substitutions(comment, substitutions)
-        area = _resolve_substitutions(area, substitutions)
+    # Merge extras under the file-local substitutions so a key defined
+    # both in the file and in a package keeps the local value — the
+    # same precedence esphome applies during ``do_packages_pass``.
+    if extra_substitutions:
+        merged: dict[str, str] = {**extra_substitutions, **substitutions}
+    else:
+        merged = substitutions
+
+    if merged:
+        name = _resolve_substitutions(name, merged)
+        friendly_name = _resolve_substitutions(friendly_name, merged)
+        comment = _resolve_substitutions(comment, merged)
+        area = _resolve_substitutions(area, merged)
 
     return name, friendly_name, comment, area
 
@@ -804,13 +820,20 @@ def load_device_from_storage(
         yaml_content = path.read_text(encoding="utf-8")
     except OSError:
         yaml_content = ""
-    yaml_name, yaml_friendly, yaml_comment, yaml_area = parse_esphome_meta(yaml_content)
     # Full resolved config (``!include`` / packages / ``!secret``
     # expanded) drives the api-encryption flag — a bare regex on raw
     # YAML would miss configs that pull the api block in via include
     # or split it across packages. ``None`` on parse failure is fine;
     # ``api_encrypted`` falls back to False.
     resolved_config = load_device_yaml(path)
+    # Feed the merged ``substitutions:`` from the resolved config back
+    # into the meta reader so ``esphome.friendly_name: $room`` resolves
+    # against substitutions contributed by ``packages:`` / ``!include``
+    # — not just the ones inline in this file (#917).
+    yaml_name, yaml_friendly, yaml_comment, yaml_area = parse_esphome_meta(
+        yaml_content,
+        extra_substitutions=_extract_resolved_substitutions(resolved_config),
+    )
 
     fallback_name = configuration_stem(filename)
     storage_name = storage.name if storage else None
@@ -1220,3 +1243,21 @@ def _resolve_substitutions(value: str | None, subs: dict[str, str]) -> str | Non
             break
 
     return value
+
+
+def _extract_resolved_substitutions(config: dict | None) -> dict[str, str]:
+    """
+    Pull a string-only ``substitutions:`` map off a resolved config.
+
+    Skips entries whose value isn't a string — substitution values
+    are always strings in valid ESPHome configs, and the meta reader
+    only knows how to interpolate strings. Returns ``{}`` when the
+    config is ``None``, has no ``substitutions:`` block, or its
+    block isn't a mapping.
+    """
+    if not isinstance(config, dict):
+        return {}
+    block = config.get(const.CONF_SUBSTITUTIONS)
+    if not isinstance(block, dict):
+        return {}
+    return {k: v for k, v in block.items() if isinstance(k, str) and isinstance(v, str)}

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -256,6 +256,77 @@ esphome:
     assert friendly_name in {"${a}", "${b}"}
 
 
+def test_parse_meta_resolves_substitution_from_extras() -> None:
+    """Substitutions absent from the file but supplied via *extra_substitutions* resolve.
+
+    Mirrors the regression in #917: the user keeps shared
+    substitutions in a ``packages:`` / ``!include`` file, so
+    ``friendly_name: $room`` is unresolved when the reader only
+    looks at the file-local ``substitutions:`` block.
+    """
+    yaml_content = """
+esphome:
+  name: living-room-lamp
+  friendly_name: $room
+"""
+    _, friendly_name, _, _ = parse_esphome_meta(
+        yaml_content,
+        extra_substitutions={"room": "Living Room"},
+    )
+    assert friendly_name == "Living Room"
+
+
+def test_parse_meta_file_substitution_overrides_extras() -> None:
+    """File-local ``substitutions:`` win over *extra_substitutions* on key collisions.
+
+    Mirrors esphome's ``do_packages_pass`` precedence: the main
+    config's substitutions override package-contributed ones.
+    """
+    yaml_content = """
+substitutions:
+  room: "Office"
+esphome:
+  friendly_name: $room
+"""
+    _, friendly_name, _, _ = parse_esphome_meta(
+        yaml_content,
+        extra_substitutions={"room": "Living Room"},
+    )
+    assert friendly_name == "Office"
+
+
+def test_parse_meta_extras_fill_gaps_in_file_substitutions() -> None:
+    """Keys only present in extras still resolve when the file has its own subs block.
+
+    The two maps are merged, not swapped: a local ``substitutions:``
+    block doesn't shadow unrelated keys contributed by a package.
+    """
+    yaml_content = """
+substitutions:
+  room: "Office"
+esphome:
+  friendly_name: "${room} ${suffix}"
+"""
+    _, friendly_name, _, _ = parse_esphome_meta(
+        yaml_content,
+        extra_substitutions={"suffix": "Lamp"},
+    )
+    assert friendly_name == "Office Lamp"
+
+
+def test_parse_meta_extras_none_matches_default() -> None:
+    """Passing ``None`` for *extra_substitutions* matches the no-arg behaviour."""
+    yaml_content = """
+substitutions:
+  room: Bedroom
+esphome:
+  friendly_name: $room
+"""
+    assert parse_esphome_meta(yaml_content, extra_substitutions=None) == parse_esphome_meta(
+        yaml_content
+    )
+
+
 # ----------------------------------------------------------------------
 # compute_has_pending_changes
 # ----------------------------------------------------------------------
@@ -1222,6 +1293,64 @@ def test_load_device_falls_back_to_empty_yaml_on_read_error(
     # so the loader leans on StorageJSON for those fields.
     assert device.name == "kitchen"  # from StorageJSON.name (write_storage_json default)
     assert device.configuration == "kitchen.yaml"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_resolves_friendly_name_from_packages(tmp_path: Path) -> None:
+    """``friendly_name: $room`` resolves against substitutions inside ``packages:``.
+
+    Regression for #917: shared substitutions kept in a package
+    file weren't visible to the meta reader, so the dashboard
+    rendered ``$room`` (or the raw token) on the device card
+    instead of the resolved string.
+    """
+    (tmp_path / "common.yaml").write_text(
+        "substitutions:\n  room: Living Room\n",
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "esphome:\n"
+        "  name: lamp\n"
+        "  friendly_name: $room\n"
+        "packages:\n"
+        "  common: !include common.yaml\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.friendly_name == "Living Room"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_local_substitution_wins_over_package(tmp_path: Path) -> None:
+    """A file-local ``substitutions:`` override beats the package contribution.
+
+    Mirrors esphome's ``do_packages_pass`` precedence; the
+    dashboard card matches what the compiler would see.
+    """
+    (tmp_path / "common.yaml").write_text(
+        "substitutions:\n  room: Package Default\n",
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        "  room: Local Override\n"
+        "esphome:\n"
+        "  name: lamp\n"
+        "  friendly_name: $room\n"
+        "packages:\n"
+        "  common: !include common.yaml\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.friendly_name == "Local Override"
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")


### PR DESCRIPTION
# What does this implement/fix?

`friendly_name` / `area` / `comment` on the device card stayed
stuck on raw `$token` text whenever the substitution came from a
`packages:` block or `!include` file — the meta reader only looked
at substitutions inline in the device YAML.

Now feed the merged `substitutions:` map off the resolved config
(which already runs `do_packages_pass` + `merge_packages` upstream)
into `parse_esphome_meta` as an extras fallback. File-local
entries still win on key conflicts, matching esphome's package
merge precedence.

- Add `extra_substitutions` param to `parse_esphome_meta` so the
  meta reader can resolve `$token`s defined outside the file.
- `load_device_from_storage` extracts the merged `substitutions:`
  off `resolved_config` and threads them through.
- Unit + integration tests covering the package case, the local
  override case, and the merge-not-swap case.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/917

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
