### PR TITLE
Prefer explicit 'sensitive' flag from esphome schema dump

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1951,9 +1951,15 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
     if entry_type is None:
         entry_type = "string"
 
-    # Type promotion: schema-given ``string`` whose key/name implies a
-    # secret -> secure_string.
-    if entry_type == "string" and any(frag in key.lower() for frag in _SECRET_KEY_FRAGMENTS):
+    # Type promotion: prefer the explicit ``"sensitive"`` flag the upstream
+    # esphome dumper emits for fields wrapped in ``cv.sensitive(...)`` (added
+    # in esphome/esphome#16673; explicit migrations in #16677 cover api/wifi/
+    # ota/mqtt/web_server passwords plus SSIDs); fall back to the local
+    # key-name heuristic for older esphome versions that don't carry the
+    # flag, or for unmigrated/third-party schemas.
+    if entry_type == "string" and (
+        raw.get("sensitive") or any(frag in key.lower() for frag in _SECRET_KEY_FRAGMENTS)
+    ):
         entry_type = "secure_string"
 
     # Cleaned docs ⇒ description + help_link/docs_url candidate.

--- a/tests/test_sync_components_sensitive_flag.py
+++ b/tests/test_sync_components_sensitive_flag.py
@@ -12,52 +12,44 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from script.sync_components import (  # type: ignore[import-not-found]
     _convert_field,
 )
 
 
-@pytest.fixture
-def schema_dir(tmp_path: Path) -> Path:
-    """Empty dir for ``_convert_field`` (only used for ``extends`` lookups)."""
-    return tmp_path
-
-
 def test_explicit_sensitive_flag_promotes_string_to_secure_string(
-    schema_dir: Path,
+    tmp_path: Path,
 ) -> None:
     """Explicit ``"sensitive": true`` flips a string entry to secure_string."""
     raw = {"type": "string", "key": "Optional", "sensitive": True}
-    entry = _convert_field("bearer", raw, schema_dir)
+    entry = _convert_field("bearer", raw, tmp_path)
     assert entry is not None
     assert entry["type"] == "secure_string"
 
 
 def test_fragment_heuristic_still_promotes_for_pre_marker_esphome(
-    schema_dir: Path,
+    tmp_path: Path,
 ) -> None:
     """Pre-marker esphome has no flag; the fragment list still masks the field."""
     raw = {"type": "string", "key": "Optional"}
-    entry = _convert_field("wifi_password", raw, schema_dir)
+    entry = _convert_field("wifi_password", raw, tmp_path)
     assert entry is not None
     assert entry["type"] == "secure_string"
 
 
-def test_non_sensitive_string_field_stays_string(schema_dir: Path) -> None:
+def test_non_sensitive_string_field_stays_string(tmp_path: Path) -> None:
     """No marker, non-matching name; entry stays as a plain ``string``."""
     raw = {"type": "string", "key": "Optional"}
-    entry = _convert_field("hostname", raw, schema_dir)
+    entry = _convert_field("hostname", raw, tmp_path)
     assert entry is not None
     assert entry["type"] == "string"
 
 
 def test_sensitive_flag_on_non_string_type_does_not_promote(
-    schema_dir: Path,
+    tmp_path: Path,
 ) -> None:
     """Promotion is gated on string type; a sensitive boolean stays boolean."""
     raw = {"type": "boolean", "key": "Optional", "sensitive": True}
-    entry = _convert_field("encrypted", raw, schema_dir)
+    entry = _convert_field("encrypted", raw, tmp_path)
     assert entry is not None
     assert entry["type"] == "boolean"

--- a/tests/test_sync_components_sensitive_flag.py
+++ b/tests/test_sync_components_sensitive_flag.py
@@ -1,0 +1,63 @@
+"""Tests for the ``sensitive`` flag handling in ``_convert_field``.
+
+Upstream esphome (esphome/esphome#16673) emits ``"sensitive": true`` on
+schema entries whose validator is wrapped in ``cv.sensitive(...)``. Our
+sync prefers that explicit signal over the legacy key-name fragment
+heuristic, while keeping the heuristic as a fallback for older esphome
+versions (and for unmigrated/third-party schemas) that don't carry the
+flag yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _convert_field,
+)
+
+
+@pytest.fixture
+def schema_dir(tmp_path: Path) -> Path:
+    """Empty dir for ``_convert_field`` (only used for ``extends`` lookups)."""
+    return tmp_path
+
+
+def test_explicit_sensitive_flag_promotes_string_to_secure_string(
+    schema_dir: Path,
+) -> None:
+    """Explicit ``"sensitive": true`` flips a string entry to secure_string."""
+    raw = {"type": "string", "key": "Optional", "sensitive": True}
+    entry = _convert_field("bearer", raw, schema_dir)
+    assert entry is not None
+    assert entry["type"] == "secure_string"
+
+
+def test_fragment_heuristic_still_promotes_for_pre_marker_esphome(
+    schema_dir: Path,
+) -> None:
+    """Pre-marker esphome has no flag; the fragment list still masks the field."""
+    raw = {"type": "string", "key": "Optional"}
+    entry = _convert_field("wifi_password", raw, schema_dir)
+    assert entry is not None
+    assert entry["type"] == "secure_string"
+
+
+def test_non_sensitive_string_field_stays_string(schema_dir: Path) -> None:
+    """No marker, non-matching name; entry stays as a plain ``string``."""
+    raw = {"type": "string", "key": "Optional"}
+    entry = _convert_field("hostname", raw, schema_dir)
+    assert entry is not None
+    assert entry["type"] == "string"
+
+
+def test_sensitive_flag_on_non_string_type_does_not_promote(
+    schema_dir: Path,
+) -> None:
+    """Promotion is gated on string type; a sensitive boolean stays boolean."""
+    raw = {"type": "boolean", "key": "Optional", "sensitive": True}
+    entry = _convert_field("encrypted", raw, schema_dir)
+    assert entry is not None
+    assert entry["type"] == "boolean"


### PR DESCRIPTION
# What does this implement/fix?

Upstream esphome's schema dump now emits `"sensitive": true` on entries whose validator is wrapped in `cv.sensitive(...)` (esphome/esphome#16673; canonical fields tagged in #16677, with SSIDs added in #16690). This PR makes `sync_components.py` prefer that explicit signal when promoting string entries to `secure_string`, falling back to the existing `_SECRET_KEY_FRAGMENTS` name heuristic so older esphome versions and unmigrated/third-party schemas still get masked.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.