### PR TITLE
Document that backend issues are often frontend bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,21 @@ API server that replaces the legacy `esphome dashboard`. Single
 multiplexed `/ws` endpoint, persistent firmware-job queue, mDNS +
 ping device discovery, schema-driven component catalog, curated
 board catalog. Frontend is a separate repo
-(`esphome/device-builder-dashboard-frontend`) and ships prebuilt
+(`esphome/device-builder-frontend`) and ships prebuilt
 inside our wheel.
+
+**Issues filed here are often frontend bugs.** Users file every
+dashboard bug against this backend repo — it's the project they
+installed — but the Visual Editor, component-catalog rendering, and
+YAML-form UI all live in the `esphome/device-builder-frontend` SPA.
+When triaging an issue, check whether the symptom is UI / editor
+behaviour before assuming a backend fix, and trace both sides: the
+backend can parse and emit correctly while the frontend's rendering
+or value-sync drops the data. A frontend fix is a PR against
+`esphome/device-builder-frontend` (base `main`) that links
+`fixes <this repo's issue URL>` cross-repo. Example: issue #1005
+(dotted `logger.logs` map keys lost in the Visual Editor) was a
+frontend `data-field-key` round-trip bug, not a backend one.
 
 Base functions are in late beta; remote / offload functions are in
 early beta. Expect undocumented breaking changes until the project


### PR DESCRIPTION
# What does this implement/fix?

Adds a note to CLAUDE.md, under "What this project is", that bugs filed against this backend repo are often frontend bugs whose fix belongs in `esphome/device-builder-frontend`; users file every dashboard bug here since it's the project they installed, but the Visual Editor, catalog rendering, and YAML-form UI live in the frontend SPA. The note tells a triager to check whether the symptom is UI behaviour and to trace both sides before assuming a backend fix, using issue #1005 (dotted `logger.logs` map keys) as the example. Also corrects the frontend repo name in the same paragraph to `esphome/device-builder-frontend` to match the current remote.

**Related issue or feature (if applicable):**

- Doc follow-up to the esphome/device-builder#1005 investigation; no issue to close.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
