### PR TITLE
Co-locate catalog-touching tests onto the catalog xdist group

### DIFF
--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -425,6 +425,7 @@ async def test_create_device_with_board_id_overwrites_archived_board_id(
     assert post == {"board_id": "rp2040-new-board"}
 
 
+@pytest.mark.xdist_group("catalog")
 def test_yaml_content_for_create_threads_default_components_through(
     session_component_catalog: Any,
 ) -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -976,6 +976,7 @@ def test_generate_device_yaml_with_no_defaults_arg_unchanged() -> None:
     assert "switch:" not in out
 
 
+@pytest.mark.xdist_group("catalog")
 def test_generate_device_yaml_for_apollo_esk_1_includes_default_blocks(
     session_component_catalog: Any,
 ) -> None:
@@ -1003,6 +1004,7 @@ def test_generate_device_yaml_for_apollo_esk_1_includes_default_blocks(
     assert "web_server:" in out
 
 
+@pytest.mark.xdist_group("catalog")
 def test_resolve_default_components_falls_through_to_catalog_id(
     session_component_catalog: Any,
 ) -> None:
@@ -1023,6 +1025,7 @@ def test_resolve_default_components_falls_through_to_catalog_id(
     assert "switch.gpio" in component_ids
 
 
+@pytest.mark.xdist_group("catalog")
 def test_resolve_default_components_carries_inline_fields(
     session_component_catalog: Any,
 ) -> None:
@@ -1042,6 +1045,7 @@ def test_resolve_default_components_carries_inline_fields(
     assert web.get("version") == "3"
 
 
+@pytest.mark.xdist_group("catalog")
 def test_resolve_default_components_skips_unknown_id_with_warning(
     session_component_catalog: Any,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
# What does this implement/fix?

`session_component_catalog` is session-scoped (per xdist worker), and `ComponentCatalog.load` takes ~3.5s on CI under blockbuster. Tests that already declare `xdist_group("catalog")` land on one worker and pay the load once, but the five catalog-touching tests in `test_device_yaml.py` (4) and `tests/controllers/devices/test_create.py` (1) were not in that group, so wherever pytest-xdist scheduled them, that worker paid a fresh ~3.5s load on first use.

Add `@pytest.mark.xdist_group("catalog")` to those five tests so they land on the existing catalog worker, which has already paid the load. The other tests in those modules stay free to parallelise.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
