### PR TITLE
Fix remote-build firmware download when receiver and offloader differ in OS

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -62,6 +62,7 @@ from typing import TYPE_CHECKING, Any, cast
 from esphome.storage_json import StorageJSON
 
 from ...helpers.build_artifacts import _firmware_offset_for_platform
+from ...helpers.cross_os_path import cross_os_basename
 from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
 from ...helpers.storage_path import (
@@ -596,7 +597,7 @@ def _flash_image_basename_offset(entry: object) -> tuple[str, str]:
     if not isinstance(path_str, str) or not isinstance(offset, str):
         msg = "idedata.extra.flash_images entry missing path/offset"
         raise UnpackArtifactsError(msg)
-    return Path(path_str).name, offset
+    return cross_os_basename(path_str), offset
 
 
 def _rewrite_idedata_paths(idedata: dict[str, Any]) -> dict[str, Any]:
@@ -616,7 +617,7 @@ def _rewrite_idedata_paths(idedata: dict[str, Any]) -> dict[str, Any]:
         return idedata
     flash_images = extra.get("flash_images") or []
     rewritten = [
-        {**entry, "path": Path(entry["path"]).name}
+        {**entry, "path": cross_os_basename(entry["path"])}
         for entry in flash_images
         if isinstance(entry, dict) and isinstance(entry.get("path"), str)
     ]

--- a/esphome_device_builder/helpers/cross_os_path.py
+++ b/esphome_device_builder/helpers/cross_os_path.py
@@ -1,0 +1,29 @@
+r"""Cross-OS path utilities for receiver-shipped strings.
+
+The remote-build wire ships absolute paths from the receiver's
+filesystem. On a POSIX offloader handling a Windows receiver's
+``C:\...`` string, ``Path`` is ``PosixPath`` and treats
+backslashes as literal characters, so ``relative_to`` /
+``.parent`` / ``.name`` all misfire. Helpers here detect the
+receiver's flavour and parse accordingly.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
+
+# Drive-letter (``C:\``) or UNC (``\\server\``) prefix.
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^(?:[A-Za-z]:[\\/]|\\\\)")
+
+
+def receiver_pure_path_cls(receiver_path: str) -> type[PurePath]:
+    """Return the ``PurePath`` flavour matching *receiver_path*'s OS shape."""
+    if _WINDOWS_ABSOLUTE_PATH_RE.match(receiver_path):
+        return PureWindowsPath
+    return PurePosixPath
+
+
+def cross_os_basename(path: str) -> str:
+    """Return *path*'s trailing component, splitting on both POSIX and Windows separators."""
+    return path.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -23,7 +23,7 @@ import tarfile
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, NamedTuple
 
 from esphome.helpers import rmtree
@@ -36,6 +36,7 @@ from ..controllers.remote_build.artifacts_tarball import (
     STORAGE_MEMBER_NAME,
     VALIDATED_YAML_MEMBER_NAME,
 )
+from .cross_os_path import receiver_pure_path_cls
 from .json import dumps_indent
 from .json import loads as json_loads
 from .peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
@@ -64,7 +65,9 @@ class MaterialiseError(RuntimeError):
 class _ExtractedTarball(NamedTuple):
     storage_bytes: bytes
     idedata_bytes: bytes
-    receiver_build_path: Path
+    # ``PurePath``-flavoured per the receiver's OS so the path
+    # remap works when receiver and offloader differ.
+    receiver_build_path: PurePath
     build_path: Path
     # Optional: present when receiver-side esphome wrote a
     # validated-config cache (>= 2026.6.0).
@@ -188,12 +191,12 @@ def _device_name_from_storage(receiver_storage: dict[str, Any]) -> str:
     return device_name
 
 
-def _receiver_build_path_from_storage(receiver_storage: dict[str, Any]) -> Path:
-    """Pull the receiver-absolute build_path from the shipped storage.json."""
+def _receiver_build_path_from_storage(receiver_storage: dict[str, Any]) -> PurePath:
+    """Pull build_path from the shipped storage.json as a receiver-flavoured PurePath."""
     receiver_build_path_str = receiver_storage.get("build_path")
     if not isinstance(receiver_build_path_str, str):
         raise MaterialiseError("tarball storage.json missing required build_path field")
-    return Path(receiver_build_path_str)
+    return receiver_pure_path_cls(receiver_build_path_str)(receiver_build_path_str)
 
 
 def _read_member_optional(
@@ -304,7 +307,7 @@ def _stage_offloader_storage(
     *,
     configuration: str,
     receiver_storage_bytes: bytes,
-    receiver_build_path: Path,
+    receiver_build_path: PurePath,
     offloader_build_path: Path,
 ) -> StorageJSON:
     """Stage and return the offloader-form storage sidecar."""
@@ -317,8 +320,11 @@ def _stage_offloader_storage(
             f"StorageJSON.load returned None for the staged sidecar at {storage_path}"
         )
     if storage.firmware_bin_path is not None:
+        # ``str()`` round-trips the receiver-flavour string back out
+        # of the (possibly broken-on-this-OS) ``Path`` so
+        # ``_remap_to_offloader`` re-parses it with the right flavour.
         storage.firmware_bin_path = _remap_to_offloader(
-            Path(storage.firmware_bin_path),
+            str(storage.firmware_bin_path),
             receiver_build_path,
             offloader_build_path,
         )
@@ -332,7 +338,7 @@ def _stage_offloader_idedata(
     configuration: str,
     idedata_bytes: bytes,
     device_name: str,
-    receiver_build_path: Path,
+    receiver_build_path: PurePath,
     offloader_build_path: Path,
 ) -> Path:
     """Rewrite the receiver's idedata and save at the offloader's cache path."""
@@ -359,7 +365,7 @@ def _parse_idedata_dict(payload: bytes) -> dict[str, Any]:
 
 def _remap_idedata_build_paths(
     data: dict[str, Any],
-    receiver_build_path: Path,
+    receiver_build_path: PurePath,
     offloader_build_path: Path,
 ) -> None:
     """Rewrite prog_path + extra.flash_images[*].path to the offloader's tree."""
@@ -367,7 +373,7 @@ def _remap_idedata_build_paths(
     def _remap(value: Any) -> str | None:
         if not isinstance(value, str):
             return None
-        return str(_remap_to_offloader(Path(value), receiver_build_path, offloader_build_path))
+        return str(_remap_to_offloader(value, receiver_build_path, offloader_build_path))
 
     if (prog := _remap(data.get("prog_path"))) is not None:
         data["prog_path"] = prog
@@ -461,21 +467,32 @@ def _force_idedata_cache_hit(*, platformio_ini: Path, cached_idedata: Path) -> N
 
 
 def _remap_to_offloader(
-    receiver_abs: Path,
-    receiver_build_path: Path,
+    receiver_abs: str,
+    receiver_build_path: PurePath,
     offloader_build_path: Path,
 ) -> Path:
     """Translate *receiver_abs* under *receiver_build_path* to the offloader's tree.
 
-    Returns *receiver_abs* unchanged when it isn't actually under
-    *receiver_build_path* (cc_path-style absolute paths get
-    remapped via :func:`_remap_pio_toolchain_path` instead).
+    *receiver_abs* is parsed with the same ``PurePath`` flavour as
+    *receiver_build_path* so cross-OS receiver/offloader pairs
+    join correctly. Returns the receiver string as the offloader's
+    native ``Path`` when it isn't under *receiver_build_path*.
+    Raises :class:`MaterialiseError` on a ``..`` segment in the
+    computed relative; ``PurePath.relative_to`` doesn't normalise,
+    so a malicious ``firmware_bin_path`` like ``<build>/../evil``
+    would otherwise escape the offloader's build tree.
     """
+    receiver_cls = type(receiver_build_path)
     try:
-        relative = receiver_abs.relative_to(receiver_build_path)
+        relative = receiver_cls(receiver_abs).relative_to(receiver_build_path)
     except ValueError:
-        return receiver_abs
-    return offloader_build_path / relative
+        return Path(receiver_abs)
+    if ".." in relative.parts:
+        raise MaterialiseError(
+            f"receiver path {receiver_abs!r} contains '..' segments relative to "
+            f"build_path {str(receiver_build_path)!r}"
+        )
+    return offloader_build_path.joinpath(*relative.parts)
 
 
 def _remap_pio_toolchain_path(cc_path: str) -> str | None:

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -603,12 +603,17 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
     assert ack["accepted"] is True
     receiver_job = created_jobs[0]
     images = _write_build_artifacts_on_disk(tmp_path, configuration=receiver_job.configuration)
-    # Add the factory binary the user's install would download.
-    receiver_storage = StorageJSON.load(resolve_storage_path(receiver_job.configuration))
-    assert receiver_storage is not None
-    receiver_build = str(receiver_storage.build_path)
-    factory_path = Path(receiver_storage.firmware_bin_path).parent / "firmware.factory.bin"
-    factory_path.write_bytes(b"FACTORY-BIN-BYTES")
+
+    def _seed_factory_binary() -> str:
+        # resolve_storage_path + StorageJSON.load + write_bytes all
+        # block, so bundle them into one thread hop.
+        receiver_storage = StorageJSON.load(resolve_storage_path(receiver_job.configuration))
+        assert receiver_storage is not None
+        factory_path = Path(receiver_storage.firmware_bin_path).parent / "firmware.factory.bin"
+        factory_path.write_bytes(b"FACTORY-BIN-BYTES")
+        return str(receiver_storage.build_path)
+
+    receiver_build = await asyncio.to_thread(_seed_factory_binary)
     images["firmware.factory.bin"] = b"FACTORY-BIN-BYTES"
 
     paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
@@ -623,7 +628,10 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
 
     build_path = await asyncio.to_thread(materialise_remote_artifacts, munged, "kitchen.yaml")
 
-    staged_storage = await asyncio.to_thread(StorageJSON.load, resolve_storage_path("kitchen.yaml"))
+    def _load_staged() -> StorageJSON | None:
+        return StorageJSON.load(resolve_storage_path("kitchen.yaml"))
+
+    staged_storage = await asyncio.to_thread(_load_staged)
     assert staged_storage is not None
     assert staged_storage.firmware_bin_path is not None
     # firmware_bin_path was a Windows absolute on the wire; the

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -51,7 +51,9 @@ on the offloader side."
 from __future__ import annotations
 
 import asyncio
+import io
 import json
+import tarfile
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -62,6 +64,8 @@ from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     BUILD_INFO_MEMBER_NAME,
+    IDEDATA_MEMBER_NAME,
+    STORAGE_MEMBER_NAME,
 )
 from esphome_device_builder.helpers.build_scheduler import (
     BuildPath,
@@ -515,6 +519,122 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     yaml_path = Path(CORE.config_path).parent / "kitchen.yaml"
     hex_hash = await asyncio.to_thread(read_build_info_hash, yaml_path)
     assert hex_hash == "5a94a12d"
+
+
+_WIN_BUILD_PATH = (
+    r"C:\Users\receiver\esphome\.esphome\.remote_builds"
+    r"\_pin\.esphome\build\kitchen"
+)
+
+
+def _rewrite_tarball_to_windows_receiver(tarball: bytes, *, posix_build: str) -> bytes:
+    """Repack *tarball* with metadata paths rewritten under :data:`_WIN_BUILD_PATH`.
+
+    Lets a POSIX test host stand in for a Windows receiver: the
+    real ``pack_build_artifacts`` ran on Linux (so build-tree
+    files exist), then we munge ``storage.json`` /
+    ``idedata.json`` to look like a Windows receiver's wire
+    shape. Build-tree arcnames stay POSIX, which is what
+    production ships regardless of receiver OS.
+    """
+    buf_in = io.BytesIO(tarball)
+    buf_out = io.BytesIO()
+    with (
+        tarfile.open(fileobj=buf_in, mode="r:gz") as tar_in,
+        tarfile.open(fileobj=buf_out, mode="w:gz") as tar_out,
+    ):
+        for member in tar_in.getmembers():
+            payload = tar_in.extractfile(member).read()  # type: ignore[union-attr]
+            if member.name in (STORAGE_MEMBER_NAME, IDEDATA_MEMBER_NAME):
+                payload = _swap_metadata_paths_to_windows(payload, posix_build=posix_build)
+            info = tarfile.TarInfo(name=member.name)
+            info.size = len(payload)
+            tar_out.addfile(info, io.BytesIO(payload))
+    return buf_out.getvalue()
+
+
+def _swap_metadata_paths_to_windows(payload: bytes, *, posix_build: str) -> bytes:
+    """Rewrite every absolute path field under *posix_build* into :data:`_WIN_BUILD_PATH`."""
+    data = json.loads(payload)
+    for field in ("build_path", "firmware_bin_path", "prog_path"):
+        value = data.get(field)
+        if isinstance(value, str) and value.startswith(posix_build):
+            data[field] = _swap_prefix(value, posix_build, _WIN_BUILD_PATH)
+    for image in data.get("extra", {}).get("flash_images", []):
+        path = image.get("path")
+        if isinstance(path, str) and path.startswith(posix_build):
+            image["path"] = _swap_prefix(path, posix_build, _WIN_BUILD_PATH)
+    return json.dumps(data).encode("utf-8")
+
+
+def _swap_prefix(absolute_posix: str, posix_prefix: str, win_prefix: str) -> str:
+    """Replace *posix_prefix* with *win_prefix*, converting trailing separators to backslashes."""
+    suffix = absolute_posix[len(posix_prefix) :].lstrip("/").replace("/", "\\")
+    return win_prefix + ("\\" + suffix if suffix else "")
+
+
+@pytest.mark.asyncio
+async def test_windows_receiver_tarball_materialises_for_local_firmware_download(
+    paired_instances: PairedInstances,
+    tmp_path: Path,
+) -> None:
+    """#945: a Windows-receiver tarball materialises with offloader-local paths.
+
+    Drives the full transparent-install chain on one Noise
+    session (submit → fan-out → download_artifacts), then
+    rewrites the tarball's metadata members to look like a
+    Windows receiver sent them. Materialise + the
+    ``firmware/download`` read path must still resolve the
+    factory binary off ``firmware_bin_path.parent``.
+    """
+    await paired_instances.wait_until_session_opened()
+    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-windows-1",
+        configuration_filename="kitchen.yaml",
+        target="compile",
+        bundle_bytes=make_real_bundle(),
+    )
+    assert ack["accepted"] is True
+    receiver_job = created_jobs[0]
+    images = _write_build_artifacts_on_disk(tmp_path, configuration=receiver_job.configuration)
+    # Add the factory binary the user's install would download.
+    receiver_storage = StorageJSON.load(resolve_storage_path(receiver_job.configuration))
+    assert receiver_storage is not None
+    receiver_build = str(receiver_storage.build_path)
+    factory_path = Path(receiver_storage.firmware_bin_path).parent / "firmware.factory.bin"
+    factory_path.write_bytes(b"FACTORY-BIN-BYTES")
+    images["firmware.factory.bin"] = b"FACTORY-BIN-BYTES"
+
+    paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
+    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=receiver_job))
+    await state_changes.wait_for_status("running")
+    paired_instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=receiver_job))
+    await state_changes.wait_for_status("completed")
+    receiver_job.status = JobStatus.COMPLETED
+
+    packed = await handle.client.download_artifacts(job_id="off-windows-1")
+    munged = _rewrite_tarball_to_windows_receiver(packed.tarball, posix_build=receiver_build)
+
+    build_path = await asyncio.to_thread(materialise_remote_artifacts, munged, "kitchen.yaml")
+
+    staged_storage = await asyncio.to_thread(StorageJSON.load, resolve_storage_path("kitchen.yaml"))
+    assert staged_storage is not None
+    assert staged_storage.firmware_bin_path is not None
+    # firmware_bin_path was a Windows absolute on the wire; the
+    # offloader's staged copy must point into its own build tree.
+    assert str(staged_storage.firmware_bin_path).startswith(str(build_path))
+    download_dir = Path(staged_storage.firmware_bin_path).parent
+    # The #945 bug: this lookup raised "Binary not found" because
+    # firmware_bin_path stayed a Windows string and .parent
+    # collapsed to the dashboard cwd.
+    assert (download_dir / "firmware.factory.bin").read_bytes() == images["firmware.factory.bin"]
+    assert (download_dir / "firmware.bin").read_bytes() == images["firmware.bin"]
 
 
 def _drive_receiver_lifecycle(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -578,15 +578,7 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
     paired_instances: PairedInstances,
     tmp_path: Path,
 ) -> None:
