### PR TITLE
Co-locate automations-catalog tests onto an automations xdist group

### DIFF
--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -17,6 +17,12 @@ import pytest
 from esphome_device_builder.controllers.automations import AutomationsController, catalog
 from esphome_device_builder.helpers.api import CommandError
 
+# Co-locate every test that walks the automations catalog onto one
+# xdist worker so the ``@cache``-d :func:`catalog.load_catalog`
+# (~2.8s on CI) pays its first-call cost once instead of once per
+# worker that picks up an automations test.
+pytestmark = pytest.mark.xdist_group("automations")
+
 
 def _make_controller(config_dir: Path) -> AutomationsController:
     """Build a controller wired to a tmp config dir.


### PR DESCRIPTION
# What does this implement/fix?

Same pattern as #975 for the automations catalog. `automations.catalog.load_catalog` is `@cache`-decorated, so the first call in each xdist worker pays ~2.8s on CI (under blockbuster), then is free. The 23 tests in `test_automations_controller.py` all walk the automations catalog (via `controller.get_actions()` and friends); without an xdist group they get distributed across workers, and every worker that picks one up pays the load again. Module-level `xdist_group("automations")` consolidates them onto one worker.

Skipping `test_automations_branches.py`: only 2 of 98 tests there touch the catalog, so pinning the whole file would over-consolidate; those two are not in the current slow-test list.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
