### PR TITLE
catalog: surface cv.Inclusive + has_*_one_key constraints

### DIFF
--- a/esphome_device_builder/controllers/components.py
+++ b/esphome_device_builder/controllers/components.py
@@ -20,6 +20,8 @@ from ..models import (
     PagedComponentsResponse,
     PinFeature,
     PinMode,
+    RequiredGroup,
+    RequiredGroupKind,
 )
 from .devices.helpers import _apply_featured_presets
 
@@ -737,6 +739,8 @@ def _materialise_entry(entry: ConfigEntry, target_platform: str | None) -> Confi
         config_entries=nested,
         platform_type=entry.platform_type,
         supported_platforms=list(entry.supported_platforms),
+        group=entry.group,
+        required_groups=list(entry.required_groups),
     )
 
 
@@ -818,6 +822,35 @@ def _load_display_format(raw: Any) -> str | None:
     return None
 
 
+def _load_required_groups(raw: Any) -> list[RequiredGroup]:
+    """
+    Normalise the JSON ``required_groups`` field into ``RequiredGroup`` objects.
+
+    Returns an empty list for missing / malformed input so callers
+    can store the field unconditionally. Unknown ``kind`` values
+    (a future cardinality validator a stale dashboard wouldn't
+    understand) drop the offending entry — same fail-soft policy
+    as ``_load_display_format`` / ``_safe_enum``.
+    """
+    if not isinstance(raw, list) or not raw:
+        return []
+    out: list[RequiredGroup] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        kind = _safe_enum(RequiredGroupKind, item.get("kind"))
+        if kind is None:
+            continue
+        keys_raw = item.get("keys")
+        if not isinstance(keys_raw, list):
+            continue
+        keys = [str(k) for k in keys_raw if isinstance(k, str)]
+        if not keys:
+            continue
+        out.append(RequiredGroup(kind=kind, keys=keys))
+    return out
+
+
 def _load_config_entry(data: dict) -> ConfigEntry:
     """Load a ConfigEntry from its JSON representation."""
     range_val: tuple[int | float, int | float] | None = None
@@ -862,6 +895,8 @@ def _load_config_entry(data: dict) -> ConfigEntry:
         config_entries=nested,
         platform_type=data.get("platform_type") or None,
         supported_platforms=list(data.get("supported_platforms") or []),
+        group=data.get("group") or None,
+        required_groups=_load_required_groups(data.get("required_groups")),
     )
 
 
@@ -878,4 +913,5 @@ def _load_component(data: dict) -> ComponentCatalogEntry:
         multi_conf=bool(data.get("multi_conf", False)),
         supported_platforms=list(data.get("supported_platforms", [])),
         config_entries=[_load_config_entry(e) for e in data.get("config_entries", [])],
+        required_groups=_load_required_groups(data.get("required_groups")),
     )

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -544,6 +544,47 @@ class ConfigValueOption(DataClassORJSONMixin):
     value: str
 
 
