### PR TITLE
Enable SLOT (flake8-slots) ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ select = [
   "RUF", # ruff-specific
   "S", # flake8-bandit
   "SIM", # flake8-simplify
+  "SLOT", # flake8-slots — require ``__slots__`` on ``str`` / ``tuple`` / ``namedtuple`` subclasses
   "SLF", # flake8-self — flag cross-class private member access so the State
   # dataclass boundary stays load-bearing; sibling-module access within a
   # controller package is exempted via per-file-ignores below.

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -26,6 +26,8 @@ from esphome_device_builder.helpers.json import (
 class _StrSubclass(str):
     """Stand-in for ESPHome's ``EStr`` (a ``str`` subclass)."""
 
+    __slots__ = ()
+
 
 def test_dumps_rejects_str_subclass_keys() -> None:
     """Plain ``dumps`` keeps orjson's strict default.


### PR DESCRIPTION
# What does this implement/fix?

Enables ruff's `SLOT` (flake8-slots) rule set, which requires `__slots__` on `str` / `tuple` / `namedtuple` subclasses; aioesphomeapi already has this on. The single existing offender (`_StrSubclass` in `tests/test_helpers_json.py`, a stand-in for ESPHome's `EStr`) gains an empty `__slots__ = ()`.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
