### PR TITLE
Refuse empty content writes via devices/update_config (#951)

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -603,6 +603,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     @api_command("devices/update_config")
     async def update_config(self, *, configuration: str, content: str, **kwargs: Any) -> None:
         """Write device config YAML."""
+        if not content.strip():
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "refusing to write empty content; delete the file directly instead",
+            )
         await self._persist_yaml_mutation(configuration, content)
 
     def _schedule_storage_regenerate(self, configuration: str) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -606,7 +606,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         if not content.strip():
             raise CommandError(
                 ErrorCode.INVALID_ARGS,
-                "refusing to write empty content; delete the file directly instead",
+                f"refusing to write empty content to {configuration!r} to prevent "
+                "accidental data loss; use the delete action to remove a file",
             )
         await self._persist_yaml_mutation(configuration, content)
 

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -290,7 +290,7 @@ async def test_update_config_refuses_empty_content(
 async def test_update_config_refuses_whitespace_only_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Whitespace-only content is rejected the same as empty."""
+    """Whitespace-only content raises ``INVALID_ARGS``; file and side effects untouched."""
     controller = make_controller(tmp_path)
     regenerated = _stub_regenerate(controller)
     target = tmp_path / "secrets.yaml"

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -270,13 +270,7 @@ async def test_update_config_writes_before_requesting_reload(
 async def test_update_config_refuses_empty_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Empty content raises ``INVALID_ARGS``; the existing file is untouched.
-
-    Pins the data-loss guard against #951: a frontend state-clear that
-    led to ``content=""`` would otherwise wipe ``secrets.yaml`` (or any
-    device YAML) atomically on disk. Refuse at the endpoint regardless
-    of which client called in.
-    """
+    """Empty content raises ``INVALID_ARGS``; file and side effects untouched."""
     controller = make_controller(tmp_path)
     regenerated = _stub_regenerate(controller)
     target = tmp_path / "secrets.yaml"
@@ -296,14 +290,9 @@ async def test_update_config_refuses_empty_content(
 async def test_update_config_refuses_whitespace_only_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Whitespace-only content is treated the same as empty.
-
-    A buffer the user blanked except for stray newlines / tabs is the
-    same data-loss shape as a truly empty buffer; the existing file is
-    untouched.
-    """
+    """Whitespace-only content is rejected the same as empty."""
     controller = make_controller(tmp_path)
-    _stub_regenerate(controller)
+    regenerated = _stub_regenerate(controller)
     target = tmp_path / "secrets.yaml"
     original = "wifi_password: hunter2\n"
     target.write_text(original, encoding="utf-8")
@@ -313,6 +302,8 @@ async def test_update_config_refuses_whitespace_only_content(
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert target.read_text(encoding="utf-8") == original
+    assert regenerated == []
+    assert controller._scanner.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -31,6 +31,8 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
 
 from .conftest import MakeControllerFactory
 
@@ -262,6 +264,55 @@ async def test_update_config_writes_before_requesting_reload(
 
     assert order == ["write", "request:kitchen.yaml"]
     assert yaml_path.read_text(encoding="utf-8") == new_content
+
+
+@pytest.mark.asyncio
+async def test_update_config_refuses_empty_content(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Empty content raises ``INVALID_ARGS``; the existing file is untouched.
+
+    Pins the data-loss guard against #951: a frontend state-clear that
+    led to ``content=""`` would otherwise wipe ``secrets.yaml`` (or any
+    device YAML) atomically on disk. Refuse at the endpoint regardless
+    of which client called in.
+    """
+    controller = make_controller(tmp_path)
+    regenerated = _stub_regenerate(controller)
+    target = tmp_path / "secrets.yaml"
+    original = "wifi_password: hunter2\n"
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.update_config(configuration="secrets.yaml", content="")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert target.read_text(encoding="utf-8") == original
+    assert regenerated == []
+    assert controller._scanner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_update_config_refuses_whitespace_only_content(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Whitespace-only content is treated the same as empty.
+
+    A buffer the user blanked except for stray newlines / tabs is the
+    same data-loss shape as a truly empty buffer; the existing file is
+    untouched.
+    """
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    target = tmp_path / "secrets.yaml"
+    original = "wifi_password: hunter2\n"
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.update_config(configuration="secrets.yaml", content="  \n\t\n")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert target.read_text(encoding="utf-8") == original
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

The dashboard's secrets editor (and any future caller into
`devices/update_config`) can land empty content on disk if the
frontend hits the endpoint with a cleared / desynced buffer. The
result is data loss: a populated `secrets.yaml` (or any device YAML)
is atomically replaced with nothing.

This PR refuses empty / whitespace-only content at the endpoint with
a typed `CommandError(INVALID_ARGS, ...)`. Two new test cases pin:

1. Empty content raises `INVALID_ARGS`; the existing file on disk is
   untouched; no scanner request or storage regenerate is queued.
2. Whitespace-only content (`"  \n\t\n"`) is treated the same.

The existing positive-path tests cover the legitimate write flow
unchanged.

This is the load-bearing fix for #951. A companion frontend PR will
add defense in depth (gate the editor on `_loaded`, refuse Save when
the buffer is empty), but the endpoint guard stops the data-loss
path regardless of which client called in.

Rationale per CLAUDE.md "Design principles": "Better to error than
silently work around broken state." No legitimate dashboard flow
writes empty YAML through this endpoint; ESPHome wouldn't compile an
empty device YAML, and an empty `secrets.yaml` is equivalent to
deleting the file (different ergonomics — rm in a shell).

**Related issue or feature (if applicable):**

- fixes #951

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-dashboard-frontend#<pending — opening after this PR>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
