### PR TITLE
Skip catalog re-warm in missing-definitions test via __wrapped__

### DIFF
--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -79,13 +79,14 @@ from esphome_device_builder.models.automations import (
 
 def test_load_catalog_returns_empty_when_definitions_missing() -> None:
     """A missing ``automations.json`` resolves to empty lists, not a crash."""
-    catalog.load_catalog.cache_clear()
+    # Call ``__wrapped__`` to bypass ``functools.cache`` without
+    # touching the global cache state; a ``cache_clear`` + re-warm
+    # would otherwise re-parse the full catalog (~2.5s) for the
+    # benefit of subsequent tests.
     with patch("esphome_device_builder.controllers.automations.catalog.resources.files") as files:
         files.side_effect = ModuleNotFoundError
-        result = catalog.load_catalog()
+        result = catalog.load_catalog.__wrapped__()
     assert result == {"triggers": [], "actions": [], "conditions": [], "light_effects": []}
-    catalog.load_catalog.cache_clear()
-    catalog.load_catalog()  # re-warm with real data
 
 
 def test_condition_by_id_returns_none_for_unknown_id() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`test_load_catalog_returns_empty_when_definitions_missing` cleared the automations `load_catalog` lru-cache, ran the patched empty-definitions path, then cleared the cache again and re-warmed it for the rest of the suite; the re-warm re-parsed the full catalog and added ~3 seconds of pure waste, both on the test's own call time and on whichever later test paid the next cold load. Call the inner `load_catalog.__wrapped__()` directly so the cache stays warm and untouched.

Local: test drops from ~3.6s to ~0.6s; full suite goes from 43s to 42s on my box. Smaller followups for the remaining slow tests (boards.json drift, AST walk, featured-component queries, catalog-load itself) will land separately if they prove worth it.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
