### PR TITLE
Surface multi-sensor sub-readings on the main form

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -560,6 +560,20 @@ _FIELD_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
 # automation editor is. Skip them.
 _AUTOMATION_KEY_PREFIXES: tuple[str, ...] = ("on_",)
 
+# Base-schema references that mark a field as a *sub-reading* of a
+# multi-sensor platform (DHT exposes ``temperature:`` / ``humidity:``;
+# debug exposes ``free:`` / ``block:`` / etc). Sub-readings are
+# optional by upstream schema, but they're the *reason* a multi-sensor
+# platform exists — keeping them on the main form (not hidden under
+# "Show advanced settings") is what users expect (#983).
+_SUB_READING_BASE_SCHEMAS: frozenset[str] = frozenset(
+    {
+        "sensor._SENSOR_SCHEMA",
+        "binary_sensor._BINARY_SENSOR_SCHEMA",
+        "text_sensor._TEXT_SENSOR_SCHEMA",
+    }
+)
+
 # Map from the ``**type**`` doc prefix marker to our ConfigEntryType.
 # The schema docs lead with bracketed type names (``**[Time](...)**:``)
 # or bold scalars (``**boolean**:``); we strip the markup and look up
@@ -2104,6 +2118,16 @@ def _convert_field(key: str, raw: dict, schema_dir: Path) -> dict | None:  # noq
         key, required=required, is_structural=is_structural
     )
     yaml_only = schema_visibility == Visibility.YAML_ONLY
