### PR TITLE
Enable RSE (flake8-raise) ruff rule

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1355,7 +1355,7 @@ class DeviceBuilder:
             # CSS / etc. on a hard-reload of a deep URL — see
             # ``_ASSET_EXTENSIONS`` for the rationale.
             if tail and Path(tail).suffix.lower() in _ASSET_EXTENSIONS:
-                raise web.HTTPNotFound()
+                raise web.HTTPNotFound
             return _render_shell(request, tail=tail)
 
         app.router.add_static("/assets", assets_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ select = [
   "PTH", # flake8-use-pathlib — prefer pathlib over os.path/os primitives
   "PLR0904", # too-many-public-methods (preview) — cap new god-classes at 20
   "RET", # flake8-return
+  "RSE", # flake8-raise — flag unnecessary parens on raised exception classes (``raise X()`` → ``raise X``)
   "RUF", # ruff-specific
   "S", # flake8-bandit
   "SIM", # flake8-simplify


### PR DESCRIPTION
# What does this implement/fix?

Enables ruff's `RSE` (flake8-raise) rule set, which flags unnecessary parentheses on raised exception classes (`raise X()` should be `raise X`); aioesphomeapi already has this on. One existing occurrence in `device_builder.py` is fixed in the same commit.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
