### PR TITLE
Route metadata + job-log writes through atomic_write

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -33,6 +33,7 @@ from esphome.util import get_serial_ports
 from ..constants import DEFAULT_INGRESS_PORT, DEFAULT_REMOTE_BUILD_PORT
 from ..constants import __version__ as server_version
 from ..helpers.api import CommandError, api_command
+from ..helpers.atomic_io import atomic_write
 from ..helpers.auth import hash_password
 from ..helpers.json import JSONDecodeError, dumps_indent, loads
 from ..helpers.secrets_state import (
@@ -391,20 +392,9 @@ def _load_metadata(config_dir: Path) -> dict[str, Any]:
 
 
 def _save_metadata(config_dir: Path, data: dict[str, Any]) -> None:
-    path = config_dir / _METADATA_FILE
-    # tempfile + Path.replace so lock-free readers never observe a partial write.
-    fd, tmp_name = tempfile.mkstemp(prefix=f"{_METADATA_FILE}.", suffix=".tmp", dir=str(config_dir))
-    tmp_path = Path(tmp_name)
-    try:
-        # ``dumps_indent`` yields bytes, so open the temp file in
-        # binary mode. The on-disk file stays readable / diffable.
-        with os.fdopen(fd, "wb") as fh:
-            fh.write(dumps_indent(data))
-        tmp_path.replace(path)
-    except Exception:
-        with suppress(OSError):
-            tmp_path.unlink()
-        raise
+    # Atomic so lock-free readers never observe a partial write.
+    # ``dumps_indent`` yields bytes; the on-disk file stays readable / diffable.
+    atomic_write(config_dir / _METADATA_FILE, dumps_indent(data))
 
 
 def get_board_id(config_dir: Path, filename: str) -> str:

--- a/esphome_device_builder/controllers/firmware/persistence.py
+++ b/esphome_device_builder/controllers/firmware/persistence.py
@@ -15,15 +15,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import os
 import re
-import tempfile
 from operator import attrgetter
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from esphome.core import CORE
 
+from ...helpers.atomic_io import atomic_write
 from ...models import TERMINAL_JOB_STATUSES, FirmwareJob, JobStatus
 from ..config import _load_metadata, metadata_transaction
 from .constants import (
@@ -239,20 +238,12 @@ def _job_log_path(job_id: str) -> Path:
 
 
 def _write_job_sidecar(job_id: str, lines: list[str]) -> None:
-    """Atomically write *lines* (each carrying its own terminator) to the sidecar."""
-    path = _job_log_path(job_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f"{job_id}.", suffix=".tmp")
-    try:
-        # ``newline=""`` disables universal-newline translation so a
-        # bare ``\r`` progress terminator survives the write verbatim.
-        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
-            fh.write("".join(lines))
-        Path(tmp).replace(path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            Path(tmp).unlink()
-        raise
+    r"""Atomically write *lines* (each carrying its own terminator) to the sidecar.
+
+    Encodes to UTF-8 bytes and writes binary so no newline translation
+    can rewrite a bare ``\r`` progress terminator.
+    """
+    atomic_write(_job_log_path(job_id), "".join(lines).encode("utf-8"), make_parents=True)
 
 
 def _reconcile_sidecars(valid_ids: set[str]) -> None:

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -19,7 +19,9 @@ import tempfile
 from pathlib import Path
 
 
-def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
+def atomic_write(
+    path: Path, data: bytes, *, mode: int | None = None, make_parents: bool = False
+) -> None:
     """
     Write *data* to *path* atomically.
 
@@ -27,7 +29,12 @@ def atomic_write(path: Path, data: bytes, *, mode: int | None = None) -> None:
     place. Readers see either the old or new bytes, never a
     truncated file. ``mode`` is applied to the staging file before
     the rename; ``Path.replace`` carries that mode to the destination.
+    ``make_parents`` creates ``path.parent`` (and any missing
+    ancestors) first, for callers whose target directory may not
+    exist yet.
     """
+    if make_parents:
+        path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_str = tempfile.mkstemp(
         prefix=path.name + ".",
         suffix=".tmp",

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -56,6 +56,21 @@ def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
     assert target.read_bytes() == b"new"
 
 
+def test_atomic_write_make_parents_creates_missing_dirs(tmp_path: Path) -> None:
+    """``make_parents=True`` creates the target's missing ancestor dirs first."""
+    target = tmp_path / "a" / "b" / "demo.bin"
+    atomic_write(target, b"payload", make_parents=True)
+    assert target.read_bytes() == b"payload"
+
+
+def test_atomic_write_without_make_parents_raises_on_missing_dir(tmp_path: Path) -> None:
+    """Without ``make_parents`` a missing target directory surfaces as an error."""
+    target = tmp_path / "missing" / "demo.bin"
+    with pytest.raises(OSError):
+        atomic_write(target, b"payload")
+    assert not target.exists()
+
+
 def test_atomic_write_closes_fd_when_fdopen_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`_save_metadata` (controllers/config.py) and the firmware job-log sidecar writer `_write_job_sidecar` (controllers/firmware/persistence.py) each hand-rolled the same `mkstemp` plus write plus `Path.replace` plus unlink-on-error sequence that `helpers/atomic_io.py::atomic_write` already provides. This routes both through `atomic_write`, so there is one tested implementation of the atomic-write dance instead of three.

`atomic_write` gains a `make_parents` kwarg for the sidecar case, where the `dashboard-jobs/` directory may not exist yet; the sidecar encodes its lines to UTF-8 bytes so the binary write preserves bare carriage returns exactly as the previous `newline=""` text write did. No behavior change; the only `mkstemp` call sites left are `atomic_write` itself.

**Related issue or feature (if applicable):**

- follow-up to #1024

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-dashboard-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
