### PR TITLE
Merge multi_conf components into a YAML list on repeat add

### DIFF
--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -37,7 +37,10 @@ except AttributeError:  # pragma: no cover
 # the split arc.
 from .api_encryption import generate_api_encryption_key as generate_api_encryption_key
 from .api_encryption import rewrite_api_encryption_key as rewrite_api_encryption_key
+from .component import _mapping_body_to_list_item as _mapping_body_to_list_item
+from .component import _normalize_multi_conf_block as _normalize_multi_conf_block
 from .component import _splice_into_domain_block as _splice_into_domain_block
+from .component import _splice_into_multi_conf_block as _splice_into_multi_conf_block
 from .component import generate_component_yaml as generate_component_yaml
 from .component import merge_component_yaml as merge_component_yaml
 from .inline import _indent_block as _indent_block

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -74,17 +74,26 @@ def merge_component_yaml(
     """
     Render *component* and merge it into *existing* YAML.
 
-    For platform-style components (``sensor:``, ``output:``, ...) the
-    new ``- platform: ...`` list item is appended under the existing
-    domain block when one is already present — without this, repeatedly
-    adding components of the same domain would produce duplicate
-    top-level ``output:`` / ``sensor:`` blocks. Other components fall
-    through to a plain append.
+    Three merge shapes:
+
+    * Platform-style components (``sensor:``, ``output:``, ...) splice
+      the new ``- platform: ...`` list item under an existing domain
+      block when one is present.
+    * ``multi_conf`` non-platform components (``rtttl:``, ``i2c:``,
+      ``uart:``, ...) splice a new list item under an existing
+      top-level block, converting a mapping-form body to list form on
+      the first repeat (#953).
+    * Everything else (singleton components like ``wifi:`` / ``api:``)
+      falls through to a plain append.
     """
     block = generate_component_yaml(component, fields)
     is_platform = component.category in _ENTITY_CATEGORIES
     if is_platform:
         spliced = _splice_into_domain_block(existing, str(component.category), block)
+        if spliced is not None:
+            return spliced
+    elif component.multi_conf:
+        spliced = _splice_into_multi_conf_block(existing, component.id, block)
         if spliced is not None:
             return spliced
     return _append_block(existing, block)
@@ -274,6 +283,93 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
         before += "\n"
     insertion = "\n".join(inner_lines) + "\n"
     return before + insertion + after
+
+
+def _splice_into_multi_conf_block(existing: str, comp_id: str, block: str) -> str | None:
+    """
+    Splice *block* into an existing ``<comp_id>:`` block.
+
+    Returns ``None`` when the YAML has no ``<comp_id>:`` section (the
+    caller falls back to a plain append). Normalises any mapping-form
+    body to list-form first, then delegates to
+    :func:`_splice_into_domain_block` for the actual list-item splice
+    so trailing-blank-line and following-block handling stay shared
+    with the platform path.
+    """
+    normalized = _normalize_multi_conf_block(existing, comp_id)
+    if normalized is None:
+        return None
+    block_lines = block.splitlines()
+    if len(block_lines) < 2 or block_lines[0].rstrip() != f"{comp_id}:":
+        return None
+    list_block = f"{comp_id}:\n" + "\n".join(_mapping_body_to_list_item(block_lines[1:]))
+    return _splice_into_domain_block(normalized, comp_id, list_block)
+
+
+def _normalize_multi_conf_block(existing: str, comp_id: str) -> str | None:
+    """
+    Ensure the existing ``<comp_id>:`` body is in YAML list-form.
+
+    Returns the (possibly rewritten) YAML, or ``None`` when no
+    matching top-level block is present. A body that already starts
+    with ``- `` is returned unchanged; a mapping body is rewritten as
+    a single ``- mapping`` list item via :func:`_mapping_body_to_list_item`.
+    """
+    file_lines = existing.splitlines(keepends=True)
+    header_re = re.compile(rf"^{re.escape(comp_id)}:\s*(?:#.*)?$")
+    block_start: int | None = None
+    for idx, line in enumerate(file_lines):
+        if header_re.match(line.rstrip("\n\r")):
+            block_start = idx
+            break
+    if block_start is None:
+        return None
+
+    block_end = len(file_lines)
+    for idx in range(block_start + 1, len(file_lines)):
+        stripped = file_lines[idx].rstrip("\n\r")
+        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
+            block_end = idx
+            break
+    last_content = block_end
+    while last_content > block_start + 1 and not file_lines[last_content - 1].strip():
+        last_content -= 1
+
+    for idx in range(block_start + 1, last_content):
+        stripped = file_lines[idx].lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- "):
+            return existing
+        break
+
+    body_lines = [line.rstrip("\n\r") for line in file_lines[block_start + 1 : last_content]]
+    rewritten = "\n".join(_mapping_body_to_list_item(body_lines)) + "\n"
+    return "".join(file_lines[: block_start + 1]) + rewritten + "".join(file_lines[last_content:])
+
+
+def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
+    """
+    Convert a 2-space-indented mapping body to a YAML list item.
+
+    Each non-blank line gains one extra level of indent and the first
+    non-blank line's leading indent is replaced with ``  - `` so the
+    block reads as a single ``- mapping`` entry. Blank lines are kept
+    verbatim so vertical spacing inside the block survives the
+    rewrite.
+    """
+    result: list[str] = []
+    marked = False
+    for line in body_lines:
+        if not line.strip():
+            result.append(line)
+            continue
+        indented = ESPHOME_YAML_INDENT + line
+        if not marked and indented.startswith(ESPHOME_YAML_INDENT * 2):
+            indented = "  - " + indented[len(ESPHOME_YAML_INDENT * 2) :]
+            marked = True
+        result.append(indented)
+    return result
 
 
 def _format_yaml_value(value: Any) -> str:

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -74,17 +74,11 @@ def merge_component_yaml(
     """
     Render *component* and merge it into *existing* YAML.
 
-    Three merge shapes:
-
-    * Platform-style components (``sensor:``, ``output:``, ...) splice
-      the new ``- platform: ...`` list item under an existing domain
-      block when one is present.
-    * ``multi_conf`` non-platform components (``rtttl:``, ``i2c:``,
-      ``uart:``, ...) splice a new list item under an existing
-      top-level block, converting a mapping-form body to list form on
-      the first repeat (#953).
-    * Everything else (singleton components like ``wifi:`` / ``api:``)
-      falls through to a plain append.
+    Platform-style entity domains (``sensor:``, ``output:``, ...) and
+    ``multi_conf`` non-platform components (``rtttl:``, ``i2c:``,
+    ``uart:``, ...) splice the new entry under an existing top-level
+    block — without this, repeated adds emit duplicate top-level keys,
+    which ESPHome rejects. Singletons fall through to a plain append.
     """
     block = generate_component_yaml(component, fields)
     is_platform = component.category in _ENTITY_CATEGORIES
@@ -234,67 +228,65 @@ def _append_block(existing: str, block: str) -> str:
     return f"{base}{separator}{block}\n"
 
 
+def _find_top_level_block_bounds(file_lines: list[str], key: str) -> tuple[int, int] | None:
+    """
+    Locate the ``<key>:`` block in *file_lines*; return ``(header, end)``.
+
+    *end* is the index of the first line that belongs to the next
+    top-level block (or ``len(file_lines)`` at EOF), rewound past any
+    trailing blank lines so an inserted item lands directly after the
+    last content line. Returns ``None`` when no matching header exists.
+    """
+    header_re = re.compile(rf"^{re.escape(key)}:\s*(?:#.*)?$")
+    block_start: int | None = None
+    for idx, line in enumerate(file_lines):
+        if header_re.match(line.rstrip("\n\r")):
+            block_start = idx
+            break
+    if block_start is None:
+        return None
+
+    block_end = len(file_lines)
+    for idx in range(block_start + 1, len(file_lines)):
+        stripped = file_lines[idx].rstrip("\n\r")
+        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
+            block_end = idx
+            break
+    while block_end > block_start + 1 and not file_lines[block_end - 1].strip():
+        block_end -= 1
+    return block_start, block_end
+
+
 def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | None:
     """
     Insert the platform-list item from *block* under an existing ``<domain>:``.
 
-    Returns the merged YAML, or ``None`` when the existing file has no
-    ``<domain>:`` section (caller should fall back to appending). The
-    splice walks line-by-line: it locates the domain header, then finds
-    the first subsequent line that starts a new top-level key (column
-    zero, alphabetic) — everything in between is the existing block. The
-    new list item is inserted before that boundary, preserving any
-    trailing blank lines and content that follows.
+    Returns ``None`` when the existing file has no ``<domain>:``
+    section so the caller can fall back to appending.
     """
     block_lines = block.splitlines()
     if len(block_lines) < 2 or block_lines[0].rstrip() != f"{domain}:":
         return None
-    inner_lines = block_lines[1:]
-
     file_lines = existing.splitlines(keepends=True)
-    header_re = re.compile(rf"^{re.escape(domain)}:\s*(?:#.*)?$")
-    domain_start: int | None = None
-    for idx, line in enumerate(file_lines):
-        if header_re.match(line.rstrip("\n\r")):
-            domain_start = idx
-            break
-    if domain_start is None:
+    bounds = _find_top_level_block_bounds(file_lines, domain)
+    if bounds is None:
         return None
-
-    # Walk forward to find the first line that opens a new top-level
-    # block, or stop at EOF.
-    domain_end = len(file_lines)
-    for idx in range(domain_start + 1, len(file_lines)):
-        stripped = file_lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            domain_end = idx
-            break
-
-    # Trim trailing blank lines belonging to the domain block — we want
-    # the new item appended directly after the last content line, then
-    # the blank lines preserved before whatever comes next.
-    last_content = domain_end
-    while last_content > domain_start + 1 and not file_lines[last_content - 1].strip():
-        last_content -= 1
+    _, last_content = bounds
 
     before = "".join(file_lines[:last_content])
     after = "".join(file_lines[last_content:])
     if before and not before.endswith("\n"):
         before += "\n"
-    insertion = "\n".join(inner_lines) + "\n"
+    insertion = "\n".join(block_lines[1:]) + "\n"
     return before + insertion + after
 
 
 def _splice_into_multi_conf_block(existing: str, comp_id: str, block: str) -> str | None:
     """
-    Splice *block* into an existing ``<comp_id>:`` block.
+    Normalise ``<comp_id>:`` to list-form, then splice *block* in.
 
-    Returns ``None`` when the YAML has no ``<comp_id>:`` section (the
-    caller falls back to a plain append). Normalises any mapping-form
-    body to list-form first, then delegates to
-    :func:`_splice_into_domain_block` for the actual list-item splice
-    so trailing-blank-line and following-block handling stay shared
-    with the platform path.
+    Returns ``None`` when no such block exists so the caller can
+    fall back to a plain append.
     """
     normalized = _normalize_multi_conf_block(existing, comp_id)
     if normalized is None:
@@ -310,36 +302,22 @@ def _normalize_multi_conf_block(existing: str, comp_id: str) -> str | None:
     """
     Ensure the existing ``<comp_id>:`` body is in YAML list-form.
 
-    Returns the (possibly rewritten) YAML, or ``None`` when no
-    matching top-level block is present. A body that already starts
-    with ``- `` is returned unchanged; a mapping body is rewritten as
-    a single ``- mapping`` list item via :func:`_mapping_body_to_list_item`.
+    Returns ``None`` when no such block exists. A body whose first
+    non-comment line starts ``- ...`` (or is a bare ``-``) is already
+    list-form and passes through; a mapping body is rewritten as a
+    single ``- mapping`` item.
     """
     file_lines = existing.splitlines(keepends=True)
-    header_re = re.compile(rf"^{re.escape(comp_id)}:\s*(?:#.*)?$")
-    block_start: int | None = None
-    for idx, line in enumerate(file_lines):
-        if header_re.match(line.rstrip("\n\r")):
-            block_start = idx
-            break
-    if block_start is None:
+    bounds = _find_top_level_block_bounds(file_lines, comp_id)
+    if bounds is None:
         return None
-
-    block_end = len(file_lines)
-    for idx in range(block_start + 1, len(file_lines)):
-        stripped = file_lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            block_end = idx
-            break
-    last_content = block_end
-    while last_content > block_start + 1 and not file_lines[last_content - 1].strip():
-        last_content -= 1
+    block_start, last_content = bounds
 
     for idx in range(block_start + 1, last_content):
-        stripped = file_lines[idx].lstrip()
+        stripped = file_lines[idx].strip()
         if not stripped or stripped.startswith("#"):
             continue
-        if stripped.startswith("- "):
+        if stripped.startswith("- ") or stripped == "-":
             return existing
         break
 
@@ -352,12 +330,9 @@ def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
     """
     Convert a 2-space-indented mapping body to a YAML list item.
 
-    Each non-blank line gains one extra level of indent and the first
-    non-blank, non-comment line's leading indent is replaced with
-    ``  - ``. Anchoring the marker on a key line (not a leading
-    ``# ...``) avoids demoting a comment-decorated mapping into a
-    ``- # comment`` head item whose original mapping then dangles at
-    the wrong nesting depth.
+    The ``- `` marker is anchored on the first non-comment key line;
+    a leading ``# ...`` keeps its position so a comment-decorated
+    mapping doesn't demote into a ``- # comment`` null head item.
     """
     result: list[str] = []
     marked = False
@@ -371,7 +346,7 @@ def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
             and not line.lstrip().startswith("#")
             and indented.startswith(ESPHOME_YAML_INDENT * 2)
         ):
-            indented = "  - " + indented[len(ESPHOME_YAML_INDENT * 2) :]
+            indented = f"{ESPHOME_YAML_INDENT}- " + indented[len(ESPHOME_YAML_INDENT * 2) :]
             marked = True
         result.append(indented)
     return result

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -353,10 +353,11 @@ def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
     Convert a 2-space-indented mapping body to a YAML list item.
 
     Each non-blank line gains one extra level of indent and the first
-    non-blank line's leading indent is replaced with ``  - `` so the
-    block reads as a single ``- mapping`` entry. Blank lines are kept
-    verbatim so vertical spacing inside the block survives the
-    rewrite.
+    non-blank, non-comment line's leading indent is replaced with
+    ``  - ``. Anchoring the marker on a key line (not a leading
+    ``# ...``) avoids demoting a comment-decorated mapping into a
+    ``- # comment`` head item whose original mapping then dangles at
+    the wrong nesting depth.
     """
     result: list[str] = []
     marked = False
@@ -365,7 +366,11 @@ def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
             result.append(line)
             continue
         indented = ESPHOME_YAML_INDENT + line
-        if not marked and indented.startswith(ESPHOME_YAML_INDENT * 2):
+        if (
+            not marked
+            and not line.lstrip().startswith("#")
+            and indented.startswith(ESPHOME_YAML_INDENT * 2)
+        ):
             indented = "  - " + indented[len(ESPHOME_YAML_INDENT * 2) :]
             marked = True
         result.append(indented)

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1039,23 +1039,14 @@ def test_merge_component_yaml_singleton_without_multi_conf_falls_through() -> No
 
 
 def test_splice_into_multi_conf_block_rejects_mismatched_header() -> None:
-    """A *block* whose header doesn't match ``comp_id`` returns ``None``.
-
-    Defensive guard against a caller wiring a wrong header to the
-    splice helper; the caller falls back to a plain append.
-    """
+    """A *block* whose header doesn't match ``comp_id`` returns ``None``."""
     existing = "rtttl:\n  id: rtttl_1\n  output: buzz\n"
     block = "wifi:\n  ssid: home\n"
     assert _splice_into_multi_conf_block(existing, "rtttl", block) is None
 
 
 def test_normalize_multi_conf_block_skips_comments_above_list_form() -> None:
-    """A leading comment inside the block doesn't trigger a rewrite.
-
-    The form detector walks past comment / blank lines before
-    deciding mapping vs list, so a ``# ...`` line above an existing
-    ``- `` list item must not flip the block back to mapping form.
-    """
+    """A leading ``#`` comment above an existing ``- `` item doesn't trigger a rewrite."""
     component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
     existing = "rtttl:\n  # buzzers for the kitchen\n  - id: rtttl_1\n    output: buzz\n"
     result = merge_component_yaml(existing, component, {"id": "rtttl_2", "output": "buzz"})
@@ -1063,6 +1054,16 @@ def test_normalize_multi_conf_block_skips_comments_above_list_form() -> None:
     assert result.count("rtttl:\n") == 1
     assert "  - id: rtttl_1" in result
     assert "  - id: rtttl_2" in result
+
+
+def test_normalize_multi_conf_block_treats_bare_dash_as_list_form() -> None:
+    """A body whose head line is a bare ``-`` is already list-form."""
+    component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
+    existing = "rtttl:\n  -\n    id: rtttl_1\n    output: buzz\n"
+    result = merge_component_yaml(existing, component, {"id": "rtttl_2", "output": "buzz"})
+    assert result.count("rtttl:\n") == 1
+    assert "  -\n    id: rtttl_1" in result
+    assert "  - id: rtttl_2\n" in result
 
 
 def test_merge_component_yaml_multi_conf_preserves_leading_comment() -> None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -56,6 +56,7 @@ def _component(
     component_id: str,
     category: ComponentCategory,
     name: str = "test",
+    multi_conf: bool = False,
 ) -> ComponentCatalogEntry:
     """Minimal ComponentCatalogEntry — fields needed by yaml helpers only.
 
@@ -69,6 +70,7 @@ def _component(
         name=name,
         description="",
         category=category,
+        multi_conf=multi_conf,
     )
 
 
@@ -963,6 +965,88 @@ def test_merge_component_yaml_splices_other_platform_categories(
     assert result.count(f"{category.value}:\n") == 1
     assert "- platform: ledc" in result
     assert "- platform: gpio" in result
+
+
+_RTTTL_MAPPING = "rtttl:\n  id: rtttl_1\n  output: buzz\n"
+_RTTTL_LIST = "rtttl:\n  - id: rtttl_1\n    output: buzz\n  - id: rtttl_2\n    output: buzz\n"
+
+
+@pytest.mark.parametrize(
+    ("existing", "new_id", "expected_ids", "expected_suffix"),
+    [
+        pytest.param(
+            "esphome:\n  name: kitchen\n",
+            "rtttl_1",
+            ["rtttl_1"],
+            "rtttl:\n  id: rtttl_1\n  output: buzz\n",
+            id="first_add_emits_mapping",
+        ),
+        pytest.param(
+            f"esphome:\n  name: kitchen\n\n{_RTTTL_MAPPING}",
+            "rtttl_2",
+            ["rtttl_1", "rtttl_2"],
+            None,
+            id="second_add_converts_mapping_to_list",
+        ),
+        pytest.param(
+            f"esphome:\n  name: kitchen\n\n{_RTTTL_LIST}",
+            "rtttl_3",
+            ["rtttl_1", "rtttl_2", "rtttl_3"],
+            None,
+            id="third_add_splices_into_list",
+        ),
+        pytest.param(
+            f"esphome:\n  name: kitchen\n\n{_RTTTL_MAPPING}\nlogger:\n  level: DEBUG\n",
+            "rtttl_2",
+            ["rtttl_1", "rtttl_2"],
+            "logger:\n  level: DEBUG\n",
+            id="trailing_block_survives_conversion",
+        ),
+    ],
+)
+def test_merge_component_yaml_multi_conf(
+    existing: str,
+    new_id: str,
+    expected_ids: list[str],
+    expected_suffix: str | None,
+) -> None:
+    """Issue #953: repeated adds of a ``multi_conf`` non-platform component.
+
+    First add lands as a mapping body (single-instance shape is
+    valid ESPHome YAML and prettier than a one-item list). The
+    second add rewrites the body to list form and appends the new
+    entry; subsequent adds splice as sibling list items. A trailing
+    top-level block after the ``rtttl:`` section must survive the
+    rewrite intact.
+    """
+    component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
+    result = merge_component_yaml(existing, component, {"id": new_id, "output": "buzz"})
+
+    assert result.count("rtttl:\n") == 1
+    positions = [result.index(stem) for stem in expected_ids]
+    assert positions == sorted(positions)
+    if len(expected_ids) > 1:
+        for stem in expected_ids:
+            assert f"- id: {stem}\n" in result
+    if expected_suffix is not None:
+        assert expected_suffix in result
+
+
+def test_merge_component_yaml_singleton_without_multi_conf_falls_through() -> None:
+    """A ``multi_conf=False`` non-platform component skips the splice.
+
+    Singletons (``wifi:`` / ``api:``) should never trigger the list
+    rewrite; the caller is expected to refuse the duplicate upstream
+    rather than have the YAML helper paper over it.
+    """
+    component = _component(component_id="wifi", category=ComponentCategory.MISC, multi_conf=False)
+    result = merge_component_yaml(
+        "esphome:\n  name: kitchen\n\nwifi:\n  ssid: other\n",
+        component,
+        {"ssid": "home"},
+    )
+
+    assert result.count("wifi:\n") == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1012,15 +1012,7 @@ def test_merge_component_yaml_multi_conf(
     expected_ids: list[str],
     expected_suffix: str | None,
 ) -> None:
-    """Issue #953: repeated adds of a ``multi_conf`` non-platform component.
-
-    First add lands as a mapping body (single-instance shape is
-    valid ESPHome YAML and prettier than a one-item list). The
-    second add rewrites the body to list form and appends the new
-    entry; subsequent adds splice as sibling list items. A trailing
-    top-level block after the ``rtttl:`` section must survive the
-    rewrite intact.
-    """
+    """Repeated adds of a ``multi_conf`` component splice under one block."""
     component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
     result = merge_component_yaml(existing, component, {"id": new_id, "output": "buzz"})
 
@@ -1035,12 +1027,7 @@ def test_merge_component_yaml_multi_conf(
 
 
 def test_merge_component_yaml_singleton_without_multi_conf_falls_through() -> None:
-    """A ``multi_conf=False`` non-platform component skips the splice.
-
-    Singletons (``wifi:`` / ``api:``) should never trigger the list
-    rewrite; the caller is expected to refuse the duplicate upstream
-    rather than have the YAML helper paper over it.
-    """
+    """A ``multi_conf=False`` non-platform component skips the splice."""
     component = _component(component_id="wifi", category=ComponentCategory.MISC, multi_conf=False)
     result = merge_component_yaml(
         "esphome:\n  name: kitchen\n\nwifi:\n  ssid: other\n",
@@ -1076,6 +1063,18 @@ def test_normalize_multi_conf_block_skips_comments_above_list_form() -> None:
     assert result.count("rtttl:\n") == 1
     assert "  - id: rtttl_1" in result
     assert "  - id: rtttl_2" in result
+
+
+def test_merge_component_yaml_multi_conf_preserves_leading_comment() -> None:
+    """A leading ``#`` comment in the mapping body keeps its key as the list head."""
+    component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
+    existing = "rtttl:\n  # buzzer notes\n  id: rtttl_1\n  output: buzz\n"
+    result = merge_component_yaml(existing, component, {"id": "rtttl_2", "output": "buzz"})
+
+    assert "# buzzer notes" in result
+    assert "  - # " not in result
+    assert "  - id: rtttl_1\n" in result
+    assert "  - id: rtttl_2\n" in result
 
 
 def test_mapping_body_to_list_item_preserves_blank_lines() -> None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -31,8 +31,10 @@ import pytest
 
 from esphome_device_builder.helpers.yaml import (
     YamlUpsertNotSupportedError,
+    _mapping_body_to_list_item,
     _safe_yaml_scalar,
     _splice_into_domain_block,
+    _splice_into_multi_conf_block,
     _strip_yaml_quotes,
     generate_api_encryption_key,
     generate_component_yaml,
@@ -1047,6 +1049,47 @@ def test_merge_component_yaml_singleton_without_multi_conf_falls_through() -> No
     )
 
     assert result.count("wifi:\n") == 2
+
+
+def test_splice_into_multi_conf_block_rejects_mismatched_header() -> None:
+    """A *block* whose header doesn't match ``comp_id`` returns ``None``.
+
+    Defensive guard against a caller wiring a wrong header to the
+    splice helper; the caller falls back to a plain append.
+    """
+    existing = "rtttl:\n  id: rtttl_1\n  output: buzz\n"
+    block = "wifi:\n  ssid: home\n"
+    assert _splice_into_multi_conf_block(existing, "rtttl", block) is None
+
+
+def test_normalize_multi_conf_block_skips_comments_above_list_form() -> None:
+    """A leading comment inside the block doesn't trigger a rewrite.
+
+    The form detector walks past comment / blank lines before
+    deciding mapping vs list, so a ``# ...`` line above an existing
+    ``- `` list item must not flip the block back to mapping form.
+    """
+    component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
+    existing = "rtttl:\n  # buzzers for the kitchen\n  - id: rtttl_1\n    output: buzz\n"
+    result = merge_component_yaml(existing, component, {"id": "rtttl_2", "output": "buzz"})
+    assert "  # buzzers for the kitchen" in result
+    assert result.count("rtttl:\n") == 1
+    assert "  - id: rtttl_1" in result
+    assert "  - id: rtttl_2" in result
+
+
+def test_mapping_body_to_list_item_preserves_blank_lines() -> None:
+    """Blank lines inside the mapping body survive the list conversion.
+
+    Vertical spacing the user put between fields shouldn't collapse
+    when the block flips to list form.
+    """
+    body = ["  id: rtttl_1", "", "  output: buzz"]
+    assert _mapping_body_to_list_item(body) == [
+        "  - id: rtttl_1",
+        "",
+        "    output: buzz",
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Adding a second rtttl, i2c, uart, or any other multi_conf component was emitting two top-level keys, which ESPHome rejects. The new entry now splices under the existing block, rewriting the mapping body as a YAML list on the first repeat. Reuses the existing platform splice helper so trailing blanks and following blocks behave the same.

**Related issue or feature (if applicable):**

- fixes #953

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
