### PR TITLE
CLAUDE.md: document the dev-server pair for empirical browser testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,66 @@ the official ESPHome container and Home Assistant add-on.
   cross-platform CI commands on a single line, or use PowerShell-
   compatible backtick continuations.
 
+## Empirical browser testing
+
+When a change needs the live dashboard for verification (UI
+behaviour, WS round-trip shape, end-to-end flows), pair this
+backend with its companion frontend dev server. Tests verify
+correctness; the browser verifies what the user actually sees.
+
+**Two-process setup.**
+
+1. Backend on `:6052` in dev mode:
+
+   ```bash
+   .venv/bin/python -m esphome_device_builder --dev configs
+   ```
+
+   `--dev` serves `index.html` with `Cache-Control: no-cache`
+   so a rebuilt frontend bundle isn't masked by a stale SPA
+   shell.
+
+2. Frontend dev server in the **paired** frontend checkout
+   (`device-builder_2` pairs with `device-builder-frontend_2`,
+   etc.). The default port is 5173:
+
+   ```bash
+   cd ../device-builder-frontend_2
+   npm run dev
+   ```
+
+   The dev server proxies `/ws` to `http://localhost:6052`,
+   so the backend started above is what answers. HMR is on,
+   so a saved `.ts` source reloads in-place — no need to
+   restart between iterations.
+
+   If 5173 is already taken (a parallel session, or the user's
+   own browser is attached to an existing dev server), pass
+   `PORT=5174` (or another free port) to `npm run dev`.
+   Configure the *frontend dev server* port; the backend
+   stays on 6052 and the proxy still works.
+
+**Run both in the background** (Claude should use
+`run_in_background`) and `lsof -iTCP:6052 -sTCP:LISTEN` /
+`lsof -iTCP:5174 -sTCP:LISTEN` to wait for both to be listening
+before telling the user the dev URL. Then point the user at
+`http://localhost:<frontend-port>/`.
+
+**Cleanup.** When the user is done, kill both processes:
+
+```bash
+lsof -iTCP:6052 -iTCP:5174 -sTCP:LISTEN -t | xargs kill
+```
+
+**Alternative: production-shape testing.** When you want the
+backend to serve the actual built bundle (closer to what ships),
+build the frontend with `npm run build` in the paired checkout —
+the build output lands in the `esphome_device_builder_frontend`
+site-packages dir the backend reads from `_get_frontend_dir`. No
+proxy needed, just browse to `http://localhost:6052/`. Use the
+dev-server path for fast iteration; use the built path when you
+want to verify the bundle the user will actually receive.
+
 ## Comparison with the legacy esphome dashboard
 
 The legacy Tornado-based dashboard (`esphome/dashboard/` in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,12 +233,12 @@ correctness; the browser verifies what the user actually sees.
    so a rebuilt frontend bundle isn't masked by a stale SPA
    shell.
 
-2. Frontend dev server in the **paired** frontend checkout
-   (`device-builder_2` pairs with `device-builder-frontend_2`,
-   etc.). The default port is 5173:
+2. Frontend dev server in a checkout of the companion repo
+   ([`esphome/device-builder-frontend`](https://github.com/esphome/device-builder-frontend)).
+   The default port is 5173:
 
    ```bash
-   cd ../device-builder-frontend_2
+   cd <path-to-device-builder-frontend>
    npm run dev
    ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,22 +253,30 @@ correctness; the browser verifies what the user actually sees.
    Configure the *frontend dev server* port; the backend
    stays on 6052 and the proxy still works.
 
-**Run both in the background** (Claude should use
-`run_in_background`) and `lsof -iTCP:6052 -sTCP:LISTEN` /
-`lsof -iTCP:5174 -sTCP:LISTEN` to wait for both to be listening
-before telling the user the dev URL. Then point the user at
-`http://localhost:<frontend-port>/`.
+**Run both in the background.** If you're driving this via
+Claude Code (the agent harness this file is written for), use
+`Bash` with `run_in_background: true` so the long-lived
+processes don't block the conversation; otherwise use whatever
+your shell offers (`nohup … &`, `tmux`, a separate terminal).
 
-**Cleanup.** When the user is done, kill both processes:
+**Wait for both before telling the user the URL.** Poll
+`lsof -iTCP:6052 -sTCP:LISTEN` for the backend and
+`lsof -iTCP:<frontend-port> -sTCP:LISTEN` for the frontend
+(`<frontend-port>` is whatever you started the dev server on:
+5173 by default, or your `PORT=` override). Once both report
+LISTEN, point the user at `http://localhost:<frontend-port>/`.
+
+**Cleanup.** When the user is done, kill both processes (again
+substituting the actual `<frontend-port>` you used):
 
 ```bash
-lsof -iTCP:6052 -iTCP:5174 -sTCP:LISTEN -t | xargs kill
+lsof -iTCP:6052 -iTCP:<frontend-port> -sTCP:LISTEN -t | xargs kill
 ```
 
 **Alternative: production-shape testing.** When you want the
 backend to serve the actual built bundle (closer to what ships),
-build the frontend with `npm run build` in the paired checkout —
-the build output lands in the `esphome_device_builder_frontend`
+run `npm run build` in the companion frontend checkout — the
+build output lands in the `esphome_device_builder_frontend`
 site-packages dir the backend reads from `_get_frontend_dir`. No
 proxy needed, just browse to `http://localhost:6052/`. Use the
 dev-server path for fast iteration; use the built path when you


### PR DESCRIPTION
# What does this implement/fix?

Captures the two-process dev-server workflow we landed on while shipping the lazy-bodies + batch fetch rework on #939 and esphome/device-builder-frontend#424.

When a change needs the live dashboard for verification (UI behaviour, WS round-trip shape, end-to-end flows), pair this backend's `--dev` mode with the companion frontend dev server in the paired checkout (`device-builder_2` pairs with `device-builder-frontend_2`, etc.). The frontend dev server proxies `/ws` to `localhost:6052`, so the backend started here is what answers; HMR removes the restart-between-changes loop. Doc covers the port-collision fallback (`PORT=5174` when 5173 is taken), running both in the background, waiting for `lsof -sTCP:LISTEN` before announcing the URL, the one-line teardown, and the production-shape alternative via `npm run build` into the site-packages dir for verifying the bundle the user actually ships with.

The tests-verify-correctness vs browser-verifies-what-the-user-sees framing is the why; doing this once meant several rounds of trial-and-error during #939 that future contributors shouldn't have to repeat.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
