### PR TITLE
Skip PR Labels check for bot-authored PRs

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -6,6 +6,10 @@ name: PR Labels
 # the "Types of changes" checkbox in the PR template and apply it
 # automatically — most external contributors can't label their own
 # PRs. The job only fails when no checkbox is ticked.
+#
+# Bot-authored PRs (dependabot, pre-commit-ci, …) don't fill in the
+# PR template; they tag themselves with the appropriate label
+# directly, so the job skips them.
 
 # yamllint disable-line rule:truthy
 on:
@@ -26,7 +30,9 @@ jobs:
   apply_label:
     name: Apply
     runs-on: ubuntu-latest
-    if: github.event.pull_request.state == 'open'
+    if: >-
+      github.event.pull_request.state == 'open'
+      && github.event.pull_request.user.type != 'Bot'
     steps:
       - name: 🏷 Apply label from PR description checkbox
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Dependabot and pre-commit-ci don't fill in the PR template, so the PR Labels job fails on their PRs (e.g. #1002); they already self-apply the right label (`dependencies` / `ci`), so the workflow now skips PRs whose author type is `Bot`.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.json` has **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