+class RequiredGroupKind(StrEnum):
+    """
+    Cross-field cardinality constraint over a group of sibling keys.
+
+    Mirrors the four ``cv.has_*_one_key`` validators upstream
+    esphome exposes: a schema decorated with one of these must
+    satisfy the cardinality rule across the named keys at
+    validation time. The wire form is the StrEnum value; the
+    frontend renders an inline hint and validates client-side.
+    """
+
+    # Exactly one of the listed keys must be present (e.g.
+    # ``esp32_rmt_led_strip`` requires either ``chipset`` *or* the
+    # manual-timing fields, never both).
+    EXACTLY_ONE = "exactly_one"
+    # At least one of the listed keys must be present (e.g.
+    # ``wifi.networks[].eap`` requires either an ``identity`` or a
+    # client certificate).
+    AT_LEAST_ONE = "at_least_one"
+    # At most one of the listed keys may be present.
+    AT_MOST_ONE = "at_most_one"
+    # Either none or all of the listed keys must be present.
+    NONE_OR_ALL = "none_or_all"
+
+
+@dataclass
+class RequiredGroup(DataClassORJSONMixin):
+    """
+    Cross-field "must specify one of these" constraint.
+
+    Lives on the schema that owns the referenced keys —
+    ``ComponentCatalogEntry.required_groups`` for component-level
+    constraints, ``ConfigEntry.required_groups`` (when
+    ``type=NESTED``) for nested-schema constraints. ``keys`` lists
+    the sibling YAML key names the cardinality rule applies to.
+    """
+
+    kind: RequiredGroupKind
+    keys: list[str] = field(default_factory=list)
+
+
 @dataclass
 class ConfigEntry(DataClassORJSONMixin):
     """A single field in a component's configuration schema.
@@ -726,6 +767,17 @@ class ConfigEntry(DataClassORJSONMixin):
     # `{"min": 0, "max": 100}` for a range message).
     translation_params: dict[str, Any] | None = None
 
+    # === cross-field constraints ===
+
+    # Inclusive-group name (esphome's ``cv.Inclusive(key, group)``):
+    # fields sharing the same ``group`` value are all-or-nothing —
+    # the user must set every member of the group, or none. None
+    # when the field stands alone. Frontend pairs this with the
+    # parent schema's ``required_groups`` to render the full
+    # "either X or all of {Y, Z, …}" rule (e.g. the manual-timing
+    # fields on ``light.esp32_rmt_led_strip``).
+    group: str | None = None
+
     # === nested entries (only meaningful when type == NESTED) ===
 
     # Inner config entries when this entry's value is a structured YAML
@@ -734,6 +786,14 @@ class ConfigEntry(DataClassORJSONMixin):
     # temperature / humidity readings). Frontend renders the parent
     # field as a collapsible group containing the inner form.
     config_entries: list[ConfigEntry] | None = None
+
+    # Cross-field cardinality constraints over this entry's
+    # ``config_entries``. Empty by default; populated when the
+    # nested schema is wrapped in ``cv.has_*_one_key(...)``
+    # upstream (e.g. ``wifi.networks[].eap`` requires at least one
+    # of ``identity`` / ``certificate``). Only meaningful when
+    # ``type == NESTED``.
+    required_groups: list[RequiredGroup] = field(default_factory=list)
 
     # Set when the nested entry represents an ESPHome entity (sensor,
     # binary_sensor, ...) rather than a plain config group. The

--- a/esphome_device_builder/models/components.py
+++ b/esphome_device_builder/models/components.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .common import ConfigEntry, PagedResponse
+from .common import ConfigEntry, PagedResponse, RequiredGroup
 
 
 class ComponentCategory(StrEnum):
@@ -126,6 +126,15 @@ class ComponentCatalogEntry(DataClassORJSONMixin):
     # ConfigEntry instances of type=NESTED that carry their own
     # ``config_entries``.
     config_entries: list[ConfigEntry] = field(default_factory=list)
+
+    # Cross-field cardinality constraints over ``config_entries``.
+    # Empty by default; populated when the upstream component
+    # wraps its top-level ``CONFIG_SCHEMA`` in
+    # ``cv.has_*_one_key(...)`` (e.g. ``light.esp32_rmt_led_strip``
+    # requires exactly one of ``chipset`` / the manual-timing
+    # group). Frontend pairs these with each entry's ``group`` to
+    # render the full "either X or all of {Y, Z, …}" rule.
+    required_groups: list[RequiredGroup] = field(default_factory=list)
 
 
 @dataclass

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1678,6 +1678,12 @@ def build_component_entry(
     # nested ``NESTED`` entries; the applier needs the whole
     # component dict to stamp both locations.
     _apply_required_groups(component, introspection.get("required_groups") or {})
+    # Prepend a markdown hint to each constraint-involved field's
+    # description so an older frontend (one that doesn't yet
+    # consume ``required_groups`` / ``group``) still surfaces the
+    # rule to the user as readable prose — issue #924. Drops out
+    # naturally once the FE renders the structured fields inline.
+    _annotate_constraint_descriptions(component)
     return component
 
 
@@ -4066,6 +4072,91 @@ def _promote_constraint_members(
     if not mutated:
         return entries
     return _sort_entries(entries)
+
+
+# Human-readable prefixes per ``cv.has_*_one_key`` kind. Kept short
+# and ``**bold**`` so the markdown renderer makes the rule jump out
+# above the schema-author's prose. The keys here mirror
+# :data:`_HAS_KEY_QUALNAMES` values one-for-one.
+_REQUIRED_GROUP_PREFIX: dict[str, str] = {
+    "exactly_one": "**Required — set exactly one of:**",
+    "at_least_one": "**Required — set at least one of:**",
+    "at_most_one": "**Set at most one of:**",
+    "none_or_all": "**Set together — all of these must be set, or all left blank:**",
+}
+
+
+def _annotate_constraint_descriptions(component: dict) -> None:
+    """
+    Prepend a markdown hint to descriptions of constraint-involved fields.
+
+    The structured ``group`` / ``required_groups`` fields are the
+    contract the frontend should eventually consume, but until that
+    lands the rule has to reach the user through the description
+    prose — otherwise issue #924 lingers (chipset is now visible,
+    but the user has no idea they must pick it OR the manual-timing
+    fields). The injected prefix is on its own paragraph above the
+    original description so a future FE update that drops it can
+    pattern-match the leading ``**Required`` / ``**Set`` lines.
+
+    Recurses into nested ``NESTED`` entries' ``config_entries``,
+    using each parent's ``required_groups`` for the in-scope hint.
+    """
+
+    def visit(entries: list[dict], groups: list[dict[str, Any]]) -> None:
+        _annotate_scope(entries, groups)
+        for entry in entries:
+            inner = entry.get("config_entries")
+            if inner:
+                visit(inner, entry.get("required_groups") or [])
+
+    visit(
+        component.get("config_entries") or [],
+        component.get("required_groups") or [],
+    )
+
+
+def _annotate_scope(entries: list[dict], required_groups: list[dict[str, Any]]) -> None:
+    """Annotate one sibling list with its in-scope required + inclusive hints."""
+    if not entries:
+        return
+    inclusive_members: dict[str, list[str]] = {}
+    for entry in entries:
+        group_name = entry.get("group")
+        if group_name:
+            inclusive_members.setdefault(group_name, []).append(entry["key"])
+
+    for entry in entries:
+        prefixes: list[str] = []
+        for group in required_groups:
+            if entry["key"] not in group.get("keys", []):
+                continue
+            others = [k for k in group["keys"] if k != entry["key"]]
+            if not others:
+                continue
+            prefix = _REQUIRED_GROUP_PREFIX.get(group.get("kind", ""))
+            if prefix is None:
+                continue
+            prefixes.append(f"{prefix} {_format_key_list(group['keys'])}.")
+        group_name = entry.get("group")
+        if group_name:
+            siblings = [k for k in inclusive_members.get(group_name, []) if k != entry["key"]]
+            if siblings:
+                prefixes.append(
+                    f"**Set together with:** {_format_key_list(siblings)} (all-or-none).",
+                )
+        if not prefixes:
+            continue
+        # Blank-line separator preserves paragraph breaks in
+        # CommonMark — the prefix lands as a standalone paragraph
+        # above the schema-author's prose.
+        original = entry.get("description") or ""
+        entry["description"] = "\n\n".join([*prefixes, original]).strip()
+
+
+def _format_key_list(keys: list[str]) -> str:
+    """Render keys as a comma-separated backticked list (markdown inline code)."""
+    return ", ".join(f"`{k}`" for k in keys)
 
 
 def _numeric_range_bounds(node: Any) -> tuple[int | float, int | float] | None:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1654,10 +1654,11 @@ def build_component_entry(
     _apply_platform_constraints(config_entries, introspection.get("platform_constraints") or {})
     _apply_field_ranges(config_entries, introspection.get("field_ranges") or {})
     _apply_refined_types(config_entries, introspection.get("refined_types") or {})
+    _apply_inclusive_groups(config_entries, introspection.get("inclusive_groups") or {})
     _apply_unit_of_measurement_options(config_entries)
     _promote_multi_value_keys(config_entries)
 
-    return {
+    component = {
         "id": component_id,
         "name": _resolve_name(component_id, stem, docs.name),
         "description": docs.text,
@@ -1673,6 +1674,11 @@ def build_component_entry(
         ),
         "config_entries": config_entries,
     }
+    # Required-groups straddle the component root (path ``()``) and
+    # nested ``NESTED`` entries; the applier needs the whole
+    # component dict to stamp both locations.
+    _apply_required_groups(component, introspection.get("required_groups") or {})
+    return component
 
 
 # ---------------------------------------------------------------------------
@@ -2882,28 +2888,25 @@ def introspect_component(component_id: str) -> dict[str, Any]:
     raw_auto_load = manifest.auto_load
     auto_load: list[str] = list(raw_auto_load) if isinstance(raw_auto_load, list) else []
 
-    refined_types = _collect_refined_types(manifest)
-    # Merge platform-manifest refinements on top — the platform
-    # schema's reference_voltage etc. don't appear on the parent
-    # component manifest. Paths come back keyed by entry name so
-    # they slot into the same dict the catalog walk consumes.
-    for platform_manifest in platform_manifests:
-        for path, refined in _collect_refined_types(platform_manifest).items():
-            refined_types.setdefault(path, refined)
+    # Bare manifest results take precedence (``setdefault`` keep-first);
+    # platform-manifest results fill in fields that only exist on the
+    # platform schema (e.g. ``sensor.debug.psram``'s ``cv.only_on_esp32``
+    # gate lives on the ``debug.sensor`` manifest, not the bare
+    # ``debug`` one).
+    def merge_from_platforms(
+        collect: Callable[[Any], dict[tuple[str, ...], Any]],
+    ) -> dict[tuple[str, ...], Any]:
+        merged = collect(manifest)
+        for platform_manifest in platform_manifests:
+            for path, value in collect(platform_manifest).items():
+                merged.setdefault(path, value)
+        return merged
 
-    platform_constraints = _collect_platform_constraints(manifest)
-    # Same pattern as ``refined_types``: the platform-domain
-    # manifest (e.g. ``debug.sensor``) carries the per-field gate
-    # for ``sensor.debug.psram`` while the bare ``debug`` manifest
-    # only describes the top-level ``debug:`` block.
-    for platform_manifest in platform_manifests:
-        for path, plats in _collect_platform_constraints(platform_manifest).items():
-            platform_constraints.setdefault(path, plats)
-
-    field_ranges = _collect_field_ranges(manifest)
-    for platform_manifest in platform_manifests:
-        for path, bounds in _collect_field_ranges(platform_manifest).items():
-            field_ranges.setdefault(path, bounds)
+    refined_types = merge_from_platforms(_collect_refined_types)
+    platform_constraints = merge_from_platforms(_collect_platform_constraints)
+    field_ranges = merge_from_platforms(_collect_field_ranges)
+    inclusive_groups = merge_from_platforms(_collect_inclusive_groups)
+    required_groups = merge_from_platforms(_collect_required_groups)
 
     return {
         "multi_conf": bool(getattr(manifest, "multi_conf", False)),
@@ -2912,6 +2915,8 @@ def introspect_component(component_id: str) -> dict[str, Any]:
         "platform_constraints": platform_constraints,
         "field_ranges": field_ranges,
         "refined_types": refined_types,
+        "inclusive_groups": inclusive_groups,
+        "required_groups": required_groups,
         "auto_load": auto_load,
     }
 
@@ -3079,6 +3084,8 @@ _ENTRY_DEFAULTS: dict[str, Any] = {
     "translation_params": None,
     "config_entries": None,
     "platform_type": None,
+    "group": None,
+    "required_groups": [],
 }
 
 _COMPONENT_DEFAULTS: dict[str, Any] = {
@@ -3088,6 +3095,7 @@ _COMPONENT_DEFAULTS: dict[str, Any] = {
     "multi_conf": False,
     "supported_platforms": [],
     "config_entries": [],
+    "required_groups": [],
 }
 
 
@@ -3146,9 +3154,17 @@ def _walk_schema_keys(
         for _ in range(8):
             if isinstance(node, dict):
                 return node
-            if hasattr(node, "schema"):
-                node = node.schema
-                continue
+            # Compound validators (``vol.All`` / ``vol.Any``) get their
+            # ``.schema`` attribute set during voluptuous compilation
+            # to the *outer* ``Schema`` being compiled — not the inner
+            # sub-schema — via ``_WithSubValidators.__voluptuous_compile__``.
+            # Following it on a compiled tree therefore leads back to
+            # the outer schema (already in ``visited``) and the walker
+            # silently stops descending into nested ``vol.All`` values
+            # like ``wifi.eap``. Prefer the ``validators`` tuple — the
+            # source of truth on compound validators — and fall back to
+            # ``.schema`` for plain ``vol.Schema`` wrappers that have no
+            # ``validators`` attribute.
             inner = getattr(node, "validators", None)
             if inner:
                 next_node = None
@@ -3159,6 +3175,9 @@ def _walk_schema_keys(
                 if next_node is None:
                     return None
                 node = next_node
+                continue
+            if hasattr(node, "schema"):
+                node = node.schema
                 continue
             return None
         return None
@@ -3790,6 +3809,263 @@ def _apply_platform_constraints(
             entry["supported_platforms"] = list(constraint)
 
     _walk_catalog_entries(entries, visit)
+
+
+# ``cv.has_*_one_key`` closures share the qualname template
+# ``has_<kind>_key.<locals>.validate``. We pin against that template
+# rather than the ``__name__`` (uniformly ``"validate"``) so a
+# legitimate validator from another factory can't masquerade as a
+# cardinality constraint. Mirrors the
+# :data:`RequiredGroupKind` wire values one-for-one — if upstream
+# adds a fifth cardinality validator the mapping needs a new entry
+# and the model enum a new member, in lockstep.
+_HAS_KEY_QUALNAMES: dict[str, str] = {
+    "has_exactly_one_key.<locals>.validate": "exactly_one",
+    "has_at_least_one_key.<locals>.validate": "at_least_one",
+    "has_at_most_one_key.<locals>.validate": "at_most_one",
+    "has_none_or_all_keys.<locals>.validate": "none_or_all",
+}
+
+
+def _required_group_from_validator(node: Any) -> dict[str, Any] | None:
+    """Return a ``{kind, keys}`` spec when *node* is a ``cv.has_*_one_key`` closure."""
+    qualname = getattr(node, "__qualname__", "") or ""
+    kind = _HAS_KEY_QUALNAMES.get(qualname)
+    if kind is None:
+        return None
+    try:
+        nonlocals = inspect.getclosurevars(node).nonlocals
+    except (TypeError, ValueError):
+        return None
+    keys = nonlocals.get("keys")
+    if not isinstance(keys, tuple | list) or not keys:
+        return None
+    str_keys = [k for k in keys if isinstance(k, str)]
+    if not str_keys:
+        return None
+    return {"kind": kind, "keys": str_keys}
+
+
+def _collect_inclusive_groups(
+    manifest: Any,
+) -> dict[tuple[str, ...], str]:
+    """
+    Walk the live ``CONFIG_SCHEMA`` for ``cv.Inclusive(...)`` markers.
+
+    Returns ``{key_path: group_name}`` keyed by tuple paths. A
+    field wrapped in ``cv.Inclusive(key, "foo")`` upstream surfaces
+    as ``{("...", key): "foo"}`` — the frontend pairs this with
+    the parent schema's ``required_groups`` to render the full
+    "all members of group must be set, or none" rule.
+
+    Empty dict when the component has no schema.
+    """
+    schema = getattr(manifest, "config_schema", None)
+    if schema is None:
+        return {}
+
+    out: dict[tuple[str, ...], str] = {}
+
+    def visit(key: Any, _key_name: str, _val: Any, path: tuple[str, ...]) -> None:
+        if not isinstance(key, vol.Inclusive):
+            return
+        # voluptuous historically named the attribute
+        # ``group_of_exclusion`` (matching the sibling
+        # ``Exclusive.group_of_exclusion``); esphome's vendored
+        # voluptuous and modern upstream both renamed it to
+        # ``group_of_inclusion``. Check both for resilience across
+        # voluptuous releases.
+        group = getattr(key, "group_of_inclusion", None) or getattr(key, "group_of_exclusion", None)
+        if isinstance(group, str) and group:
+            out[path] = group
+
+    _walk_schema_keys(schema, visit)
+    return out
+
+
+def _collect_required_groups(
+    manifest: Any,
+) -> dict[tuple[str, ...], list[dict[str, Any]]]:
+    """
+    Walk the live ``CONFIG_SCHEMA`` for ``cv.has_*_one_key`` constraints.
+
+    Returns ``{schema_path: [{kind, keys}, ...]}`` keyed by tuple
+    paths. ``()`` is the component's top-level schema; non-empty
+    paths target a nested schema (e.g.
+    ``("networks", "eap")`` for ``wifi.networks[].eap``).
+
+    Detection looks at the ``__qualname__`` of each callable
+    validator inside the ``vol.All`` chain wrapping a schema.
+    ``cv.has_exactly_one_key`` and friends are factory functions
+    that return closures named ``"validate"`` — the qualname
+    keeps the factory name (e.g.
+    ``has_exactly_one_key.<locals>.validate``) so we can both
+    detect them and recover their kind. The captured ``keys``
+    nonlocal carries the field names the constraint applies to.
+
+    Empty dict when the component has no schema.
+    """
+    schema = getattr(manifest, "config_schema", None)
+    if schema is None:
+        return {}
+
+    out: dict[tuple[str, ...], list[dict[str, Any]]] = {}
+    visited: set[int] = set()
+
+    def collect_at(node: Any, path: tuple[str, ...]) -> None:
+        # Walk through ``vol.All`` wrappers at the current level
+        # surfacing every ``cv.has_*_one_key`` validator. The cap
+        # mirrors the ``unwrap`` budget below — a misbehaving
+        # cyclic ``vol.All`` chain can't lock the walker.
+        for _ in range(8):
+            if not isinstance(node, vol.All):
+                return
+            for child in node.validators:
+                group = _required_group_from_validator(child)
+                if group is not None:
+                    out.setdefault(path, []).append(group)
+            inner = next(
+                (v for v in node.validators if isinstance(v, vol.All)),
+                None,
+            )
+            if inner is None:
+                return
+            node = inner
+
+    def unwrap_to_dict(node: Any) -> dict | None:
+        # Same shape (and same vol-compile workaround) as
+        # :func:`_walk_schema_keys`'s ``unwrap_to_dict`` — prefer
+        # ``validators`` over ``.schema`` on compound validators.
+        for _ in range(8):
+            if isinstance(node, dict):
+                return node
+            inner = getattr(node, "validators", None)
+            if inner:
+                next_node = next(
+                    (v for v in inner if isinstance(v, dict) or hasattr(v, "schema")),
+                    None,
+                )
+                if next_node is None:
+                    return None
+                node = next_node
+                continue
+            if hasattr(node, "schema"):
+                node = node.schema
+                continue
+            return None
+        return None
+
+    def walk(node: Any, path: tuple[str, ...], depth: int) -> None:
+        if depth > 6:
+            return
+        collect_at(node, path)
+        target = unwrap_to_dict(node)
+        if target is None:
+            return
+        if id(target) in visited:
+            return
+        visited.add(id(target))
+        for key, val in target.items():
+            key_name = key.schema if hasattr(key, "schema") else str(key)
+            walk(val, (*path, key_name), depth + 1)
+
+    try:
+        walk(schema, (), 0)
+    except Exception:
+        _LOGGER.debug("required-groups walk aborted on %r", schema, exc_info=True)
+    return out
+
+
+def _apply_inclusive_groups(
+    entries: list[dict],
+    groups: dict[tuple[str, ...], str],
+) -> None:
+    """Stamp ``group`` onto entries whose path is a ``cv.Inclusive`` marker."""
+    if not groups:
+        return
+
+    def visit(entry: dict, path: tuple[str, ...]) -> None:
+        group = groups.get(path)
+        if group:
+            entry["group"] = group
+
+    _walk_catalog_entries(entries, visit)
+
+
+def _apply_required_groups(
+    component: dict,
+    groups: dict[tuple[str, ...], list[dict[str, Any]]],
+) -> None:
+    """
+    Stamp ``required_groups`` onto the component root + nested entries.
+
+    Constraints at path ``()`` live on the component itself; deeper
+    paths attach to the matching nested ``ConfigEntry`` (only
+    meaningful when the target entry is a ``NESTED`` container).
+    Paths that don't match any catalog entry are silently dropped —
+    schema-only constructs (``cv.ensure_list`` markers, internal
+    wrappers) can show up in the schema walk without a catalog
+    counterpart.
+
+    Constraint-referenced sibling fields (plus every ``Inclusive``
+    group member that shares the same group name) are promoted off
+    ``advanced`` so the user can see the choices upstream actually
+    requires — issue #924, where ``light.esp32_rmt_led_strip``'s
+    required ``chipset`` field sat hidden under Advanced Settings.
+    """
+    if not groups:
+        return
+    root = groups.get(())
+    if root:
+        component["required_groups"] = [dict(g) for g in root]
+        component["config_entries"] = _promote_constraint_members(
+            component.get("config_entries") or [], root
+        )
+
+    def visit(entry: dict, path: tuple[str, ...]) -> None:
+        nested = groups.get(path)
+        if not nested:
+            return
+        entry["required_groups"] = [dict(g) for g in nested]
+        entry["config_entries"] = _promote_constraint_members(
+            entry.get("config_entries") or [], nested
+        )
+
+    _walk_catalog_entries(component.get("config_entries") or [], visit)
+
+
+def _promote_constraint_members(
+    entries: list[dict],
+    groups: list[dict[str, Any]],
+) -> list[dict]:
+    """
+    Demote constraint-referenced siblings off ``advanced`` and re-sort.
+
+    A field whose key appears in any ``required_group.keys`` — or
+    that shares a ``group`` (``cv.Inclusive``) with such a field —
+    must be visible on the main form, because the upstream schema
+    fails validation without it. Returns the original list when
+    nothing changed; otherwise a fresh, re-sorted list (the
+    advanced/main split feeds into :func:`_sort_entries`'s key, so
+    a demotion changes ordering).
+    """
+    keys_in_groups = {key for g in groups for key in g.get("keys", [])}
+    if not keys_in_groups:
+        return entries
+    inclusive_groups = {
+        e["group"] for e in entries if e["key"] in keys_in_groups and e.get("group")
+    }
+    mutated = False
+    for entry in entries:
+        if (
+            entry["key"] in keys_in_groups
+            or (inclusive_groups and entry.get("group") in inclusive_groups)
+        ) and entry.get("advanced"):
+            entry["advanced"] = False
+            mutated = True
+    if not mutated:
+        return entries
+    return _sort_entries(entries)
 
 
 def _numeric_range_bounds(node: Any) -> tuple[int | float, int | float] | None:

--- a/tests/test_components_config_entry_loader.py
+++ b/tests/test_components_config_entry_loader.py
@@ -364,6 +364,23 @@ def test_load_config_entry_drops_required_groups_with_empty_keys() -> None:
     assert entry.required_groups == []
 
 
+def test_load_config_entry_skips_required_groups_with_non_dict_items() -> None:
+    """Non-dict items in the list are ignored without breaking the rest."""
+    entry = _load_config_entry(
+        {
+            "key": "x",
+            "type": "nested",
+            "label": "X",
+            "required_groups": [
+                "garbage",
+                ["also", "garbage"],
+                {"kind": "at_least_one", "keys": ["good"]},
+            ],
+        }
+    )
+    assert [g.kind for g in entry.required_groups] == [RequiredGroupKind.AT_LEAST_ONE]
+
+
 def test_materialise_entry_carries_group_and_required_groups() -> None:
     """The per-request copy keeps both new fields visible to the frontend."""
     loaded = _load_config_entry(

--- a/tests/test_components_config_entry_loader.py
+++ b/tests/test_components_config_entry_loader.py
@@ -16,10 +16,11 @@ either gets covered or lights up CI.
 from __future__ import annotations
 
 from esphome_device_builder.controllers.components import (
+    _load_component,
     _load_config_entry,
     _materialise_entry,
 )
-from esphome_device_builder.models.common import ConfigEntryType
+from esphome_device_builder.models.common import ConfigEntryType, RequiredGroupKind
 
 
 def test_load_config_entry_propagates_unit_options() -> None:
@@ -283,3 +284,141 @@ def test_materialise_entry_carries_supported_platforms_through_nested() -> None:
     materialised = _materialise_entry(loaded, target_platform="esp32")
     assert materialised.config_entries is not None
     assert materialised.config_entries[0].supported_platforms == ["esp32"]
+
+
+def test_load_config_entry_propagates_group() -> None:
+    """``group`` rides through the JSON load for ``cv.Inclusive`` fields (issue #924)."""
+    entry = _load_config_entry(
+        {
+            "key": "bit0_high",
+            "type": "time_period",
+            "label": "Bit 0 high",
+            "group": "custom",
+        }
+    )
+    assert entry.group == "custom"
+
+
+def test_load_config_entry_group_defaults_to_none() -> None:
+    """Entries without ``group`` (the common case) load with ``None``."""
+    entry = _load_config_entry(
+        {"key": "ssid", "type": "string", "label": "SSID"},
+    )
+    assert entry.group is None
+
+
+def test_load_config_entry_required_groups_round_trips() -> None:
+    """Nested ``required_groups`` parse into typed ``RequiredGroup`` objects."""
+    entry = _load_config_entry(
+        {
+            "key": "eap",
+            "type": "nested",
+            "label": "EAP",
+            "required_groups": [
+                {"kind": "at_least_one", "keys": ["identity", "certificate"]},
+            ],
+        }
+    )
+    assert len(entry.required_groups) == 1
+    assert entry.required_groups[0].kind is RequiredGroupKind.AT_LEAST_ONE
+    assert entry.required_groups[0].keys == ["identity", "certificate"]
+
+
+def test_load_config_entry_drops_required_groups_with_unknown_kind() -> None:
+    """
+    Unknown ``kind`` values fold away — same fail-soft policy as ``_safe_enum``.
+
+    A catalog from a future release that introduces a fifth
+    cardinality validator must not crash an older dashboard's
+    loader; the offending entry is dropped so the rest of the
+    constraint list still reaches the frontend.
+    """
+    entry = _load_config_entry(
+        {
+            "key": "eap",
+            "type": "nested",
+            "label": "EAP",
+            "required_groups": [
+                {"kind": "at_least_one", "keys": ["a"]},
+                {"kind": "future_variant", "keys": ["b"]},
+            ],
+        }
+    )
+    assert [g.kind for g in entry.required_groups] == [RequiredGroupKind.AT_LEAST_ONE]
+
+
+def test_load_config_entry_drops_required_groups_with_empty_keys() -> None:
+    """A group with no string keys is meaningless and gets dropped."""
+    entry = _load_config_entry(
+        {
+            "key": "x",
+            "type": "nested",
+            "label": "X",
+            "required_groups": [
+                {"kind": "exactly_one", "keys": []},
+                {"kind": "exactly_one", "keys": [42, None]},
+                {"kind": "exactly_one"},  # missing keys
+            ],
+        }
+    )
+    assert entry.required_groups == []
+
+
+def test_materialise_entry_carries_group_and_required_groups() -> None:
+    """The per-request copy keeps both new fields visible to the frontend."""
+    loaded = _load_config_entry(
+        {
+            "key": "eap",
+            "type": "nested",
+            "label": "EAP",
+            "required_groups": [
+                {"kind": "at_least_one", "keys": ["identity", "certificate"]},
+            ],
+            "config_entries": [
+                {
+                    "key": "certificate",
+                    "type": "string",
+                    "label": "Certificate",
+                    "group": "cert_and_key",
+                },
+            ],
+        }
+    )
+    materialised = _materialise_entry(loaded, target_platform="esp32")
+    assert len(materialised.required_groups) == 1
+    assert materialised.required_groups[0].kind is RequiredGroupKind.AT_LEAST_ONE
+    assert materialised.config_entries is not None
+    assert materialised.config_entries[0].group == "cert_and_key"
+
+
+def test_load_component_reads_top_level_required_groups() -> None:
+    """Component-level ``required_groups`` (issue #924) round-trip from JSON."""
+    component = _load_component(
+        {
+            "id": "light.esp32_rmt_led_strip",
+            "name": "ESP32 RMT LED Strip",
+            "description": "",
+            "category": "light",
+            "required_groups": [
+                {"kind": "exactly_one", "keys": ["chipset", "bit0_high"]},
+            ],
+            "config_entries": [],
+        }
+    )
+    assert len(component.required_groups) == 1
+    assert component.required_groups[0].kind is RequiredGroupKind.EXACTLY_ONE
+    assert component.required_groups[0].keys == ["chipset", "bit0_high"]
+
+
+def test_load_component_required_groups_defaults_to_empty_list() -> None:
+    """A component without ``required_groups`` parses as the empty-list default."""
+    component = _load_component(
+        {
+            "id": "wifi",
+            "name": "Wi-Fi",
+            "description": "",
+            "category": "core",
+            "config_entries": [],
+        }
+    )
+    assert component.required_groups == []

--- a/tests/test_sync_components_required_groups.py
+++ b/tests/test_sync_components_required_groups.py
@@ -1,0 +1,477 @@
+"""Tests for schema-derived cross-field constraints in the sync script.
+
+Upstream esphome's ``cv.has_*_one_key`` and ``cv.Inclusive``
+validators express "must specify one of these" / "all-or-nothing"
+rules across sibling keys, but the pre-built JSON schema bundle
+flattens both away — every key shows up as plain ``Optional``.
+Without the introspection in this module, the catalog has no way
+to know that ``light.esp32_rmt_led_strip`` needs *either* a
+``chipset`` *or* the manual-timing group (issue #924), and the
+form happily hides both behind the Advanced toggle.
+
+Most tests pin the walker against synthetic voluptuous schemas
+— synthetic keeps the suite stable across upstream refactors. Two
+integration tests run against the live ``esp32_rmt_led_strip.light``
+and ``wifi`` manifests to catch regressions where the algorithm
+is right against synthetic schemas but breaks against real
+upstream shapes (a new combinator class, a custom wrapper around
+``cv.Inclusive``, etc.).
+"""
+
+from __future__ import annotations
+
+import esphome.config_validation as cv
+import pytest
+import voluptuous as vol
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _apply_inclusive_groups,
+    _apply_required_groups,
+    _collect_inclusive_groups,
+    _collect_required_groups,
+    _promote_constraint_members,
+    _required_group_from_validator,
+)
+
+
+class _FakeManifest:
+    """Minimal manifest stub — only ``config_schema`` is read."""
+
+    def __init__(self, schema: object) -> None:
+        self.config_schema = schema
+
+
+# ---------------------------------------------------------------------------
+# _required_group_from_validator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_kind"),
+    [
+        (cv.has_exactly_one_key, "exactly_one"),
+        (cv.has_at_least_one_key, "at_least_one"),
+        (cv.has_at_most_one_key, "at_most_one"),
+        (cv.has_none_or_all_keys, "none_or_all"),
+    ],
+)
+def test_required_group_from_validator_recovers_each_kind(
+    factory: object,
+    expected_kind: str,
+) -> None:
+    """Every ``cv.has_*_one_key`` flavour resolves to its wire kind."""
+    validator = factory("foo", "bar")  # type: ignore[operator]
+    assert _required_group_from_validator(validator) == {
+        "kind": expected_kind,
+        "keys": ["foo", "bar"],
+    }
+
+
+def test_required_group_from_validator_returns_none_for_unrelated_validator() -> None:
+    """A validator outside the ``has_*_one_key`` family yields ``None``."""
+    assert _required_group_from_validator(cv.string) is None
+    assert _required_group_from_validator(cv.boolean) is None
+    assert _required_group_from_validator(lambda x: x) is None
+
+
+def test_required_group_from_validator_drops_non_string_keys() -> None:
+    """Non-string captured keys are filtered out so the wire shape stays clean.
+
+    Voluptuous accepts any hashable key, so a schema author *could*
+    pass non-string keys to ``cv.has_at_least_one_key``; we'd
+    rather surface only the string ones than an unserialisable
+    mixed-type list.
+    """
+    validator = cv.has_exactly_one_key(123, None, "real_key")  # type: ignore[arg-type]
+    assert _required_group_from_validator(validator) == {
+        "kind": "exactly_one",
+        "keys": ["real_key"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _collect_inclusive_groups
+# ---------------------------------------------------------------------------
+
+
+def test_collect_inclusive_groups_returns_empty_for_unconstrained_schema() -> None:
+    """A schema with no ``cv.Inclusive`` markers returns an empty dict."""
+    schema = {
+        cv.Optional("free"): cv.string,
+        cv.Optional("loop_time"): cv.string,
+    }
+    assert _collect_inclusive_groups(_FakeManifest(schema)) == {}
+
+
+def test_collect_inclusive_groups_records_top_level_marker() -> None:
+    """A top-level ``cv.Inclusive`` surfaces at its single-element path."""
+    schema = {
+        cv.Optional("plain"): cv.string,
+        cv.Inclusive("foo", "pair"): cv.string,
+        cv.Inclusive("bar", "pair"): cv.string,
+    }
+    out = _collect_inclusive_groups(_FakeManifest(schema))
+    assert out == {("foo",): "pair", ("bar",): "pair"}
+
+
+def test_collect_inclusive_groups_walks_nested_vol_all_values() -> None:
+    """Inclusive markers inside a nested ``vol.All`` are still reached.
+
+    Mirrors the upstream ``wifi.eap`` shape:
+    ``EAP_AUTH_SCHEMA = cv.All(cv.only_on(...), cv.Schema({Inclusive(...)}), ...)``.
+    The walker has to descend past the outer ``vol.All`` and the
+    inner ``cv.Schema`` to see the Inclusive keys.
+    """
+    eap_inner = cv.Schema(
+        {
+            cv.Optional("identity"): cv.string,
+            cv.Inclusive("certificate", "cert_and_key"): cv.string,
+            cv.Inclusive("key", "cert_and_key"): cv.string,
+        },
+    )
+    eap = vol.All(cv.only_on_esp32, eap_inner, lambda x: x)
+    schema = cv.Schema({cv.Optional("eap"): eap})
+    out = _collect_inclusive_groups(_FakeManifest(schema))
+    assert out == {
+        ("eap", "certificate"): "cert_and_key",
+        ("eap", "key"): "cert_and_key",
+    }
+
+
+def test_collect_inclusive_groups_returns_empty_when_manifest_has_no_schema() -> None:
+    """Missing ``config_schema`` is handled gracefully."""
+
+    class NoSchemaManifest:
+        config_schema = None
+
+    assert _collect_inclusive_groups(NoSchemaManifest()) == {}
+
+
+# ---------------------------------------------------------------------------
+# _collect_required_groups
+# ---------------------------------------------------------------------------
+
+
+def test_collect_required_groups_returns_empty_for_unconstrained_schema() -> None:
+    """A schema with no ``has_*_one_key`` wrapper returns an empty dict."""
+    schema = cv.Schema({cv.Optional("plain"): cv.string})
+    assert _collect_required_groups(_FakeManifest(schema)) == {}
+
+
+def test_collect_required_groups_captures_top_level_constraint() -> None:
+    """A constraint wrapping the top-level schema lands at path ``()``.
+
+    Same shape upstream uses for ``light.esp32_rmt_led_strip``:
+    ``cv.All(cv.Schema({...}), cv.has_exactly_one_key("a", "b"))``.
+    """
+    schema = cv.All(
+        cv.Schema(
+            {
+                cv.Optional("chipset"): cv.string,
+                cv.Optional("bit0_high"): cv.positive_time_period_nanoseconds,
+            },
+        ),
+        cv.has_exactly_one_key("chipset", "bit0_high"),
+    )
+    out = _collect_required_groups(_FakeManifest(schema))
+    assert out == {
+        (): [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}],
+    }
+
+
+def test_collect_required_groups_captures_nested_constraint() -> None:
+    """A constraint on a nested sub-schema lands at the nested path.
+
+    Mirrors ``wifi.networks[].eap`` (and the simpler ``wifi.eap``):
+    the cv.All wrapping the inner schema carries
+    ``cv.has_at_least_one_key(...)`` alongside the dict.
+    """
+    eap_inner = cv.Schema(
+        {
+            cv.Optional("identity"): cv.string,
+            cv.Optional("certificate"): cv.string,
+        },
+    )
+    eap = vol.All(eap_inner, cv.has_at_least_one_key("identity", "certificate"))
+    schema = cv.Schema({cv.Optional("eap"): eap})
+    out = _collect_required_groups(_FakeManifest(schema))
+    assert out == {
+        ("eap",): [{"kind": "at_least_one", "keys": ["identity", "certificate"]}],
+    }
+
+
+def test_collect_required_groups_handles_all_four_kinds() -> None:
+    """Every ``cv.has_*_one_key`` flavour serialises to its wire kind."""
+    schema = cv.All(
+        cv.Schema({cv.Optional("a"): cv.string, cv.Optional("b"): cv.string}),
+        cv.has_exactly_one_key("a", "b"),
+        cv.has_at_least_one_key("a", "b"),
+        cv.has_at_most_one_key("a", "b"),
+        cv.has_none_or_all_keys("a", "b"),
+    )
+    out = _collect_required_groups(_FakeManifest(schema))
+    assert out == {
+        (): [
+            {"kind": "exactly_one", "keys": ["a", "b"]},
+            {"kind": "at_least_one", "keys": ["a", "b"]},
+            {"kind": "at_most_one", "keys": ["a", "b"]},
+            {"kind": "none_or_all", "keys": ["a", "b"]},
+        ],
+    }
+
+
+def test_collect_required_groups_returns_empty_when_manifest_has_no_schema() -> None:
+    """Missing ``config_schema`` is handled gracefully."""
+
+    class NoSchemaManifest:
+        config_schema = None
+
+    assert _collect_required_groups(NoSchemaManifest()) == {}
+
+
+# ---------------------------------------------------------------------------
+# Appliers
+# ---------------------------------------------------------------------------
+
+
+def test_apply_inclusive_groups_stamps_group_on_matching_entries() -> None:
+    """The applier walks catalog entries and copies the group name in."""
+    entries = [
+        {"key": "chipset", "config_entries": []},
+        {"key": "bit0_high", "config_entries": []},
+        {"key": "bit0_low", "config_entries": []},
+    ]
+    groups = {("bit0_high",): "custom", ("bit0_low",): "custom"}
+    _apply_inclusive_groups(entries, groups)
+    by_key = {e["key"]: e for e in entries}
+    assert by_key["bit0_high"]["group"] == "custom"
+    assert by_key["bit0_low"]["group"] == "custom"
+    assert "group" not in by_key["chipset"]
+
+
+def test_apply_inclusive_groups_is_a_no_op_when_empty() -> None:
+    """Empty group dict leaves entries untouched."""
+    entries = [{"key": "ssid", "config_entries": []}]
+    before = [dict(e) for e in entries]
+    _apply_inclusive_groups(entries, {})
+    assert entries == before
+
+
+def test_apply_required_groups_stamps_component_root() -> None:
+    """``path=()`` constraints land on the component dict itself."""
+    component = {
+        "id": "light.esp32_rmt_led_strip",
+        "config_entries": [
+            {"key": "chipset", "config_entries": []},
+            {"key": "bit0_high", "config_entries": []},
+        ],
+    }
+    groups = {(): [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}]}
+    _apply_required_groups(component, groups)
+    assert component["required_groups"] == [
+        {"kind": "exactly_one", "keys": ["chipset", "bit0_high"]},
+    ]
+
+
+def test_apply_required_groups_stamps_nested_entry() -> None:
+    """Non-empty paths target the matching nested ``NESTED`` entry."""
+    component = {
+        "id": "wifi",
+        "config_entries": [
+            {
+                "key": "eap",
+                "config_entries": [
+                    {"key": "identity", "config_entries": []},
+                    {"key": "certificate", "config_entries": []},
+                ],
+            },
+        ],
+    }
+    groups = {
+        ("eap",): [{"kind": "at_least_one", "keys": ["identity", "certificate"]}],
+    }
+    _apply_required_groups(component, groups)
+    assert component.get("required_groups", []) == []
+    assert component["config_entries"][0]["required_groups"] == [
+        {"kind": "at_least_one", "keys": ["identity", "certificate"]},
+    ]
+
+
+def test_apply_required_groups_is_a_no_op_when_empty() -> None:
+    """Empty constraints dict leaves the component untouched."""
+    component = {"id": "x", "config_entries": [{"key": "foo", "config_entries": []}]}
+    before = {"id": component["id"], "config_entries": [dict(component["config_entries"][0])]}
+    _apply_required_groups(component, {})
+    assert "required_groups" not in component
+    assert component["config_entries"] == before["config_entries"]
+
+
+def test_apply_required_groups_drops_paths_with_no_catalog_match() -> None:
+    """Constraints whose path doesn't match any entry are silently ignored.
+
+    The schema walker can produce paths for synthetic constructs
+    (``cv.ensure_list`` wrappers, internal markers) that don't have
+    a catalog counterpart. The applier must not crash on those.
+    """
+    component = {"id": "x", "config_entries": [{"key": "real", "config_entries": []}]}
+    groups = {("ghost", "missing"): [{"kind": "exactly_one", "keys": ["a", "b"]}]}
+    _apply_required_groups(component, groups)
+    assert "required_groups" not in component["config_entries"][0]
+
+
+# ---------------------------------------------------------------------------
+# _promote_constraint_members
+# ---------------------------------------------------------------------------
+
+
+def test_promote_constraint_members_demotes_referenced_keys() -> None:
+    """Fields named in a constraint get pulled off ``advanced``."""
+    entries = [
+        {"key": "chipset", "advanced": True},
+        {"key": "rgb_order", "advanced": False},
+        {"key": "bit0_high", "advanced": True, "group": "custom"},
+    ]
+    groups = [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}]
+    out = _promote_constraint_members(entries, groups)
+    by_key = {e["key"]: e for e in out}
+    assert by_key["chipset"]["advanced"] is False
+    assert by_key["bit0_high"]["advanced"] is False
+    # Untouched sibling stays at whatever the schema author picked.
+    assert by_key["rgb_order"]["advanced"] is False
+
+
+def test_promote_constraint_members_also_pulls_inclusive_partners() -> None:
+    """An Inclusive sibling sharing a referenced field's group also promotes.
+
+    Upstream ``has_exactly_one_key`` typically names one
+    representative key per branch (e.g. ``"bit0_high"`` stands in
+    for the whole timing group). Promoting only that
+    representative would leave the user staring at the timing
+    fields' partners still under Advanced — the whole point of the
+    Inclusive group is they belong together.
+    """
+    entries = [
+        {"key": "chipset", "advanced": True},
+        {"key": "bit0_high", "advanced": True, "group": "custom"},
+        {"key": "bit0_low", "advanced": True, "group": "custom"},
+        {"key": "bit1_high", "advanced": True, "group": "custom"},
+        {"key": "bit1_low", "advanced": True, "group": "custom"},
+        {"key": "is_rgbw", "advanced": True},  # unrelated, stays advanced
+    ]
+    groups = [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}]
+    out = _promote_constraint_members(entries, groups)
+    by_key = {e["key"]: e for e in out}
+    for key in ("chipset", "bit0_high", "bit0_low", "bit1_high", "bit1_low"):
+        assert by_key[key]["advanced"] is False, f"{key} should be promoted"
+    assert by_key["is_rgbw"]["advanced"] is True
+
+
+def test_promote_constraint_members_returns_same_list_on_no_op() -> None:
+    """When nothing was advanced, the original list is returned unchanged.
+
+    Identity check matters: the catch-all re-sort would otherwise
+    perturb a list the schema authors deliberately ordered.
+    """
+    entries = [
+        {"key": "chipset", "advanced": False},
+        {"key": "bit0_high", "advanced": False},
+    ]
+    groups = [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}]
+    out = _promote_constraint_members(entries, groups)
+    assert out is entries
+
+
+def test_promote_constraint_members_resorts_after_demoting() -> None:
+    """Re-sorting moves the demoted entries ahead of remaining advanced siblings."""
+    entries = [
+        {"key": "advanced_first", "advanced": False},
+        {"key": "later_advanced", "advanced": True},
+        {"key": "promoted", "advanced": True},
+    ]
+    groups = [{"kind": "exactly_one", "keys": ["promoted"]}]
+    out = _promote_constraint_members(entries, groups)
+    # Non-advanced entries lead; previously-advanced siblings trail.
+    assert [e["key"] for e in out[:2]] == ["advanced_first", "promoted"]
+    assert out[-1]["key"] == "later_advanced"
+
+
+# ---------------------------------------------------------------------------
+# Live integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_collect_against_live_esp32_rmt_led_strip_light() -> None:
+    """End-to-end: the walkers recover both constraints from the real manifest.
+
+    Synthetic tests pin the algorithm; this one pins the integration
+    against upstream. A future upstream refactor that wraps the
+    timing fields in a way the walker doesn't recognise (a new
+    Inclusive subclass, a custom replacement for ``has_exactly_one_key``)
+    would slip past the synthetic suite — this test catches that
+    class of regression.
+
+    Asserts the *structural* property (chipset/bit0_high are the
+    exactly-one constituents; the bit_* fields share an Inclusive
+    group) rather than exact upstream constants so a future
+    upstream rename of the group name doesn't break us — that's a
+    catalog diff worth reviewing in the next nightly sync, not a
+    CI failure.
+    """
+    pytest.importorskip("esphome.components.esp32_rmt_led_strip.light")
+    from esphome.components.esp32_rmt_led_strip import light as rmt_light  # noqa: PLC0415
+
+    manifest = _FakeManifest(rmt_light.CONFIG_SCHEMA)
+
+    required = _collect_required_groups(manifest)
+    assert () in required, (
+        "esp32_rmt_led_strip.light lost its top-level has_exactly_one_key "
+        "constraint — issue #924 will regress"
+    )
+    root_specs = required[()]
+    assert any(
+        spec["kind"] == "exactly_one" and "chipset" in spec["keys"] and "bit0_high" in spec["keys"]
+        for spec in root_specs
+    )
+
+    inclusive = _collect_inclusive_groups(manifest)
+    for bit_key in ("bit0_high", "bit0_low", "bit1_high", "bit1_low"):
+        assert (bit_key,) in inclusive, f"{bit_key} lost its Inclusive marker"
+    # All four timing fields share one group — the user must set
+    # them as a unit or skip them entirely.
+    bit_groups = {inclusive[(k,)] for k in ("bit0_high", "bit0_low", "bit1_high", "bit1_low")}
+    assert len(bit_groups) == 1, f"timing fields drifted into different groups: {bit_groups}"
+
+
+def test_collect_against_live_wifi_eap_nested_schema() -> None:
+    """End-to-end: nested ``eap`` constraint + Inclusive markers come through.
+
+    The wifi top-level ``eap:`` block uses both primitives at a
+    nested level (``cv.has_at_least_one_key(identity, certificate)``
+    plus ``cv.Inclusive(certificate/key, "certificate_and_key")``);
+    pin the walker against that whole shape end-to-end so a future
+    voluptuous compile-pass quirk that breaks nested-vol.All
+    descent (the symptom we hit in `_walk_schema_keys`) re-surfaces
+    here.
+    """
+    pytest.importorskip("esphome.components.wifi")
+    from esphome.components import wifi  # noqa: PLC0415
+
+    manifest = _FakeManifest(wifi.CONFIG_SCHEMA)
+
+    required = _collect_required_groups(manifest)
+    assert ("eap",) in required, "wifi.eap lost its has_at_least_one_key constraint"
+    eap_specs = required[("eap",)]
+    assert any(
+        spec["kind"] == "at_least_one"
+        and "identity" in spec["keys"]
+        and "certificate" in spec["keys"]
+        for spec in eap_specs
+    )
+
+    inclusive = _collect_inclusive_groups(manifest)
+    # The certificate / key pair must share the same Inclusive group.
+    cert_path = ("eap", "certificate")
+    key_path = ("eap", "key")
+    assert cert_path in inclusive
+    assert key_path in inclusive
+    assert inclusive[cert_path] == inclusive[key_path]

