### PR TITLE
Update esphome-docs references to esphome.io after repo rename

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,7 +209,7 @@ narrow live `esphome` introspection cover most fields; `multi_conf`,
 `platform_defaults`, `supported_platforms`, type refinement (boolean / float
 recovery), and `unit_of_measurement` autocomplete options come from the live
 package. Component-level descriptions and titles fall back to the docs MDX
-(`esphome-docs` shallow clone) when the schema's index is sparse.
+(`esphome.io` shallow clone) when the schema's index is sparse.
 
 The same script runs nightly via
 [`.github/workflows/sync-component-catalog.yml`](../.github/workflows/sync-component-catalog.yml)

--- a/script/check_catalog.py
+++ b/script/check_catalog.py
@@ -275,7 +275,7 @@ def _check_no_field_bullet_descriptions(catalog: ComponentCatalog) -> list[str]:
 
     The pattern is imported from ``script/sync_components.py`` so a widening
     on the sync side automatically tightens the check side — they cannot
-    drift apart. Triggered when the upstream esphome-docs schema_doc bug
+    drift apart. Triggered when the upstream esphome.io schema_doc bug
     leaks past ``_repair_field_bullet_descriptions``.
     """
     failures: list[str] = []

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -67,12 +67,12 @@ _CACHE_ROOT = _REPO_ROOT / ".cache"
 _RELEASES_API = "https://api.github.com/repos/esphome/esphome-schema/releases"
 _SCHEMA_URL_TEMPLATE = "https://schema.esphome.io/{version}/schema.zip"
 _DOCS_INDEX_URL = (
-    "https://raw.githubusercontent.com/esphome/esphome-docs/current/"
+    "https://raw.githubusercontent.com/esphome/esphome.io/current/"
     "src/content/docs/components/index.mdx"
 )
-_DOCS_REPO_URL = "https://github.com/esphome/esphome-docs.git"
+_DOCS_REPO_URL = "https://github.com/esphome/esphome.io.git"
 _DOCS_REPO_BRANCH = "current"
-_DOCS_CLONE_DIR = "esphome-docs"
+_DOCS_CLONE_DIR = "esphome.io"
 _IMAGE_BASE_URL = "https://esphome.io/images/"
 
 # CDN at schema.esphome.io rejects requests without a recognisable
@@ -982,7 +982,7 @@ def build_catalog(
                 continue
             out.append(entry)
 
-    # Workaround for an upstream esphome-docs bug: see
+    # Workaround for an upstream esphome.io bug: see
     # ``_repair_field_bullet_descriptions``.
     _repair_field_bullet_descriptions(out)
 
@@ -1023,7 +1023,7 @@ def _repair_field_bullet_descriptions(entries: list[dict]) -> None:
     """
     Repair descriptions baked from a stray first bullet of an MDX list.
 
-    Workaround for an upstream bug in ``esphome-docs``'s
+    Workaround for an upstream bug in ``esphome.io``'s
     ``script/schema_doc.py``: when an MDX page documents a platform
     component with ``## <Platform>`` -> ``### Configuration variables``
     (no prose intro between the two headings -- ``debug.mdx`` is the
@@ -1073,7 +1073,7 @@ def _repair_field_bullet_descriptions(entries: list[dict]) -> None:
     if repaired or cleared:
         _LOGGER.info(
             "Repaired %d field-bullet description(s) from umbrella, cleared %d "
-            "(upstream esphome-docs bug)",
+            "(upstream esphome.io bug)",
             repaired,
             cleared,
         )
@@ -1286,7 +1286,7 @@ def _load_mdx_descriptions() -> dict[str, str]:
     Falls back to the first prose paragraph when the frontmatter
     description is missing.
 
-    Caches the cloned docs repo in ``.cache/esphome-docs/`` so re-runs
+    Caches the cloned docs repo in ``.cache/esphome.io/`` so re-runs
     don't refetch.
     """
     docs_dir = _ensure_docs_repo()
@@ -1482,7 +1482,7 @@ def _extract_mdx_field_descriptions(text: str) -> dict[str, str]:  # noqa: C901
 
 
 def _ensure_docs_repo() -> Path | None:
-    """Clone or update the esphome-docs repo (shallow). Returns its path."""
+    """Clone or update the esphome.io repo (shallow). Returns its path."""
     import subprocess
 
     target = _CACHE_ROOT / _DOCS_CLONE_DIR
@@ -1501,7 +1501,7 @@ def _ensure_docs_repo() -> Path | None:
         return target
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    _LOGGER.info("Cloning esphome-docs (shallow) to %s", target)
+    _LOGGER.info("Cloning esphome.io (shallow) to %s", target)
     try:
         subprocess.run(
             [
@@ -1518,7 +1518,7 @@ def _ensure_docs_repo() -> Path | None:
             timeout=120,
         )
     except Exception:
-        _LOGGER.warning("Could not clone esphome-docs — descriptions stay empty")
+        _LOGGER.warning("Could not clone esphome.io — descriptions stay empty")
         return None
     return target
 
@@ -1617,7 +1617,7 @@ def load_image_map() -> dict[str, str]:
     No ImagesMap if the docs file can't be fetched — image_url stays
     empty for every component.
     """
-    cache_file = _CACHE_ROOT / "esphome-docs-index.mdx"
+    cache_file = _CACHE_ROOT / "esphome.io-index.mdx"
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     if not cache_file.exists():
         try:


### PR DESCRIPTION
# What does this implement/fix?

The upstream `esphome/esphome-docs` repository has been renamed to `esphome/esphome.io`. Update direct references — GitHub URLs (clone + raw), local cache directory names, log messages, and docstring/comment mentions — to the new name. GitHub still redirects the old URL, but pinning the canonical name keeps the catalog sync wiring honest and the on-disk cache directory aligned with the upstream repo name.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.