### PR TITLE
Fix HA add-on auth log messages directing to non-existent options

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -1193,21 +1193,24 @@ class DeviceBuilder:
                 # add-on log so the operator sees exactly what to
                 # change.
                 msg = (
-                    "Refusing to start: --ha-addon is set, "
-                    "DISABLE_HA_AUTHENTICATION forces public-port auth, "
-                    "and USERNAME/PASSWORD is not configured. Set "
-                    "USERNAME and PASSWORD via the add-on options, or "
-                    "unset DISABLE_HA_AUTHENTICATION to use ingress-only "
-                    "mode."
+                    "Refusing to start: DISABLE_HA_AUTHENTICATION "
+                    "forces public-port auth, but the HA add-on is "
+                    "ingress-only by design and doesn't expose "
+                    "USERNAME/PASSWORD options. Turn "
+                    '"Disable external authentication" off to use '
+                    "ingress-only mode, or run the standalone PyPI "
+                    "install for password-gated LAN access. See "
+                    'README "Home Assistant add-on".'
                 )
                 raise RuntimeError(msg)
             _LOGGER.warning(
-                "Public port %d NOT bound: --ha-addon is set but "
-                "USERNAME/PASSWORD is not configured. Running "
-                "ingress-only — the dashboard works through the Home "
-                "Assistant UI. To enable LAN access on port %d, set "
-                "USERNAME and PASSWORD via the add-on options.",
-                settings.port,
+                "Public port %d NOT bound: the HA add-on is "
+                "ingress-only by design and doesn't expose "
+                "USERNAME/PASSWORD options. The dashboard is "
+                "reachable through the Home Assistant UI. For "
+                "password-gated LAN access, run the standalone PyPI "
+                'install on the same network. See README "Home '
+                'Assistant add-on".',
                 settings.port,
             )
             app = self.create_app(trusted=True, with_ingress_site=False)

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -113,7 +113,13 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
         "expected the loud 'Public port ... NOT bound' warning describing "
         "why the public port was suppressed and how to enable it"
     )
-    assert "USERNAME and PASSWORD" in warning_messages[0]
+    # Pin the addon-specific framing so a future copy edit can't
+    # silently regress to the pre-#943 wording that pointed
+    # operators at add-on options that don't exist.
+    warning = warning_messages[0]
+    assert "ingress-only" in warning
+    assert "doesn't expose" in warning
+    assert "standalone PyPI install" in warning
 
 
 def test_ha_addon_no_password_no_ingress_refuses_to_start(


### PR DESCRIPTION
# What does this implement/fix?

The HA add-on emits two log messages when no `USERNAME` / `PASSWORD` is set, both telling the operator to "set USERNAME and PASSWORD via the add-on options". The add-on's `config.yaml` schema doesn't expose those options and isn't going to (README "Home Assistant add-on" explains why; the supervisor `/auth` endpoint has no rate limiting so an exposed port 6052 would brute force every HA account). Operators follow the message, look in the add-on UI, find nothing, and are stuck. This rewires both messages to match the README: the add-on is ingress only by design, and the documented LAN access path is the standalone PyPI install. No behavior change; the refuse to start in Case A and the warning in Case B both still fire, just with copy that points operators at things that exist.

**Related issue or feature (if applicable):**

- fixes #943

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
