### PR TITLE
Drop redundant uv python install step that flakes on Windows cache hit

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,11 +1,21 @@
 name: Set up uv and managed Python
 description: |
-  Installs uv plus astral's PGO/LTO/BOLT/mimalloc-built CPython for
-  the requested version. setup-uv only sets ``UV_PYTHON``; this
-  composite also runs ``uv python install`` so the interpreter is
-  on disk before later steps reach for it (otherwise a job that
-  restores a cached venv would race a lazy fetch and blow up on
-  broken symlinks).
+  Installs uv and configures it for astral's PGO/LTO/BOLT/mimalloc-built
+  CPython at the requested version. setup-uv only sets ``UV_PYTHON``;
+  the interpreter itself is fetched lazily on the first ``uv venv`` /
+  ``uv pip install`` the caller runs, which is enough for every job
+  the composite is used in today.
+
+  The previous explicit ``uv python install`` step has been removed
+  because it flakes on Windows when the cached interpreter dir is
+  restored: ``uv`` then tries to recreate the minor-version reparse
+  point and trips ``os error 4394`` ("mismatch between the tag
+  specified in the request and the tag present in the reparse
+  point"). ``uv venv`` doesn't recreate the link and so doesn't
+  collide. If a future job restores a cached venv without ever
+  running ``uv venv`` / ``uv pip`` (so the lazy install never
+  fires), re-add the explicit step gated on
+  ``runner.os != 'Windows'`` to dodge the same race.
 
   Built for the 3.14 CI matrix where the tail-call interpreter
   measurably shortens the suite; jobs that need stock CPython
@@ -37,9 +47,3 @@ runs:
         # touching deps, so the post-step cache save would
         # otherwise abort the job.
         ignore-nothing-to-cache: true
-
-    - name: Install Python interpreter
-      shell: bash
-      env:
-        PYTHON_VERSION: ${{ inputs.python-version }}
-      run: uv python install "${PYTHON_VERSION}"


### PR DESCRIPTION
# What does this implement/fix?

The Windows pytest job intermittently fails the new composite action's `uv python install` step with `os error 4394` ("mismatch between the tag specified in the request and the tag present in the reparse point"); the cached Python install dir restored a moment earlier holds the minor-version reparse point and `uv` then refuses to recreate it. The step was redundant anyway since every caller runs `uv venv` next, and `uv venv` triggers the same lazy install without touching the reparse point.

Drop the explicit `uv python install` from the composite; document the failure mode so the step doesn't get re-added without thinking about Windows.

Example flake: https://github.com/esphome/device-builder/actions/runs/26523444499/job/78120587758

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
