### PR TITLE
Isolate emit-split roundtrip test to the pin_features rejection

### DIFF
--- a/tests/test_sync_components_emit_split.py
+++ b/tests/test_sync_components_emit_split.py
@@ -28,6 +28,11 @@ def test_emit_split_catalog_refuses_body_that_fails_mashumaro_roundtrip(
             "id": "stepper.bench",
             "name": "Bench Stepper",
             "category": "stepper",
+            # ``description`` is required with no default; without it
+            # from_dict would fail on the missing field before ever
+            # reaching ``pin_features``, so the test would pass even if
+            # the bad value below were replaced with a valid one.
+            "description": "",
             "config_entries": [
                 {
                     "key": "dir_pin",


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1011 addressing review comments that landed after merge.

The `test_emit_split_catalog_refuses_body_that_fails_mashumaro_roundtrip` fixture was missing the required `description` field, so `ComponentCatalogEntry.from_dict` raised on the absent field before it ever evaluated `pin_features`; the test passed for the wrong reason and would have stayed green even if the bad `pin_features` value were replaced with a valid one. Adding `description` isolates the assertion to the `pin_features` rejection it claims to pin.

The other two review notes need no change; the lstat/resolve rationale comment is already present on main (the bot reviewed an intermediate commit), and the index entries are already covered by the `is_unsafe_component_id` loop, which runs over the whole catalog and raises before the index payload is built.

**Related issue or feature (if applicable):**

- follow-up to #1011

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
