### PR TITLE
Enable PIE (flake8-pie) ruff rule

### DIFF
--- a/esphome_device_builder/controllers/firmware/_upload_targets_fallback.py
+++ b/esphome_device_builder/controllers/firmware/_upload_targets_fallback.py
@@ -20,7 +20,7 @@ def get_port_type(port: str) -> PortType:
     """Classify a user-supplied ``--device`` string."""
     if port == "BOOTSEL":
         return PortType.BOOTSEL
-    if port.startswith("/") or port.startswith("COM"):
+    if port.startswith(("/", "COM")):
         return PortType.SERIAL
     if port == "MQTT":
         return PortType.MQTT

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -1098,7 +1098,7 @@ def _parse_inline_value(raw: str) -> str:
     Strips an inline ``# comment`` and matching surrounding quotes.
     """
     value = raw.strip()
-    if "#" in value and not (value.startswith('"') or value.startswith("'")):
+    if "#" in value and not value.startswith(('"', "'")):
         value = value.split("#", 1)[0].rstrip()
     if (value.startswith('"') and value.endswith('"')) or (
         value.startswith("'") and value.endswith("'")

--- a/esphome_device_builder/helpers/mac_addresses.py
+++ b/esphome_device_builder/helpers/mac_addresses.py
@@ -48,10 +48,7 @@ def _has_bluetooth(loaded_integrations: list[str]) -> bool:
     new bluetooth-related integration name added upstream Just Works
     without a parallel update here.
     """
-    return any(
-        name.startswith("esp32_ble") or name.startswith("bluetooth_")
-        for name in loaded_integrations
-    )
+    return any(name.startswith(("esp32_ble", "bluetooth_")) for name in loaded_integrations)
 
 
 def _offset_last_octet(primary: str, offset: int) -> str:

--- a/esphome_device_builder/helpers/yaml/api_encryption.py
+++ b/esphome_device_builder/helpers/yaml/api_encryption.py
@@ -41,7 +41,7 @@ def rewrite_api_encryption_key(yaml_text: str, new_key: str) -> str:
         # mask the ``${`` prefix and cause us to rewrite a value the
         # user explicitly indirected.
         unquoted = _strip_yaml_quotes(raw)
-        if unquoted.startswith("!secret") or unquoted.startswith("${"):
+        if unquoted.startswith(("!secret", "${")):
             return None
         return rendered
 

--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -264,7 +264,7 @@ def _safe_yaml_scalar(value: str) -> str:
         return f'"{value}"'
     if value[0] in _PLAIN_SCALAR_INDICATOR_LEAD:
         return _quote(value)
-    if value.endswith(":") or value.endswith(" "):
+    if value.endswith((":", " ")):
         return _quote(value)
     if any(s in value for s in _PLAIN_SCALAR_FORBIDDEN_SUBSTR):
         return _quote(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ select = [
   "LOG", # flake8-logging — catch ``logging.warn`` / wrong exception handling on the logger
   "N", # pep8-naming
   "PERF", # performance
+  "PIE", # flake8-pie — misc lints (collapse duplicate startswith/endswith, prefer ``list`` over ``lambda: []``)
   "PL", # pylint
   "PTH", # flake8-use-pathlib — prefer pathlib over os.path/os primitives
   "PLR0904", # too-many-public-methods (preview) — cap new god-classes at 20

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1924,7 +1924,7 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
             if "time_period" in ref:
                 entry_type = "time_period"
                 break
-            if ref.endswith(".positive_float") or ref.endswith(".float_"):
+            if ref.endswith((".positive_float", ".float_")):
                 entry_type = "float"
                 break
             if "positive_int" in ref or ref.endswith(".int_"):

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -1548,7 +1548,7 @@ async def test_get_serial_ports_returns_empty_when_no_ports(
     """
     monkeypatch.setattr(
         "esphome_device_builder.controllers.config.get_serial_ports",
-        lambda: [],
+        list,
     )
     controller = _make_controller(tmp_path)
 

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -399,7 +399,7 @@ def test_local_addresses_deduplicates_repeated_ips(monkeypatch: pytest.MonkeyPat
 
 def test_local_addresses_returns_empty_when_no_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
     """No adapters at all — return an empty list, not a crash."""
-    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", lambda: [])
+    monkeypatch.setattr(dashboard_advertise.ifaddr, "get_adapters", list)
     assert _local_addresses() == []
 
 


### PR DESCRIPTION
# What does this implement/fix?

Enables ruff's `PIE` (flake8-pie) rule set; aioesphomeapi already has this on. Collapses six duplicated `startswith` / `endswith` calls into single tuple-argument calls (PIE810), and replaces two `lambda: []` test stubs with `list` (PIE807, ruff auto-fix).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
