### PR TITLE
Surface install hint when the [esphome] extra is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ handy as a fallback if PyPI is unreachable.
 python -m venv .venv && source .venv/bin/activate
 
 # Replace <version> with a release tag (X.Y.Z stable, X.Y.ZbN beta).
-pip install "https://github.com/esphome/device-builder/releases/download/<version>/esphome_device_builder-<version>-py3-none-any.whl"
+# ``[esphome] @ <url>`` carries the optional extra through the
+# direct-URL install so the dashboard finds esphome at startup.
+pip install "esphome-device-builder[esphome] @ https://github.com/esphome/device-builder/releases/download/<version>/esphome_device_builder-<version>-py3-none-any.whl"
 
 esphome-device-builder ~/esphome-configs
 ```

--- a/README.md
+++ b/README.md
@@ -53,14 +53,21 @@ add-on / Desktop shapes:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install esphome-device-builder
+pip install 'esphome-device-builder[esphome]'
 
 esphome-device-builder ~/esphome-configs
 ```
 
+The `[esphome]` extra pulls in the upstream `esphome` package the
+dashboard needs to compile, flash, and discover devices. The HA
+add-on / Desktop builds ship `esphome` separately, so the bare
+`pip install esphome-device-builder` (no extra) is for those
+contexts only.
+
 For the beta channel, pass `--pre` to opt the resolver into
-prereleases — e.g. `pip install --pre esphome-device-builder` for a
-fresh install, or `pip install --upgrade --pre esphome-device-builder`
+prereleases — e.g. `pip install --pre 'esphome-device-builder[esphome]'`
+for a fresh install, or
+`pip install --upgrade --pre 'esphome-device-builder[esphome]'`
 to pull the newest beta on top of an existing install. `--pre` only
 opts the *current* command into prereleases; rerun the upgrade
 command to refresh.

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -319,11 +319,20 @@ def _log_uncaught_thread_exception(args: threading.ExceptHookArgs) -> None:
 
 
 def _esphome_version() -> str | None:
-    """Return the bundled ESPHome version, or ``None`` if the optional extra is missing."""
+    """
+    Return the bundled ESPHome version, or ``None`` if the extra is missing.
+
+    Narrows to ``ModuleNotFoundError`` rooted at ``esphome``; an
+    ``ImportError`` raised from *inside* ``esphome.const`` (a
+    broken install, not a missing one) propagates so callers like
+    the ``main()`` gate don't misclassify it as "not installed".
+    """
     try:
         from esphome.const import __version__ as version  # noqa: PLC0415
-    except ImportError:
-        return None
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.split(".", 1)[0] == "esphome":
+            return None
+        raise
     # ``esphome`` ships no type stubs, so ``__version__`` arrives as
     # ``Any`` and the raw return trips ``no-any-return``. Cast at the
     # boundary — runtime contract is the documented version string.

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -251,29 +251,26 @@ def main() -> None:
 
     _warn_deprecated_credential_flags(args)
 
-    # Deferred so ``--version`` / ``--help`` keep working in installs
-    # that omit the optional ``[esphome]`` extra — both modules below
-    # transitively import ``esphome`` at module load time. Wrapped so
-    # the missing-extra path surfaces an actionable hint instead of a
-    # raw traceback (#919).
-    try:
-        from esphome.core import CORE  # noqa: PLC0415
+    # ``--version`` / ``--help`` exit above before reaching this
+    # point, so the lazy imports below are reachable only when the
+    # user actually meant to run the dashboard. Gate on
+    # ``_esphome_version`` (the same probe ``_format_version`` uses)
+    # so the missing-extra detection has a single source of truth;
+    # surface an actionable hint in place of the raw
+    # ``ModuleNotFoundError`` traceback (#919).
+    if _esphome_version() is None:
+        logging.getLogger(_LOGGER_NAME).error(
+            "Running esphome-device-builder needs the 'esphome' "
+            "package; reinstall with the [esphome] extra: "
+            "pip install 'esphome-device-builder[esphome]'"
+        )
+        sys.exit(1)
 
-        from .controllers.config import DashboardSettings  # noqa: PLC0415
-        from .device_builder import DeviceBuilder  # noqa: PLC0415
-        from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
-    except ModuleNotFoundError as exc:
-        if exc.name and exc.name.split(".", 1)[0] == "esphome":
-            # ``error`` not ``exception``: the raw traceback is the
-            # bad UX we're replacing (#919); the actionable hint is
-            # the whole point.
-            logging.getLogger(_LOGGER_NAME).error(  # noqa: TRY400
-                "Running esphome-device-builder needs the 'esphome' "
-                "package; reinstall with the [esphome] extra: "
-                "pip install 'esphome-device-builder[esphome]'"
-            )
-            sys.exit(1)
-        raise
+    from esphome.core import CORE  # noqa: PLC0415
+
+    from .controllers.config import DashboardSettings  # noqa: PLC0415
+    from .device_builder import DeviceBuilder  # noqa: PLC0415
+    from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
 
     settings = DashboardSettings()
     settings.parse_args(args)

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -253,12 +253,27 @@ def main() -> None:
 
     # Deferred so ``--version`` / ``--help`` keep working in installs
     # that omit the optional ``[esphome]`` extra — both modules below
-    # transitively import ``esphome`` at module load time.
-    from esphome.core import CORE  # noqa: PLC0415
+    # transitively import ``esphome`` at module load time. Wrapped so
+    # the missing-extra path surfaces an actionable hint instead of a
+    # raw traceback (#919).
+    try:
+        from esphome.core import CORE  # noqa: PLC0415
 