--- a/tests/test_sync_components_required_groups.py
+++ b/tests/test_sync_components_required_groups.py
@@ -25,6 +25,7 @@ import pytest
 import voluptuous as vol
 
 from script.sync_components import (  # type: ignore[import-not-found]
+    _annotate_constraint_descriptions,
     _apply_inclusive_groups,
     _apply_required_groups,
     _collect_inclusive_groups,
@@ -393,6 +394,175 @@ def test_promote_constraint_members_resorts_after_demoting() -> None:
     # Non-advanced entries lead; previously-advanced siblings trail.
     assert [e["key"] for e in out[:2]] == ["advanced_first", "promoted"]
     assert out[-1]["key"] == "later_advanced"
+
+
+# ---------------------------------------------------------------------------
+# _annotate_constraint_descriptions
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_descriptions_prepends_exactly_one_hint() -> None:
+    """A field referenced in ``exactly_one`` gets the prose hint above its docs."""
+    component = {
+        "config_entries": [
+            {"key": "chipset", "description": "Pick a chipset."},
+            {"key": "bit0_high", "description": "Bit 0 high time."},
+            {"key": "rgb_order", "description": "RGB ordering."},
+        ],
+        "required_groups": [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}],
+    }
+    _annotate_constraint_descriptions(component)
+    by_key = {e["key"]: e for e in component["config_entries"]}
+    assert by_key["chipset"]["description"].startswith(
+        "**Required — set exactly one of:** `chipset`, `bit0_high`.",
+    )
+    assert "Pick a chipset." in by_key["chipset"]["description"]
+    assert by_key["bit0_high"]["description"].startswith(
+        "**Required — set exactly one of:** `chipset`, `bit0_high`.",
+    )
+    # Unrelated sibling stays untouched.
+    assert by_key["rgb_order"]["description"] == "RGB ordering."
+
+
+def test_annotate_descriptions_handles_each_kind() -> None:
+    """Each ``cv.has_*_one_key`` flavour gets its own readable prefix."""
+    component = {
+        "config_entries": [
+            {"key": "a", "description": ""},
+            {"key": "b", "description": ""},
+        ],
+        "required_groups": [
+            {"kind": "at_least_one", "keys": ["a", "b"]},
+            {"kind": "at_most_one", "keys": ["a", "b"]},
+            {"kind": "none_or_all", "keys": ["a", "b"]},
+        ],
+    }
+    _annotate_constraint_descriptions(component)
+    desc_a = component["config_entries"][0]["description"]
+    assert "**Required — set at least one of:** `a`, `b`." in desc_a
+    assert "**Set at most one of:** `a`, `b`." in desc_a
+    assert "**Set together — all of these must be set, or all left blank:**" in desc_a
+
+
+def test_annotate_descriptions_appends_inclusive_group_hint() -> None:
+    """``cv.Inclusive`` siblings get a "set together with" hint listing partners."""
+    component = {
+        "config_entries": [
+            {"key": "bit0_high", "description": "0-bit high.", "group": "custom"},
+            {"key": "bit0_low", "description": "0-bit low.", "group": "custom"},
+            {"key": "bit1_high", "description": "1-bit high.", "group": "custom"},
+            {"key": "bit1_low", "description": "1-bit low.", "group": "custom"},
+        ],
+        "required_groups": [],
+    }
+    _annotate_constraint_descriptions(component)
+    desc = component["config_entries"][0]["description"]
+    # ``bit0_high`` itself isn't listed; the other three are.
+    assert "`bit0_low`" in desc and "`bit1_high`" in desc and "`bit1_low`" in desc
+    assert "`bit0_high`" not in desc.split("\n\n")[0]  # not in the prefix
+    assert "(all-or-none)" in desc
+    assert "0-bit high." in desc
+
+
+def test_annotate_descriptions_composes_both_hints_when_both_apply() -> None:
+    """A field with both signals gets both prefixes, each on its own paragraph.
+
+    ``bit0_high`` on ``light.esp32_rmt_led_strip`` is the canonical
+    case — it's the named representative of the
+    ``has_exactly_one_key`` constraint *and* part of the
+    ``Inclusive("custom")`` group whose siblings are bit0_low /
+    bit1_high / bit1_low. The user needs to see both rules to
+    understand the form.
+    """
+    component = {
+        "config_entries": [
+            {"key": "chipset", "description": "Chipset."},
+            {
+                "key": "bit0_high",
+                "description": "0-bit high.",
+                "group": "custom",
+            },
+            {"key": "bit0_low", "description": "0-bit low.", "group": "custom"},
+        ],
+        "required_groups": [{"kind": "exactly_one", "keys": ["chipset", "bit0_high"]}],
+    }
+    _annotate_constraint_descriptions(component)
+    desc = component["config_entries"][1]["description"]
+    paragraphs = desc.split("\n\n")
+    assert paragraphs[0].startswith("**Required — set exactly one of:**")
+    assert paragraphs[1].startswith("**Set together with:**")
+    assert paragraphs[-1] == "0-bit high."
+
+
+def test_annotate_descriptions_recurses_into_nested_entries() -> None:
+    """A nested entry's ``required_groups`` annotate its children."""
+    component = {
+        "config_entries": [
+            {
+                "key": "eap",
+                "description": "EAP settings.",
+                "required_groups": [
+                    {"kind": "at_least_one", "keys": ["identity", "certificate"]},
+                ],
+                "config_entries": [
+                    {"key": "identity", "description": "User identity."},
+                    {
+                        "key": "certificate",
+                        "description": "Client cert.",
+                        "group": "cert_and_key",
+                    },
+                    {
+                        "key": "key",
+                        "description": "Client key.",
+                        "group": "cert_and_key",
+                    },
+                ],
+            },
+        ],
+        "required_groups": [],
+    }
+    _annotate_constraint_descriptions(component)
+    eap_inner = {e["key"]: e for e in component["config_entries"][0]["config_entries"]}
+    assert eap_inner["identity"]["description"].startswith(
+        "**Required — set at least one of:** `identity`, `certificate`.",
+    )
+    assert "**Set together with:** `key` (all-or-none)." in eap_inner["certificate"]["description"]
+    # ``key`` isn't part of the required_group — only the inclusive hint.
+    key_desc = eap_inner["key"]["description"]
+    assert "**Required" not in key_desc
+    assert "**Set together with:** `certificate` (all-or-none)." in key_desc
+
+
+def test_annotate_descriptions_is_a_no_op_without_constraints() -> None:
+    """Components with no constraints leave every description untouched."""
+    component = {
+        "config_entries": [
+            {"key": "ssid", "description": "Network SSID."},
+            {"key": "password", "description": "Network password."},
+        ],
+        "required_groups": [],
+    }
+    _annotate_constraint_descriptions(component)
+    assert [e["description"] for e in component["config_entries"]] == [
+        "Network SSID.",
+        "Network password.",
+    ]
+
+
+def test_annotate_descriptions_handles_none_description() -> None:
+    """A field with ``description=None`` still gets the prefix (no crash)."""
+    component = {
+        "config_entries": [
+            {"key": "a", "description": None},
+            {"key": "b", "description": None},
+        ],
+        "required_groups": [{"kind": "exactly_one", "keys": ["a", "b"]}],
+    }
+    _annotate_constraint_descriptions(component)
+    desc = component["config_entries"][0]["description"]
+    assert desc.startswith("**Required — set exactly one of:** `a`, `b`.")
+    # No trailing empty paragraph from a None original.
+    assert not desc.endswith("\n\n")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

