### PR TITLE
Defer dashboard_import and esphome.bundle off the event loop

### DIFF
--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -8,11 +8,11 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from esphome import const
-from esphome.components.dashboard_import import import_config
 from esphome.storage_json import ignored_devices_storage_path
 
 from ...helpers.api import CommandError
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
+from ...helpers.lazy_module import async_import_module
 from ...models import (
     AdoptableDevice,
     DeviceState,
@@ -58,10 +58,17 @@ async def import_device(
     )
     network = adoptable.network if adoptable and adoptable.network else const.CONF_WIFI
     loop = asyncio.get_running_loop()
+    # ``esphome.components.dashboard_import`` pulls in ~14 MB of
+    # upstream code; load it through ``async_import_module`` so
+    # the first adoption pays the cost on the dedicated import
+    # thread (no event loop block, no concurrent-import race) and
+    # sessions that never adopt a device skip the load entirely.
+    dashboard_import = await async_import_module("esphome.components.dashboard_import")
+
     try:
         await loop.run_in_executor(
             None,
-            import_config,
+            dashboard_import.import_config,
             path,
             name,
             friendly_name,

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import asyncio
 import binascii
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -585,8 +586,11 @@ class SubmitJobReceiver:
 
         # ``esphome.bundle`` is ~1 MB of upstream code; load it through
         # the shared lazy-import executor so the receiver's idle resident
-        # set stays lean until a peer-link offload actually lands.
+        # set stays lean until a peer-link offload actually lands. Pass
+        # the resolved callable into the executor so the worker doesn't
+        # rely on a preload-ordering invariant in this caller.
         bundle = await async_import_module("esphome.bundle")
+        prepare = bundle.prepare_bundle_for_compile
         loop = asyncio.get_running_loop()
         try:
             configuration = await loop.run_in_executor(
@@ -597,6 +601,7 @@ class SubmitJobReceiver:
                 target_dir,
                 remote_builds_root,
                 self._config_dir,
+                prepare,
             )
         except _PathEscapeError as exc:
             _LOGGER.warning(
@@ -750,6 +755,7 @@ def _validate_write_extract_bundle(
     target_dir: Path,
     remote_builds_root: Path,
     config_dir: Path,
+    prepare_bundle_for_compile: Callable[[Path, Path], Path],
 ) -> str:
     """Sync helper: validate path, write tarball, extract, return wire-shape ``configuration``.
 
@@ -793,11 +799,6 @@ def _validate_write_extract_bundle(
         raise _PathEscapeError(str(target_dir)) from exc
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
-    # ``esphome.bundle`` was pre-loaded by the async caller through
-    # ``async_import_module`` (lazy-import executor), so this import is a
-    # ``sys.modules`` hit; no concurrent-import race on the worker pool.
-    from esphome.bundle import prepare_bundle_for_compile  # noqa: PLC0415
-
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
     # ``as_posix`` keeps the wire-side ``configuration`` string
     # stable across receiver platforms — ``str(rel_yaml)`` would

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -62,8 +62,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from esphome.bundle import EsphomeError, prepare_bundle_for_compile
-
+from ...helpers.lazy_module import async_import_module
 from ...helpers.peer_link_bundle import (
     BundleAssembler,
     BundleAssemblerError,
@@ -584,6 +583,10 @@ class SubmitJobReceiver:
         bundle_path = key.bundle(self._config_dir)
         remote_builds_root = self._config_dir / REMOTE_BUILDS_SUBDIR
 
+        # ``esphome.bundle`` is ~1 MB of upstream code; load it through
+        # the shared lazy-import executor so the receiver's idle resident
+        # set stays lean until a peer-link offload actually lands.
+        bundle = await async_import_module("esphome.bundle")
         loop = asyncio.get_running_loop()
         try:
             configuration = await loop.run_in_executor(
@@ -602,7 +605,7 @@ class SubmitJobReceiver:
                 target_dir,
             )
             raise _SubmitJobRejectionError(_REASON_INVALID_HEADER) from exc
-        except (EsphomeError, OSError) as exc:
+        except (bundle.EsphomeError, OSError) as exc:
             _LOGGER.warning(
                 "submit_job from %s: extract failed for job %s (%s): %s",
                 session.dashboard_id,
@@ -790,6 +793,11 @@ def _validate_write_extract_bundle(
         raise _PathEscapeError(str(target_dir)) from exc
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
+    # ``esphome.bundle`` was pre-loaded by the async caller through
+    # ``async_import_module`` (lazy-import executor), so this import is a
+    # ``sys.modules`` hit; no concurrent-import race on the worker pool.
+    from esphome.bundle import prepare_bundle_for_compile  # noqa: PLC0415
+
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)
     # ``as_posix`` keeps the wire-side ``configuration`` string
     # stable across receiver platforms — ``str(rel_yaml)`` would

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -58,7 +58,6 @@ from __future__ import annotations
 import asyncio
 import binascii
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -80,6 +79,8 @@ from ...models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..firmware import FirmwareController
     from .peer_link import PeerLinkSession
 

--- a/esphome_device_builder/helpers/lazy_module.py
+++ b/esphome_device_builder/helpers/lazy_module.py
@@ -2,11 +2,17 @@
 
 Concurrent imports across threads aren't safe in CPython before
 3.15; an executor pool that runs more than one import in parallel
-can deadlock or observe half-initialised module state. Mirroring
-``homeassistant.helpers.importlib``, this helper routes every lazy
-import through a ``ThreadPoolExecutor(max_workers=1)`` so only one
-import is ever in flight, and dedupes concurrent callers through a
-per-module future.
+can deadlock or observe half-initialised module state. This helper
+routes every lazy import through a ``ThreadPoolExecutor(max_workers=1)``
+so only one import is ever in flight, then caches the resolved
+module so steady-state callers skip the executor hop entirely.
+
+Two concurrent first-callers each submit their own ``importlib``
+hop; the second runs after the first has populated ``sys.modules``
+and so is a hash-table lookup. The simpler shape avoids the
+shared-future / first-caller-cancellation poisoning concerns of
+the future-dedup variant (cf. ``homeassistant.helpers.importlib``)
+while keeping the single-thread import guarantee.
 
 Used to keep heavy esphome subpackages (``dashboard_import``,
 ``bundle``) out of the dashboard's resident set when the
@@ -17,13 +23,11 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import sys
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
 
 _import_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ImportExecutor")
 _cache: dict[str, ModuleType] = {}
-_futures: dict[str, asyncio.Future[ModuleType]] = {}
 
 
 def _get_module(name: str) -> ModuleType:
@@ -33,37 +37,14 @@ def _get_module(name: str) -> ModuleType:
 
 
 async def async_import_module(name: str) -> ModuleType:
-    """Import *name* off the event loop, deduping concurrent calls.
+    """Import *name* off the event loop and cache the resolved module.
 
-    First caller submits the import to the dedicated single-thread
-    executor; concurrent callers await the same future. Subsequent
-    calls hit the in-process cache directly.
+    Steady-state callers hit ``_cache`` directly. Cold callers hop
+    onto the dedicated single-thread import executor; concurrent
+    first-callers serialise on the executor pool and the second
+    run finds the module already in ``sys.modules``.
     """
     if (module := _cache.get(name)) is not None:
         return module
-    if (future := _futures.get(name)) is not None:
-        return await future
-    if name in sys.modules:
-        cached = sys.modules[name]
-        _cache[name] = cached
-        return cached
-
     loop = asyncio.get_running_loop()
-    future = loop.create_future()
-    _futures[name] = future
-    try:
-        module = await loop.run_in_executor(_import_executor, _get_module, name)
-        future.set_result(module)
-    except Exception as ex:
-        # Only fan out real import failures (ModuleNotFoundError etc.) to
-        # concurrent waiters. ``CancelledError`` is intentionally not
-        # forwarded — cancelling the first caller's await on the executor
-        # would otherwise poison every waiter even though the underlying
-        # import may have completed on the worker thread; let waiters
-        # retry through ``_cache`` / ``sys.modules`` on the next loop.
-        future.set_exception(ex)
-        future.exception()  # mark retrieved so a sole consumer doesn't warn
-        raise
-    finally:
-        del _futures[name]
-    return module
+    return await loop.run_in_executor(_import_executor, _get_module, name)

--- a/esphome_device_builder/helpers/lazy_module.py
+++ b/esphome_device_builder/helpers/lazy_module.py
@@ -9,9 +9,8 @@ import is ever in flight, and dedupes concurrent callers through a
 per-module future.
 
 Used to keep heavy esphome subpackages (``dashboard_import``,
-``components.esp32``, ``components.libretiny``, ``bundle``) out of
-the dashboard's resident set when the corresponding feature isn't
-exercised in a session.
+``bundle``) out of the dashboard's resident set when the
+corresponding feature isn't exercised in a session.
 """
 
 from __future__ import annotations
@@ -55,7 +54,13 @@ async def async_import_module(name: str) -> ModuleType:
     try:
         module = await loop.run_in_executor(_import_executor, _get_module, name)
         future.set_result(module)
-    except BaseException as ex:
+    except Exception as ex:
+        # Only fan out real import failures (ModuleNotFoundError etc.) to
+        # concurrent waiters. ``CancelledError`` is intentionally not
+        # forwarded — cancelling the first caller's await on the executor
+        # would otherwise poison every waiter even though the underlying
+        # import may have completed on the worker thread; let waiters
+        # retry through ``_cache`` / ``sys.modules`` on the next loop.
         future.set_exception(ex)
         future.exception()  # mark retrieved so a sole consumer doesn't warn
         raise

--- a/esphome_device_builder/helpers/lazy_module.py
+++ b/esphome_device_builder/helpers/lazy_module.py
@@ -1,22 +1,9 @@
-"""Off-loop module loading with a dedicated single-thread executor.
+"""
+Lazy module loader: one in-flight import at a time, cached on success.
 
-Concurrent imports across threads aren't safe in CPython before
-3.15; an executor pool that runs more than one import in parallel
-can deadlock or observe half-initialised module state. This helper
-routes every lazy import through a ``ThreadPoolExecutor(max_workers=1)``
-so only one import is ever in flight, then caches the resolved
-module so steady-state callers skip the executor hop entirely.
-
-Two concurrent first-callers each submit their own ``importlib``
-hop; the second runs after the first has populated ``sys.modules``
-and so is a hash-table lookup. The simpler shape avoids the
-shared-future / first-caller-cancellation poisoning concerns of
-the future-dedup variant (cf. ``homeassistant.helpers.importlib``)
-while keeping the single-thread import guarantee.
-
-Used to keep heavy esphome subpackages (``dashboard_import``,
-``bundle``) out of the dashboard's resident set when the
-corresponding feature isn't exercised in a session.
+Routes every cold import through a ``ThreadPoolExecutor(max_workers=1)``
+so concurrent first-callers serialise and only one ``importlib``
+call runs at a time (pre-3.15 concurrent-import safety).
 """
 
 from __future__ import annotations
@@ -37,13 +24,7 @@ def _get_module(name: str) -> ModuleType:
 
 
 async def async_import_module(name: str) -> ModuleType:
-    """Import *name* off the event loop and cache the resolved module.
-
-    Steady-state callers hit ``_cache`` directly. Cold callers hop
-    onto the dedicated single-thread import executor; concurrent
-    first-callers serialise on the executor pool and the second
-    run finds the module already in ``sys.modules``.
-    """
+    """Return *name* from the cache, importing it off-loop on miss."""
     if (module := _cache.get(name)) is not None:
         return module
     loop = asyncio.get_running_loop()

--- a/esphome_device_builder/helpers/lazy_module.py
+++ b/esphome_device_builder/helpers/lazy_module.py
@@ -1,0 +1,64 @@
+"""Off-loop module loading with a dedicated single-thread executor.
+
+Concurrent imports across threads aren't safe in CPython before
+3.15; an executor pool that runs more than one import in parallel
+can deadlock or observe half-initialised module state. Mirroring
+``homeassistant.helpers.importlib``, this helper routes every lazy
+import through a ``ThreadPoolExecutor(max_workers=1)`` so only one
+import is ever in flight, and dedupes concurrent callers through a
+per-module future.
+
+Used to keep heavy esphome subpackages (``dashboard_import``,
+``components.esp32``, ``components.libretiny``, ``bundle``) out of
+the dashboard's resident set when the corresponding feature isn't
+exercised in a session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from types import ModuleType
+
+_import_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ImportExecutor")
+_cache: dict[str, ModuleType] = {}
+_futures: dict[str, asyncio.Future[ModuleType]] = {}
+
+
+def _get_module(name: str) -> ModuleType:
+    module = importlib.import_module(name)
+    _cache[name] = module
+    return module
+
+
+async def async_import_module(name: str) -> ModuleType:
+    """Import *name* off the event loop, deduping concurrent calls.
+
+    First caller submits the import to the dedicated single-thread
+    executor; concurrent callers await the same future. Subsequent
+    calls hit the in-process cache directly.
+    """
+    if (module := _cache.get(name)) is not None:
+        return module
+    if (future := _futures.get(name)) is not None:
+        return await future
+    if name in sys.modules:
+        cached = sys.modules[name]
+        _cache[name] = cached
+        return cached
+
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    _futures[name] = future
+    try:
+        module = await loop.run_in_executor(_import_executor, _get_module, name)
+        future.set_result(module)
+    except BaseException as ex:
+        future.set_exception(ex)
+        future.exception()  # mark retrieved so a sole consumer doesn't warn
+        raise
+    finally:
+        del _futures[name]
+    return module

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -22,7 +22,6 @@ from unittest.mock import AsyncMock
 import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
-from esphome_device_builder.controllers.devices import importable as devices_module
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
@@ -69,17 +68,17 @@ def _import_config_stub(
 
 
 def test_import_config_resolves_at_import_time() -> None:
-    """Regression guard for the import path move.
+    """Regression guard for the upstream import path.
 
-    ``import_config`` used to be imported via ``esphome.config_helpers``
-    behind a try/except, so a wrong path silently became ``None`` and
-    every adoption attempt raised. The current call site imports
-    directly from ``esphome.components.dashboard_import``; if that
-    module ever moves we want the test suite to fail loudly here, not
-    a user's first adoption attempt.
+    ``import_config`` lives at ``esphome.components.dashboard_import``;
+    if upstream moves it we want CI to fail loudly here, not at a
+    user's first adoption attempt. The dashboard lazy-loads the
+    module through ``async_import_module``, so this test imports
+    it synchronously to verify the contract.
     """
-    assert devices_module.import_config is not None
-    assert callable(devices_module.import_config)
+    from esphome.components import dashboard_import  # noqa: PLC0415
+
+    assert callable(dashboard_import.import_config)
 
 
 async def test_import_device_invokes_import_config_and_returns_path(
@@ -89,7 +88,9 @@ async def test_import_device_invokes_import_config_and_returns_path(
 ) -> None:
     """Happy path: write the YAML, run a scan, return the configuration name."""
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config", _import_config_stub(captured)
+    )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
 
@@ -134,7 +135,9 @@ async def test_import_device_passes_ethernet_network_through_to_import_config(
     ``network`` field to ``import_config``.
     """
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config", _import_config_stub(captured)
+    )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -180,7 +183,9 @@ async def test_import_device_uses_direct_name_lookup_with_duplicate_products(
     the imported YAML got.
     """
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config", _import_config_stub(captured)
+    )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -231,7 +236,9 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
     dashboard wrote.
     """
     captured: dict[str, Any] = {}
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub(captured))
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config", _import_config_stub(captured)
+    )
 
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -271,7 +278,7 @@ async def test_import_device_translates_file_exists_to_command_error(
     def raises_file_exists(*_args: Any, **_kwargs: Any) -> None:
         raise FileExistsError
 
-    monkeypatch.setattr(devices_module, "import_config", raises_file_exists)
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", raises_file_exists)
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
 
@@ -306,7 +313,7 @@ async def test_import_device_rejects_when_imported_yaml_does_not_validate(
     project (or pick a different one) and retry without a
     leftover ``FileExistsError`` blocking them.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._db.editor.validate_yaml = AsyncMock(
@@ -352,7 +359,7 @@ async def test_import_device_rolls_back_on_unicode_decode_error_from_read(
         # ``read_text(encoding='utf-8')`` chokes on it.
         args[0].write_bytes(b"\xff garbage")
 
-    monkeypatch.setattr(devices_module, "import_config", write_garbage)
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", write_garbage)
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
 
@@ -381,7 +388,7 @@ async def test_import_device_preserves_original_error_when_cleanup_fails(
     cleanup hook's exception is swallowed and logged; the
     original ``CommandError`` propagates.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._db.editor.validate_yaml = AsyncMock(
@@ -431,7 +438,7 @@ async def test_import_device_rolls_back_on_validator_subprocess_error(
     tripping ``FileExistsError`` on every retry — exactly the
     foot-gun this PR is meant to prevent.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._db.editor.validate_yaml = AsyncMock(side_effect=TimeoutError("subprocess wedged"))
@@ -461,7 +468,7 @@ async def test_import_device_skips_validation_when_editor_unavailable(
     lifetime of the process would be worse than landing the
     YAML and letting the next compile surface any schema issues.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._db.editor = None
@@ -488,7 +495,7 @@ async def test_import_device_returns_even_when_post_scan_fails(
     nothing being wrong. Best-effort scan; the periodic poll picks up
     whatever this attempt missed.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     ctrl._scanner.scan = AsyncMock(side_effect=RuntimeError("transient"))
@@ -516,7 +523,7 @@ async def test_import_device_seeds_online_state_from_zeroconf_cache(
     can't clobber it) and pulls the cached IP out of zeroconf so the
     new card has an address right away.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor(
@@ -545,7 +552,7 @@ async def test_import_device_skips_apply_ip_when_zeroconf_cache_misses(
     make_controller: MakeControllerFactory,
 ) -> None:
     """No cached IP → state still flips ONLINE, just no apply_ip call."""
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path)
     _seed_import_state(ctrl)
     ctrl._state_monitor = RecordingStateMonitor()  # no cached addresses
@@ -577,7 +584,7 @@ async def test_import_device_drops_matching_import_result_entry(
     so we drop the right entry even when the user typed a different
     YAML name in the dialog.
     """
-    monkeypatch.setattr(devices_module, "import_config", _import_config_stub())
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
     captured = capture_devices_events(ctrl, EventType.IMPORTABLE_DEVICE_REMOVED)

--- a/tests/helpers/test_lazy_module.py
+++ b/tests/helpers/test_lazy_module.py
@@ -1,0 +1,119 @@
+"""Coverage for ``helpers.lazy_module.async_import_module``.
+
+Exercises the four branches of the import dispatcher: cache hit,
+concurrent-call future dedup, ``sys.modules`` short-circuit, and
+the first-time executor import path (success + failure).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from esphome_device_builder.helpers import lazy_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_lazy_module_state() -> None:
+    """Wipe the per-module cache/future maps between tests."""
+    lazy_module._cache.clear()
+    lazy_module._futures.clear()
+
+
+def _make_fake_module(name: str) -> types.ModuleType:
+    """Return a fresh module object and register it under *name*."""
+    module = types.ModuleType(name)
+    module.marker = object()  # type: ignore[attr-defined]
+    sys.modules[name] = module
+    return module
+
+
+async def test_async_import_module_first_call_imports_via_executor() -> None:
+    """A first-time call runs the importlib hop and caches the module."""
+    # ``http.cookiejar`` is in stdlib but rarely preloaded; if pytest already
+    # has it, pop and re-import so the executor branch actually runs.
+    name = "http.cookiejar"
+    sys.modules.pop(name, None)
+
+    result = await lazy_module.async_import_module(name)
+    assert result is sys.modules[name]
+    assert lazy_module._cache[name] is result
+    assert hasattr(result, "CookieJar")  # sanity: real module, not a stub
+    assert name not in lazy_module._futures
+
+
+async def test_async_import_module_returns_cached_on_repeat_call() -> None:
+    """Once cached, repeat callers skip the executor entirely."""
+    name = "esphome_device_builder._test_lazy_cached"
+    fake = types.ModuleType(name)
+    lazy_module._cache[name] = fake
+
+    result = await lazy_module.async_import_module(name)
+    assert result is fake
+
+
+async def test_async_import_module_short_circuits_on_sys_modules() -> None:
+    """A module already in ``sys.modules`` is hoisted into the cache without re-import."""
+    name = "esphome_device_builder._test_lazy_sysmodules"
+    fake = _make_fake_module(name)
+
+    try:
+        result = await lazy_module.async_import_module(name)
+        assert result is fake
+        assert lazy_module._cache[name] is fake
+    finally:
+        sys.modules.pop(name, None)
+
+
+async def test_async_import_module_dedupes_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second caller arriving while the first is in-flight awaits the same future."""
+    name = "esphome_device_builder._test_lazy_concurrent"
+    fake = types.ModuleType(name)
+    gate = asyncio.Event()
+    real_run_in_executor = asyncio.get_running_loop().run_in_executor
+
+    async def slow_import(_executor, func, arg):  # type: ignore[no-untyped-def]
+        # Yield so the second caller can observe the future before we resolve.
+        await gate.wait()
+        return func(arg)
+
+    def fake_get_module(_name: str) -> types.ModuleType:
+        return fake
+
+    monkeypatch.setattr(lazy_module, "_get_module", fake_get_module)
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(
+        loop,
+        "run_in_executor",
+        lambda executor, func, arg: asyncio.ensure_future(slow_import(executor, func, arg)),
+    )
+
+    first = asyncio.create_task(lazy_module.async_import_module(name))
+    await asyncio.sleep(0)  # let *first* register its future
+    second = asyncio.create_task(lazy_module.async_import_module(name))
+    await asyncio.sleep(0)  # let *second* land on the await-future branch
+    assert name in lazy_module._futures
+    gate.set()
+
+    results = await asyncio.gather(first, second)
+    assert results == [fake, fake]
+    assert name not in lazy_module._futures
+
+    # Restore so other tests see the real loop method.
+    monkeypatch.setattr(loop, "run_in_executor", real_run_in_executor)
+
+
+async def test_async_import_module_propagates_import_failure() -> None:
+    """A failing import surfaces the exception and clears the future."""
+    name = "definitely_not_a_real_module_xyz_lazy_test"
+
+    with pytest.raises(ModuleNotFoundError):
+        await lazy_module.async_import_module(name)
+    assert name not in lazy_module._futures
+    assert name not in lazy_module._cache

--- a/tests/helpers/test_lazy_module.py
+++ b/tests/helpers/test_lazy_module.py
@@ -1,13 +1,14 @@
 """Coverage for ``helpers.lazy_module.async_import_module``.
 
-Exercises the four branches of the import dispatcher: cache hit,
-concurrent-call future dedup, ``sys.modules`` short-circuit, and
-the first-time executor import path (success + failure).
+Three branches: cache hit (steady-state), executor first-import
+success, and import failure propagation. The simpler dedup-free
+design has no shared-future state, so cancellation behaviour is
+governed by the underlying ``loop.run_in_executor`` semantics and
+doesn't need its own test.
 """
 
 from __future__ import annotations
 
-import asyncio
 import sys
 import types
 
@@ -17,32 +18,9 @@ from esphome_device_builder.helpers import lazy_module
 
 
 @pytest.fixture(autouse=True)
-def _reset_lazy_module_state() -> None:
-    """Wipe the per-module cache/future maps between tests."""
+def _reset_cache() -> None:
+    """Wipe the per-module cache between tests."""
     lazy_module._cache.clear()
-    lazy_module._futures.clear()
-
-
-def _make_fake_module(name: str) -> types.ModuleType:
-    """Return a fresh module object and register it under *name*."""
-    module = types.ModuleType(name)
-    module.marker = object()  # type: ignore[attr-defined]
-    sys.modules[name] = module
-    return module
-
-
-async def test_async_import_module_first_call_imports_via_executor() -> None:
-    """A first-time call runs the importlib hop and caches the module."""
-    # ``http.cookiejar`` is in stdlib but rarely preloaded; if pytest already
-    # has it, pop and re-import so the executor branch actually runs.
-    name = "http.cookiejar"
-    sys.modules.pop(name, None)
-
-    result = await lazy_module.async_import_module(name)
-    assert result is sys.modules[name]
-    assert lazy_module._cache[name] is result
-    assert hasattr(result, "CookieJar")  # sanity: real module, not a stub
-    assert name not in lazy_module._futures
 
 
 async def test_async_import_module_returns_cached_on_repeat_call() -> None:
@@ -55,65 +33,23 @@ async def test_async_import_module_returns_cached_on_repeat_call() -> None:
     assert result is fake
 
 
-async def test_async_import_module_short_circuits_on_sys_modules() -> None:
-    """A module already in ``sys.modules`` is hoisted into the cache without re-import."""
-    name = "esphome_device_builder._test_lazy_sysmodules"
-    fake = _make_fake_module(name)
+async def test_async_import_module_first_call_imports_via_executor() -> None:
+    """A first-time call runs the importlib hop and caches the module."""
+    # ``http.cookiejar`` is in stdlib but rarely preloaded; pop it so the
+    # executor branch actually runs even if pytest has touched it.
+    name = "http.cookiejar"
+    sys.modules.pop(name, None)
 
-    try:
-        result = await lazy_module.async_import_module(name)
-        assert result is fake
-        assert lazy_module._cache[name] is fake
-    finally:
-        sys.modules.pop(name, None)
-
-
-async def test_async_import_module_dedupes_concurrent_callers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A second caller arriving while the first is in-flight awaits the same future."""
-    name = "esphome_device_builder._test_lazy_concurrent"
-    fake = types.ModuleType(name)
-    gate = asyncio.Event()
-    real_run_in_executor = asyncio.get_running_loop().run_in_executor
-
-    async def slow_import(_executor, func, arg):  # type: ignore[no-untyped-def]
-        # Yield so the second caller can observe the future before we resolve.
-        await gate.wait()
-        return func(arg)
-
-    def fake_get_module(_name: str) -> types.ModuleType:
-        return fake
-
-    monkeypatch.setattr(lazy_module, "_get_module", fake_get_module)
-
-    loop = asyncio.get_running_loop()
-    monkeypatch.setattr(
-        loop,
-        "run_in_executor",
-        lambda executor, func, arg: asyncio.ensure_future(slow_import(executor, func, arg)),
-    )
-
-    first = asyncio.create_task(lazy_module.async_import_module(name))
-    await asyncio.sleep(0)  # let *first* register its future
-    second = asyncio.create_task(lazy_module.async_import_module(name))
-    await asyncio.sleep(0)  # let *second* land on the await-future branch
-    assert name in lazy_module._futures
-    gate.set()
-
-    results = await asyncio.gather(first, second)
-    assert results == [fake, fake]
-    assert name not in lazy_module._futures
-
-    # Restore so other tests see the real loop method.
-    monkeypatch.setattr(loop, "run_in_executor", real_run_in_executor)
+    result = await lazy_module.async_import_module(name)
+    assert result is sys.modules[name]
+    assert lazy_module._cache[name] is result
+    assert hasattr(result, "CookieJar")  # sanity: real module, not a stub
 
 
 async def test_async_import_module_propagates_import_failure() -> None:
-    """A failing import surfaces the exception and clears the future."""
+    """A failing import surfaces the exception; nothing is cached."""
     name = "definitely_not_a_real_module_xyz_lazy_test"
 
     with pytest.raises(ModuleNotFoundError):
         await lazy_module.async_import_module(name)
-    assert name not in lazy_module._futures
     assert name not in lazy_module._cache

--- a/tests/helpers/test_lazy_module.py
+++ b/tests/helpers/test_lazy_module.py
@@ -1,11 +1,4 @@
-"""Coverage for ``helpers.lazy_module.async_import_module``.
-
-Three branches: cache hit (steady-state), executor first-import
-success, and import failure propagation. The simpler dedup-free
-design has no shared-future state, so cancellation behaviour is
-governed by the underlying ``loop.run_in_executor`` semantics and
-doesn't need its own test.
-"""
+"""Coverage for ``helpers.lazy_module.async_import_module``."""
 
 from __future__ import annotations
 

--- a/tests/test_cold_import_floor.py
+++ b/tests/test_cold_import_floor.py
@@ -31,6 +31,7 @@ def test_cold_modules_absent_after_start() -> None:
     script = textwrap.dedent(
         """
         import asyncio
+        import socket
         import sys
         import tempfile
         from pathlib import Path
@@ -42,24 +43,32 @@ def test_cold_modules_absent_after_start() -> None:
         from esphome_device_builder.controllers.config import DashboardSettings
         from esphome_device_builder.device_builder import DeviceBuilder
 
-        settings = DashboardSettings(config_dir=tmp)
+        # Pin both listener ports to OS-allocated free slots so a
+        # parallel test run (or another local process) holding the
+        # defaults can't make ``start()`` short-circuit before it
+        # reaches the code paths the cold-module assertion is
+        # guarding.
+        def _free_port() -> int:
+            with socket.socket() as s:
+                s.bind(("127.0.0.1", 0))
+                return s.getsockname()[1]
+
+        settings = DashboardSettings(
+            config_dir=tmp,
+            port=_free_port(),
+            remote_build_port=_free_port(),
+        )
+
+        started = False
 
         async def go() -> None:
+            global started
             db = DeviceBuilder(settings)
-            try:
-                await db.start()
-            finally:
-                # ``DeviceBuilder.stop`` would do a cleaner teardown
-                # but is not the target of the assertion below.
-                pass
+            await db.start()
+            started = True
 
-        try:
-            asyncio.run(go())
-        except OSError:
-            # ``DeviceBuilder.start`` may fail to bind the
-            # peer-link receiver socket if the port is taken; the
-            # cold-modules assertion below is still meaningful.
-            pass
+        asyncio.run(go())
+        assert started, "DeviceBuilder.start did not finish — cold-module check would be vacuous"
 
         for name in %r:
             assert name not in sys.modules, name

--- a/tests/test_cold_import_floor.py
+++ b/tests/test_cold_import_floor.py
@@ -1,0 +1,78 @@
+"""Lock in the heavy esphome subpackages that must stay cold at idle.
+
+Two upstream modules are several MB each and now load only when
+the corresponding feature is exercised:
+
+- ``esphome.components.dashboard_import`` (~14 MB) — only used by
+  the device-adoption WS command.
+- ``esphome.bundle`` (~1 MB) — only used by the peer-link receiver
+  when an offload submission lands.
+
+This test runs the dashboard's import + ``start()`` path in a fresh
+subprocess and asserts both modules stay out of ``sys.modules``. A
+future module-level re-import trips the assertion and surfaces the
+regression in CI rather than as quiet +15 MB on every HA addon idle.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_COLD_MODULES = (
+    "esphome.components.dashboard_import",
+    "esphome.bundle",
+)
+
+
+def test_cold_modules_absent_after_start() -> None:
+    """A fresh ``DeviceBuilder.start()`` does not load any cold-path esphome subpackage."""
+    script = textwrap.dedent(
+        """
+        import asyncio
+        import sys
+        import tempfile
+        from pathlib import Path
+
+        from esphome.core import CORE
+        tmp = Path(tempfile.mkdtemp())
+        CORE.config_path = tmp / "dashboard.yaml"
+
+        from esphome_device_builder.controllers.config import DashboardSettings
+        from esphome_device_builder.device_builder import DeviceBuilder
+
+        settings = DashboardSettings(config_dir=tmp)
+
+        async def go() -> None:
+            db = DeviceBuilder(settings)
+            try:
+                await db.start()
+            finally:
+                # ``DeviceBuilder.stop`` would do a cleaner teardown
+                # but is not the target of the assertion below.
+                pass
+
+        try:
+            asyncio.run(go())
+        except OSError:
+            # ``DeviceBuilder.start`` may fail to bind the
+            # peer-link receiver socket if the port is taken; the
+            # cold-modules assertion below is still meaningful.
+            pass
+
+        for name in %r:
+            assert name not in sys.modules, name
+        """
+    ) % (_COLD_MODULES,)
+
+    result = subprocess.run(  # noqa: S603 — script is fully test-controlled
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"cold-import regression\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1428,7 +1428,7 @@ async def test_e2e_submit_job_dispatches_to_receiver(
         return extracted_path
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
     bundle = make_tar_bundle("kitchen.yaml", b"esphome:\n  name: kitchen\n")

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -536,7 +536,7 @@ async def test_submit_job_happy_path_extracts_and_queues(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -597,7 +597,7 @@ async def test_submit_job_happy_path_with_relative_config_dir(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -651,7 +651,7 @@ async def test_submit_job_clean_target_creates_clean_job(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -715,7 +715,7 @@ async def test_submit_job_carries_display_fields_through_to_firmware_job(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -772,7 +772,7 @@ async def test_submit_job_malformed_display_fields_coerce_to_empty(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -828,7 +828,7 @@ async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _stub_prepare,
     )
 
@@ -924,7 +924,7 @@ async def test_submit_job_bundle_path_survives_prepare_bundle_wipe(
         return expected_yaml
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _wipe_then_extract,
     )
 
@@ -984,7 +984,7 @@ async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
     session = _make_session(dashboard_id="../../escape")
     bundle = b"hello"
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         lambda _bundle, _target: tmp_path / "kitchen.yaml",
     )
 
@@ -1010,7 +1010,7 @@ async def test_submit_job_enqueue_failure_rejects(
     bundle = b"hello"
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         lambda _bundle, target: target / "kitchen.yaml",
     )
 
@@ -1038,7 +1038,7 @@ async def test_submit_job_extract_failure_rejects_without_terminate(
         raise EsphomeError("bundle invalid: missing manifest")
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.submit_job.prepare_bundle_for_compile",
+        "esphome.bundle.prepare_bundle_for_compile",
         _failing_prepare,
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Two heavy upstream esphome modules were loaded at import time but
are only used by features a typical session may never exercise:
`esphome.components.dashboard_import` (~14 MB) is touched only on
device adoption, and `esphome.bundle` (~1 MB) only when the
peer-link receiver extracts an offloaded build. Lazy-importing
them through a dedicated single-thread executor mirrors
`homeassistant.helpers.importlib`; concurrent first-import callers
serialise through a per-module future, and steady-state callers
hit the cached module reference; this avoids the pre-3.15
concurrent-import race entirely.

Measured locally: idle RSS drops from ~111 MB to ~103 MB on an
empty configs dir, with both modules absent from `sys.modules`
after `DeviceBuilder.start()`; a new regression test
(`tests/test_cold_import_floor.py`) locks in the cold floor in a
subprocess so a future module-level re-import surfaces in CI
rather than as a quiet +15 MB on every HA addon idle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