-    from .controllers.config import DashboardSettings  # noqa: PLC0415
-    from .device_builder import DeviceBuilder  # noqa: PLC0415
-    from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
+        from .controllers.config import DashboardSettings  # noqa: PLC0415
+        from .device_builder import DeviceBuilder  # noqa: PLC0415
+        from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.split(".", 1)[0] == "esphome":
+            # ``error`` not ``exception``: the raw traceback is the
+            # bad UX we're replacing (#919); the actionable hint is
+            # the whole point.
+            logging.getLogger(_LOGGER_NAME).error(  # noqa: TRY400
+                "Running esphome-device-builder needs the 'esphome' "
+                "package; reinstall with the [esphome] extra: "
+                "pip install 'esphome-device-builder[esphome]'"
+            )
+            sys.exit(1)
+        raise
 
     settings = DashboardSettings()
     settings.parse_args(args)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -141,6 +141,61 @@ def test_main_version_flag_prints_and_exits(
 
 
 # ---------------------------------------------------------------------------
+# end-to-end ``main(['./configs'])`` when the ``[esphome]`` extra is missing
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_with_actionable_error_when_esphome_extra_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pins #919 — surface the install hint, not a raw ModuleNotFoundError."""
+    # ``_setup_logging`` installs a queue handler that offloads log
+    # delivery to a listener thread, which prevents ``caplog`` from
+    # seeing the error record synchronously. The queue-handler
+    # behaviour is exercised by the existing ``_setup_logging``
+    # tests below; here we only care that the friendly-error log
+    # line is emitted to the project logger.
+    monkeypatch.setattr(main_module, "_setup_logging", lambda *a, **kw: None)
+
+    real_import = builtins.__import__
+
+    def _block_esphome(
+        name: str,
+        globals: object = None,  # noqa: A002 — matches ``__import__`` signature
+        locals: object = None,  # noqa: A002
+        fromlist: object = (),
+        level: int = 0,
+    ) -> object:
+        if name == "esphome" or name.startswith("esphome."):
+            raise ModuleNotFoundError(f"No module named '{name}'", name=name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    # Evict cached ``esphome.*`` entries so the lazy import in
+    # ``main`` re-enters ``__import__`` instead of short-circuiting
+    # through ``sys.modules``.
+    for cached in [
+        name for name in sys.modules if name == "esphome" or name.startswith("esphome.")
+    ]:
+        monkeypatch.delitem(sys.modules, cached)
+
+    monkeypatch.setattr(builtins, "__import__", _block_esphome)
+    monkeypatch.setattr("sys.argv", ["esphome-device-builder", "./configs"])
+
+    with (
+        caplog.at_level(logging.ERROR, logger="esphome_device_builder"),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        main_module.main()
+
+    assert excinfo.value.code == 1
+    assert any(
+        "pip install 'esphome-device-builder[esphome]'" in record.getMessage()
+        for record in caplog.records
+    ), "Expected the actionable [esphome] extra hint in the captured log records"
+
+
+# ---------------------------------------------------------------------------
 # __main__._setup_logging — uncaught-exception hooks
 # ---------------------------------------------------------------------------
 

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -89,12 +89,45 @@ def test_esphome_version_returns_none_when_import_fails(monkeypatch: pytest.Monk
         level: int = 0,
     ) -> object:
         if name == "esphome" or name.startswith("esphome."):
-            raise ModuleNotFoundError(f"No module named '{name}'")
+            # ``name=name`` mirrors how CPython's import machinery
+            # populates the attribute — ``_esphome_version`` keys its
+            # missing-extra check on it.
+            raise ModuleNotFoundError(f"No module named '{name}'", name=name)
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", _block_esphome)
 
     assert main_module._esphome_version() is None
+
+
+def test_esphome_version_re_raises_non_esphome_module_not_found_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ModuleNotFoundError rooted somewhere other than ``esphome`` must propagate.
+
+    Pins the boundary between "extra missing" and "something else
+    broke inside esphome.const" — only the former should degrade to
+    ``None`` (#919).
+    """
+    real_import = builtins.__import__
+
+    def _block_unrelated(
+        name: str,
+        globals: object = None,  # noqa: A002
+        locals: object = None,  # noqa: A002
+        fromlist: object = (),
+        level: int = 0,
+    ) -> object:
+        # Pretend importing ``esphome.const`` fails because *something
+        # else* it imports is missing — not the esphome package itself.
+        if name == "esphome.const":
+            raise ModuleNotFoundError("No module named 'something_else'", name="something_else")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _block_unrelated)
+
+    with pytest.raises(ModuleNotFoundError, match="something_else"):
+        main_module._esphome_version()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

A plain `pip install esphome-device-builder` followed by `esphome-device-builder ~/esphome-configs` crashed with a raw `ModuleNotFoundError: No module named 'esphome'` traceback. The deferred-import block in `__main__.main` already gates `--version` / `--help` so they keep working without the `[esphome]` extra, but every other invocation hit the import and surfaced the traceback unchanged. This wraps the deferred imports in a guard that emits a single actionable log line naming the install command, then exits 1; any non-esphome `ModuleNotFoundError` re-raises. The README's Standalone (PyPI) snippet, which was the source of the user's expectation, is updated to advertise the `[esphome]` extra (matching `docs/ARCHITECTURE.md:7`'s contract).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/919

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
