### PR TITLE
Resolve area and comment from StorageJSON for nested substitutions

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -179,6 +179,13 @@ _has_native_wifi = _select_wifi_helper(_esphome_has_native_wifi)
 # matches ``$name`` or ``${name}`` where name is alphanumeric + underscore.
 _SUBSTITUTION_RE = re.compile(r"\$(\{[a-zA-Z0-9_]*\}|[a-zA-Z0-9_]+)")
 
+# "Looks like an unresolved substitution token" — any ``${...}`` (incl. the
+# nested jinja ``${device.area}`` form ``_SUBSTITUTION_RE`` deliberately
+# won't match) or ``$identifier``. Excludes a literal ``$`` followed by a
+# digit / space / punctuation (e.g. ``"Replaces a $40 sensor"``) so a
+# fully-resolved edit carrying a literal ``$`` isn't mistaken for one.
+_UNRESOLVED_SUBSTITUTION_RE = re.compile(r"\$\{|\$[a-zA-Z_]")
+
 # Cap on recursive substitution passes — protects against circular
 # references (``a: ${b}`` / ``b: ${a}``) without bailing on legitimately
 # deep chains a user might write.
@@ -733,6 +740,23 @@ def parse_esphome_meta(
     return meta["name"], meta["friendly_name"], meta["comment"], meta["area"]
 
 
+def _effective_meta(yaml_value: str | None, storage_value: str | None) -> str | None:
+    """
+    Pick the metadata to display, preferring a resolved value.
+
+    The raw-text YAML read reflects unsaved edits immediately, so it
+    wins when fully resolved. A value still holding a substitution token
+    (a nested ``${device.area}`` the raw reader can't expand) defers to
+    StorageJSON, which esphome resolved at build time. A literal ``$``
+    that isn't substitution-shaped doesn't count as unresolved.
+    """
+    if yaml_value is not None and not _UNRESOLVED_SUBSTITUTION_RE.search(yaml_value):
+        return yaml_value
+    if storage_value:
+        return storage_value
+    return yaml_value
+
+
 # ---------------------------------------------------------------------------
 # Device construction
 # ---------------------------------------------------------------------------
@@ -839,14 +863,17 @@ def load_device_from_storage(
     )
 
     storage_friendly = storage.friendly_name if storage else None
-    friendly_name = yaml_friendly if yaml_friendly is not None else (storage_friendly or name)
+    ef_friendly = _effective_meta(yaml_friendly, storage_friendly)
+    friendly_name = ef_friendly if ef_friendly is not None else name
 
     storage_comment = storage.comment if storage else None
-    comment = yaml_comment if yaml_comment is not None else storage_comment
+    comment = _effective_meta(yaml_comment, storage_comment)
 
-    # ``esphome.area`` only lives in the YAML — StorageJSON doesn't carry
-    # it, so there's no fallback. Empty string when absent.
-    area = yaml_area or ""
+    # ``StorageJSON`` carries ``area`` on esphome builds that persist it
+    # (resolved post-compile); ``getattr`` falls through to the raw YAML
+    # token on older builds and never-compiled devices.
+    storage_area = getattr(storage, "area", None) if storage else None
+    area = _effective_meta(yaml_area, storage_area) or ""
 
     yaml_mtime = path.stat().st_mtime if path.exists() else None
     bin_mtime: float | None = None

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1551,6 +1551,124 @@ def test_load_device_local_substitution_wins_over_package(tmp_path: Path) -> Non
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_unresolved_comment_defers_to_storage(tmp_path: Path) -> None:
+    """An unresolved ``${...}`` comment uses the compiled StorageJSON value."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        "  device:\n"
+        '    comment: "Front Room"\n'
+        "esphome:\n"
+        "  name: lamp\n"
+        "  comment: ${device.comment}\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml", overrides={"comment": "Front Room"})
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.comment == "Front Room"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_unresolved_friendly_name_defers_to_storage(tmp_path: Path) -> None:
+    """An unresolved ``${...}`` friendly_name uses the compiled StorageJSON value."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        "  device:\n"
+        '    friendly_name: "Front Room"\n'
+        "esphome:\n"
+        "  name: lamp\n"
+        "  friendly_name: ${device.friendly_name}\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml", overrides={"friendly_name": "Front Room"})
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.friendly_name == "Front Room"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_area_from_storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``area`` comes from StorageJSON when the YAML value is unresolved."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        "  device:\n"
+        '    area: "Living Room"\n'
+        "esphome:\n"
+        "  name: lamp\n"
+        "  area: ${device.area}\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml")
+
+    # The pinned esphome's ``_load_impl`` doesn't read ``area`` yet, so
+    # simulate the future build output (esphome/esphome#16710) by setting
+    # it on the loaded StorageJSON.
+    real_load = device_yaml.StorageJSON.load
+
+    def _load_with_area(path: Path) -> Any:
+        storage = real_load(path)
+        if storage is not None:
+            storage.area = "Living Room"
+        return storage
+
+    monkeypatch.setattr(device_yaml.StorageJSON, "load", staticmethod(_load_with_area))
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.area == "Living Room"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_resolved_yaml_meta_wins_over_storage(tmp_path: Path) -> None:
+    """A fully resolved YAML value still beats StorageJSON (immediate edits)."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "esphome:\n  name: lamp\n  comment: Edited In Editor\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml", overrides={"comment": "Old Compiled"})
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.comment == "Edited In Editor"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_cleared_comment_not_replaced_by_storage(tmp_path: Path) -> None:
+    """An explicitly cleared ``comment: ""`` stays empty, not refilled from storage."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        'esphome:\n  name: lamp\n  comment: ""\n',
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml", overrides={"comment": "Old Compiled"})
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.comment == ""
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_literal_dollar_comment_is_not_unresolved(tmp_path: Path) -> None:
+    """A literal ``$`` that isn't substitution-shaped still wins over storage."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        'esphome:\n  name: lamp\n  comment: "Replaces a $40 sensor"\n',
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml", overrides={"comment": "Old Compiled"})
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.comment == "Replaces a $40 sensor"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
 def test_load_device_records_firmware_bin_mtime_when_present(tmp_path: Path) -> None:
     """``bin_mtime`` is populated when the firmware binary actually exists on disk.
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes the area and comment fields not resolving when they reference a nested, jinja key-value substitution such as `${device.area}` (where `substitutions` defines `device` as a mapping).

The raw-text metadata reader can't expand that form, so an unresolved `${...}` token was being used verbatim and shadowing the value esphome had already resolved at build time. This change defers to the StorageJSON value whenever the YAML value still carries an unresolved `${...}`, so a fully resolved YAML edit still wins for immediate feedback but a stale token no longer hides the compiled value. It also reads `area` from StorageJSON, which previously had no fallback at all; that field is populated by the companion esphome change esphome/esphome#16710, read here via getattr so it is forward compatible and the esphome dependency is not bumped.

Note: the metadata resolves after a compile (StorageJSON is build output); a never-compiled device with a nested substitution still shows the raw token until its first build.

`device_yaml.py` is already over the 800 line soft cap; this is a small bugfix, so per the cap policy it does not include a split.

**Related issue or feature (if applicable):**

- fixes #1010

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
