### PR TITLE
Enable PYI (flake8-pyi) ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ select = [
   "PL", # pylint
   "PTH", # flake8-use-pathlib — prefer pathlib over os.path/os primitives
   "PLR0904", # too-many-public-methods (preview) — cap new god-classes at 20
+  "PYI", # flake8-pyi — type-stub correctness (collapses ``int | float`` to ``float``, etc.)
   "RET", # flake8-return
   "RUF", # ruff-specific
   "S", # flake8-bandit

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1183,7 +1183,7 @@ def test_generate_component_yaml_emits_plain_string_unquoted() -> None:
 
 
 @pytest.mark.parametrize("value", [42, 3.14])
-def test_generate_component_yaml_emits_numeric_value_via_str(value: int | float) -> None:
+def test_generate_component_yaml_emits_numeric_value_via_str(value: float) -> None:
     """Numbers render via ``str()`` — ints stay ints, floats keep the dot.
 
     A regression that quoted numbers (``priority: "0"``) changes the


### PR DESCRIPTION
# What does this implement/fix?

Enables ruff's `PYI` (flake8-pyi) rule set, which checks type-stub correctness (collapses `int | float` to `float`, etc.); aioesphomeapi already has this on. The one existing offender (PYI041 on a parametrized test signature) is fixed by the ruff auto-fix in the same commit.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
