### PR TITLE
Drive flicker dedup test until cache_calls crosses the boundary

### DIFF
--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1446,10 +1446,18 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
     monitor.state.dns_cache.has_cached_failure = MagicMock(side_effect=_has_cached_failure)
     _shrink_ping_intervals(monkeypatch)
 
+    async def _wait_for_flicker() -> None:
+        # Drive the loop until ``zom.local`` has been re-examined
+        # enough times to cross the dns_failed boundary at least once;
+        # a fixed ``asyncio.sleep`` flakes on slow xdist workers when
+        # only the first sweep lands inside the window.
+        while cache_calls["n"] < 4:
+            await asyncio.sleep(0)
+
     with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
-            await _let_ping_loop_run_briefly(monitor)
+            await asyncio.wait_for(_wait_for_flicker(), timeout=2.0)
         finally:
             await _stop_and_drain(monitor)
 
@@ -1457,7 +1465,7 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
         r for r in caplog.records if "Pinging" in r.message or "Skipping" in r.message
     ]
     assert len(membership_logs) == 1
-    assert cache_calls["n"] >= 2
+    assert cache_calls["n"] >= 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

`test_dns_failure_flicker_does_not_re_emit_log` slept a flat 50 ms and then asserted `cache_calls["n"] >= 2`; on slow xdist workers (observed on Ubuntu Python 3.12 CI) the first sweep consumed the whole window and only one cache call landed, flipping the test red. Replace the fixed `_let_ping_loop_run_briefly` sleep with a `while cache_calls["n"] < 4: await asyncio.sleep(0)` spin under a 2 s outer cap so the test waits for the actual flicker boundary instead of a timing window. The dedup assertion (`len(membership_logs) == 1`) now exercises >= 4 sweeps' worth of flips rather than whatever the runner gave us.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
