### PR TITLE
Tidy bug-report template header and add Desktop app option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,24 +5,32 @@ type: "Bug"
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >
         Thanks for trying the new dashboard! 🙏
 
-        **Looking to request a feature?** This template is for bug reports only. Feature ideas belong in the
+
+        **Looking to request a feature?** This template is for bug reports only.
+        Feature ideas belong in the
         [esphome org-level Discussions board](https://github.com/orgs/esphome/discussions);
         planned / in-progress work is tracked on the
         [Device Builder project board](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22).
 
+
         Before filing, please confirm:
+
+
         - **Not an ESPHome core problem** — compile errors / device behaviour /
-          component bugs belong in the [esphome repo](https://github.com/esphome/esphome/issues/new/choose).
+        component bugs belong in the
+        [esphome repo](https://github.com/esphome/esphome/issues/new/choose).
+
         - **Not already tracked** — check
-          [open issues](https://github.com/esphome/device-builder-dashboard-backend/issues)
-          and the
-          [project backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22).
+        [open issues](https://github.com/esphome/device-builder-dashboard-backend/issues)
+        and the
+        [project backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22).
+
         - **Not better suited to chat** — quick questions and feedback land
-          faster in the
-          [Discord channel](https://discord.gg/Rf2jWGVjaK).
+        faster in the
+        [Discord channel](https://discord.gg/Rf2jWGVjaK).
 
   - type: textarea
     id: what-happened
@@ -61,6 +69,7 @@ body:
         - From source (script/setup)
         - ESPHome container (preview toggle)
         - Home Assistant App (preview toggle)
+        - Desktop app
         - Other / not sure
     validations:
       required: true


### PR DESCRIPTION
# What does this implement/fix?

The intro markdown block in the bug-report issue template was rendering with hard line breaks mid-sentence (visible newlines around the links in each paragraph and bullet). GitHub issue-form `markdown` blocks preserve source newlines literally, so the hard-wrapped YAML source bled straight through to the rendered template.

Switch the block to a folded YAML scalar (`>`) so paragraphs and bullets can still be wrapped in source for readability while rendering as single lines. Blank-line discipline keeps the paragraph breaks and the bulleted list intact.

Also adds "Desktop app" to the **How did you install it?** dropdown so reporters using the desktop build can pick it.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.