### PR TITLE
Enable C90 (mccabe complexity) ruff rule

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -716,7 +716,7 @@ def _indent_for_top_list(rendered_item: str) -> str:
     return rendered_item
 
 
-def _locate_top_list_item(
+def _locate_top_list_item(  # noqa: C901
     lines: list[str],
     domain: str,
     index: int,

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .controller import DevicesController
 
 
-async def clone_device(
+async def clone_device(  # noqa: C901
     controller: DevicesController,
     *,
     configuration: str,

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .controller import DevicesController
 
 
-async def create_device(  # noqa: PLR0912, PLR0915
+async def create_device(  # noqa: PLR0912, PLR0915, C901
     controller: DevicesController,
     *,
     name: str,

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -73,7 +73,7 @@ _LOGGER = logging.getLogger(__name__)
 _TERMINAL_WIRE_STATUSES: frozenset[str] = frozenset({"completed", "failed", "cancelled"})
 
 
-async def run_remote_job(
+async def run_remote_job(  # noqa: C901
     controller: FirmwareController,
     job: FirmwareJob,
 ) -> None:

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -42,7 +42,7 @@ async def run_queue(controller: FirmwareController) -> None:
         await controller._execute_job(job)
 
 
-async def execute_job(  # noqa: PLR0912, PLR0915
+async def execute_job(  # noqa: PLR0912, PLR0915, C901
     controller: FirmwareController, job: FirmwareJob
 ) -> None:
     """Execute a single firmware job."""

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -182,7 +182,7 @@ def _load_storage_for_pack(configuration: str) -> tuple[Path, StorageJSON]:
     return storage_path, storage
 
 
-def _collect_pack_members(
+def _collect_pack_members(  # noqa: C901
     *,
     configuration: str,
     storage: StorageJSON,

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -449,7 +449,7 @@ class PeerLinkClient:
             self._last_connect_error = f"{type(exc).__name__}: {exc}"
             return _LOCAL_CLOSE_TRANSPORT_ERROR
 
-    async def _run_session_loops(self, channel: PeerLinkChannel) -> str:
+    async def _run_session_loops(self, channel: PeerLinkChannel) -> str:  # noqa: C901
         """
         Run the receive loop with a heartbeat task in parallel.
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -426,7 +426,7 @@ class DeviceBuilder:
             len(self.command_handlers),
         )
 
-    async def stop(self) -> None:
+    async def stop(self) -> None:  # noqa: C901
         """Shut down the application."""
         if self._bg_task:
             self._bg_task.cancel()
@@ -1244,7 +1244,7 @@ class DeviceBuilder:
             return None
 
     @staticmethod
-    def _register_frontend(
+    def _register_frontend(  # noqa: C901
         app: web.Application, frontend_dir: Path, *, dev_mode: bool = False
     ) -> None:
         """Register routes for the built frontend.

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -671,7 +671,7 @@ def extract_directly_referenced_integrations(
     return sorted(out)
 
 
-def parse_esphome_meta(  # noqa: PLR0912
+def parse_esphome_meta(  # noqa: PLR0912, C901
     yaml_content: str,
     extra_substitutions: dict[str, str] | None = None,
 ) -> tuple[str | None, str | None, str | None, str | None]:

--- a/esphome_device_builder/helpers/event_bus.py
+++ b/esphome_device_builder/helpers/event_bus.py
@@ -197,7 +197,7 @@ class StreamControls:
     end: Callable[[], None]
 
 
-async def stream_events(
+async def stream_events(  # noqa: C901
     *,
     client: Any,
     message_id: str,

--- a/esphome_device_builder/helpers/remote_build_cleanup.py
+++ b/esphome_device_builder/helpers/remote_build_cleanup.py
@@ -44,7 +44,7 @@ from .remote_build_layout import BUNDLE_SUFFIX, REMOTE_BUILDS_SUBDIR, RemoteBuil
 _LOGGER = logging.getLogger(__name__)
 
 
-def sweep_remote_builds(
+def sweep_remote_builds(  # noqa: C901
     config_dir: Path,
     *,
     ttl_seconds: float,

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -90,7 +90,7 @@ def merge_component_yaml(
     return _append_block(existing, block)
 
 
-def generate_component_yaml(
+def generate_component_yaml(  # noqa: C901
     component: ComponentCatalogEntry,
     fields: dict[str, Any],
 ) -> str:

--- a/esphome_device_builder/helpers/yaml/inline.py
+++ b/esphome_device_builder/helpers/yaml/inline.py
@@ -126,7 +126,7 @@ def remove_inline_handler(
     return None
 
 
-def _locate_component_instance(
+def _locate_component_instance(  # noqa: C901
     lines: list[str],
     domain: str,
     component_id: str,

--- a/esphome_device_builder/helpers/yaml/top_block.py
+++ b/esphome_device_builder/helpers/yaml/top_block.py
@@ -13,7 +13,7 @@ from .scalar import (
 from .substitution import rewrite_name_or_substitution
 
 
-def _locate_top_block(lines: list[str], block_key: str) -> tuple[int, int, str] | None:
+def _locate_top_block(lines: list[str], block_key: str) -> tuple[int, int, str] | None:  # noqa: C901
     """
     Find the column-0 ``block_key:`` block; return ``(start, end, child_indent)``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,10 @@ select = [
   "B", # flake8-bugbear
   "BLE", # flake8-blind-except — flag ``except Exception:`` so the catch scope is deliberate
   "C4", # flake8-comprehensions
+  "C90", # mccabe complexity — flag new functions whose cyclomatic complexity
+  # exceeds the default 10 branches. 31 pre-existing offenders are
+  # grandfathered with inline ``# noqa: C901`` so this rule catches *new*
+  # accidental complexity without forcing a refactor on existing code.
   "D", # pydocstyle
   "DTZ", # flake8-datetimez — flag naive datetime construction; force explicit tz
   "E", # pycodestyle errors

--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -146,7 +146,7 @@ _EXPECTATIONS: list[tuple[str, list[tuple[str, str, bool | None, str | None]]]] 
 ]
 
 
-def main() -> int:
+def main() -> int:  # noqa: C901
     catalog = ComponentCatalog()
     catalog.load()
     if not catalog._components:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1345,7 +1345,7 @@ _CONFIG_VAR_LINE = re.compile(
 )
 
 
-def _extract_mdx_field_descriptions(text: str) -> dict[str, str]:
+def _extract_mdx_field_descriptions(text: str) -> dict[str, str]:  # noqa: C901
     """Parse the ``## Configuration variables`` section into a field map.
 
     Captures one description per top-level bullet — including
@@ -1457,7 +1457,7 @@ _FRONTMATTER_DESCRIPTION = re.compile(
 )
 
 
-def _extract_mdx_description(text: str) -> str:
+def _extract_mdx_description(text: str) -> str:  # noqa: C901
     """Return the curated description for a component MDX file.
 
     Tries the frontmatter ``description:`` field first; falls back to
@@ -1767,7 +1767,7 @@ def _apply_visibility_cascade(
             )
 
 
-def _convert_config_vars(
+def _convert_config_vars(  # noqa: C901
     schema_node: dict,
     schema_dir: Path,
     *,
@@ -1828,7 +1828,7 @@ def _convert_config_vars(
     return _sort_entries(out)
 
 
-def _resolve_extends(ref: str, schema_dir: Path) -> dict[str, dict]:
+def _resolve_extends(ref: str, schema_dir: Path) -> dict[str, dict]:  # noqa: C901
     """Look up an ``extends`` reference and return its config_vars.
 
     *ref* is shaped ``<file>.<schema_name>`` — e.g.
@@ -1877,7 +1877,7 @@ def _resolve_extends(ref: str, schema_dir: Path) -> dict[str, dict]:
     return inner
 
 
-def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noqa: PLR0912, PLR0915
+def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noqa: PLR0912, PLR0915, C901
     """Build a single ConfigEntry dict from a schema's config_var entry."""
     if not isinstance(raw, dict):
         # Some schemas use bare ``{}``-shaped placeholders for fields
@@ -3137,7 +3137,7 @@ def _strip_entry_defaults(entry: dict) -> dict:
     return out
 
 
-def _walk_schema_keys(
+def _walk_schema_keys(  # noqa: C901
     schema: Any,
     visit: Callable[[Any, str, Any, tuple[str, ...]], None],
 ) -> None:
@@ -3338,7 +3338,7 @@ _UNIT_FALLBACKS: dict[str, list[str]] = {
 }
 
 
-def _extract_validator_units(validator: Any) -> list[str] | None:  # noqa: PLR0911
+def _extract_validator_units(validator: Any) -> list[str] | None:  # noqa: PLR0911, C901
     """Pull the unit option list out of a ``cv.float_with_unit`` validator.
 
     Inspects the closure cells produced by ``float_with_unit``: a
@@ -3411,7 +3411,7 @@ def _extract_validator_units(validator: Any) -> list[str] | None:  # noqa: PLR09
     return None
 
 
-def _collect_refined_types(
+def _collect_refined_types(  # noqa: C901
     manifest: Any,
 ) -> dict[tuple[str, ...], RefinedType]:
     """Walk the live ``CONFIG_SCHEMA`` to recover types the schema lost.
@@ -3895,7 +3895,7 @@ def _collect_inclusive_groups(
     return out
 
 
-def _collect_required_groups(
+def _collect_required_groups(  # noqa: C901
     manifest: Any,
 ) -> dict[tuple[str, ...], list[dict[str, Any]]]:
     """
@@ -4122,7 +4122,7 @@ def _annotate_constraint_descriptions(component: dict) -> None:
     )
 
 
-def _annotate_scope(entries: list[dict], required_groups: list[dict[str, Any]]) -> None:
+def _annotate_scope(entries: list[dict], required_groups: list[dict[str, Any]]) -> None:  # noqa: C901
     """Annotate one sibling list with its in-scope required + inclusive hints."""
     if not entries:
         return
@@ -4398,7 +4398,7 @@ _CORE_AUTOMATION_LABELS: dict[str, str] = {
 _CORE_AUTOMATION_DOCS = "https://esphome.io/automations/actions"
 
 
-def build_automations(
+def build_automations(  # noqa: C901
     *,
     schema_dir: Path,
     component_ids: set[str],

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1165,7 +1165,7 @@ def _build_tags(name: str, type_field: str | None) -> list[str]:
     return tags
 
 
-def _make_record(  # noqa: PLR0911 — distinct skip reasons each get their own early exit
+def _make_record(  # noqa: C901, PLR0911 — distinct skip reasons each get their own early exit
     src: _DeviceSource,
     components_index: dict[str, dict[str, Any]],
     revision: str,

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -201,7 +201,7 @@ def _build_components_index() -> dict | None:
     return by_id
 
 
-def _validate_featured(
+def _validate_featured(  # noqa: C901
     board_id: str,
     data: dict,
     pins_by_gpio: dict[int, dict],
@@ -290,7 +290,7 @@ def _validate_default_components(
     return out
 
 
-def _validate_featured_component(
+def _validate_featured_component(  # noqa: C901
     board_id: str,
     idx: int,
     entry: dict,

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1167,7 +1167,7 @@ async def test_start_spawns_run_task_when_paho_available(
     assert monitor.running is False
 
 
-async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(
+async def test_connect_and_listen_subscribes_publishes_and_runs_listen_ping(  # noqa: C901
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``_connect_and_listen`` wires paho callbacks, subscribes, and runs the inner tasks.


### PR DESCRIPTION
# What does this implement/fix?

Enables ruff's `C90` (mccabe complexity) rule set; aioesphomeapi already has this on. The default complexity threshold (10) flags 31 existing functions, all of which are grandfathered with inline `# noqa: C901`; the intent is to catch *new* accidental complexity without forcing a refactor on existing code, same pattern PLR0904 already uses.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