-    """#945: a Windows-receiver tarball materialises with offloader-local paths.
-
-    Drives the full transparent-install chain on one Noise
-    session (submit → fan-out → download_artifacts), then
-    rewrites the tarball's metadata members to look like a
-    Windows receiver sent them. Materialise + the
-    ``firmware/download`` read path must still resolve the
-    factory binary off ``firmware_bin_path.parent``.
-    """
+    """Windows-receiver tarball over a real Noise session lands a readable factory binary."""
     await paired_instances.wait_until_session_opened()
     created_jobs = _wire_receiver_firmware_recorder(paired_instances)
     state_changes = capture_events(

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -624,7 +624,9 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
     receiver_job.status = JobStatus.COMPLETED
 
     packed = await handle.client.download_artifacts(job_id="off-windows-1")
-    munged = _rewrite_tarball_to_windows_receiver(packed.tarball, posix_build=receiver_build)
+    munged = await asyncio.to_thread(
+        _rewrite_tarball_to_windows_receiver, packed.tarball, posix_build=receiver_build
+    )
 
     build_path = await asyncio.to_thread(materialise_remote_artifacts, munged, "kitchen.yaml")
 

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -750,27 +750,14 @@ def _windows_storage_dict(*, build_path: str, firmware_bin_path: str) -> dict[st
 def test_remap_to_offloader_translates_receiver_path_across_os(
     tmp_path: Path, receiver_build: Any, receiver_firmware: str
 ) -> None:
-    """A receiver path remaps under the offloader build, even when the OS flavours differ.
-
-    Repro for #945: a Windows ``firmware_bin_path`` parsed with
-    ``Path()`` on Linux collapses to a single-component PosixPath
-    whose ``relative_to`` falls through to the unchanged-input
-    branch, leaving the offloader's ``firmware/download`` looking
-    in the wrong place.
-    """
+    """Receiver path under receiver build remaps under offloader build for either flavour."""
     offloader_build = tmp_path / "build" / "dev"
     result = _remap_to_offloader(receiver_firmware, receiver_build, offloader_build)
     assert result == offloader_build / ".pioenvs" / "dev" / "firmware.bin"
 
 
 def test_remap_to_offloader_rejects_dotdot_traversal_in_receiver_path(tmp_path: Path) -> None:
-    """A receiver ``..`` segment after the build prefix is rejected as traversal.
-
-    ``PurePath.relative_to`` doesn't normalise, so a malicious
-    ``firmware_bin_path = <build>/../../etc/passwd`` would
-    otherwise land in the offloader's join and escape on the
-    next ``.resolve()``.
-    """
+    """A ``..`` segment in the computed relative raises MaterialiseError."""
     receiver_build = PureWindowsPath(_WIN_BUILD_PATH)
     offloader_build = tmp_path / "build" / "dev"
     malicious = _WIN_BUILD_PATH + r"\..\..\..\Windows\System32\evil.bin"
@@ -779,14 +766,7 @@ def test_remap_to_offloader_rejects_dotdot_traversal_in_receiver_path(tmp_path: 
 
 
 def test_materialise_windows_receiver_storage_remaps_firmware_bin_path(tmp_path: Path) -> None:
-    """A Windows-receiver tarball materialises with offloader-local paths.
-
-    Repro for #945: build_path / firmware_bin_path arrive as
-    Windows absolutes; tar arcnames stay POSIX. Asserts the
-    staged StorageJSON points into the offloader's tree so
-    ``firmware/download`` can read the factory binary off
-    ``firmware_bin_path.parent``.
-    """
+    """Windows-flavoured tarball metadata materialises to offloader-local paths on disk."""
     win_firmware_bin = _WIN_BUILD_PATH + r"\.pioenvs\dev\firmware.bin"
     storage = _windows_storage_dict(build_path=_WIN_BUILD_PATH, firmware_bin_path=win_firmware_bin)
     idedata = {

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -20,7 +20,7 @@ import os
 import sys
 import tarfile
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 from unittest.mock import patch
 
@@ -708,9 +708,135 @@ def test_remap_to_offloader_returns_input_when_not_under_build_path(tmp_path: Pa
     """An absolute path that isn't under receiver_build_path passes through unchanged."""
     receiver_build = tmp_path / "receiver_build"
     offloader_build = tmp_path / "offloader_build"
-    outside = Path("/totally/unrelated/path.bin")
+    outside = "/totally/unrelated/path.bin"
     result = _remap_to_offloader(outside, receiver_build, offloader_build)
-    assert result == outside
+    assert result == Path(outside)
+
+
+_WIN_BUILD_PATH = r"C:\Users\receiver\esphome\.esphome\.remote_builds\_pin\.esphome\build\dev"
+
+
+def _windows_storage_dict(*, build_path: str, firmware_bin_path: str) -> dict[str, Any]:
+    """Receiver-side ``storage.json`` shape carrying Windows-absolute paths."""
+    return {
+        "storage_version": 1,
+        "name": "dev",
+        "esp_platform": "ESP32",
+        "build_path": build_path,
+        "firmware_bin_path": firmware_bin_path,
+        "loaded_integrations": [],
+        "loaded_platforms": [],
+        "no_mdns": False,
+        "framework": "arduino",
+        "core_platform": "esp32",
+    }
+
+
+@pytest.mark.parametrize(
+    ("receiver_build", "receiver_firmware"),
+    [
+        pytest.param(
+            PureWindowsPath(_WIN_BUILD_PATH),
+            _WIN_BUILD_PATH + r"\.pioenvs\dev\firmware.bin",
+            id="windows_receiver",
+        ),
+        pytest.param(
+            PurePosixPath("/home/builder/.esphome/.remote_builds/pin/build/dev"),
+            "/home/builder/.esphome/.remote_builds/pin/build/dev/.pioenvs/dev/firmware.bin",
+            id="posix_receiver",
+        ),
+    ],
+)
+def test_remap_to_offloader_translates_receiver_path_across_os(
+    tmp_path: Path, receiver_build: Any, receiver_firmware: str
+) -> None:
+    """A receiver path remaps under the offloader build, even when the OS flavours differ.
+
+    Repro for #945: a Windows ``firmware_bin_path`` parsed with
+    ``Path()`` on Linux collapses to a single-component PosixPath
+    whose ``relative_to`` falls through to the unchanged-input
+    branch, leaving the offloader's ``firmware/download`` looking
+    in the wrong place.
+    """
+    offloader_build = tmp_path / "build" / "dev"
+    result = _remap_to_offloader(receiver_firmware, receiver_build, offloader_build)
+    assert result == offloader_build / ".pioenvs" / "dev" / "firmware.bin"
+
+
+def test_remap_to_offloader_rejects_dotdot_traversal_in_receiver_path(tmp_path: Path) -> None:
+    """A receiver ``..`` segment after the build prefix is rejected as traversal.
+
+    ``PurePath.relative_to`` doesn't normalise, so a malicious
+    ``firmware_bin_path = <build>/../../etc/passwd`` would
+    otherwise land in the offloader's join and escape on the
+    next ``.resolve()``.
+    """
+    receiver_build = PureWindowsPath(_WIN_BUILD_PATH)
+    offloader_build = tmp_path / "build" / "dev"
+    malicious = _WIN_BUILD_PATH + r"\..\..\..\Windows\System32\evil.bin"
+    with pytest.raises(MaterialiseError, match=r"contains '\.\.'"):
+        _remap_to_offloader(malicious, receiver_build, offloader_build)
+
+
+def test_materialise_windows_receiver_storage_remaps_firmware_bin_path(tmp_path: Path) -> None:
+    """A Windows-receiver tarball materialises with offloader-local paths.
+
+    Repro for #945: build_path / firmware_bin_path arrive as
+    Windows absolutes; tar arcnames stay POSIX. Asserts the
+    staged StorageJSON points into the offloader's tree so
+    ``firmware/download`` can read the factory binary off
+    ``firmware_bin_path.parent``.
+    """
+    win_firmware_bin = _WIN_BUILD_PATH + r"\.pioenvs\dev\firmware.bin"
+    storage = _windows_storage_dict(build_path=_WIN_BUILD_PATH, firmware_bin_path=win_firmware_bin)
+    idedata = {
+        "prog_path": _WIN_BUILD_PATH + r"\.pioenvs\dev\firmware.elf",
+        "extra": {
+            "flash_images": [
+                {
+                    "path": _WIN_BUILD_PATH + r"\.pioenvs\dev\bootloader.bin",
+                    "offset": "0x1000",
+                }
+            ]
+        },
+    }
+    tarball = _synthetic_tarball(
+        storage=storage,
+        idedata=idedata,
+        extra_members=[
+            (".pioenvs/dev/firmware.bin", b"FIRMWARE"),
+            (".pioenvs/dev/firmware.factory.bin", b"FACTORY"),
+            (".pioenvs/dev/bootloader.bin", b"BOOT"),
+        ],
+    )
+    build_path = _materialise_in_tmp(tarball, tmp_path, configuration="dev.yaml")
+
+    staged_storage = json.loads(resolve_storage_path("dev.yaml").read_bytes())
+    assert staged_storage["build_path"] == str(build_path)
+    expected_firmware_bin = build_path / ".pioenvs" / "dev" / "firmware.bin"
+    assert staged_storage["firmware_bin_path"] == str(expected_firmware_bin)
+
+    # firmware/download path: base_dir = firmware_bin_path.parent.
+    factory_bin = Path(staged_storage["firmware_bin_path"]).parent / "firmware.factory.bin"
+    assert factory_bin.is_file()
+    assert factory_bin.read_bytes() == b"FACTORY"
+
+    staged_idedata = json.loads(resolve_idedata_path("dev.yaml", name="dev").read_bytes())
+    assert staged_idedata["prog_path"] == str(build_path / ".pioenvs" / "dev" / "firmware.elf")
+    assert staged_idedata["extra"]["flash_images"][0]["path"] == str(
+        build_path / ".pioenvs" / "dev" / "bootloader.bin"
+    )
+
+
+def test_materialise_rejects_dotdot_in_receiver_storage(tmp_path: Path) -> None:
+    """A malicious receiver shipping ``..`` in ``firmware_bin_path`` is rejected."""
+    storage = _windows_storage_dict(
+        build_path=_WIN_BUILD_PATH,
+        firmware_bin_path=_WIN_BUILD_PATH + r"\..\..\..\Windows\System32\evil.bin",
+    )
+    tarball = _synthetic_tarball(storage=storage)
+    with pytest.raises(MaterialiseError, match=r"contains '\.\.'"):
+        _materialise_in_tmp(tarball, tmp_path, configuration="dev.yaml")
 
 
 def test_materialise_rejects_cumulative_member_size(

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -899,6 +899,45 @@ def test_unpack_artifacts_response_directory_entry_raises() -> None:
         )
 
 
+def test_unpack_artifacts_response_rewrites_windows_paths_to_basenames() -> None:
+    r"""Windows-receiver flash-image paths still rewrite to basenames on a POSIX offloader.
+
+    ``Path(entry["path"]).name`` on Linux treats backslashes as
+    literal characters, so a Windows path like
+    ``C:\...\bootloader.bin`` would round-trip the entire
+    string into the ``path`` field and the offloader's lookup
+    would miss. The cross-OS basename helper must return just
+    the trailing component.
+    """
+    win_path = r"C:\Users\receiver\.esphome\build\dev\.pioenvs\dev\bootloader.bin"
+    idedata_bytes = json.dumps(
+        {"extra": {"flash_images": [{"path": win_path, "offset": "0x1000"}]}}
+    ).encode("utf-8")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        idedata_info = tarfile.TarInfo(name="idedata.json")
+        idedata_info.size = len(idedata_bytes)
+        tar.addfile(idedata_info, io.BytesIO(idedata_bytes))
+        firmware_info = tarfile.TarInfo(name="firmware.bin")
+        firmware_info.size = 4
+        tar.addfile(firmware_info, io.BytesIO(b"FIRM"))
+        # The receiver-side packer stores flash images flat at
+        # the basename; mirror that here.
+        bootloader_info = tarfile.TarInfo(name="bootloader.bin")
+        bootloader_info.size = 4
+        tar.addfile(bootloader_info, io.BytesIO(b"BOOT"))
+
+    response = unpack_artifacts_response(
+        DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x10000"),
+        job_id="j",
+    )
+
+    image_names = [image["name"] for image in response["images"]]
+    assert image_names == ["firmware.bin", "bootloader.bin"]
+    rewritten_paths = [entry["path"] for entry in response["idedata"]["extra"]["flash_images"]]
+    assert rewritten_paths == ["bootloader.bin"]
+
+
 def test_unpack_artifacts_response_missing_flash_image_from_extras_raises() -> None:
     """An extra-flash-image entry whose tarball member is missing raises."""
     idedata_bytes = json.dumps(


### PR DESCRIPTION
# What does this implement/fix?

A paired Windows receiver writes Windows absolute paths into `storage.json` and `idedata.json`. On a POSIX offloader (HA addon), `Path("C:\\...")` collapses to a single component `PosixPath` because `\` is not a separator, so `_remap_to_offloader`'s `relative_to` falls through to the unchanged input branch; the offloader then stores a Windows string `firmware_bin_path` and `firmware/download` raises "Binary not found".

Detect the receiver's path flavour from its `build_path` prefix (drive letter or UNC), parse receiver paths with the matching `PureWindowsPath` or `PurePosixPath`, then join the resulting relative parts onto the offloader's native `Path`. Reject `..` segments in the computed relative as a traversal guard since `PurePath.relative_to` does not normalise. The shared detection plus a cross-OS basename helper live in a new `helpers/cross_os_path.py` so the tarball unpacker's flash-image basename lookup uses the same logic.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/945

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
