### PR TITLE
Use eager task creation for background and websocket tasks

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -17,6 +17,7 @@ from esphome.const import __version__ as esphome_version
 from ..constants import __version__
 from ..controllers.auth import AuthError
 from ..helpers.api import CommandError
+from ..helpers.async_ import create_eager_task
 from ..helpers.auth import extract_bearer_token
 from ..helpers.event_bus import StreamBackpressureError
 from ..helpers.json import JSONDecodeError, dumps_str, loads
@@ -164,7 +165,7 @@ class WebSocketClient:
 
     def create_task(self, coro: Any) -> asyncio.Task:
         """Create a tracked task."""
-        task = asyncio.create_task(coro)
+        task = create_eager_task(coro)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
         return task

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -45,6 +45,7 @@ from .controllers.onboarding import OnboardingController
 from .controllers.remote_build import OffloaderController, ReceiverController
 from .controllers.remote_build.peer_link import PEER_LINK_PATH, make_peer_link_handler
 from .helpers.api import CommandHandler, collect_api_commands
+from .helpers.async_ import create_eager_task
 from .helpers.auth import auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
@@ -418,7 +419,7 @@ class DeviceBuilder:
             self.command_handlers["auth"] = self.command_handlers["auth/login"]
 
         # Start background polling
-        self._bg_task = asyncio.create_task(self._run_background())
+        self._bg_task = create_eager_task(self._run_background())
 
         _LOGGER.info(
             "Device Builder ready — config dir: %s, %d commands registered",
@@ -676,7 +677,7 @@ class DeviceBuilder:
     def create_background_task(self, coro: Any) -> asyncio.Task:
         """Create a tracked background task."""
         assert self.loop is not None  # type narrowing
-        task = self.loop.create_task(coro)
+        task = create_eager_task(coro, loop=self.loop)
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
         return task

--- a/esphome_device_builder/helpers/async_.py
+++ b/esphome_device_builder/helpers/async_.py
@@ -1,0 +1,25 @@
+"""Asyncio task helpers."""
+
+from __future__ import annotations
+
+from asyncio import AbstractEventLoop, Task, get_running_loop
+from collections.abc import Coroutine
+from typing import Any
+
+
+def create_eager_task[T](
+    coro: Coroutine[Any, Any, T],
+    *,
+    name: str | None = None,
+    loop: AbstractEventLoop | None = None,
+) -> Task[T]:
+    """
+    Create a task from a coroutine and schedule it to run immediately.
+
+    ``eager_start=True`` runs the coroutine synchronously up to its first
+    suspension point, so one that completes without ever awaiting never
+    reaches the event loop's task queue.
+    """
+    if loop is None:
+        loop = get_running_loop()
+    return Task(coro, loop=loop, name=name, eager_start=True)

--- a/tests/test_helpers_async.py
+++ b/tests/test_helpers_async.py
@@ -1,0 +1,57 @@
+"""Tests for ``helpers/async_.py`` — eager task creation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.helpers.async_ import create_eager_task
+
+
+@pytest.mark.asyncio
+async def test_eager_task_runs_synchronously_until_first_await() -> None:
+    ran: list[str] = []
+
+    async def coro() -> str:
+        ran.append("before")
+        await asyncio.sleep(0)
+        ran.append("after")
+        return "done"
+
+    task = create_eager_task(coro())
+    assert ran == ["before"]
+    assert await task == "done"
+    assert ran == ["before", "after"]
+
+
+@pytest.mark.asyncio
+async def test_eager_task_completes_without_loop_turn() -> None:
+    async def coro() -> int:
+        return 42
+
+    task = create_eager_task(coro())
+    assert task.done()
+    assert task.result() == 42
+
+
+@pytest.mark.asyncio
+async def test_eager_task_sets_name() -> None:
+    async def coro() -> None:
+        return None
+
+    task = create_eager_task(coro(), name="my-task")
+    assert task.get_name() == "my-task"
+    await task
+
+
+@pytest.mark.asyncio
+async def test_eager_task_uses_explicit_loop() -> None:
+    loop = asyncio.get_running_loop()
+
+    async def coro() -> None:
+        return None
+
+    task = create_eager_task(coro(), loop=loop)
+    assert task.get_loop() is loop
+    await task


### PR DESCRIPTION
# What does this implement/fix?

Route background and websocket task creation through a new `create_eager_task` helper. `eager_start=True` runs a coroutine synchronously up to its first await, so a task that finishes without ever suspending never reaches the event loop's task queue.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1052

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [ ] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
