### PR TITLE
Fix stale device-builder-dashboard links in issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,7 @@ body:
         [esphome repo](https://github.com/esphome/esphome/issues/new/choose).
 
         - **Not already tracked** — check
-        [open issues](https://github.com/esphome/device-builder-dashboard-backend/issues)
+        [open issues](https://github.com/esphome/device-builder/issues)
         and the
         [project backlog](https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22).
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -25,7 +25,7 @@ contact_links:
       concrete plan, it'll move to a tracked issue.
 
   - name: 🗺️ Device Builder backlog (planned / in-progress work)
-    url: https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder-dashboard%22
+    url: https://github.com/orgs/esphome/projects/7/views/1?filterQuery=project%3A%22device-builder%22
     about: |
       The dashboard is still in active development. Before filing,
       please check the project board — your idea or issue may

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,14 +28,14 @@ same label to slot this change into the next release notes.
 
 <!--
 The frontend ships prebuilt inside our wheel
-(esphome/device-builder-dashboard-frontend). Flag anything that
+(esphome/device-builder-frontend). Flag anything that
 needs a coordinated change there — new ConfigEntryType values,
 new WS commands or events, model shape changes, etc. Link the
 companion frontend PR if there is one.
 -->
 
 - [ ] No frontend change needed
-- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>
+- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>
 
 ## Checklist
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

The "Device Builder backlog" link on the New Issue chooser filtered the org project by the pre-rename value project:"device-builder-dashboard", so the board opened empty. It now uses project:"device-builder", matching the two links already in bug_report.yml. While here, the other pre-rename slugs in the same templates are made canonical; device-builder-dashboard-backend/issues and device-builder-dashboard-frontend resolved only via GitHub's rename redirect.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1037

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