+    # Sub-sensor readings on multi-sensor platforms (DHT temperature /
+    # humidity, debug.sensor's free / block / loop_time / ..., ADS1115's
+    # named ADC reads) extend a base sensor schema; the bundle marks
+    # the reference in ``schema.extends``. They're optional, so
+    # ``_classify_advanced`` defaults them to advanced — but they're
+    # the whole reason a multi-sensor platform exists, so surface them
+    # on the main form rather than under "Show advanced settings"
+    # (#983).
+    if extends and _SUB_READING_BASE_SCHEMAS.intersection(extends):
+        advanced = False
 
     default_value, gated_component = _extract_default(raw, key=key)
     entry: dict[str, Any] = {

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -109,7 +109,7 @@ def test_no_extends_field_unaffected() -> None:
 
 def test_catalog_dht_sub_readings_not_advanced() -> None:
     """Real catalog: DHT temperature + humidity surface on the main form."""
-    catalog = json.loads(_CATALOG_PATH.read_text())
+    catalog = json.loads(_CATALOG_PATH.read_text(encoding="utf-8"))
     dht = next(c for c in catalog["components"] if c["id"] == "sensor.dht")
     by_key = {e["key"]: e for e in dht["config_entries"]}
     assert by_key["temperature"]["advanced"] is False
@@ -118,7 +118,7 @@ def test_catalog_dht_sub_readings_not_advanced() -> None:
 
 def test_catalog_debug_sub_readings_not_advanced_but_id_stays() -> None:
     """All 7 debug sub-readings surface; ``debug_id`` (an ID) stays advanced."""
-    catalog = json.loads(_CATALOG_PATH.read_text())
+    catalog = json.loads(_CATALOG_PATH.read_text(encoding="utf-8"))
     debug = next(c for c in catalog["components"] if c["id"] == "sensor.debug")
     by_key = {e["key"]: e for e in debug["config_entries"]}
     sub_readings = (

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -1,17 +1,4 @@
-"""
-Pins the sub-sensor-reading discoverability path (#983).
-
-A platform sensor's sub-readings (e.g. ``dht.sensor.temperature``,
-``debug.sensor.free``) extend a base sensor schema; the upstream
-bundle marks the reference via ``schema.extends:
-["sensor._SENSOR_SCHEMA"]``. Those fields default to
-``advanced=True`` (every optional field does), which shoves them
-behind "Show advanced settings" and leaves the platform's form
-looking empty. The fix forces ``advanced=False`` for any field
-whose schema extends a sub-reading base schema; this test pins
-that behaviour both at ``_convert_field`` granularity and against
-the rendered catalog.
-"""
+"""Sub-readings on multi-sensor platforms surface on the main form."""
 
 from __future__ import annotations
 
@@ -19,7 +6,6 @@ import json
 from pathlib import Path
 
 from script.sync_components import (  # type: ignore[import-not-found]
-    _SUB_READING_BASE_SCHEMAS,
     _convert_field,
 )
 
@@ -36,20 +22,6 @@ def _convert(raw: dict) -> dict:
     entry = _convert_field("temperature", raw, _UNUSED_SCHEMA_DIR)
     assert entry is not None
     return entry
-
-
-def test_sub_reading_base_schemas_contract() -> None:
-    """The frozenset names the three multi-sensor base schemas we recognise."""
-    assert (
-        frozenset(
-            {
-                "sensor._SENSOR_SCHEMA",
-                "binary_sensor._BINARY_SENSOR_SCHEMA",
-                "text_sensor._TEXT_SENSOR_SCHEMA",
-            }
-        )
-        == _SUB_READING_BASE_SCHEMAS
-    )
 
 
 def test_sub_reading_extends_overrides_advanced_to_false() -> None:

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -1,0 +1,138 @@
+"""
+Pins the sub-sensor-reading discoverability path (#983).
+
+A platform sensor's sub-readings (e.g. ``dht.sensor.temperature``,
+``debug.sensor.free``) extend a base sensor schema; the upstream
+bundle marks the reference via ``schema.extends:
+["sensor._SENSOR_SCHEMA"]``. Those fields default to
+``advanced=True`` (every optional field does), which shoves them
+behind "Show advanced settings" and leaves the platform's form
+looking empty. The fix forces ``advanced=False`` for any field
+whose schema extends a sub-reading base schema; this test pins
+that behaviour both at ``_convert_field`` granularity and against
+the rendered catalog.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _SUB_READING_BASE_SCHEMAS,
+    _convert_field,
+)
+
+_UNUSED_SCHEMA_DIR = Path("/unused")
+_CATALOG_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "esphome_device_builder"
+    / "definitions"
+    / "components.json"
+)
+
+
+def _convert(raw: dict) -> dict:
+    entry = _convert_field("temperature", raw, _UNUSED_SCHEMA_DIR)
+    assert entry is not None
+    return entry
+
+
+def test_sub_reading_base_schemas_contract() -> None:
+    """The frozenset names the three multi-sensor base schemas we recognise."""
+    assert (
+        frozenset(
+            {
+                "sensor._SENSOR_SCHEMA",
+                "binary_sensor._BINARY_SENSOR_SCHEMA",
+                "text_sensor._TEXT_SENSOR_SCHEMA",
+            }
+        )
+        == _SUB_READING_BASE_SCHEMAS
+    )
+
+
+def test_sub_reading_extends_overrides_advanced_to_false() -> None:
+    """A field whose schema extends a sensor base lands not-advanced (#983)."""
+    raw = {
+        "key": "Optional",
+        "type": "schema",
+        "schema": {
+            "config_vars": {"name": {"key": "Required"}},
+            "extends": ["sensor._SENSOR_SCHEMA"],
+        },
+    }
+    assert _convert(raw)["advanced"] is False
+
+
+def test_binary_sensor_and_text_sensor_bases_also_override() -> None:
+    """The override applies to all three multi-sensor base schemas."""
+    for base in (
+        "binary_sensor._BINARY_SENSOR_SCHEMA",
+        "text_sensor._TEXT_SENSOR_SCHEMA",
+    ):
+        raw = {
+            "key": "Optional",
+            "type": "schema",
+            "schema": {"config_vars": {}, "extends": [base]},
+        }
+        assert _convert(raw)["advanced"] is False, f"failed for {base}"
+
+
+def test_non_sub_reading_nested_keeps_default_advanced() -> None:
+    """A nested field that does NOT extend a sensor base stays as classified."""
+    raw = {
+        "key": "Optional",
+        "type": "schema",
+        "schema": {
+            "config_vars": {"scan_window": {"key": "Optional"}},
+            # Different base — e.g. a plain config block.
+            "extends": ["esp32_ble_tracker._SCAN_PARAMETERS_SCHEMA"],
+        },
+    }
+    # ``_classify_advanced`` defaults optional fields to advanced —
+    # the override doesn't touch this case.
+    assert _convert(raw)["advanced"] is True
+
+
+def test_no_extends_field_unaffected() -> None:
+    """Fields with no ``extends`` reference are untouched by the override."""
+    raw = {
+        "key": "Optional",
+        "type": "string",
+    }
+    # No extends → no override → falls back to ``_classify_advanced``.
+    # ``temperature`` isn't in IMPORTANT_KEYS or ADVANCED_BASE_KEYS, so
+    # ``_classify_advanced`` returns the default ``True`` for optionals.
+    assert _convert(raw)["advanced"] is True
+
+
+def test_catalog_dht_sub_readings_not_advanced() -> None:
+    """Real catalog: DHT temperature + humidity surface on the main form."""
+    catalog = json.loads(_CATALOG_PATH.read_text())
+    dht = next(c for c in catalog["components"] if c["id"] == "sensor.dht")
+    by_key = {e["key"]: e for e in dht["config_entries"]}
+    assert by_key["temperature"]["advanced"] is False
+    assert by_key["humidity"]["advanced"] is False
+
+
+def test_catalog_debug_sub_readings_not_advanced_but_id_stays() -> None:
+    """All 7 debug sub-readings surface; ``debug_id`` (an ID) stays advanced."""
+    catalog = json.loads(_CATALOG_PATH.read_text())
+    debug = next(c for c in catalog["components"] if c["id"] == "sensor.debug")
+    by_key = {e["key"]: e for e in debug["config_entries"]}
+    sub_readings = (
+        "block",
+        "cpu_frequency",
+        "fragmentation",
+        "free",
+        "loop_time",
+        "min_free",
+        "psram",
+    )
+    for key in sub_readings:
+        assert by_key[key]["advanced"] is False, f"{key} should not be advanced"
+    # ``debug_id`` is the platform's GeneratedID field, not a
+    # sub-reading; the override doesn't reach it and the default
+    # classification still applies.
+    assert by_key["debug_id"]["advanced"] is True


### PR DESCRIPTION
# What does this implement/fix?

Platform sensors (DHT, debug, ADS1115, ...) expose their readings as optional nested fields keyed on the reading name; `_classify_advanced` defaulted those to `advanced=True`, so every sub-reading was hidden under "Show advanced settings" and the platform's main form looked empty. Users thought they added the wrong component. This forces `advanced=False` for any field whose schema extends `sensor._SENSOR_SCHEMA`, `binary_sensor._BINARY_SENSOR_SCHEMA`, or `text_sensor._TEXT_SENSOR_SCHEMA` (the bundle already carries that signal under `schema.extends`; no live introspection needed). The existing `renderNestedField` then renders the sub-readings as collapsed-with-chevron cards on the main form; click a chevron to expand and edit, type a name to materialise the reading in YAML.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/983

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
