### PR TITLE
Bump fnv-hash-fast floor to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "cryptography>=42.0.2",
   # Cheap non-cryptographic hash for the editor's
   # validate-result cache (content → cached subprocess result).
-  "fnv-hash-fast>=1.0.0",
+  "fnv-hash-fast>=2.0.0",
   "ifaddr>=0.2.0",
   "mashumaro>=3.13",
   "orjson>=3.9.0",


### PR DESCRIPTION
# What does this implement/fix?

`fnv_hash_fast` 1.x is Cython based and raises `IndexError: Out of bounds on buffer access (axis 0)` when handed empty bytes; `_fnv_impl.pyx` line 11 dereferences `&data[0]` on a zero length memoryview. The editor controller hits this on every `validate_yaml` call with empty content. 2.0.0 swapped the Cython path for a plain C extension that iterates over `0..len` and so handles empty input cleanly. Bumping the floor pins the dashboard past the bug.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [x] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