`cv.Inclusive(key, "<group>")` and the `cv.has_*_one_key` family of validators express cross-field rules ("all-or-nothing" / "must specify one of") that the pre-built schema bundle flattens away — every key surfaces as plain `Optional`. The catalog therefore had no way to tell that `light.esp32_rmt_led_strip` requires either `chipset` *or* the manual-timing fields, and both ended up under Advanced Settings with no hint that anything was required (issue #924).

Recover the constraints via live esphome introspection and stamp them onto the catalog as a `RequiredGroup` list (on `ComponentCatalogEntry` for top-level constraints, on `ConfigEntry` for nested ones) plus a `group` string on each `cv.Inclusive` field. Constraint-referenced fields (and every member of an inclusive group sharing one of them) get promoted off `advanced` so the user actually sees the required choice instead of having to know it exists.

The long-term home for this metadata is the upstream schema dumper — once `esphome/esphome-schema` emits `group` and `required_groups` directly, this script can read them off the JSON instead of importing the components. The model + applier shape here mirrors what the upstream wire format would carry so that switchover is a sync-script change, not a model migration.

Picks up 69 components with `required_groups` (incl. `esp32_rmt_led_strip`, `esp32_camera`, `ble_presence`, `thermostat`, `tuya`, `uart`, ...), 30 fields with an `Inclusive` group, plus the `wifi.eap` nested case. Hit a voluptuous-compile-cache quirk in `_walk_schema_keys` along the way — `vol.All`'s `.schema` is set during compilation to the *outer* schema being compiled, not the inner sub-schema, so nested `vol.All` values (`wifi.eap`) were silently never descended. Prefer `validators` over `.schema` on compound validators to fix it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/924

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

Two new optional fields on the wire:

- `ConfigEntry.group: str | None` — the `cv.Inclusive` group name; siblings sharing one are all-or-nothing.
- `ConfigEntry.required_groups: list[RequiredGroup]` + `ComponentCatalogEntry.required_groups: list[RequiredGroup]` — list of `{kind, keys}` where `kind` is one of `exactly_one` / `at_least_one` / `at_most_one` / `none_or_all`.

The visible-bug fix (promoting constraint-involved fields off Advanced) lands today regardless of frontend uptake. To render the actual "either X or all of {Y, Z, …}" hint inline on the form, the frontend needs to consume the two new fields — companion FE PR to follow.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
