### PR TITLE
Remove redundant pytest.mark.asyncio decorators

### DIFF
--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -305,7 +305,7 @@ def seed_device() -> SeedDeviceFactory:
     blockbuster on the CI Linux runners flags the underlying
     ``os.path.abspath`` from a synchronous async-test context.
     Pushing the write to a thread keeps the seed call cheap to
-    use from any ``@pytest.mark.asyncio`` test.
+    use from any async test.
     """
 
     async def _seed(

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -58,7 +58,6 @@ def _ext_storage_for_archive(redirect_storage_path: None) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_archive_moves_yaml_to_archive_dir(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -84,7 +83,6 @@ async def test_archive_moves_yaml_to_archive_dir(
     assert archived.read_text() == original_text
 
 
-@pytest.mark.asyncio
 async def test_archive_wipes_build_directory(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -107,7 +105,6 @@ async def test_archive_wipes_build_directory(
     assert not build_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_archive_wipes_storage_sidecar(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -132,7 +129,6 @@ async def test_archive_wipes_storage_sidecar(
     assert not storage_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_archive_clears_volatile_metadata_keeps_identity(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -189,7 +185,6 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
     assert controller._metadata_store.get("kitchen.yaml") == {}
 
 
-@pytest.mark.asyncio
 async def test_archive_drops_metadata_entry_when_only_volatile_fields(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -225,7 +220,6 @@ async def test_archive_drops_metadata_entry_when_only_volatile_fields(
     assert "kitchen.yaml" not in raw
 
 
-@pytest.mark.asyncio
 async def test_archive_succeeds_when_never_compiled(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -248,7 +242,6 @@ async def test_archive_succeeds_when_never_compiled(
     assert (tmp_path / "archive" / "kitchen.yaml").exists()
 
 
-@pytest.mark.asyncio
 async def test_archive_collision_raises_invalid_args(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -285,7 +278,6 @@ async def test_archive_collision_raises_invalid_args(
     assert (tmp_path / "kitchen.yaml").read_text() == "second version\n"
 
 
-@pytest.mark.asyncio
 async def test_archive_missing_file_raises_file_not_found(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -301,7 +293,6 @@ async def test_archive_missing_file_raises_file_not_found(
         await controller._archive_single("ghost.yaml")
 
 
-@pytest.mark.asyncio
 async def test_archive_device_full_flow_calls_scanner(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -324,7 +315,6 @@ async def test_archive_device_full_flow_calls_scanner(
     assert controller._scanner.calls == [("scan",)]
 
 
-@pytest.mark.asyncio
 async def test_unarchive_device_full_flow_calls_scanner(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -345,7 +335,6 @@ async def test_unarchive_device_full_flow_calls_scanner(
     assert controller._scanner.calls == [("scan",)]
 
 
-@pytest.mark.asyncio
 async def test_list_archived_full_flow(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -370,7 +359,6 @@ async def test_list_archived_full_flow(
     assert rows[0]["friendly_name"] == "Kitchen"
 
 
-@pytest.mark.asyncio
 async def test_archive_device_translates_missing_to_command_error(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -388,7 +376,6 @@ async def test_archive_device_translates_missing_to_command_error(
     assert exc.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_unarchive_device_translates_missing_to_command_error(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -404,7 +391,6 @@ async def test_unarchive_device_translates_missing_to_command_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_unarchive_moves_yaml_back(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -426,7 +412,6 @@ async def test_unarchive_moves_yaml_back(
     assert (tmp_path / "kitchen.yaml").exists()
 
 
-@pytest.mark.asyncio
 async def test_unarchive_refuses_to_clobber_active_config(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -454,7 +439,6 @@ async def test_unarchive_refuses_to_clobber_active_config(
     assert active.read_text() == "# active, freshly written\n"
 
 
-@pytest.mark.asyncio
 async def test_unarchive_missing_archive_file_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -485,7 +469,6 @@ async def test_unarchive_missing_archive_file_raises(
         "with\x00null.yaml",
     ],
 )
-@pytest.mark.asyncio
 async def test_archive_rejects_path_traversal(
     tmp_path: Path, make_controller: MakeControllerFactory, configuration: str
 ) -> None:
@@ -565,7 +548,6 @@ def test_clear_volatile_device_metadata_drops_corrupt_non_dict_entry(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_archived_removes_yaml_and_sidecars(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -592,7 +574,6 @@ async def test_delete_archived_removes_yaml_and_sidecars(
     assert not storage_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_delete_archived_preserves_active_sidecars(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -626,7 +607,6 @@ async def test_delete_archived_preserves_active_sidecars(
     assert storage_path.read_text() == '{"name":"active"}'
 
 
-@pytest.mark.asyncio
 async def test_delete_archived_succeeds_without_sidecars(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -646,7 +626,6 @@ async def test_delete_archived_succeeds_without_sidecars(
     assert not (archive_dir / "kitchen.yaml").exists()
 
 
-@pytest.mark.asyncio
 async def test_delete_archived_missing_raises_file_not_found(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -656,7 +635,6 @@ async def test_delete_archived_missing_raises_file_not_found(
         await controller._delete_archived_single("ghost.yaml")
 
 
-@pytest.mark.asyncio
 async def test_delete_archived_translates_missing_to_command_error(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -69,7 +69,6 @@ def _device(name: str, *, ip: str = "", ip_addresses: list[str] | None = None) -
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_create_device_writes_file_content_verbatim(
     tmp_path: Path, make_controller: MakeControllerFactory
@@ -102,7 +101,6 @@ async def test_create_device_writes_file_content_verbatim(
     pio_lookup.assert_called_once()
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_create_device_falls_back_to_platform_variant_lookup(
     tmp_path: Path, make_controller: MakeControllerFactory
@@ -133,7 +131,6 @@ async def test_create_device_falls_back_to_platform_variant_lookup(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_device_unlinks_yaml_then_scans(
     tmp_path: Path,
@@ -157,7 +154,6 @@ async def test_delete_device_unlinks_yaml_then_scans(
     assert ("scan",) in controller._scanner.calls
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_bulk_returns_per_device_success_with_mixed_outcomes(
     tmp_path: Path,
@@ -195,7 +191,6 @@ async def test_delete_bulk_returns_per_device_success_with_mixed_outcomes(
     assert len(scan_calls) == 1
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_archive_bulk_returns_per_device_success_with_mixed_outcomes(
     tmp_path: Path,
@@ -242,7 +237,6 @@ async def test_archive_bulk_returns_per_device_success_with_mixed_outcomes(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_resolves_through_yaml_loader(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -266,7 +260,6 @@ async def test_get_api_key_resolves_through_yaml_loader(
     assert result == {"key": "a/c+inline-key=="}
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_returns_empty_when_no_encryption(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -288,7 +281,6 @@ async def test_get_api_key_returns_empty_when_no_encryption(
     assert result == {"key": ""}
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_falls_back_to_esphome_config_subprocess(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -336,7 +328,6 @@ async def test_get_api_key_falls_back_to_esphome_config_subprocess(
     assert result == {"key": "ZGFzaGJvYXJkLWtleS1mcm9tLWVzcGhvbWUtY29uZmln"}
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_subprocess_returns_empty_on_nonzero_exit(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -370,7 +361,6 @@ async def test_get_api_key_subprocess_returns_empty_on_nonzero_exit(
     assert result == {"key": ""}
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_subprocess_returns_empty_on_unparsable_yaml(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -402,7 +392,6 @@ async def test_get_api_key_subprocess_returns_empty_on_unparsable_yaml(
     assert result == {"key": ""}
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_subprocess_returns_empty_on_oserror(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -430,7 +419,6 @@ async def test_get_api_key_subprocess_returns_empty_on_oserror(
     assert result == {"key": ""}
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_skips_subprocess_when_fast_path_finds_key(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -457,7 +445,6 @@ async def test_get_api_key_skips_subprocess_when_fast_path_finds_key(
     spawn_spy.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -494,7 +481,6 @@ async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_add_component_unknown_id_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -517,7 +503,6 @@ async def test_add_component_unknown_id_raises(
         )
 
 
-@pytest.mark.asyncio
 async def test_add_component_missing_required_field_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -650,7 +635,6 @@ def test_on_firmware_job_completed_skips_when_configuration_empty(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_persist_build_size_writes_triple(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -670,7 +654,6 @@ async def test_persist_build_size_writes_triple(
     }
 
 
-@pytest.mark.asyncio
 async def test_persist_device_metadata_async_routes_store_field_to_store(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -825,7 +808,6 @@ def test_on_scan_change_removed_revisits_importables(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_stream_subprocess_applies_line_transform(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -52,7 +52,6 @@ def _seed_device(
     return yaml_path, build_path
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_wipes_build_directory(
     tmp_path: Path, make_controller: MakeControllerFactory
@@ -72,7 +71,6 @@ async def test_delete_wipes_build_directory(
     assert not (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").exists()
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_succeeds_when_never_compiled(
     tmp_path: Path, make_controller: MakeControllerFactory
@@ -87,7 +85,6 @@ async def test_delete_succeeds_when_never_compiled(
     assert not yaml_path.exists()
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_tolerates_missing_build_directory(
     tmp_path: Path, make_controller: MakeControllerFactory
@@ -102,7 +99,6 @@ async def test_delete_tolerates_missing_build_directory(
     assert not yaml_path.exists()
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures("redirect_storage_path")
 async def test_delete_tolerates_rmtree_failure(
     tmp_path: Path,
@@ -126,7 +122,6 @@ async def test_delete_tolerates_rmtree_failure(
     assert build_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_delete_raises_when_yaml_missing(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -57,7 +57,6 @@ def _stub_regenerate(controller: DevicesController) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_config_returns_yaml_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -78,7 +77,6 @@ async def test_get_config_returns_yaml_content(
     assert result == yaml_content
 
 
-@pytest.mark.asyncio
 async def test_get_config_decodes_utf8_with_unicode(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -98,7 +96,6 @@ async def test_get_config_decodes_utf8_with_unicode(
     assert result == yaml_content
 
 
-@pytest.mark.asyncio
 async def test_get_config_propagates_file_not_found(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -122,7 +119,6 @@ async def test_get_config_propagates_file_not_found(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_config_writes_content_to_disk(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -137,7 +133,6 @@ async def test_update_config_writes_content_to_disk(
     assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8") == new_content
 
 
-@pytest.mark.asyncio
 async def test_update_config_overwrites_existing_yaml(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -157,7 +152,6 @@ async def test_update_config_overwrites_existing_yaml(
     assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8") == new_content
 
 
-@pytest.mark.asyncio
 async def test_update_config_writes_utf8_unicode_intact(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -182,7 +176,6 @@ async def test_update_config_writes_utf8_unicode_intact(
     assert (tmp_path / "kuche.yaml").read_text(encoding="utf-8") == new_content
 
 
-@pytest.mark.asyncio
 async def test_update_config_triggers_scan(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -204,7 +197,6 @@ async def test_update_config_triggers_scan(
     assert controller._scanner.calls == [("request", "new.yaml")]
 
 
-@pytest.mark.asyncio
 async def test_update_config_schedules_storage_regenerate(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -229,7 +221,6 @@ async def test_update_config_schedules_storage_regenerate(
     assert regenerated == ["kitchen.yaml"]
 
 
-@pytest.mark.asyncio
 async def test_update_config_writes_before_requesting_reload(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -266,7 +257,6 @@ async def test_update_config_writes_before_requesting_reload(
     assert yaml_path.read_text(encoding="utf-8") == new_content
 
 
-@pytest.mark.asyncio
 async def test_update_config_refuses_empty_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -286,7 +276,6 @@ async def test_update_config_refuses_empty_content(
     assert controller._scanner.calls == []
 
 
-@pytest.mark.asyncio
 async def test_update_config_refuses_whitespace_only_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -306,7 +295,6 @@ async def test_update_config_refuses_whitespace_only_content(
     assert controller._scanner.calls == []
 
 
-@pytest.mark.asyncio
 async def test_round_trip_update_then_get_returns_written_content(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_lifecycle_e2e.py
+++ b/tests/controllers/devices/test_lifecycle_e2e.py
@@ -127,7 +127,6 @@ def _capture_inner_lifecycle(controller: DevicesController) -> Iterator[list[str
         yield log
 
 
-@pytest.mark.asyncio
 async def test_start_runs_full_initialisation_chain(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_db: MakeDbFactory
 ) -> None:
@@ -184,7 +183,6 @@ async def test_start_runs_full_initialisation_chain(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_stop_tears_down_monitors_and_unsubscribes(
     tmp_path: Path, make_db: MakeDbFactory
 ) -> None:
@@ -207,7 +205,6 @@ async def test_stop_tears_down_monitors_and_unsubscribes(
     assert log == ["mqtt.stop", "state_monitor.stop"]
 
 
-@pytest.mark.asyncio
 async def test_stop_is_idempotent_without_started_listener(
     tmp_path: Path, make_db: MakeDbFactory
 ) -> None:
@@ -233,7 +230,6 @@ async def test_stop_is_idempotent_without_started_listener(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_poll_rescans_and_reconciles_mqtt(tmp_path: Path, make_db: MakeDbFactory) -> None:
     """``poll()`` runs a fresh scan + MQTT reconcile.
 

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -27,8 +27,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from esphome_device_builder.models import (
     AdoptableDevice,
     Device,
@@ -82,7 +80,6 @@ def test_get_devices_returns_scanner_snapshot(
     assert [d.name for d in snapshot] == ["kitchen", "bedroom"]
 
 
-@pytest.mark.asyncio
 async def test_get_device_states_returns_configuration_keyed_map(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -106,7 +103,6 @@ async def test_get_device_states_returns_configuration_keyed_map(
     assert states == {"kitchen.yaml": "online", "bedroom.yaml": "offline"}
 
 
-@pytest.mark.asyncio
 async def test_list_devices_scans_then_returns_configured_and_importable(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -130,7 +126,6 @@ async def test_list_devices_scans_then_returns_configured_and_importable(
     assert ("scan",) in controller._scanner.calls
 
 
-@pytest.mark.asyncio
 async def test_list_devices_filters_importable_already_configured(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_metadata_store.py
+++ b/tests/controllers/devices/test_metadata_store.py
@@ -33,7 +33,6 @@ def _make_store(tmp_path: Path) -> DeviceMetadataStore:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_async_load_with_no_files_leaves_state_empty(tmp_path: Path) -> None:
     """No shared sidecar + no new file → empty RAM, no disk writes."""
     store = _make_store(tmp_path)
@@ -45,7 +44,6 @@ async def test_async_load_with_no_files_leaves_state_empty(tmp_path: Path) -> No
     assert not (tmp_path / ".device-builder.json").exists()
 
 
-@pytest.mark.asyncio
 async def test_async_load_migrates_live_fields_from_shared_sidecar(tmp_path: Path) -> None:
     """First-run migration pulls store-shaped fields out of the shared sidecar."""
     await asyncio.to_thread(
@@ -89,7 +87,6 @@ async def test_async_load_migrates_live_fields_from_shared_sidecar(tmp_path: Pat
     assert (tmp_path / ".device-builder-devices.json").exists()
 
 
-@pytest.mark.asyncio
 async def test_async_load_skips_migration_when_new_file_exists(tmp_path: Path) -> None:
     """Pre-existing new file wins; orphan fields in the shared sidecar are left alone."""
     new_path = tmp_path / ".device-builder-devices.json"
@@ -111,7 +108,6 @@ async def test_async_load_skips_migration_when_new_file_exists(tmp_path: Path) -
     }
 
 
-@pytest.mark.asyncio
 async def test_async_load_drops_shared_entry_with_only_store_fields(tmp_path: Path) -> None:
     """A shared-sidecar entry holding only store-shaped fields collapses out."""
     await asyncio.to_thread(
@@ -135,7 +131,6 @@ async def test_async_load_drops_shared_entry_with_only_store_fields(tmp_path: Pa
     assert "kitchen.yaml" not in shared
 
 
-@pytest.mark.asyncio
 async def test_async_load_migration_is_idempotent_across_loads(tmp_path: Path) -> None:
     """Second ``async_load`` reads the new file; shared sidecar stays byte-identical."""
     await asyncio.to_thread(
@@ -161,7 +156,6 @@ async def test_async_load_migration_is_idempotent_across_loads(tmp_path: Path) -
     assert await asyncio.to_thread(_load_metadata, tmp_path) == shared_after_first
 
 
-@pytest.mark.asyncio
 async def test_async_load_preserves_top_level_catalogs(tmp_path: Path) -> None:
     """Migration leaves ``_labels`` / ``_preferences`` / ``_remote_build`` alone."""
     await asyncio.to_thread(
@@ -187,7 +181,6 @@ async def test_async_load_preserves_top_level_catalogs(tmp_path: Path) -> None:
     assert shared["_remote_build"] == {"enabled": True}
 
 
-@pytest.mark.asyncio
 async def test_e2e_pre_pr_shape_migrates_through_resolver(
     tmp_path: Path,
     make_controller: Any,
@@ -259,7 +252,6 @@ async def test_e2e_pre_pr_shape_migrates_through_resolver(
     }
 
 
-@pytest.mark.asyncio
 async def test_async_load_recovers_from_corrupt_store_json(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -274,7 +266,6 @@ async def test_async_load_recovers_from_corrupt_store_json(
     assert any("corrupt JSON" in r.message for r in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_async_load_recovers_from_non_dict_store_json(tmp_path: Path) -> None:
     """A non-dict top-level value in the store file decodes as empty state."""
     (tmp_path / ".device-builder-devices.json").write_bytes(b"[1, 2, 3]")
@@ -285,7 +276,6 @@ async def test_async_load_recovers_from_non_dict_store_json(tmp_path: Path) -> N
     assert store.snapshot_all() == {}
 
 
-@pytest.mark.asyncio
 async def test_migration_strip_skips_non_dict_entries(tmp_path: Path) -> None:
     """A non-dict entry in the shared sidecar doesn't trip the strip phase."""
     await asyncio.to_thread(
@@ -306,7 +296,6 @@ async def test_migration_strip_skips_non_dict_entries(tmp_path: Path) -> None:
     assert shared["bad.yaml"] == "not-a-dict"
 
 
-@pytest.mark.asyncio
 async def test_migration_strip_handles_concurrent_corruption(tmp_path: Path) -> None:
     """A migrated entry that turns non-dict between read and strip skips cleanly."""
     store = _make_store(tmp_path)
@@ -319,7 +308,6 @@ async def test_migration_strip_handles_concurrent_corruption(tmp_path: Path) -> 
     assert shared == {"kitchen.yaml": "not-a-dict"}
 
 
-@pytest.mark.asyncio
 async def test_round_trip_after_migration(tmp_path: Path) -> None:
     """Migration → mutate → flush → reload: full state round-trips through disk."""
     await asyncio.to_thread(
@@ -338,7 +326,6 @@ async def test_round_trip_after_migration(tmp_path: Path) -> None:
     assert second.get("kitchen.yaml") == {"ip": "192.168.1.42", "deployed_version": "2026.5.1"}
 
 
-@pytest.mark.asyncio
 async def test_async_load_drops_corrupt_non_dict_entries(tmp_path: Path) -> None:
     """A non-dict shared-sidecar entry is ignored during migration, not crashed on."""
     await asyncio.to_thread(
@@ -379,7 +366,6 @@ def test_get_returns_defensive_copy(tmp_path: Path) -> None:
     assert store._state["kitchen.yaml"]["ip"] == "10.0.0.1"
 
 
-@pytest.mark.asyncio
 async def test_update_merges_truthy_fields_into_entry(tmp_path: Path) -> None:
     """Truthy values write; subsequent updates merge into the entry."""
     store = _make_store(tmp_path)
@@ -393,7 +379,6 @@ async def test_update_merges_truthy_fields_into_entry(tmp_path: Path) -> None:
     }
 
 
-@pytest.mark.asyncio
 async def test_update_treats_none_as_leave_alone(tmp_path: Path) -> None:
     """``None`` keeps the existing value."""
     store = _make_store(tmp_path)
@@ -403,7 +388,6 @@ async def test_update_treats_none_as_leave_alone(tmp_path: Path) -> None:
     assert store.get("kitchen.yaml") == {"ip": "10.0.0.1", "deployed_version": "2026.5.1"}
 
 
-@pytest.mark.asyncio
 async def test_update_treats_falsy_as_clear(tmp_path: Path) -> None:
     """A falsy value pops the field; an empty entry drops the filename."""
     store = _make_store(tmp_path)
@@ -417,7 +401,6 @@ async def test_update_treats_falsy_as_clear(tmp_path: Path) -> None:
     assert "kitchen.yaml" not in store.snapshot_all()
 
 
-@pytest.mark.asyncio
 async def test_update_replaces_inner_dict_never_mutates_in_place(tmp_path: Path) -> None:
     """Captured reference sees the pre-update state — no in-place writes."""
     store = _make_store(tmp_path)
@@ -435,7 +418,6 @@ async def test_update_replaces_inner_dict_never_mutates_in_place(tmp_path: Path)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_set_field_writes_empty_string_literally(tmp_path: Path) -> None:
     """``set_field`` persists the empty-string sentinel that ``update`` would clear."""
     store = _make_store(tmp_path)
@@ -443,7 +425,6 @@ async def test_set_field_writes_empty_string_literally(tmp_path: Path) -> None:
     assert store.get("kitchen.yaml") == {"api_encryption_active": ""}
 
 
-@pytest.mark.asyncio
 async def test_set_field_overwrites_existing_value(tmp_path: Path) -> None:
     """A subsequent ``set_field`` replaces the prior value verbatim."""
     store = _make_store(tmp_path)
@@ -452,7 +433,6 @@ async def test_set_field_overwrites_existing_value(tmp_path: Path) -> None:
     assert store.get("kitchen.yaml") == {"api_encryption_active": ""}
 
 
-@pytest.mark.asyncio
 async def test_set_field_replaces_inner_dict_never_mutates_in_place(tmp_path: Path) -> None:
     """Captured reference sees the pre-write state — no in-place writes."""
     store = _make_store(tmp_path)
@@ -465,7 +445,6 @@ async def test_set_field_replaces_inner_dict_never_mutates_in_place(tmp_path: Pa
     assert store._state["kitchen.yaml"] is not captured
 
 
-@pytest.mark.asyncio
 async def test_set_field_no_op_when_value_unchanged(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -486,7 +465,6 @@ async def test_set_field_no_op_when_value_unchanged(
     assert schedules == [_DEFAULT_SAVE_DELAY]
 
 
-@pytest.mark.asyncio
 async def test_update_idempotent_no_op_when_value_unchanged(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -513,7 +491,6 @@ async def test_update_idempotent_no_op_when_value_unchanged(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remove_drops_entry_and_flushes(tmp_path: Path) -> None:
     """``remove`` pops + flushes immediately so a quick restart can't resurrect."""
     store = _make_store(tmp_path)
@@ -528,7 +505,6 @@ async def test_remove_drops_entry_and_flushes(tmp_path: Path) -> None:
     assert b"kitchen.yaml" not in on_disk
 
 
-@pytest.mark.asyncio
 async def test_remove_unknown_filename_is_noop(tmp_path: Path) -> None:
     """``remove`` for a filename never in the store doesn't touch disk."""
     store = _make_store(tmp_path)
@@ -536,7 +512,6 @@ async def test_remove_unknown_filename_is_noop(tmp_path: Path) -> None:
     assert not (tmp_path / ".device-builder-devices.json").exists()
 
 
-@pytest.mark.asyncio
 async def test_clear_volatile_pops_every_store_field(tmp_path: Path) -> None:
     """``clear_volatile`` drops every store-owned field for the filename."""
     store = _make_store(tmp_path)
@@ -559,7 +534,6 @@ async def test_clear_volatile_pops_every_store_field(tmp_path: Path) -> None:
     assert store.get("kitchen.yaml") == {}
 
 
-@pytest.mark.asyncio
 async def test_clear_volatile_replaces_entry_does_not_mutate_in_place(tmp_path: Path) -> None:
     """A reference held mid-iteration sees the pre-clear state, not a half-cleared one."""
     store = _make_store(tmp_path)
@@ -572,7 +546,6 @@ async def test_clear_volatile_replaces_entry_does_not_mutate_in_place(tmp_path: 
     assert captured == {"ip": "10.0.0.1", "deployed_config_hash": "abc12345"}
 
 
-@pytest.mark.asyncio
 async def test_clear_volatile_unknown_filename_is_noop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -622,7 +595,6 @@ def test_store_fields_pinned() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_multiple_updates_coalesce_into_one_disk_write(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -657,7 +629,6 @@ async def test_multiple_updates_coalesce_into_one_disk_write(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_then_load_round_trip(tmp_path: Path) -> None:
     """A second store instance reads back what the first one persisted."""
     first = _make_store(tmp_path)

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -67,7 +67,6 @@ def _reset_fake_path_existing() -> Any:
     _FakePath.existing = set()
 
 
-@pytest.mark.asyncio
 async def test_rename_target_filename_collision_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -88,7 +87,6 @@ async def test_rename_target_filename_collision_raises(
     assert "already exists" in excinfo.value.message
 
 
-@pytest.mark.asyncio
 async def test_rename_same_name_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -109,7 +107,6 @@ async def test_rename_same_name_raises(
     assert "must differ" in excinfo.value.message
 
 
-@pytest.mark.asyncio
 async def test_rename_same_name_raises_for_yml_extension(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -132,7 +129,6 @@ async def test_rename_same_name_raises_for_yml_extension(
     assert "must differ" in excinfo.value.message
 
 
-@pytest.mark.asyncio
 async def test_rename_queues_firmware_job(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -162,7 +158,6 @@ async def test_rename_queues_firmware_job(
     assert controller._scanner.calls == []
 
 
-@pytest.mark.asyncio
 async def test_rename_missing_firmware_controller_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_search_yaml.py
+++ b/tests/controllers/devices/test_search_yaml.py
@@ -55,7 +55,6 @@ def _seed_yaml(tmp_path: Path, name: str, content: str) -> None:
 
 
 @pytest.mark.parametrize("query", ["", "   ", "\t"])
-@pytest.mark.asyncio
 async def test_search_yaml_empty_query_returns_empty_without_io(
     query: str,
     tmp_path: Path,
@@ -85,7 +84,6 @@ async def test_search_yaml_empty_query_returns_empty_without_io(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_substring_match_returns_per_device_hits(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -135,7 +133,6 @@ async def test_search_yaml_substring_match_returns_per_device_hits(
     ]
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_friendly_name_falls_back_to_device_name(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -163,7 +160,6 @@ async def test_search_yaml_friendly_name_falls_back_to_device_name(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_default_is_case_insensitive(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -184,7 +180,6 @@ async def test_search_yaml_default_is_case_insensitive(
     assert results[0]["matches"][0]["line_number"] == 1
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_case_sensitive_opt_in(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -208,7 +203,6 @@ async def test_search_yaml_case_sensitive_opt_in(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_caps_matches_per_file(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -235,7 +229,6 @@ async def test_search_yaml_caps_matches_per_file(
     assert len(results[0]["matches"]) == 5
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_caps_total_results(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -266,7 +259,6 @@ async def test_search_yaml_caps_total_results(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_serialises_concurrent_calls(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -317,7 +309,6 @@ async def test_search_yaml_serialises_concurrent_calls(
     assert max_in_flight == 1
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_skips_missing_files(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -351,7 +342,6 @@ async def test_search_yaml_skips_missing_files(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_default_context_is_two_lines(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -382,7 +372,6 @@ async def test_search_yaml_default_context_is_two_lines(
     ]
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_context_lines_zero_drops_window(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -408,7 +397,6 @@ async def test_search_yaml_context_lines_zero_drops_window(
     assert results[0]["matches"][0]["after"] == []
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_context_lines_clamped_to_max(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -437,7 +425,6 @@ async def test_search_yaml_context_lines_clamped_to_max(
     assert len(results[0]["matches"][0]["after"]) == MAX_CONTEXT_LINES
 
 
-@pytest.mark.asyncio
 async def test_search_yaml_negative_context_lines_falls_back_to_zero(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_search_yaml_fixtures.py
+++ b/tests/controllers/devices/test_search_yaml_fixtures.py
@@ -42,8 +42,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
-
 from esphome_device_builder.models import Device, DeviceState
 
 if TYPE_CHECKING:
@@ -86,7 +84,6 @@ def _seed_fleet(tmp_path: Path) -> list[Device]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_bluetooth_proxy_query_picks_out_proxy_devices(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -108,7 +105,6 @@ async def test_bluetooth_proxy_query_picks_out_proxy_devices(
     assert matched == {"bluetooth_proxy.yaml", "ethernet_proxy.yaml"}
 
 
-@pytest.mark.asyncio
 async def test_ethernet_query_isolates_the_ethernet_device(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -137,7 +133,6 @@ async def test_ethernet_query_isolates_the_ethernet_device(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_cse7766_block_returns_multiple_lines_in_order(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -172,7 +167,6 @@ async def test_cse7766_block_returns_multiple_lines_in_order(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_comment_text_is_searchable(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -195,7 +189,6 @@ async def test_comment_text_is_searchable(
     assert "coexistence" in results[0]["matches"][0]["line_text"]
 
 
-@pytest.mark.asyncio
 async def test_substitution_interpolation_matches_as_literal_text(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -218,7 +211,6 @@ async def test_substitution_interpolation_matches_as_literal_text(
     assert len(results[0]["matches"]) >= 1
 
 
-@pytest.mark.asyncio
 async def test_secret_reference_is_searchable(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -251,7 +243,6 @@ async def test_secret_reference_is_searchable(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_per_file_cap_holds_against_chatty_fixture(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -274,7 +265,6 @@ async def test_per_file_cap_holds_against_chatty_fixture(
     assert len(plug_hits[0]["matches"]) == 5
 
 
-@pytest.mark.asyncio
 async def test_yaml_directive_marker_does_not_break_match(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -54,7 +54,6 @@ def _make_device(filename: str = "kitchen.yaml", labels: list[str] | None = None
     return make_label_test_device(filename, labels)
 
 
-@pytest.mark.asyncio
 async def test_set_labels_persists_and_reloads(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -84,7 +83,6 @@ async def test_set_labels_persists_and_reloads(
     assert result.labels == ["lbl-a", "lbl-b"]
 
 
-@pytest.mark.asyncio
 async def test_set_labels_clear_drops_sidecar_key(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -103,7 +101,6 @@ async def test_set_labels_clear_drops_sidecar_key(
     assert result.labels == []
 
 
-@pytest.mark.asyncio
 async def test_set_labels_unknown_id_rejected_without_partial_write(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -135,7 +132,6 @@ async def test_set_labels_unknown_id_rejected_without_partial_write(
     assert ("reload", "kitchen.yaml") not in scanner.calls
 
 
-@pytest.mark.asyncio
 async def test_set_labels_rejects_path_traversal(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -168,7 +164,6 @@ async def test_set_labels_rejects_path_traversal(
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_set_labels_rejects_non_list_label_ids(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -187,7 +182,6 @@ async def test_set_labels_rejects_non_list_label_ids(
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_set_labels_rejects_non_string_label_id(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -216,7 +210,6 @@ async def test_set_labels_rejects_non_string_label_id(
     assert "labels" not in meta
 
 
-@pytest.mark.asyncio
 async def test_set_labels_rejects_unknown_configuration(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -247,7 +240,6 @@ async def test_set_labels_rejects_unknown_configuration(
     assert ("reload", "ghost.yaml") not in scanner.calls
 
 
-@pytest.mark.asyncio
 async def test_reload_configuration_delegates_to_scanner(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -269,7 +261,6 @@ async def test_reload_configuration_delegates_to_scanner(
     assert ("reload", "kitchen.yaml") in controller._scanner.calls
 
 
-@pytest.mark.asyncio
 async def test_set_labels_round_trips_through_metadata(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_set_labels_bulk.py
+++ b/tests/controllers/devices/test_set_labels_bulk.py
@@ -6,8 +6,6 @@ import asyncio
 import json
 from pathlib import Path
 
-import pytest
-
 from esphome_device_builder.controllers.config import save_labels
 from esphome_device_builder.models import Label
 
@@ -18,7 +16,6 @@ from .conftest import (
 )
 
 
-@pytest.mark.asyncio
 async def test_set_labels_bulk_applies_each_update(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -57,7 +54,6 @@ async def test_set_labels_bulk_applies_each_update(
     assert ("reload", "garage.yaml") in scanner.calls
 
 
-@pytest.mark.asyncio
 async def test_set_labels_bulk_reports_per_entry_failure(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -89,7 +85,6 @@ async def test_set_labels_bulk_reports_per_entry_failure(
     assert "garage.yaml" not in raw
 
 
-@pytest.mark.asyncio
 async def test_set_labels_bulk_preserves_input_order_with_duplicates(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -118,7 +113,6 @@ async def test_set_labels_bulk_preserves_input_order_with_duplicates(
     assert raw["kitchen.yaml"]["labels"] == ["lbl-b"]
 
 
-@pytest.mark.asyncio
 async def test_set_labels_bulk_malformed_row_isolates_failure(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -153,7 +147,6 @@ async def test_set_labels_bulk_malformed_row_isolates_failure(
     assert raw["kitchen.yaml"]["labels"] == ["lbl-a"]
 
 
-@pytest.mark.asyncio
 async def test_set_labels_bulk_empty_updates_returns_empty(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_stop_stream.py
+++ b/tests/controllers/devices/test_stop_stream.py
@@ -49,7 +49,6 @@ def _make_ws_client() -> WebSocketClient:
     return WebSocketClient(MagicMock(), MagicMock(), authenticated=True)
 
 
-@pytest.mark.asyncio
 async def test_stop_stream_returns_false_without_client(
     tmp_path: Any, make_controller: MakeControllerFactory
 ) -> None:
@@ -67,7 +66,6 @@ async def test_stop_stream_returns_false_without_client(
     assert result == {"cancelled": False}
 
 
-@pytest.mark.asyncio
 async def test_stop_stream_cancels_registered_task(
     tmp_path: Any, make_controller: MakeControllerFactory
 ) -> None:
@@ -106,7 +104,6 @@ async def test_stop_stream_cancels_registered_task(
     assert task.cancelled()
 
 
-@pytest.mark.asyncio
 async def test_stop_stream_returns_false_for_unknown_stream(
     tmp_path: Any, make_controller: MakeControllerFactory
 ) -> None:
@@ -126,7 +123,6 @@ async def test_stop_stream_returns_false_for_unknown_stream(
     assert result == {"cancelled": False}
 
 
-@pytest.mark.asyncio
 async def test_stop_stream_returns_false_after_double_cancel(
     tmp_path: Any, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -90,7 +90,6 @@ async def _drain(controller: DevicesController) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_regenerate_spawns_esphome_compile_only_generate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -210,7 +209,6 @@ def test_regenerate_skips_after_failed_marker(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_regenerate_marks_failed_on_nonzero_exit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -249,7 +247,6 @@ async def test_regenerate_marks_failed_on_nonzero_exit(
     assert controller.state.regenerate_pending == set()
 
 
-@pytest.mark.asyncio
 async def test_regenerate_marks_failed_on_spawn_oserror(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -293,7 +290,6 @@ async def test_regenerate_marks_failed_on_spawn_oserror(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_regenerate_dedupes_same_tick_calls(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -336,7 +332,6 @@ async def test_regenerate_dedupes_same_tick_calls(
     assert controller.state.regenerate_pending == set()
 
 
-@pytest.mark.asyncio
 async def test_regenerate_pending_blocks_in_flight_dupe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -388,7 +383,6 @@ async def test_regenerate_pending_blocks_in_flight_dupe(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -434,7 +428,6 @@ async def test_regenerate_persists_mtime_and_wallclock_on_failure(
     assert md.get("regen_failed_at") == 1700000000.0
 
 
-@pytest.mark.asyncio
 async def test_regenerate_persists_stamp_on_spawn_oserror(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -476,7 +469,6 @@ async def test_regenerate_persists_stamp_on_spawn_oserror(
     assert md.get("regen_failed_at") == 1700000050.0
 
 
-@pytest.mark.asyncio
 async def test_regenerate_clears_failure_stamp_on_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -522,7 +514,6 @@ async def test_regenerate_clears_failure_stamp_on_success(
     assert "regen_failed_at" not in md
 
 
-@pytest.mark.asyncio
 async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -573,7 +564,6 @@ async def test_regenerate_skips_when_stamp_fresh_and_mtime_matches(
     assert controller.state.regenerate_failed == {"kitchen.yaml"}
 
 
-@pytest.mark.asyncio
 async def test_regenerate_retries_when_stamp_older_than_ttl(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -624,7 +614,6 @@ async def test_regenerate_retries_when_stamp_older_than_ttl(
     assert len(spawn_calls) == 1
 
 
-@pytest.mark.asyncio
 async def test_regenerate_runs_when_yaml_mtime_moves_past_stamp(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -676,7 +665,6 @@ async def test_regenerate_runs_when_yaml_mtime_moves_past_stamp(
     assert len(spawn_calls) == 1
 
 
-@pytest.mark.asyncio
 async def test_regenerate_runs_when_yaml_missing_for_stamp_check(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -719,7 +707,6 @@ async def test_regenerate_runs_when_yaml_missing_for_stamp_check(
     assert len(spawn_calls) == 1
 
 
-@pytest.mark.asyncio
 async def test_regenerate_clamps_negative_stamp_age(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -767,7 +754,6 @@ async def test_regenerate_clamps_negative_stamp_age(
     assert spawn_calls == []
 
 
-@pytest.mark.asyncio
 async def test_regenerate_runs_when_only_one_stamp_half_present(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -813,7 +799,6 @@ async def test_regenerate_runs_when_only_one_stamp_half_present(
     assert len(spawn_calls) == 1
 
 
-@pytest.mark.asyncio
 async def test_regenerate_runs_when_stamp_has_corrupt_value(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -865,7 +850,6 @@ async def test_regenerate_runs_when_stamp_has_corrupt_value(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_regenerate_persists_hash_and_clears_stamp_in_one_transaction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -933,7 +917,6 @@ async def test_regenerate_persists_hash_and_clears_stamp_in_one_transaction(
     assert "regen_failed_at" not in md
 
 
-@pytest.mark.asyncio
 async def test_regenerate_success_clears_stamp_when_build_info_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/controllers/devices/test_subscribe_reachability.py
+++ b/tests/controllers/devices/test_subscribe_reachability.py
@@ -167,7 +167,6 @@ async def _subscribe_and_wait(
     return task
 
 
-@pytest.mark.asyncio
 async def test_subscribe_emits_initial_snapshot_then_confirmation(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -205,7 +204,6 @@ async def test_subscribe_emits_initial_snapshot_then_confirmation(
             await task
 
 
-@pytest.mark.asyncio
 async def test_live_event_for_subscribed_device_forwards(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -249,7 +247,6 @@ async def test_live_event_for_subscribed_device_forwards(
             await task
 
 
-@pytest.mark.asyncio
 async def test_live_event_for_other_device_is_filtered(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -290,7 +287,6 @@ async def test_live_event_for_other_device_is_filtered(
             await task
 
 
-@pytest.mark.asyncio
 async def test_subscribe_unknown_device_raises_not_found(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -308,7 +304,6 @@ async def test_subscribe_unknown_device_raises_not_found(
     assert exc.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_subscribe_missing_device_name_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -325,7 +320,6 @@ async def test_subscribe_missing_device_name_raises(
     assert exc.value.code == ErrorCode.INVALID_MESSAGE
 
 
-@pytest.mark.asyncio
 async def test_cancel_via_stop_stream_detaches_listener(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -370,7 +364,6 @@ async def test_cancel_via_stop_stream_detaches_listener(
     assert "m1" not in client._stream_tasks
 
 
-@pytest.mark.asyncio
 async def test_subscribe_without_client_returns_silently(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -479,7 +472,6 @@ def test_scan_change_removed_clears_tracker(
     assert snap["ping_last_seen_seconds_ago"] is None
 
 
-@pytest.mark.asyncio
 async def test_refresh_loop_only_calls_resolve_when_source_is_mdns(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -524,7 +516,6 @@ async def test_refresh_loop_only_calls_resolve_when_source_is_mdns(
     state_monitor.refresh_mdns.assert_awaited_with("kitchen")
 
 
-@pytest.mark.asyncio
 async def test_refresh_loop_sleeps_until_cache_expiry(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -570,7 +561,6 @@ async def test_refresh_loop_sleeps_until_cache_expiry(
     assert sleep_durations[1] == pytest.approx(_MDNS_REFRESH_PADDING_SECONDS)
 
 
-@pytest.mark.asyncio
 async def test_refresh_loop_skips_wire_query_when_recheck_finds_fresh_cache(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_toggle_ignore.py
+++ b/tests/controllers/devices/test_toggle_ignore.py
@@ -75,7 +75,6 @@ def _patch_ignored_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     )
 
 
-@pytest.mark.asyncio
 async def test_toggle_ignore_true_adds_to_set_and_persists(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -95,7 +94,6 @@ async def test_toggle_ignore_true_adds_to_set_and_persists(
     assert payload == {"ignored_devices": ["kitchen-1a2b3c"]}
 
 
-@pytest.mark.asyncio
 async def test_toggle_ignore_false_removes_and_persists(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -123,7 +121,6 @@ async def test_toggle_ignore_false_removes_and_persists(
     await controller.toggle_ignore(name="never-ignored", ignore=False)
 
 
-@pytest.mark.asyncio
 async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -164,7 +161,6 @@ async def test_toggle_ignore_mirrors_flag_onto_cached_adoptable_and_fires(
     assert fired[0].data == {"device": cached}
 
 
-@pytest.mark.asyncio
 async def test_toggle_ignore_does_not_fire_when_state_unchanged(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_update_device.py
+++ b/tests/controllers/devices/test_update_device.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-import pytest
-
 from esphome_device_builder.controllers.config import (
     get_device_metadata,
     set_device_metadata,
@@ -30,7 +28,6 @@ from esphome_device_builder.controllers.config import (
 from .conftest import MakeControllerFactory
 
 
-@pytest.mark.asyncio
 async def test_update_device_writes_full_metadata(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -68,7 +65,6 @@ async def test_update_device_writes_full_metadata(
     assert meta["board_id"] == "esp32-c3-devkitm-1"
 
 
-@pytest.mark.asyncio
 async def test_update_device_partial_keeps_unrelated_fields(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -101,7 +97,6 @@ async def test_update_device_partial_keeps_unrelated_fields(
     assert response.board_id == "esp32-c3-devkitm-1"
 
 
-@pytest.mark.asyncio
 async def test_update_device_falls_back_to_name_for_missing_friendly_name(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
@@ -124,7 +119,6 @@ async def test_update_device_falls_back_to_name_for_missing_friendly_name(
     assert response.board_id == "esp32-c3-devkitm-1"
 
 
-@pytest.mark.asyncio
 async def test_update_device_persists_via_executor(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_yaml_search_cache.py
+++ b/tests/controllers/devices/test_yaml_search_cache.py
@@ -28,8 +28,6 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from esphome_device_builder.controllers.devices._yaml_search_cache import (
     MAX_FILE_BYTES,
     YamlSearchCache,
@@ -40,7 +38,6 @@ from esphome_device_builder.controllers.devices._yaml_search_cache import (
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_cold_call_reads_file_and_caches(tmp_path: Path) -> None:
     """First call against a fresh file reads from disk + splits lines.
 
@@ -58,7 +55,6 @@ async def test_cold_call_reads_file_and_caches(tmp_path: Path) -> None:
     assert lines == ["esphome:", "  name: kitchen", "wifi:"]
 
 
-@pytest.mark.asyncio
 async def test_warm_call_returns_cached_without_reading(tmp_path: Path) -> None:
     """Second call against an unchanged file doesn't re-read.
 
@@ -81,7 +77,6 @@ async def test_warm_call_returns_cached_without_reading(tmp_path: Path) -> None:
     assert second is first  # same list object — the cache returned the cached one
 
 
-@pytest.mark.asyncio
 async def test_mtime_change_invalidates_cache(tmp_path: Path) -> None:
     """A new mtime forces a re-read; the cached entry is replaced.
 
@@ -112,7 +107,6 @@ async def test_mtime_change_invalidates_cache(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_missing_file_returns_none_and_clears_stale(tmp_path: Path) -> None:
     """File deleted between calls → ``None`` + cache entry removed.
 
@@ -144,7 +138,6 @@ async def test_missing_file_returns_none_and_clears_stale(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_unreadable_file_returns_none_and_clears_stale(tmp_path: Path) -> None:
     """File stats OK but read fails → ``None`` + cache entry removed.
 
@@ -188,7 +181,6 @@ async def test_unreadable_file_returns_none_and_clears_stale(tmp_path: Path) -> 
     assert refreshed == ["wifi:"]
 
 
-@pytest.mark.asyncio
 async def test_prune_drops_only_stale_entries(tmp_path: Path) -> None:
     """``prune(live)`` removes entries whose key isn't in *live*.
 
@@ -223,7 +215,6 @@ async def test_prune_drops_only_stale_entries(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> None:
     """Two simultaneous misses on the same file collapse to one read.
 
@@ -261,7 +252,6 @@ async def test_concurrent_misses_against_same_file_read_once(tmp_path: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_oversize_file_returns_none_without_loading(tmp_path: Path) -> None:
     """Files past ``MAX_FILE_BYTES`` are skipped *before* read_text fires.
 
@@ -295,7 +285,6 @@ async def test_oversize_file_returns_none_without_loading(tmp_path: Path) -> Non
     assert read_calls == 0
 
 
-@pytest.mark.asyncio
 async def test_oversize_file_drops_stale_cache_entry(tmp_path: Path) -> None:
     """A previously-cached small file is evicted if it grows past the cap.
 

--- a/tests/controllers/devices/test_yaml_search_module.py
+++ b/tests/controllers/devices/test_yaml_search_module.py
@@ -27,8 +27,6 @@ import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 
-import pytest
-
 from esphome_device_builder.controllers.devices._yaml_search import (
     MAX_LINES_PER_FILE,
     search_yaml_devices,
@@ -67,7 +65,6 @@ def _rel(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_returns_results_and_live_configurations(tmp_path: Path) -> None:
     """Result tuple shape — pinned for the controller's cache prune.
 
@@ -113,7 +110,6 @@ async def test_returns_results_and_live_configurations(tmp_path: Path) -> None:
     assert live == {"kitchen.yaml", "bedroom.yaml"}
 
 
-@pytest.mark.asyncio
 async def test_friendly_name_falls_back_to_device_name(tmp_path: Path) -> None:
     """Empty ``friendly_name`` → result row uses ``device_name``.
 
@@ -144,7 +140,6 @@ async def test_friendly_name_falls_back_to_device_name(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_case_insensitive_caller_lowered_needle(tmp_path: Path) -> None:
     """``case_sensitive=False`` lowers each line; needle is pre-lowered.
 
@@ -170,7 +165,6 @@ async def test_case_insensitive_caller_lowered_needle(tmp_path: Path) -> None:
     assert len(results) == 1
 
 
-@pytest.mark.asyncio
 async def test_case_sensitive_distinguishes_case(tmp_path: Path) -> None:
     """``case_sensitive=True`` treats each line as-is."""
     cache = YamlSearchCache()
@@ -194,7 +188,6 @@ async def test_case_sensitive_distinguishes_case(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_max_lines_per_file_caps_pathological_files(tmp_path: Path) -> None:
     """Files past ``MAX_LINES_PER_FILE`` lines are scanned only up to the cap.
 
@@ -262,7 +255,6 @@ async def test_max_lines_per_file_caps_pathological_files(tmp_path: Path) -> Non
     assert results == []
 
 
-@pytest.mark.asyncio
 async def test_per_file_cap_truncates_matches(tmp_path: Path) -> None:
     """One device's match list caps at ``per_file_cap``."""
     cache = YamlSearchCache()
@@ -281,7 +273,6 @@ async def test_per_file_cap_truncates_matches(tmp_path: Path) -> None:
     assert len(results[0]["matches"]) == 3
 
 
-@pytest.mark.asyncio
 async def test_total_results_cap_short_circuits_walk(tmp_path: Path) -> None:
     """Walk stops once ``max_results`` is reached.
 
@@ -323,7 +314,6 @@ async def test_total_results_cap_short_circuits_walk(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_unmatched_device_omitted_from_results(tmp_path: Path) -> None:
     """A device with no matches is skipped from ``results``."""
     cache = YamlSearchCache()
@@ -349,7 +339,6 @@ async def test_unmatched_device_omitted_from_results(tmp_path: Path) -> None:
     assert live == {"kitchen.yaml", "bedroom.yaml"}
 
 
-@pytest.mark.asyncio
 async def test_unreadable_file_skipped_but_visited(tmp_path: Path) -> None:
     """Cache returns ``None`` → device skipped from results.
 
@@ -385,7 +374,6 @@ async def test_unreadable_file_skipped_but_visited(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_yields_to_event_loop_between_devices(tmp_path: Path) -> None:
     """``await asyncio.sleep(0)`` between devices keeps the loop responsive.
 
@@ -439,7 +427,6 @@ async def test_yields_to_event_loop_between_devices(tmp_path: Path) -> None:
     assert ticks >= len(devices)
 
 
-@pytest.mark.asyncio
 async def test_match_includes_full_context_window_when_not_at_edge(
     tmp_path: Path,
 ) -> None:

--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -69,7 +69,6 @@ def _job(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_rename_returns_queued_rename_job(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -91,7 +90,6 @@ async def test_rename_returns_queued_rename_job(
     assert job.new_name == "livingroom"
 
 
-@pytest.mark.asyncio
 async def test_rename_rejects_when_target_filename_already_exists(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -121,7 +119,6 @@ async def test_rename_rejects_when_target_filename_already_exists(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_follow_job_raises_value_error_for_unknown_job_id(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -138,7 +135,6 @@ async def test_follow_job_raises_value_error_for_unknown_job_id(
         await controller.follow_job(job_id="ghost-id", client=MagicMock())
 
 
-@pytest.mark.asyncio
 async def test_follow_jobs_returns_immediately_when_client_is_none(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -166,7 +162,6 @@ async def test_follow_jobs_returns_immediately_when_client_is_none(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_run_queue_skips_cancelled_jobs_without_spawning(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -205,7 +200,6 @@ async def test_run_queue_skips_cancelled_jobs_without_spawning(
     assert spawned is False
 
 
-@pytest.mark.asyncio
 async def test_terminate_current_process_no_op_when_no_process(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_bulk_order.py
+++ b/tests/controllers/firmware/test_bulk_order.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from esphome_device_builder.controllers.firmware.bulk import _esphome_version_sort_key
 from esphome_device_builder.models import Device, JobType
 from tests.conftest import make_device
@@ -39,7 +37,6 @@ def _device(
     )
 
 
-@pytest.mark.asyncio
 async def test_install_bulk_queues_stale_devices_before_pending_changes(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -81,7 +78,6 @@ async def test_install_bulk_queues_stale_devices_before_pending_changes(
     assert [job.job_type for job in jobs] == [JobType.INSTALL] * 5
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_preserves_tail_input_order(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -114,7 +110,6 @@ async def test_bulk_order_preserves_tail_input_order(
     ]
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_keeps_newer_deployed_versions_in_tail(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -145,7 +140,6 @@ async def test_bulk_order_keeps_newer_deployed_versions_in_tail(
     ]
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_uses_update_available_as_stale_gate(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -174,7 +168,6 @@ async def test_bulk_order_uses_update_available_as_stale_gate(
     ]
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_sorts_prerelease_numbers_numerically(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -201,7 +194,6 @@ async def test_bulk_order_sorts_prerelease_numbers_numerically(
     assert [job.configuration for job in jobs] == ["beta-2.yaml", "beta-10.yaml"]
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_keeps_missing_versions_out_of_stale_bucket(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -237,7 +229,6 @@ async def test_bulk_order_keeps_missing_versions_out_of_stale_bucket(
     ]
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_treats_unknown_deployed_version_as_oldest_stale(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -262,7 +253,6 @@ def test_esphome_version_sort_key_handles_missing_versions() -> None:
     assert _esphome_version_sort_key("") == _esphome_version_sort_key(None)
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_uses_stale_first_order(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -280,7 +270,6 @@ async def test_compile_bulk_uses_stale_first_order(
     assert [job.job_type for job in jobs] == [JobType.COMPILE, JobType.COMPILE]
 
 
-@pytest.mark.asyncio
 async def test_bulk_order_preserves_input_without_devices_controller(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -61,7 +61,6 @@ def _job(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_cancel_raises_not_found_for_unknown_job_id(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -88,7 +87,6 @@ async def test_cancel_raises_not_found_for_unknown_job_id(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_cancel_queued_job_marks_terminal_and_fires_event(
     firmware_controller_factory: FirmwareControllerFactory,
     capture_firmware_events: CaptureEventsFactory,
@@ -112,7 +110,6 @@ async def test_cancel_queued_job_marks_terminal_and_fires_event(
     assert [(e.event_type, e.data) for e in captured] == [(EventType.JOB_CANCELLED, {"job": job})]
 
 
-@pytest.mark.asyncio
 async def test_cancel_queued_job_prunes_history_before_persisting(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -146,7 +143,6 @@ async def test_cancel_queued_job_prunes_history_before_persisting(
     assert order == ["prune", "persist"]
 
 
-@pytest.mark.asyncio
 async def test_cancel_queued_does_not_touch_terminate_current_process(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -173,7 +169,6 @@ async def test_cancel_queued_does_not_touch_terminate_current_process(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_cancel_running_job_records_intent_and_terminates(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -195,7 +190,6 @@ async def test_cancel_running_job_records_intent_and_terminates(
     controller._terminate_current_process.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_cancel_running_job_does_not_fire_event_directly(
     firmware_controller_factory: FirmwareControllerFactory,
     capture_firmware_events: CaptureEventsFactory,
@@ -220,7 +214,6 @@ async def test_cancel_running_job_does_not_fire_event_directly(
     assert job.status == JobStatus.RUNNING
 
 
-@pytest.mark.asyncio
 async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -241,7 +234,6 @@ async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
     controller._terminate_current_process.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_cancel_running_job_with_mismatched_current_job_raises(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -270,7 +262,6 @@ async def test_cancel_running_job_with_mismatched_current_job_raises(
     "status",
     [JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED],
 )
-@pytest.mark.asyncio
 async def test_cancel_terminal_job_raises_invalid_args(
     status: JobStatus,
     firmware_controller_factory: FirmwareControllerFactory,

--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -83,7 +83,6 @@ def _pairing(
     )
 
 
-@pytest.mark.asyncio
 async def test_clean_returns_queued_job_with_clean_type(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -106,7 +105,6 @@ async def test_clean_returns_queued_job_with_clean_type(
     assert job.configuration == "kitchen.yaml"
 
 
-@pytest.mark.asyncio
 async def test_clean_rejects_traversal_configuration(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -128,7 +126,6 @@ async def test_clean_rejects_traversal_configuration(
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_clean_enqueues_before_firing_job_queued(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -155,7 +152,6 @@ async def test_clean_enqueues_before_firing_job_queued(
     assert log[1][1].data == {"job": job}
 
 
-@pytest.mark.asyncio
 async def test_clean_registers_job_in_jobs_map(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -183,7 +179,6 @@ async def test_clean_registers_job_in_jobs_map(
     "active_status",
     [JobStatus.QUEUED, JobStatus.RUNNING],
 )
-@pytest.mark.asyncio
 async def test_clean_rejects_when_active_build_for_same_configuration(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -230,7 +225,6 @@ async def test_clean_rejects_when_active_build_for_same_configuration(
     assert active.status == active_status
 
 
-@pytest.mark.asyncio
 async def test_clean_succeeds_when_active_build_targets_different_configuration(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -253,7 +247,6 @@ async def test_clean_succeeds_when_active_build_targets_different_configuration(
     assert job.job_type == JobType.CLEAN
 
 
-@pytest.mark.asyncio
 async def test_clean_supersedes_other_active_clean_on_same_configuration(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -277,7 +270,6 @@ async def test_clean_supersedes_other_active_clean_on_same_configuration(
     assert second.job_id != first.job_id
 
 
-@pytest.mark.asyncio
 async def test_clean_succeeds_after_terminal_active_build(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -304,7 +296,6 @@ async def test_clean_succeeds_after_terminal_active_build(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clean_fans_out_to_connected_approved_peers(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -364,7 +355,6 @@ async def test_clean_fans_out_to_connected_approved_peers(
     assert all(j.configuration == "kitchen.yaml" for j in clean_jobs)
 
 
-@pytest.mark.asyncio
 async def test_clean_fan_out_does_not_supersede_sibling_jobs(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -412,7 +402,6 @@ async def test_clean_fan_out_does_not_supersede_sibling_jobs(
     }
 
 
-@pytest.mark.asyncio
 async def test_repeat_clean_supersedes_entire_prior_fan_out_batch(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -477,7 +466,6 @@ async def test_repeat_clean_supersedes_entire_prior_fan_out_batch(
     assert len(active) == 3
 
 
-@pytest.mark.asyncio
 async def test_clean_skips_disconnected_or_pending_peers(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -516,7 +504,6 @@ async def test_clean_skips_disconnected_or_pending_peers(
     assert remote_pins == {"c".ljust(64, "0")}
 
 
-@pytest.mark.asyncio
 async def test_clean_with_no_remote_build_controller_skips_fan_out(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,

--- a/tests/controllers/firmware/test_clear.py
+++ b/tests/controllers/firmware/test_clear.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-import pytest
-
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
@@ -44,7 +42,6 @@ def _job(job_id: str, status: JobStatus, *, job_type: JobType = JobType.COMPILE)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clear_default_removes_all_terminal_states(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -66,7 +63,6 @@ async def test_clear_default_removes_all_terminal_states(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_clear_default_keeps_queued_and_running_jobs(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -89,7 +85,6 @@ async def test_clear_default_keeps_queued_and_running_jobs(
     assert {j.job_id for j in await controller.get_jobs()} == {"q", "r"}
 
 
-@pytest.mark.asyncio
 async def test_clear_default_with_no_terminal_jobs_is_noop(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -117,7 +112,6 @@ async def test_clear_default_with_no_terminal_jobs_is_noop(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clear_with_specific_status_removes_only_that_status(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -140,7 +134,6 @@ async def test_clear_with_specific_status_removes_only_that_status(
     assert {j.job_id for j in await controller.get_jobs()} == {"f", "x"}
 
 
-@pytest.mark.asyncio
 async def test_clear_with_status_string_matches_enum_value(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -164,7 +157,6 @@ async def test_clear_with_status_string_matches_enum_value(
     assert {j.job_id for j in await controller.get_jobs()} == {"f"}
 
 
-@pytest.mark.asyncio
 async def test_clear_with_status_can_remove_active_jobs(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -188,7 +180,6 @@ async def test_clear_with_status_can_remove_active_jobs(
     assert {j.job_id for j in await controller.get_jobs()} == {"q", "c"}
 
 
-@pytest.mark.asyncio
 async def test_clear_with_status_no_matches_is_noop(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -209,7 +200,6 @@ async def test_clear_with_status_no_matches_is_noop(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_clear_persists_after_removal(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -240,7 +230,6 @@ async def test_clear_persists_after_removal(
     assert seen_ids_at_persist == {"q"}
 
 
-@pytest.mark.asyncio
 async def test_clear_accepts_arbitrary_kwargs(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -261,7 +250,6 @@ async def test_clear_accepts_arbitrary_kwargs(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_clear_with_empty_jobs_map_is_noop(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_compile.py
+++ b/tests/controllers/firmware/test_compile.py
@@ -30,7 +30,6 @@ from tests.controllers.firmware.conftest import (
 )
 
 
-@pytest.mark.asyncio
 async def test_compile_returns_queued_job_with_compile_type(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -52,7 +51,6 @@ async def test_compile_returns_queued_job_with_compile_type(
     assert job.configuration == "kitchen.yaml"
 
 
-@pytest.mark.asyncio
 async def test_compile_rejects_traversal_configuration(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -74,7 +72,6 @@ async def test_compile_rejects_traversal_configuration(
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_compile_enqueues_before_firing_job_queued(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -101,7 +98,6 @@ async def test_compile_enqueues_before_firing_job_queued(
     assert log[1][1].data == {"job": job}
 
 
-@pytest.mark.asyncio
 async def test_compile_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_compile_bulk.py
+++ b/tests/controllers/firmware/test_compile_bulk.py
@@ -38,7 +38,6 @@ from tests.controllers.firmware.conftest import (
 )
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_returns_queued_jobs_for_every_config(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -61,7 +60,6 @@ async def test_compile_bulk_returns_queued_jobs_for_every_config(
     assert all(j.status == JobStatus.QUEUED for j in jobs)
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -91,7 +89,6 @@ async def test_compile_bulk_rejects_whole_batch_on_traversal_entry(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -112,7 +109,6 @@ async def test_compile_bulk_rejects_whole_batch_on_empty_entry(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_skips_entries_with_enqueue_command_error(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -161,7 +157,6 @@ async def test_compile_bulk_skips_entries_with_enqueue_command_error(
     assert "locked.yaml" in {j.configuration for j in await controller.get_jobs()}
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_reraises_no_compatible_peer(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -190,7 +185,6 @@ async def test_compile_bulk_reraises_no_compatible_peer(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_install_bulk_reraises_no_compatible_peer(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -208,7 +202,6 @@ async def test_install_bulk_reraises_no_compatible_peer(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_empty_input_returns_empty_list(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -226,7 +219,6 @@ async def test_compile_bulk_empty_input_returns_empty_list(
     assert await controller.get_jobs() == []
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_fires_job_queued_per_successful_entry(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,

--- a/tests/controllers/firmware/test_download.py
+++ b/tests/controllers/firmware/test_download.py
@@ -66,7 +66,6 @@ def _make_firmware(build_dir: Path, name: str, payload: bytes) -> Path:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_download_raises_when_storage_missing(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -83,7 +82,6 @@ async def test_download_raises_when_storage_missing(
         await controller.download(configuration="kitchen.yaml", file="firmware.bin")
 
 
-@pytest.mark.asyncio
 async def test_download_raises_when_firmware_bin_path_unset(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -102,7 +100,6 @@ async def test_download_raises_when_firmware_bin_path_unset(
         await controller.download(configuration="kitchen.yaml", file="firmware.bin")
 
 
-@pytest.mark.asyncio
 async def test_download_raises_on_traversal_in_file(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -127,7 +124,6 @@ async def test_download_raises_on_traversal_in_file(
         await controller.download(configuration="kitchen.yaml", file="../../../secret.txt")
 
 
-@pytest.mark.asyncio
 async def test_download_raises_when_binary_missing(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -152,7 +148,6 @@ async def test_download_raises_when_binary_missing(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_download_returns_base64_payload_uncompressed(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -176,7 +171,6 @@ async def test_download_returns_base64_payload_uncompressed(
     assert base64.b64decode(result["data"]) == payload
 
 
-@pytest.mark.asyncio
 async def test_download_validator_runs_before_ext_storage_path(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -217,7 +211,6 @@ async def test_download_validator_runs_before_ext_storage_path(
     assert invocations == []
 
 
-@pytest.mark.asyncio
 async def test_download_returns_gzipped_payload_when_compressed(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -150,7 +150,6 @@ async def _run_until_terminal(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_compile_runs_subprocess_to_completion(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -202,7 +201,6 @@ async def test_compile_runs_subprocess_to_completion(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_compile_nonzero_exit_marks_failed(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -231,7 +229,6 @@ async def test_compile_nonzero_exit_marks_failed(
     assert captured["job_completed"] == []
 
 
-@pytest.mark.asyncio
 async def test_compile_exit_zero_with_error_pattern_marks_failed(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -262,7 +259,6 @@ async def test_compile_exit_zero_with_error_pattern_marks_failed(
     assert captured["job_completed"] == []
 
 
-@pytest.mark.asyncio
 async def test_compile_platformio_no_module_named_pip_shrug_is_not_failure(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -295,7 +291,6 @@ async def test_compile_platformio_no_module_named_pip_shrug_is_not_failure(
     assert captured["job_failed"] == []
 
 
-@pytest.mark.asyncio
 async def test_compile_no_module_named_esphome_renders_actionable_hint(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -337,7 +332,6 @@ async def test_compile_no_module_named_esphome_renders_actionable_hint(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_compile_mid_run_cancel_marks_cancelled(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -433,7 +427,6 @@ async def test_compile_mid_run_cancel_marks_cancelled(
     assert job.job_id not in controller.state.cancel_requested
 
 
-@pytest.mark.asyncio
 async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -517,7 +510,6 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")
-@pytest.mark.asyncio
 async def test_execute_job_runner_shutdown_kills_subprocess_group(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -615,7 +607,6 @@ async def test_execute_job_runner_shutdown_kills_subprocess_group(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_compile_progress_lines_fire_job_progress(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -657,7 +648,6 @@ async def test_compile_progress_lines_fire_job_progress(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_run_queue_routes_reset_build_env_through_clean_all_subprocess(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -707,7 +697,6 @@ async def test_run_queue_routes_reset_build_env_through_clean_all_subprocess(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_compile_inflight_output_trims_when_cap_exceeded(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -778,7 +767,6 @@ async def test_compile_inflight_output_trims_when_cap_exceeded(
     assert all(status is JobStatus.RUNNING for status, _, _ in inflight)
 
 
-@pytest.mark.asyncio
 async def test_compile_repeats_error_pattern_short_circuits_check(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:
@@ -812,7 +800,6 @@ async def test_compile_repeats_error_pattern_short_circuits_check(
     assert job.exit_code == 0
 
 
-@pytest.mark.asyncio
 async def test_compile_cr_progress_lines_collapsed_in_storage(
     firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
 ) -> None:

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -156,7 +156,6 @@ def test_resolve_download_component_handles_none() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_returns_empty_when_storage_missing(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -176,7 +175,6 @@ async def test_get_binaries_returns_empty_when_storage_missing(
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_returns_empty_when_target_platform_missing(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -196,7 +194,6 @@ async def test_get_binaries_returns_empty_when_target_platform_missing(
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_logs_and_returns_empty_on_module_failure(
     tmp_path: Path,
     caplog: Any,
@@ -238,7 +235,6 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
     tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -273,7 +269,6 @@ async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
     assert captured[0].name == "kitchen"
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
     tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -304,7 +299,6 @@ async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
     assert len(captured) == 1
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_returns_module_list_verbatim(
     tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_get_jobs.py
+++ b/tests/controllers/firmware/test_get_jobs.py
@@ -18,8 +18,6 @@ noticing.
 
 from __future__ import annotations
 
-import pytest
-
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
@@ -46,7 +44,6 @@ def _job(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_returns_every_job_when_unfiltered(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -67,7 +64,6 @@ async def test_get_jobs_returns_every_job_when_unfiltered(
     assert {j.job_id for j in result} == {"a", "b", "c"}
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_sorts_newest_first_by_created_at(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -90,7 +86,6 @@ async def test_get_jobs_sorts_newest_first_by_created_at(
     assert [j.job_id for j in result] == ["new", "middle", "old"]
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_filters_by_status(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -110,7 +105,6 @@ async def test_get_jobs_filters_by_status(
     assert result == [completed]
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_filters_by_configuration(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -125,7 +119,6 @@ async def test_get_jobs_filters_by_configuration(
     assert result == [garage]
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_combines_status_and_configuration_filters(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -142,7 +135,6 @@ async def test_get_jobs_combines_status_and_configuration_filters(
     assert result == [kitchen_done]
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_filter_with_no_matches_returns_empty_list(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -163,7 +155,6 @@ async def test_get_jobs_filter_with_no_matches_returns_empty_list(
     assert result == []
 
 
-@pytest.mark.asyncio
 async def test_get_jobs_on_empty_controller_returns_empty_list(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -178,7 +169,6 @@ async def test_get_jobs_on_empty_controller_returns_empty_list(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_job_returns_the_matching_job_for_known_id(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -197,7 +187,6 @@ async def test_get_job_returns_the_matching_job_for_known_id(
     assert result is target
 
 
-@pytest.mark.asyncio
 async def test_get_job_returns_none_for_unknown_id(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -214,7 +203,6 @@ async def test_get_job_returns_none_for_unknown_id(
     assert await controller.get_job(job_id="ghost") is None
 
 
-@pytest.mark.asyncio
 async def test_get_job_does_not_mutate_state(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_helpers.py
+++ b/tests/controllers/firmware/test_helpers.py
@@ -176,7 +176,6 @@ def test_names_touched_by_job_with_empty_configuration_is_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_verify_esphome_importable_success_with_known_module() -> None:
     """A trivial Python ``-c`` that prints its version returns ``(True, output)``.
 
@@ -191,7 +190,6 @@ async def test_verify_esphome_importable_success_with_known_module() -> None:
     assert "1.2.3" in detail
 
 
-@pytest.mark.asyncio
 async def test_verify_esphome_importable_returns_false_on_no_module_named() -> None:
     """Even on a 0 exit, output containing ``No module named`` flips the result.
 
@@ -205,7 +203,6 @@ async def test_verify_esphome_importable_returns_false_on_no_module_named() -> N
     assert "No module named" in detail
 
 
-@pytest.mark.asyncio
 async def test_verify_esphome_importable_returns_false_on_nonzero_exit() -> None:
     """Non-zero exit → ``(False, output_or_exit_marker)``."""
     cmd = [sys.executable, "-c", "import sys; sys.exit(3)"]
@@ -214,7 +211,6 @@ async def test_verify_esphome_importable_returns_false_on_nonzero_exit() -> None
     assert "exit 3" in detail
 
 
-@pytest.mark.asyncio
 async def test_verify_esphome_importable_returns_false_on_oserror() -> None:
     """A missing executable returns ``(False, "FileNotFoundError: ...")``.
 
@@ -228,7 +224,6 @@ async def test_verify_esphome_importable_returns_false_on_oserror() -> None:
     assert "FileNotFoundError" in detail or "OSError" in detail
 
 
-@pytest.mark.asyncio
 async def test_verify_esphome_importable_returns_false_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/controllers/firmware/test_install.py
+++ b/tests/controllers/firmware/test_install.py
@@ -46,7 +46,6 @@ from tests.controllers.firmware.conftest import (
 )
 
 
-@pytest.mark.asyncio
 async def test_install_returns_queued_job_with_install_type(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -66,7 +65,6 @@ async def test_install_returns_queued_job_with_install_type(
     assert job.configuration == "kitchen.yaml"
 
 
-@pytest.mark.asyncio
 async def test_install_defaults_port_to_ota(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -91,7 +89,6 @@ async def test_install_defaults_port_to_ota(
     "port",
     ["/dev/ttyUSB0", "192.168.1.5", "kitchen.local", "fe80::1"],
 )
-@pytest.mark.asyncio
 async def test_install_forwards_custom_port_to_job(
     tmp_path: Path, port: str, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -110,7 +107,6 @@ async def test_install_forwards_custom_port_to_job(
     assert job.port == port
 
 
-@pytest.mark.asyncio
 async def test_install_validates_port_before_configuration(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -140,7 +136,6 @@ async def test_install_validates_port_before_configuration(
     assert "Invalid configuration filename" not in exc.value.message
 
 
-@pytest.mark.asyncio
 async def test_install_rejects_traversal_configuration(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -160,7 +155,6 @@ async def test_install_rejects_traversal_configuration(
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_install_enqueues_before_firing_job_queued(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -195,7 +189,6 @@ async def test_install_enqueues_before_firing_job_queued(
     assert log[1][1].data == {"job": job}
 
 
-@pytest.mark.asyncio
 async def test_install_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -284,7 +277,6 @@ def _stub_remote_build(
     controller._db.remote_build_offloader = remote_build
 
 
-@pytest.mark.asyncio
 async def test_install_routes_to_local_when_no_paired_receivers(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -307,7 +299,6 @@ async def test_install_routes_to_local_when_no_paired_receivers(
     assert job.source_label == ""
 
 
-@pytest.mark.asyncio
 async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -341,7 +332,6 @@ async def test_install_routes_to_remote_when_pairing_is_idle_and_connected(
     assert job.source_esphome_version == "2026.5.0"
 
 
-@pytest.mark.asyncio
 async def test_install_force_local_bypasses_scheduler(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -374,7 +364,6 @@ async def test_install_force_local_bypasses_scheduler(
     assert job.source_label == ""
 
 
-@pytest.mark.asyncio
 async def test_compile_force_local_bypasses_scheduler(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -395,7 +384,6 @@ async def test_compile_force_local_bypasses_scheduler(
     assert job.source_pin_sha256 == ""
 
 
-@pytest.mark.asyncio
 async def test_compile_bulk_force_local_bypasses_scheduler(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -418,7 +406,6 @@ async def test_compile_bulk_force_local_bypasses_scheduler(
     assert [j.source for j in jobs] == [JobSource.LOCAL, JobSource.LOCAL]
 
 
-@pytest.mark.asyncio
 async def test_install_force_local_default_false_keeps_scheduler_behaviour(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -444,7 +431,6 @@ async def test_install_force_local_default_false_keeps_scheduler_behaviour(
     assert job.source is JobSource.REMOTE
 
 
-@pytest.mark.asyncio
 async def test_install_still_routes_remote_when_receiver_is_busy(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -475,7 +461,6 @@ async def test_install_still_routes_remote_when_receiver_is_busy(
     assert job.source_pin_sha256 == _PIN
 
 
-@pytest.mark.asyncio
 async def test_install_serial_port_can_route_remote(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -503,7 +488,6 @@ async def test_install_serial_port_can_route_remote(
     assert job.source_pin_sha256 == _PIN
 
 
-@pytest.mark.asyncio
 async def test_install_falls_back_to_local_when_remote_build_controller_absent(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -524,7 +508,6 @@ async def test_install_falls_back_to_local_when_remote_build_controller_absent(
     assert job.source is JobSource.LOCAL
 
 
-@pytest.mark.asyncio
 async def test_install_falls_back_to_local_when_scheduler_picked_pin_disappeared(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -576,7 +559,6 @@ async def test_install_falls_back_to_local_when_scheduler_picked_pin_disappeared
     assert job.source_pin_sha256 == ""
 
 
-@pytest.mark.asyncio
 async def test_install_bulk_routes_each_config_through_the_scheduler(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -612,7 +594,6 @@ async def test_install_bulk_routes_each_config_through_the_scheduler(
     assert all(j.source_label == "desktop" for j in jobs)
 
 
-@pytest.mark.asyncio
 async def test_install_bulk_serial_port_routes_every_config_remote(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_job_output_sidecar.py
+++ b/tests/controllers/firmware/test_job_output_sidecar.py
@@ -45,7 +45,6 @@ def _terminal_job(output: list[str]) -> FirmwareJob:
     )
 
 
-@pytest.mark.asyncio
 async def test_terminal_output_flushed_to_sidecar_and_stripped_from_blob(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -67,7 +66,6 @@ async def test_terminal_output_flushed_to_sidecar_and_stripped_from_blob(
     assert "output" not in entries[0]
 
 
-@pytest.mark.asyncio
 async def test_active_output_kept_in_ram_and_inline_in_blob(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -166,7 +164,6 @@ def test_write_sidecar_cleans_up_temp_on_failure(monkeypatch: pytest.MonkeyPatch
     assert [p for p in log_dir.iterdir() if p.suffix == ".tmp"] == []
 
 
-@pytest.mark.asyncio
 async def test_legacy_inline_output_migrates_to_sidecar_on_load(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -184,7 +181,6 @@ async def test_legacy_inline_output_migrates_to_sidecar_on_load(
     assert await asyncio.to_thread(read_job_output, "t1") == ["legacy a\n", "legacy b\n"]
 
 
-@pytest.mark.asyncio
 async def test_migration_isolates_per_job_write_failure(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -237,7 +233,6 @@ async def test_migration_isolates_per_job_write_failure(
     assert any("Failed to migrate job bad1" in r.message for r in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_persist_reaps_orphaned_sidecar(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -257,7 +252,6 @@ async def test_persist_reaps_orphaned_sidecar(
     assert await asyncio.to_thread(lambda: _job_log_path("t1").exists())
 
 
-@pytest.mark.asyncio
 async def test_persist_reaps_orphaned_tmp_file(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -281,7 +275,6 @@ async def test_persist_reaps_orphaned_tmp_file(
     assert await asyncio.to_thread(lambda: _job_log_path("t1").exists())
 
 
-@pytest.mark.asyncio
 async def test_concurrent_persist_snapshots_under_lock_and_keeps_all_jobs(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -319,7 +312,6 @@ async def test_concurrent_persist_snapshots_under_lock_and_keeps_all_jobs(
     assert {e["job_id"] for e in _blob_jobs(tmp_path)} == {"t1", "t2"}
 
 
-@pytest.mark.asyncio
 async def test_old_job_log_viewable_via_follow_job_after_restart(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_persistence.py
+++ b/tests/controllers/firmware/test_persistence.py
@@ -122,7 +122,6 @@ async def _restart(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_queued_job_survives_dashboard_restart(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -154,7 +153,6 @@ async def test_queued_job_survives_dashboard_restart(
     assert queued_arg.job_id == queued.job_id
 
 
-@pytest.mark.asyncio
 async def test_running_job_re_queues_with_clean_state_after_restart(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -231,7 +229,6 @@ async def test_running_job_re_queues_with_clean_state_after_restart(
     assert queued.job_id in queued_ids
 
 
-@pytest.mark.asyncio
 async def test_resumed_running_job_completes_on_next_run(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -320,7 +317,6 @@ async def test_resumed_running_job_completes_on_next_run(
     assert any("dashboard restarted mid-build" in line for line in recovered)
 
 
-@pytest.mark.asyncio
 async def test_cancelled_job_survives_restart_without_being_requeued(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -355,7 +351,6 @@ async def test_cancelled_job_survives_restart_without_being_requeued(
     reader.state.queue.put.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_cold_start_with_no_metadata_file_is_empty(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_runtime: None,
@@ -381,7 +376,6 @@ async def test_cold_start_with_no_metadata_file_is_empty(
 # dashboard recovers and surfaces the rest of the queue.
 
 
-@pytest.mark.asyncio
 async def test_corrupt_entry_in_metadata_does_not_block_startup(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -421,7 +415,6 @@ async def test_corrupt_entry_in_metadata_does_not_block_startup(
     "garbage",
     ["not-a-dict", 42, None, ["nested", "list"]],
 )
-@pytest.mark.asyncio
 async def test_non_dict_entry_in_metadata_does_not_crash_warning_path(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -467,7 +460,6 @@ async def test_non_dict_entry_in_metadata_does_not_crash_warning_path(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_start_logs_error_when_esphome_cli_sanity_check_fails(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -29,8 +29,6 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 from esphome_device_builder.controllers._device_scanner import (
     DeviceFileMetadata,
     DeviceScanner,
@@ -60,7 +58,6 @@ def _device(name: str = "kitchen", **overrides: Any) -> Device:
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_reload_rereads_state_and_fires_updated(tmp_path: Path) -> None:
     """Reload re-runs the loader and fires ``UPDATED`` so listeners refresh."""
     yaml_path = tmp_path / "kitchen.yaml"
@@ -86,7 +83,6 @@ async def test_reload_rereads_state_and_fires_updated(tmp_path: Path) -> None:
     assert changes == [(ScanChange.UPDATED, refreshed)]
 
 
-@pytest.mark.asyncio
 async def test_reload_unknown_filename_is_noop(tmp_path: Path) -> None:
     """Reload of an untracked file returns False without touching listeners."""
     changes: list[tuple[ScanChange, Device]] = []
@@ -273,7 +269,6 @@ def test_unhandled_job_type_with_configuration_falls_through_silently() -> None:
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_refresh_after_compile_persists_hash_and_reloads(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -310,7 +305,6 @@ async def test_refresh_after_compile_persists_hash_and_reloads(
     assert controller._scanner.calls == [("reload", "kitchen.yaml")]
 
 
-@pytest.mark.asyncio
 async def test_refresh_after_compile_skips_persist_on_hash_failure(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
@@ -349,7 +343,6 @@ async def test_refresh_after_compile_skips_persist_on_hash_failure(
     assert controller._scanner.calls == [("reload", "kitchen.yaml")]
 
 
-@pytest.mark.asyncio
 async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypatch: Any) -> None:
     """UPLOAD-only doesn't recompile — skip the heavy hash subprocess entirely."""
     compute_calls: list[Path] = []
@@ -438,7 +431,6 @@ def _flush_controller(device: Device) -> tuple[Any, list[Any]]:
     return controller, fired
 
 
-@pytest.mark.asyncio
 async def test_sync_after_flash_pins_deployed_hash_and_clears_pending() -> None:
     """Post-flash sync flips deployed → expected and emits ``DEVICE_UPDATED``."""
     device = _device(
@@ -458,7 +450,6 @@ async def test_sync_after_flash_pins_deployed_hash_and_clears_pending() -> None:
     assert [t for t, _p in fired] == [EventType.DEVICE_UPDATED]
 
 
-@pytest.mark.asyncio
 async def test_sync_after_flash_no_expected_hash_is_noop() -> None:
     """Without ``expected_config_hash`` we have nothing to pin — fall back to mtime."""
     device = _device(
@@ -476,7 +467,6 @@ async def test_sync_after_flash_no_expected_hash_is_noop() -> None:
     assert fired == []
 
 
-@pytest.mark.asyncio
 async def test_sync_after_flash_already_in_sync_is_noop() -> None:
     """Already-matching hashes skip both the cache write and the event."""
     device = _device(
@@ -493,7 +483,6 @@ async def test_sync_after_flash_already_in_sync_is_noop() -> None:
     assert fired == []
 
 
-@pytest.mark.asyncio
 async def test_sync_after_flash_unknown_configuration_is_noop() -> None:
     """Configuration not in the scanner's device list — silently skip."""
     device = _device(

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -332,7 +332,6 @@ def _fire_session_closed(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_translates_output_and_completes(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -385,7 +384,6 @@ async def test_remote_compile_translates_output_and_completes(
     )
 
 
-@pytest.mark.asyncio
 async def test_remote_clean_dispatches_with_clean_target_and_finalises_on_completed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -438,7 +436,6 @@ async def test_remote_clean_dispatches_with_clean_target_and_finalises_on_comple
     client.download_artifacts.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_plumbs_device_names_from_local_scanner(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -488,7 +485,6 @@ async def test_remote_compile_plumbs_device_names_from_local_scanner(
     )
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_falls_through_when_no_device_matches(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -523,7 +519,6 @@ async def test_remote_compile_falls_through_when_no_device_matches(
     )
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_progress_translates_to_local_progress_event(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -560,7 +555,6 @@ async def test_remote_compile_progress_translates_to_local_progress_event(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_ignores_events_for_other_jobs(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -601,7 +595,6 @@ async def test_remote_compile_ignores_events_for_other_jobs(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_failed_status_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -627,7 +620,6 @@ async def test_remote_compile_failed_status_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_rejected_ack_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -646,7 +638,6 @@ async def test_remote_compile_rejected_ack_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_receiver_unreachable_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -667,7 +658,6 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_unsupported_job_type_fails_locally(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -703,7 +693,6 @@ async def test_remote_compile_unsupported_job_type_fails_locally(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -739,7 +728,6 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_cancel_beats_receiver_completed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -779,7 +767,6 @@ async def test_remote_compile_cancel_beats_receiver_completed(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -809,7 +796,6 @@ async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -850,7 +836,6 @@ async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_bundle_file_missing_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -871,7 +856,6 @@ async def test_remote_compile_bundle_file_missing_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_bundle_build_error_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -898,7 +882,6 @@ async def test_remote_compile_bundle_build_error_fires_job_failed(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_missing_source_pin_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -922,7 +905,6 @@ async def test_remote_compile_missing_source_pin_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_no_remote_build_controller_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -943,7 +925,6 @@ async def test_remote_compile_no_remote_build_controller_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_submit_no_session_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -967,7 +948,6 @@ async def test_remote_compile_submit_no_session_fires_job_failed(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1024,7 +1004,6 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     ), output_lines
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_session_lost_synthetic_line_skips_leading_newline(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1060,7 +1039,6 @@ async def test_remote_compile_session_lost_synthetic_line_skips_leading_newline(
     assert "server_shutting_down" in synthetic
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_cancel_translation_handles_missing_session(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1097,7 +1075,6 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1123,7 +1100,6 @@ async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1158,7 +1134,6 @@ async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_execute_job_routes_remote_source_through_remote_runner(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1196,7 +1171,6 @@ async def test_execute_job_routes_remote_source_through_remote_runner(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_submit_job_ack_echoes_caller_job_id(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1233,7 +1207,6 @@ async def test_submit_job_ack_echoes_caller_job_id(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_ignores_session_closed_for_other_pin(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1271,7 +1244,6 @@ async def test_remote_compile_ignores_session_closed_for_other_pin(
     assert job.status == JobStatus.COMPLETED
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1327,7 +1299,6 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1379,7 +1350,6 @@ async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_locally(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1478,7 +1448,6 @@ def patch_materialise(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return stub
 
 
-@pytest.mark.asyncio
 async def test_remote_install_resets_progress_between_compile_and_upload(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1526,7 +1495,6 @@ async def test_remote_install_resets_progress_between_compile_and_upload(
     assert captured[EventType.JOB_PROGRESS][0]["job_id"] == job.job_id
 
 
-@pytest.mark.asyncio
 async def test_remote_install_completes_after_local_upload_succeeds(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1565,7 +1533,6 @@ async def test_remote_install_completes_after_local_upload_succeeds(
     patch_materialise.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_remote_install_local_upload_failure_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1591,7 +1558,6 @@ async def test_remote_install_local_upload_failure_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_install_download_artifacts_failure_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1616,7 +1582,6 @@ async def test_remote_install_download_artifacts_failure_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_install_materialise_failure_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1645,7 +1610,6 @@ async def test_remote_install_materialise_failure_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_install_materialise_oserror_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1673,7 +1637,6 @@ async def test_remote_install_materialise_oserror_fires_job_failed(
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_fetch_and_run_local_upload_pre_spawn_cancel_finalises_locally(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -1693,7 +1656,6 @@ async def test_fetch_and_run_local_upload_pre_spawn_cancel_finalises_locally(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
@@ -1757,7 +1719,6 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_terminates(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_materialise: MagicMock,
@@ -1822,7 +1783,6 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
-@pytest.mark.asyncio
 async def test_fetch_and_materialise_cancel_post_staging_finalises_locally(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_materialise: MagicMock,
@@ -1851,7 +1811,6 @@ async def test_fetch_and_materialise_cancel_post_staging_finalises_locally(
     patch_materialise.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -142,7 +142,6 @@ def test_running_rename_blocks_install(
         controller._check_rename_lock(_job("inst1", "kitchen.yaml", JobType.INSTALL))
 
 
-@pytest.mark.asyncio
 async def test_install_bulk_skips_locked_configs_and_queues_the_rest(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_reset_build_env.py
+++ b/tests/controllers/firmware/test_reset_build_env.py
@@ -30,8 +30,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from esphome_device_builder.models import EventType, JobStatus, JobType
 from tests.controllers.firmware.conftest import (
     BareFirmwareControllerFactory,
@@ -45,7 +43,6 @@ from tests.controllers.firmware.conftest import (
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_reset_build_env_returns_queued_job_with_reset_type(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -64,7 +61,6 @@ async def test_reset_build_env_returns_queued_job_with_reset_type(
     assert job.job_type == JobType.RESET_BUILD_ENV
 
 
-@pytest.mark.asyncio
 async def test_reset_build_env_uses_empty_configuration(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -87,7 +83,6 @@ async def test_reset_build_env_uses_empty_configuration(
     assert job.configuration == ""
 
 
-@pytest.mark.asyncio
 async def test_reset_build_env_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -99,7 +94,6 @@ async def test_reset_build_env_registers_job_in_jobs_map(
     assert await controller.get_job(job_id=job.job_id) is job
 
 
-@pytest.mark.asyncio
 async def test_reset_build_env_fires_job_queued_after_enqueue(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -126,7 +120,6 @@ async def test_reset_build_env_fires_job_queued_after_enqueue(
     assert log[1][1].data == {"job": job}
 
 
-@pytest.mark.asyncio
 async def test_reset_build_env_accepts_arbitrary_kwargs(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_supersede.py
+++ b/tests/controllers/firmware/test_supersede.py
@@ -29,13 +29,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from esphome_device_builder.models import FirmwareJob, JobStatus, JobType
 from tests.controllers.firmware.conftest import FirmwareControllerFactory
 
 
-@pytest.mark.asyncio
 async def test_resubmit_cancels_previous_queued_job_for_same_configuration(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -57,7 +54,6 @@ async def test_resubmit_cancels_previous_queued_job_for_same_configuration(
     assert jobs[second.job_id].status == JobStatus.QUEUED
 
 
-@pytest.mark.asyncio
 async def test_resubmit_does_not_cancel_jobs_for_different_configuration(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -81,7 +77,6 @@ async def test_resubmit_does_not_cancel_jobs_for_different_configuration(
     assert jobs[garage.job_id].status == JobStatus.QUEUED
 
 
-@pytest.mark.asyncio
 async def test_resubmit_does_not_cancel_itself(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -106,7 +101,6 @@ async def test_resubmit_does_not_cancel_itself(
     assert jobs[first.job_id].status == JobStatus.QUEUED
 
 
-@pytest.mark.asyncio
 async def test_resubmit_cancels_running_predecessor(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -149,7 +143,6 @@ async def test_resubmit_cancels_running_predecessor(
     assert jobs[second.job_id].status == JobStatus.QUEUED
 
 
-@pytest.mark.asyncio
 async def test_resubmit_does_not_cancel_terminal_jobs_for_same_config(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -195,7 +188,6 @@ async def test_resubmit_does_not_cancel_terminal_jobs_for_same_config(
     assert jobs[fresh.job_id].status == JobStatus.QUEUED
 
 
-@pytest.mark.asyncio
 async def test_supersede_does_not_run_for_empty_configuration(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/controllers/firmware/test_traversal_validation.py
+++ b/tests/controllers/firmware/test_traversal_validation.py
@@ -56,7 +56,6 @@ def test_sync_validate_rejects_empty_string(
     assert "must not be empty" in excinfo.value.message
 
 
-@pytest.mark.asyncio
 async def test_validate_configuration_boundary_runs_in_executor(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -74,7 +73,6 @@ async def test_validate_configuration_boundary_runs_in_executor(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_validate_configurations_boundary_raises_on_bad_entry(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -96,7 +94,6 @@ async def test_validate_configurations_boundary_raises_on_bad_entry(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_validate_configurations_boundary_all_valid(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -106,7 +103,6 @@ async def test_validate_configurations_boundary_all_valid(
     await controller._validate_configurations_boundary(["kitchen.yaml", "garage.yaml"])
 
 
-@pytest.mark.asyncio
 async def test_get_binaries_rejects_traversal(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -123,7 +119,6 @@ async def test_get_binaries_rejects_traversal(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_download_rejects_traversal(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -135,7 +130,6 @@ async def test_download_rejects_traversal(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_rename_rejects_traversal_in_new_name(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -156,7 +150,6 @@ async def test_rename_rejects_traversal_in_new_name(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_rename_rejects_collision_with_existing_yaml(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -179,7 +172,6 @@ async def test_rename_rejects_collision_with_existing_yaml(
     assert "livingroom.yaml already exists" in excinfo.value.message
 
 
-@pytest.mark.asyncio
 async def test_rename_rejects_same_name(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_upload.py
+++ b/tests/controllers/firmware/test_upload.py
@@ -36,7 +36,6 @@ from tests.controllers.firmware.conftest import (
 )
 
 
-@pytest.mark.asyncio
 async def test_upload_returns_queued_job_with_upload_type(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -57,7 +56,6 @@ async def test_upload_returns_queued_job_with_upload_type(
     assert job.configuration == "kitchen.yaml"
 
 
-@pytest.mark.asyncio
 async def test_upload_defaults_port_to_empty_string(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -85,7 +83,6 @@ async def test_upload_defaults_port_to_empty_string(
     "port",
     ["OTA", "/dev/ttyUSB0", "192.168.1.5", "kitchen.local", "fe80::1"],
 )
-@pytest.mark.asyncio
 async def test_upload_forwards_custom_port_to_job(
     tmp_path: Path, port: str, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -104,7 +101,6 @@ async def test_upload_forwards_custom_port_to_job(
     assert job.port == port
 
 
-@pytest.mark.asyncio
 async def test_upload_validates_port_before_configuration(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -134,7 +130,6 @@ async def test_upload_validates_port_before_configuration(
     assert "Invalid configuration filename" not in exc.value.message
 
 
-@pytest.mark.asyncio
 async def test_upload_rejects_traversal_configuration(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
@@ -155,7 +150,6 @@ async def test_upload_rejects_traversal_configuration(
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_upload_enqueues_before_firing_job_queued(
     tmp_path: Path,
     firmware_controller_factory: FirmwareControllerFactory,
@@ -181,7 +175,6 @@ async def test_upload_enqueues_before_firing_job_queued(
     assert log[1][1].data == {"job": job}
 
 
-@pytest.mark.asyncio
 async def test_upload_registers_job_in_jobs_map(
     tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -264,7 +264,6 @@ def _set_esphome_cmd(controller: FirmwareController) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_install_serial_chip_match_proceeds_to_completed(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -303,7 +302,6 @@ async def test_install_serial_chip_match_proceeds_to_completed(
 
 
 @pytest.mark.parametrize("submit_command", ["install", "upload"])
-@pytest.mark.asyncio
 async def test_serial_chip_mismatch_marks_failed_with_message(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -354,7 +352,6 @@ async def test_serial_chip_mismatch_marks_failed_with_message(
     assert captured["job_completed"] == []
 
 
-@pytest.mark.asyncio
 async def test_install_serial_no_chip_detected_proceeds_to_completed(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -421,7 +418,6 @@ async def test_install_serial_no_chip_detected_proceeds_to_completed(
     ],
     ids=["ota", "ipv4", "mdns_hostname", "windows_com"],
 )
-@pytest.mark.asyncio
 async def test_install_non_dev_port_skips_chip_check(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -464,7 +460,6 @@ async def test_install_non_dev_port_skips_chip_check(
     assert job.status == JobStatus.COMPLETED
 
 
-@pytest.mark.asyncio
 async def test_install_serial_no_storage_skips_check(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -508,7 +503,6 @@ async def test_install_serial_no_storage_skips_check(
     assert job.status == JobStatus.COMPLETED
 
 
-@pytest.mark.asyncio
 async def test_install_serial_storage_without_target_platform_skips_check(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -547,7 +541,6 @@ async def test_install_serial_storage_without_target_platform_skips_check(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -633,7 +626,6 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     assert captured["job_failed"] == []
 
 
-@pytest.mark.asyncio
 async def test_cancel_during_verify_chip_marks_job_cancelled(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,
@@ -704,7 +696,6 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_tracked_subprocess_registers_and_clears_current_process(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -748,7 +739,6 @@ async def test_tracked_subprocess_registers_and_clears_current_process(
     assert controller.state.current_process is None
 
 
-@pytest.mark.asyncio
 async def test_tracked_subprocess_restores_prior_value_on_exit(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -783,7 +773,6 @@ async def test_tracked_subprocess_restores_prior_value_on_exit(
     assert controller.state.current_process is sentinel  # restored
 
 
-@pytest.mark.asyncio
 async def test_tracked_subprocess_restores_prior_value_on_exception(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
@@ -825,7 +814,6 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
     assert controller.state.current_process is None
 
 
-@pytest.mark.asyncio
 async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -167,7 +167,6 @@ def catalog() -> BoardCatalog:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_board_returns_match_by_id(catalog: BoardCatalog) -> None:
     """``boards/get_board`` returns the entry whose ``id`` matches."""
     board = await catalog.get_board(board_id="m5stack-cores3")
@@ -176,7 +175,6 @@ async def test_get_board_returns_match_by_id(catalog: BoardCatalog) -> None:
     assert board.esphome.variant == Esp32Variant.ESP32S3
 
 
-@pytest.mark.asyncio
 async def test_get_board_returns_none_for_unknown_id(catalog: BoardCatalog) -> None:
     """Unknown board id → ``None`` (not an exception).
 
@@ -206,7 +204,6 @@ def test_get_by_id_is_synchronous_alias_for_get_board(catalog: BoardCatalog) -> 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_boards_unfiltered_returns_everything_with_total(
     catalog: BoardCatalog,
 ) -> None:
@@ -218,7 +215,6 @@ async def test_get_boards_unfiltered_returns_everything_with_total(
     assert resp.limit == 50
 
 
-@pytest.mark.asyncio
 async def test_get_boards_filters_by_platform(catalog: BoardCatalog) -> None:
     """``platform=esp8266`` drops every entry on a different platform."""
     resp = await catalog.get_boards(platform=Platform.ESP8266)
@@ -227,7 +223,6 @@ async def test_get_boards_filters_by_platform(catalog: BoardCatalog) -> None:
     assert {b.id for b in resp.boards} == {"d1-mini", "generic-esp8266"}
 
 
-@pytest.mark.asyncio
 async def test_get_boards_filters_by_variant_case_insensitive(
     catalog: BoardCatalog,
 ) -> None:
@@ -244,7 +239,6 @@ async def test_get_boards_filters_by_variant_case_insensitive(
     assert {b.id for b in resp.boards} == {"seeed-xiao-esp32c3", "generic-esp32c3"}
 
 
-@pytest.mark.asyncio
 async def test_get_boards_filters_by_tag(catalog: BoardCatalog) -> None:
     """``tag=display`` returns only the entry tagged for it."""
     resp = await catalog.get_boards(tag=BoardTag.DISPLAY)
@@ -253,7 +247,6 @@ async def test_get_boards_filters_by_tag(catalog: BoardCatalog) -> None:
     assert resp.boards[0].id == "m5stack-cores3"
 
 
-@pytest.mark.asyncio
 async def test_get_boards_query_searches_name_description_manufacturer_id_tags(
     catalog: BoardCatalog,
 ) -> None:
@@ -279,7 +272,6 @@ async def test_get_boards_query_searches_name_description_manufacturer_id_tags(
     assert {b.id for b in by_id.boards} == {"generic-esp8266"}
 
 
-@pytest.mark.asyncio
 async def test_get_boards_filters_compose(catalog: BoardCatalog) -> None:
     """Multiple filters AND together — platform + variant + tag.
 
@@ -301,7 +293,6 @@ async def test_get_boards_filters_compose(catalog: BoardCatalog) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_boards_sorts_featured_first_generic_last(
     catalog: BoardCatalog,
 ) -> None:
@@ -324,7 +315,6 @@ async def test_get_boards_sorts_featured_first_generic_last(
     assert ids[2] == "m5stack-cores3"
 
 
-@pytest.mark.asyncio
 async def test_get_boards_paginates_via_offset_and_limit(
     catalog: BoardCatalog,
 ) -> None:
@@ -345,7 +335,6 @@ async def test_get_boards_paginates_via_offset_and_limit(
     assert [b.id for b in resp.boards] == ["m5stack-cores3", "generic-esp32c3"]
 
 
-@pytest.mark.asyncio
 async def test_get_boards_offset_past_end_returns_empty_page(
     catalog: BoardCatalog,
 ) -> None:

--- a/tests/controllers/test_build_size_refresher.py
+++ b/tests/controllers/test_build_size_refresher.py
@@ -23,8 +23,6 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-import pytest
-
 from esphome_device_builder.controllers._build_size_refresher import BuildSizeRefresher
 from esphome_device_builder.helpers.build_size import (
     BuildDirSignal,
@@ -77,7 +75,6 @@ def _make(
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_request_adds_to_pending_set_and_wakes_event(tmp_path: Path) -> None:
     """``request`` is sync, idempotent, and signals the wake event."""
     refresher, _, _ = _make(tmp_path)
@@ -88,7 +85,6 @@ async def test_request_adds_to_pending_set_and_wakes_event(tmp_path: Path) -> No
     assert refresher._wake.is_set()
 
 
-@pytest.mark.asyncio
 async def test_start_is_idempotent(tmp_path: Path) -> None:
     """A second ``start`` while the worker is alive is a no-op."""
     refresher, _, _ = _make(tmp_path)
@@ -99,7 +95,6 @@ async def test_start_is_idempotent(tmp_path: Path) -> None:
     await refresher.stop()
 
 
-@pytest.mark.asyncio
 async def test_stop_with_no_running_worker_is_noop(tmp_path: Path) -> None:
     """``stop`` on a never-started refresher must not raise."""
     refresher, _, _ = _make(tmp_path)
@@ -112,7 +107,6 @@ async def test_stop_with_no_running_worker_is_noop(tmp_path: Path) -> None:
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_worker_drains_pending_and_fires_on_refreshed(tmp_path: Path) -> None:
     """A request lands in the queue; the worker walks + fires the callback."""
     done = asyncio.Event()
@@ -143,7 +137,6 @@ async def test_worker_drains_pending_and_fires_on_refreshed(tmp_path: Path) -> N
     assert refresher.pending == set()
 
 
-@pytest.mark.asyncio
 async def test_worker_skips_callback_when_refresh_returns_none(tmp_path: Path) -> None:
     """Refresh returning ``None`` (cache hit) → no ``on_refreshed`` invoke.
 
@@ -192,7 +185,6 @@ async def test_worker_skips_callback_when_refresh_returns_none(tmp_path: Path) -
     assert refreshed == []
 
 
-@pytest.mark.asyncio
 async def test_worker_logs_and_continues_on_refresh_exception(tmp_path: Path, caplog: Any) -> None:
     """A per-iteration walk error logs + keeps the worker alive for the next item.
 
@@ -248,7 +240,6 @@ async def test_worker_logs_and_continues_on_refresh_exception(tmp_path: Path, ca
     assert refreshed == ["kitchen.yaml"]
 
 
-@pytest.mark.asyncio
 async def test_worker_logs_and_continues_on_callback_exception(tmp_path: Path, caplog: Any) -> None:
     """``on_refreshed`` raising must not kill the worker either."""
     error_seen = asyncio.Event()
@@ -300,7 +291,6 @@ async def test_worker_logs_and_continues_on_callback_exception(tmp_path: Path, c
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_enqueue_stale_fleet_pushes_divergent_filenames(tmp_path: Path) -> None:
     """``find_stale_build_dirs`` returns a list → each one ends up in pending."""
     refresher, _, _ = _make(tmp_path, filenames=["a.yaml", "b.yaml", "c.yaml"])
@@ -313,7 +303,6 @@ async def test_enqueue_stale_fleet_pushes_divergent_filenames(tmp_path: Path) ->
     assert refresher.pending == {"a.yaml", "c.yaml"}
 
 
-@pytest.mark.asyncio
 async def test_enqueue_stale_fleet_empty_filenames_skips_executor(tmp_path: Path) -> None:
     """No configured devices → no executor handoff at all."""
     calls: list[Any] = []
@@ -338,7 +327,6 @@ async def test_enqueue_stale_fleet_empty_filenames_skips_executor(tmp_path: Path
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_worker_logs_when_initial_fleet_sweep_raises(tmp_path: Path, caplog: Any) -> None:
     """Initial sweep raising must not kill the worker — log + carry on."""
     sweep_failed = asyncio.Event()
@@ -392,7 +380,6 @@ async def test_worker_logs_when_initial_fleet_sweep_raises(tmp_path: Path, caplo
     assert refreshed == ["a.yaml"]
 
 
-@pytest.mark.asyncio
 async def test_stop_logs_unexpected_worker_exception(tmp_path: Path, caplog: Any) -> None:
     """Anything other than ``CancelledError`` from the worker gets logged.
 

--- a/tests/controllers/test_labels.py
+++ b/tests/controllers/test_labels.py
@@ -85,7 +85,6 @@ def _make_controller(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_create_label_persists_and_emits_event(tmp_path: Path) -> None:
     """Happy path: name + color saved, ``LABEL_CREATED`` fired with the label."""
     controller, captured = _make_controller(tmp_path)
@@ -106,7 +105,6 @@ async def test_create_label_persists_and_emits_event(tmp_path: Path) -> None:
     assert label_events[0].data == {"label": label}
 
 
-@pytest.mark.asyncio
 async def test_create_label_trims_whitespace(tmp_path: Path) -> None:
     """Surrounding whitespace is stripped before save AND uniqueness check."""
     controller, _ = _make_controller(tmp_path)
@@ -116,7 +114,6 @@ async def test_create_label_trims_whitespace(tmp_path: Path) -> None:
     assert label.name == "Kitchen"
 
 
-@pytest.mark.asyncio
 async def test_create_label_default_color_is_none(tmp_path: Path) -> None:
     """Omitting ``color`` lets the frontend pick a chip color."""
     controller, _ = _make_controller(tmp_path)
@@ -126,7 +123,6 @@ async def test_create_label_default_color_is_none(tmp_path: Path) -> None:
     assert label.color is None
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name", ["", "   ", "\t\n"])
 async def test_create_label_rejects_empty_name(tmp_path: Path, name: str) -> None:
     """Empty / whitespace-only names raise ``INVALID_ARGS``."""
@@ -138,7 +134,6 @@ async def test_create_label_rejects_empty_name(tmp_path: Path, name: str) -> Non
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name", [123, None, ["bad"], {"bad": True}])
 async def test_create_label_rejects_non_string_name(tmp_path: Path, name: Any) -> None:
     """Non-string ``name`` payloads raise ``INVALID_ARGS``.
@@ -155,7 +150,6 @@ async def test_create_label_rejects_non_string_name(tmp_path: Path, name: Any) -
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_create_label_rejects_overlong_name(tmp_path: Path) -> None:
     """Names longer than 50 chars (matches GitHub's cap) are rejected."""
     controller, _ = _make_controller(tmp_path)
@@ -166,7 +160,6 @@ async def test_create_label_rejects_overlong_name(tmp_path: Path) -> None:
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("color", ["red", "#fff", "#GGGGGG", "ff0000", "#ff00ff00"])
 async def test_create_label_rejects_invalid_color(tmp_path: Path, color: str) -> None:
     """Anything that isn't a 6-digit hex with leading ``#`` is rejected.
@@ -183,7 +176,6 @@ async def test_create_label_rejects_invalid_color(tmp_path: Path, color: str) ->
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_create_label_unique_name_case_insensitive(tmp_path: Path) -> None:
     """``"Kitchen"`` and ``"kitchen"`` are treated as the same name."""
     controller, _ = _make_controller(tmp_path)
@@ -203,7 +195,6 @@ async def test_create_label_unique_name_case_insensitive(tmp_path: Path) -> None
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_list_labels_returns_catalog_in_insertion_order(tmp_path: Path) -> None:
     """Catalog read returns labels in the order they were created."""
     await asyncio.to_thread(
@@ -227,7 +218,6 @@ async def test_list_labels_returns_catalog_in_insertion_order(tmp_path: Path) ->
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_update_label_rename_preserves_id_and_color(tmp_path: Path) -> None:
     """Renaming changes the name but keeps the id and existing color.
 
@@ -248,7 +238,6 @@ async def test_update_label_rename_preserves_id_and_color(tmp_path: Path) -> Non
     assert update_events[0].data == {"label": updated}
 
 
-@pytest.mark.asyncio
 async def test_update_label_clear_color_via_explicit_null(tmp_path: Path) -> None:
     """``color=None`` clears the color; sentinel pattern distinguishes from "leave alone"."""
     controller, _ = _make_controller(tmp_path)
@@ -260,7 +249,6 @@ async def test_update_label_clear_color_via_explicit_null(tmp_path: Path) -> Non
     assert updated.color is None
 
 
-@pytest.mark.asyncio
 async def test_update_label_no_changes_rejected(tmp_path: Path) -> None:
     """Passing neither name nor color is a user error.
 
@@ -277,7 +265,6 @@ async def test_update_label_no_changes_rejected(tmp_path: Path) -> None:
     assert exc_info.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_update_label_unknown_id_returns_not_found(tmp_path: Path) -> None:
     """An id that isn't in the catalog raises ``NOT_FOUND``."""
     controller, _ = _make_controller(tmp_path)
@@ -288,7 +275,6 @@ async def test_update_label_unknown_id_returns_not_found(tmp_path: Path) -> None
     assert exc_info.value.code is ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_update_label_rename_blocked_by_other_label(tmp_path: Path) -> None:
     """Renaming to another label's name is rejected; existing entries unchanged."""
     controller, _ = _make_controller(tmp_path)
@@ -310,7 +296,6 @@ async def test_update_label_rename_blocked_by_other_label(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_delete_label_removes_from_catalog_and_emits_event(tmp_path: Path) -> None:
     """Delete drops the label and broadcasts ``LABEL_DELETED`` with the id."""
     controller, captured = _make_controller(tmp_path)
@@ -326,7 +311,6 @@ async def test_delete_label_removes_from_catalog_and_emits_event(tmp_path: Path)
     assert deleted_events[0].data == {"label_id": created.id}
 
 
-@pytest.mark.asyncio
 async def test_delete_label_unknown_id_raises_not_found(tmp_path: Path) -> None:
     """Deleting a label that isn't in the catalog raises ``NOT_FOUND``.
 
@@ -343,7 +327,6 @@ async def test_delete_label_unknown_id_raises_not_found(tmp_path: Path) -> None:
     assert exc_info.value.code is ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_delete_label_cascades_through_assigned_devices(tmp_path: Path) -> None:
     """Devices that referenced the deleted label get reloaded.
 
@@ -374,7 +357,6 @@ async def test_delete_label_cascades_through_assigned_devices(tmp_path: Path) ->
     assert deleted_events[0].data == {"label_id": a.id}
 
 
-@pytest.mark.asyncio
 async def test_delete_label_tolerates_devices_controller_absent(tmp_path: Path) -> None:
     """Cascade still completes when no DevicesController is wired.
 
@@ -394,7 +376,6 @@ async def test_delete_label_tolerates_devices_controller_absent(tmp_path: Path) 
     assert "labels" not in raw["kitchen.yaml"]
 
 
-@pytest.mark.asyncio
 async def test_delete_label_swallows_per_device_reload_failures(tmp_path: Path) -> None:
     """A reload failure on one device doesn't stop the cascade.
 
@@ -433,7 +414,6 @@ async def test_delete_label_swallows_per_device_reload_failures(tmp_path: Path) 
     assert len(deleted_events) == 1
 
 
-@pytest.mark.asyncio
 async def test_delete_label_can_remove_corrupt_catalog_entry(tmp_path: Path) -> None:
     """A catalog entry that ``Label.from_dict`` would reject is still deletable.
 
@@ -470,7 +450,6 @@ async def test_delete_label_can_remove_corrupt_catalog_entry(tmp_path: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_persistence_round_trip_across_controller_instances(tmp_path: Path) -> None:
     """Labels created via one controller survive a fresh instance."""
     first, _ = _make_controller(tmp_path)

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -98,7 +98,6 @@ def receiver_firmware_cancel(paired_instances: PairedInstances) -> _FirmwareCanc
     return _FirmwareCancelStub(mock=cancel, called=called)
 
 
-@pytest.mark.asyncio
 async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     paired_instances: PairedInstances,
     receiver_firmware_cancel: _FirmwareCancelStub,
@@ -135,7 +134,6 @@ async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=job.job_id)
 
 
-@pytest.mark.asyncio
 async def test_offloader_cancel_job_full_round_trip_to_state_changed(
     paired_instances: PairedInstances,
     receiver_firmware_cancel: _FirmwareCancelStub,
@@ -185,7 +183,6 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
     assert payload["pin_sha256"] == paired_instances.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_offloader_cancel_job_unknown_correlation_drops_silently(
     paired_instances: PairedInstances,
     receiver_firmware_cancel: _FirmwareCancelStub,

--- a/tests/e2e/test_download_artifacts.py
+++ b/tests/e2e/test_download_artifacts.py
@@ -181,7 +181,6 @@ def _write_build_artifacts_on_disk(tmp_path: Path) -> dict[str, bytes]:
     return images
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_round_trip_returns_unpacked_images(
     paired_instances: PairedInstances,
     tmp_path: Path,
@@ -245,7 +244,6 @@ async def test_download_artifacts_round_trip_returns_unpacked_images(
     assert result["total_bytes"] == sum(int(img["size"]) for img in response_images)
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_unknown_job_surfaces_not_found(
     paired_instances: PairedInstances,
 ) -> None:
@@ -278,7 +276,6 @@ async def test_download_artifacts_unknown_job_surfaces_not_found(
     assert exc_info.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_job_not_completed_surfaces_precondition_failed(
     paired_instances: PairedInstances,
 ) -> None:
@@ -305,7 +302,6 @@ async def test_download_artifacts_job_not_completed_surfaces_precondition_failed
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_pack_oversize_surfaces_unavailable(
     paired_instances: PairedInstances,
     tmp_path: Path,

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -237,7 +237,6 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
     return images
 
 
-@pytest.mark.asyncio
 async def test_cold_connect_offloader_observes_initial_queue_status_then_picks_remote(
     paired_instances: PairedInstances,
 ) -> None:
@@ -292,7 +291,6 @@ async def test_cold_connect_offloader_observes_initial_queue_status_then_picks_r
     assert decision.pin_sha256 == paired_instances.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_version_match_policy_filters_mismatched_peer_end_to_end(
     paired_instances: PairedInstances,
 ) -> None:
@@ -336,7 +334,6 @@ async def test_version_match_policy_filters_mismatched_peer_end_to_end(
     assert decision.pin_sha256 == pin
 
 
-@pytest.mark.asyncio
 async def test_exact_required_raises_no_compatible_peer_end_to_end(
     paired_instances: PairedInstances,
 ) -> None:
@@ -370,7 +367,6 @@ async def test_exact_required_raises_no_compatible_peer_end_to_end(
     assert decision.pin_sha256 == pin
 
 
-@pytest.mark.asyncio
 async def test_remote_install_submit_then_lifecycle_then_download_on_one_session(
     paired_instances: PairedInstances,
     tmp_path: Path,
@@ -534,7 +530,6 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
     assert len(paired_instances.receiver_opened) == opened_at_start[1]
 
 
-@pytest.mark.asyncio
 async def test_remote_compile_materialises_for_local_firmware_download(
     paired_instances: PairedInstances,
     tmp_path: Path,
@@ -655,7 +650,6 @@ def _swap_prefix(absolute_posix: str, posix_prefix: str, win_prefix: str) -> str
     return win_prefix + ("\\" + suffix if suffix else "")
 
 
-@pytest.mark.asyncio
 async def test_windows_receiver_tarball_materialises_for_local_firmware_download(
     paired_instances: PairedInstances,
     tmp_path: Path,
@@ -814,7 +808,6 @@ async def _wait_for_offloader_idle(
         await asyncio.wait_for(queue_status_events.received.wait(), timeout=remaining)
 
 
-@pytest.mark.asyncio
 async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
     paired_instances: PairedInstances,
 ) -> None:
@@ -885,7 +878,6 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
         assert decision.pin_sha256 == paired_instances.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_failed_first_job_still_routes_remote_on_second_install(
     paired_instances: PairedInstances,
 ) -> None:
@@ -942,7 +934,6 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
     assert decision.pin_sha256 == paired_instances.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
     paired_instances: PairedInstances,
 ) -> None:

--- a/tests/e2e/test_pair_and_session.py
+++ b/tests/e2e/test_pair_and_session.py
@@ -10,13 +10,11 @@ assertions on top.
 
 from __future__ import annotations
 
-import pytest
 from esphome.const import __version__ as receiver_version
 
 from .conftest import PairedInstances
 
 
-@pytest.mark.asyncio
 async def test_paired_instances_open_peer_link_session(
     paired_instances: PairedInstances,
 ) -> None:
@@ -53,7 +51,6 @@ async def test_paired_instances_open_peer_link_session(
     assert paired_instances.offloader_dashboard_id in sessions
 
 
-@pytest.mark.asyncio
 async def test_paired_instances_teardown_closes_session_cleanly(
     paired_instances: PairedInstances,
 ) -> None:
@@ -105,7 +102,6 @@ async def test_paired_instances_teardown_closes_session_cleanly(
     assert paired_instances.offloader_closed[0]["error_detail"] == ""
 
 
-@pytest.mark.asyncio
 async def test_paired_instances_snapshot_reflects_connected_state(
     paired_instances: PairedInstances,
 ) -> None:
@@ -129,7 +125,6 @@ async def test_paired_instances_snapshot_reflects_connected_state(
     assert summary.last_connect_error == ""
 
 
-@pytest.mark.asyncio
 async def test_paired_instances_snapshot_carries_receiver_esphome_version(
     paired_instances: PairedInstances,
 ) -> None:

--- a/tests/e2e/test_submit_job.py
+++ b/tests/e2e/test_submit_job.py
@@ -53,8 +53,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
 from esphome_device_builder.models import (
     EventType,
@@ -120,7 +118,6 @@ def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[Firmwar
     return created_jobs
 
 
-@pytest.mark.asyncio
 async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
     paired_instances: PairedInstances,
 ) -> None:
@@ -195,7 +192,6 @@ async def test_submit_job_round_trip_extracts_real_bundle_and_queues_job(
     assert job.configuration == extracted_yaml.relative_to(receiver_config_dir).as_posix()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     paired_instances_relative_receiver_config_dir: PairedInstances,
 ) -> None:
@@ -237,7 +233,6 @@ async def test_submit_job_round_trip_with_relative_receiver_config_dir(
     assert job.configuration == extracted_yaml.relative_to(receiver_config_dir).as_posix()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     paired_instances: PairedInstances,
 ) -> None:
@@ -304,7 +299,6 @@ async def test_submit_job_round_trip_then_fanout_to_offloader_bus(
     assert payload["pin_sha256"] == paired_instances.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_submit_job_round_trip_carries_display_strings_to_receiver_job(
     paired_instances: PairedInstances,
 ) -> None:

--- a/tests/e2e/test_submit_job_fanout.py
+++ b/tests/e2e/test_submit_job_fanout.py
@@ -41,8 +41,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from esphome_device_builder.models import (
     EventType,
     JobLifecycleData,
@@ -53,7 +51,6 @@ from ..conftest import capture_events
 from .conftest import PairedInstances, make_and_seed_remote_peer_job
 
 
-@pytest.mark.asyncio
 async def test_remote_peer_job_lifecycle_fans_out_to_offloader_bus(
     paired_instances: PairedInstances,
 ) -> None:
@@ -106,7 +103,6 @@ async def test_remote_peer_job_lifecycle_fans_out_to_offloader_bus(
     assert running["receiver_port"] == paired_instances.receiver_server.port
 
 
-@pytest.mark.asyncio
 async def test_remote_peer_terminal_failure_carries_error_message(
     paired_instances: PairedInstances,
 ) -> None:
@@ -132,7 +128,6 @@ async def test_remote_peer_terminal_failure_carries_error_message(
     assert payload["error_message"] == "esphome compile failed: undefined reference"
 
 
-@pytest.mark.asyncio
 async def test_remote_peer_job_output_fans_out_to_offloader_bus(
     paired_instances: PairedInstances,
 ) -> None:
@@ -168,7 +163,6 @@ async def test_remote_peer_job_output_fans_out_to_offloader_bus(
     assert payload["pin_sha256"] == paired_instances.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_remote_peer_lifecycle_drops_when_session_already_closed(
     paired_instances: PairedInstances,
 ) -> None:

--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -64,7 +64,6 @@ def _install_fake_subprocess(
     return captured
 
 
-@pytest.mark.asyncio
 async def test_build_yaml_bundle_returns_subprocess_output(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -83,7 +82,6 @@ async def test_build_yaml_bundle_returns_subprocess_output(
     assert "-o" in args
 
 
-@pytest.mark.asyncio
 async def test_build_yaml_bundle_missing_yaml_raises_file_not_found(
     tmp_path: Path,
 ) -> None:
@@ -92,7 +90,6 @@ async def test_build_yaml_bundle_missing_yaml_raises_file_not_found(
         await build_yaml_bundle(tmp_path / "missing.yaml")
 
 
-@pytest.mark.asyncio
 async def test_build_yaml_bundle_subprocess_failure_raises_bundle_build_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -110,7 +107,6 @@ async def test_build_yaml_bundle_subprocess_failure_raises_bundle_build_error(
     assert "INVALID_YAML" in exc_info.value.output
 
 
-@pytest.mark.asyncio
 async def test_build_yaml_bundle_cleans_temp_file_on_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -126,7 +122,6 @@ async def test_build_yaml_bundle_cleans_temp_file_on_failure(
     assert not output_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_build_yaml_bundle_cleans_temp_file_on_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -140,7 +135,6 @@ async def test_build_yaml_bundle_cleans_temp_file_on_success(
     assert not output_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_build_yaml_bundle_timeout_raises_bundle_build_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -744,7 +744,6 @@ def test_save_preferences_round_trip(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_prefs_returns_loaded_preferences(tmp_path: Path) -> None:
     """``get_prefs`` returns the persisted blob, not a fresh default.
 
@@ -766,7 +765,6 @@ async def test_get_prefs_returns_loaded_preferences(tmp_path: Path) -> None:
     assert prefs == persisted
 
 
-@pytest.mark.asyncio
 async def test_set_prefs_merges_partial_update(tmp_path: Path) -> None:
     """Partial-update merge: only the supplied field changes.
 
@@ -794,7 +792,6 @@ async def test_set_prefs_merges_partial_update(tmp_path: Path) -> None:
     assert persisted == result
 
 
-@pytest.mark.asyncio
 async def test_get_secrets_returns_empty_when_missing(tmp_path: Path) -> None:
     """No secrets.yaml → empty list, not a raise.
 
@@ -806,7 +803,6 @@ async def test_get_secrets_returns_empty_when_missing(tmp_path: Path) -> None:
     assert keys == []
 
 
-@pytest.mark.asyncio
 async def test_get_secrets_returns_sorted_keys(tmp_path: Path) -> None:
     """Returned secret names are sorted alphabetically.
 
@@ -824,7 +820,6 @@ async def test_get_secrets_returns_sorted_keys(tmp_path: Path) -> None:
     assert keys == ["api_key", "wifi_password", "wifi_ssid"]
 
 
-@pytest.mark.asyncio
 async def test_get_info_returns_storage_metadata_dict(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -887,7 +882,6 @@ async def test_get_info_returns_storage_metadata_dict(
     }
 
 
-@pytest.mark.asyncio
 async def test_get_info_returns_none_when_storage_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -910,7 +904,6 @@ async def test_get_info_returns_none_when_storage_missing(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_get_info_rejects_path_traversal(make_settings: MakeSettingsFactory) -> None:
     """Traversal-shaped configuration raises ``CommandError(INVALID_ARGS)``.
 
@@ -1002,7 +995,6 @@ def test_rel_path_bounds_control_byte_payload(make_settings: MakeSettingsFactory
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_serial_ports_returns_path_and_desc(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1034,7 +1026,6 @@ async def test_get_serial_ports_returns_path_and_desc(
     ]
 
 
-@pytest.mark.asyncio
 async def test_get_serial_ports_runs_in_executor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1073,7 +1064,6 @@ async def test_get_serial_ports_runs_in_executor(
     )
 
 
-@pytest.mark.asyncio
 async def test_get_serial_ports_substitutes_path_for_na_description(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1220,7 +1210,6 @@ def test_read_descriptor_file_returns_none_on_oserror(tmp_path: Path) -> None:
     assert _read_descriptor_file(str(tmp_path / "does-not-exist.bin")) is None
 
 
-@pytest.mark.asyncio
 async def test_run_esptool_calls_run_subprocess_capture_with_resolved_cmd(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1259,7 +1248,6 @@ async def test_run_esptool_calls_run_subprocess_capture_with_resolved_cmd(
     assert captured_kwargs == {"timeout": 30.0}
 
 
-@pytest.mark.asyncio
 async def test_run_esptool_substitutes_minus_one_when_returncode_is_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1287,7 +1275,6 @@ async def test_run_esptool_substitutes_minus_one_when_returncode_is_none(
     assert timed_out is True
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_omits_board_id_when_read_flash_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1358,7 +1345,6 @@ def _mock_run_esptool(monkeypatch: pytest.MonkeyPatch, side_effect):
     monkeypatch.setattr("esphome_device_builder.controllers.config._run_esptool", fake)
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_returns_chip_and_board_id_on_full_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1385,7 +1371,6 @@ async def test_detect_chip_returns_chip_and_board_id_on_full_success(
     }
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_omits_board_id_when_manifest_read_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1412,7 +1397,6 @@ async def test_detect_chip_omits_board_id_when_manifest_read_fails(
     assert "board_id" not in result
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_rejects_missing_or_invalid_port(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
 
@@ -1425,7 +1409,6 @@ async def test_detect_chip_rejects_missing_or_invalid_port(tmp_path: Path) -> No
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_surfaces_port_busy_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1447,7 +1430,6 @@ async def test_detect_chip_surfaces_port_busy_message(
     assert "/dev/ttyUSB0" in exc.value.message
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_surfaces_no_response_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1467,7 +1449,6 @@ async def test_detect_chip_surfaces_no_response_message(
     assert "cable" in exc.value.message.lower() or "boot" in exc.value.message.lower()
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_surfaces_permission_denied_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1488,7 +1469,6 @@ async def test_detect_chip_surfaces_permission_denied_message(
     assert "dialout" in exc.value.message.lower()
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_surfaces_timeout_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1502,7 +1482,6 @@ async def test_detect_chip_surfaces_timeout_message(
     assert "didn't finish in time" in exc.value.message.lower()
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_surfaces_unknown_chip_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1519,7 +1498,6 @@ async def test_detect_chip_surfaces_unknown_chip_message(
     assert "manually" in exc.value.message.lower()
 
 
-@pytest.mark.asyncio
 async def test_detect_chip_surfaces_no_esptool_message(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1536,7 +1514,6 @@ async def test_detect_chip_surfaces_no_esptool_message(
     assert "esptool" in exc.value.message.lower()
 
 
-@pytest.mark.asyncio
 async def test_get_serial_ports_returns_empty_when_no_ports(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_config_hash.py
+++ b/tests/test_config_hash.py
@@ -97,7 +97,6 @@ def test_returns_none_when_hash_missing_or_wrong_type(tmp_path: Path) -> None:
     assert read_build_info_hash(yaml_path) is None
 
 
-@pytest.mark.asyncio
 async def test_async_wrapper_dispatches_to_sync_reader(tmp_path: Path) -> None:
     """``compute_yaml_config_hash`` returns the same value as ``read_build_info_hash``.
 

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -484,7 +484,6 @@ def test_set_remote_build_port_updates_subsequent_advertise() -> None:
     assert decoded["remote_build_port"] == "7000"
 
 
-@pytest.mark.asyncio
 async def test_refresh_republishes_when_only_txt_changed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -523,7 +522,6 @@ async def test_refresh_republishes_when_only_txt_changed(
     assert decoded["pin_sha256"] == "a" * 64
 
 
-@pytest.mark.asyncio
 async def test_refresh_no_op_when_nothing_changed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -564,7 +562,6 @@ def test_service_instance_name_returns_none_before_register() -> None:
     assert advertiser.service_instance_name is None
 
 
-@pytest.mark.asyncio
 async def test_service_instance_name_returns_published_name_after_register(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -593,7 +590,6 @@ def test_service_target_endpoint_returns_none_before_register() -> None:
     assert advertiser.service_target_endpoint is None
 
 
-@pytest.mark.asyncio
 async def test_service_target_endpoint_returns_none_when_info_lacks_server_or_port(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -626,7 +622,6 @@ async def test_service_target_endpoint_returns_none_when_info_lacks_server_or_po
         await advertiser.unregister()
 
 
-@pytest.mark.asyncio
 async def test_service_target_endpoint_returns_lowercased_no_trailing_dot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -684,7 +679,6 @@ def _make_zeroconf_mock() -> MagicMock:
     return zc
 
 
-@pytest.mark.asyncio
 async def test_register_calls_async_register_service(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dashboard_advertise, "_local_addresses", lambda: ["192.168.1.10"])
     advertiser = _make_advertiser(name="green", hostname="green.local")
@@ -701,7 +695,6 @@ async def test_register_calls_async_register_service(monkeypatch: pytest.MonkeyP
     assert info.parsed_addresses() == ["192.168.1.10"]
 
 
-@pytest.mark.asyncio
 async def test_register_runs_address_enumeration_in_executor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -731,7 +724,6 @@ async def test_register_runs_address_enumeration_in_executor(
     assert dashboard_advertise._local_addresses in captured
 
 
-@pytest.mark.asyncio
 async def test_register_is_idempotent() -> None:
     advertiser = _make_advertiser(name="green", hostname="green.local")
     zc = _make_zeroconf_mock()
@@ -741,7 +733,6 @@ async def test_register_is_idempotent() -> None:
     zc.async_register_service.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_register_failure_clears_state() -> None:
     """A zeroconf register-side error leaves the advertiser unregistered.
 
@@ -758,7 +749,6 @@ async def test_register_failure_clears_state() -> None:
     zc.async_unregister_service.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_register_starts_refresh_loop_task() -> None:
     """``register`` spawns a named background task that drives the refresh tick."""
     advertiser = _make_advertiser(name="green", hostname="green.local")
@@ -773,7 +763,6 @@ async def test_register_starts_refresh_loop_task() -> None:
         await advertiser.unregister()
 
 
-@pytest.mark.asyncio
 async def test_refresh_loop_invokes_refresh_on_each_tick(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -807,7 +796,6 @@ async def test_refresh_loop_invokes_refresh_on_each_tick(
         await advertiser.unregister()
 
 
-@pytest.mark.asyncio
 async def test_refresh_loop_survives_refresh_exceptions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -840,7 +828,6 @@ async def test_refresh_loop_survives_refresh_exceptions(
         await advertiser.unregister()
 
 
-@pytest.mark.asyncio
 async def test_unregister_cancels_refresh_loop() -> None:
     """``unregister`` drains the periodic-refresh task before tearing down."""
     advertiser = _make_advertiser(name="green", hostname="green.local")
@@ -853,7 +840,6 @@ async def test_unregister_cancels_refresh_loop() -> None:
     assert advertiser._refresh_task is None
 
 
-@pytest.mark.asyncio
 async def test_unregister_swallows_refresh_task_exception() -> None:
     """
     Drain a refresh task that ended in a non-``CancelledError`` exception.
@@ -889,7 +875,6 @@ async def test_unregister_swallows_refresh_task_exception() -> None:
     assert advertiser._refresh_task is None
 
 
-@pytest.mark.asyncio
 async def test_unregister_calls_async_unregister_service() -> None:
     advertiser = _make_advertiser(name="green", hostname="green.local")
     zc = _make_zeroconf_mock()
@@ -899,14 +884,12 @@ async def test_unregister_calls_async_unregister_service() -> None:
     zc.async_unregister_service.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_unregister_without_register_is_noop() -> None:
     advertiser = _make_advertiser(name="green", hostname="green.local")
     await advertiser.unregister()
     assert advertiser.registered is False
 
 
-@pytest.mark.asyncio
 async def test_refresh_skips_when_addresses_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Calling ``refresh`` when ``_local_addresses`` hasn't changed is a no-op.
@@ -927,7 +910,6 @@ async def test_refresh_skips_when_addresses_unchanged(monkeypatch: pytest.Monkey
     zc.async_update_service.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_refresh_publishes_via_update_service_when_addresses_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -957,14 +939,12 @@ async def test_refresh_publishes_via_update_service_when_addresses_change(
     assert sorted(new_info.parsed_addresses()) == sorted(["192.168.1.42", "fdc8::1"])
 
 
-@pytest.mark.asyncio
 async def test_refresh_is_noop_when_not_registered() -> None:
     """``refresh()`` before ``register()`` is a no-op (no zeroconf to talk to)."""
     advertiser = _make_advertiser(name="green", hostname="green.local")
     assert await advertiser.refresh() is False
 
 
-@pytest.mark.asyncio
 async def test_refresh_swallows_update_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """A zeroconf update-side error doesn't surface to the caller."""
     addresses = ["192.168.1.10"]
@@ -984,7 +964,6 @@ async def test_refresh_swallows_update_errors(monkeypatch: pytest.MonkeyPatch) -
     zc.async_update_service.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_unregister_swallows_zeroconf_errors() -> None:
     """A teardown-time zeroconf failure must not surface to the caller."""
     advertiser = _make_advertiser(name="green", hostname="green.local")
@@ -1000,7 +979,6 @@ async def test_unregister_swallows_zeroconf_errors() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_device_builder_skips_advertise_when_zeroconf_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     make_settings,
@@ -1033,7 +1011,6 @@ async def test_device_builder_skips_advertise_when_zeroconf_unavailable(
     assert constructed == [], "advertise must skip when zeroconf is None"
 
 
-@pytest.mark.asyncio
 async def test_device_builder_skips_advertise_in_ha_addon_mode(
     monkeypatch: pytest.MonkeyPatch,
     make_settings,
@@ -1068,7 +1045,6 @@ async def test_device_builder_skips_advertise_in_ha_addon_mode(
     assert constructed == [], "advertise must be skipped in HA addon mode"
 
 
-@pytest.mark.asyncio
 async def test_device_builder_constructs_advertiser_when_zeroconf_present(
     monkeypatch: pytest.MonkeyPatch,
     make_settings,

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -60,7 +60,6 @@ def test_init_leaves_controllers_unset(make_settings: MakeSettingsFactory) -> No
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_start_initialises_all_controllers(
     make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
@@ -90,7 +89,6 @@ async def test_start_initialises_all_controllers(
         await db.stop()
 
 
-@pytest.mark.asyncio
 async def test_start_registers_command_handlers_from_every_controller(
     make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
@@ -124,7 +122,6 @@ async def test_start_registers_command_handlers_from_every_controller(
         await db.stop()
 
 
-@pytest.mark.asyncio
 async def test_start_spawns_background_polling_task(
     make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
@@ -145,7 +142,6 @@ async def test_start_spawns_background_polling_task(
         await db.stop()
 
 
-@pytest.mark.asyncio
 async def test_background_poll_skips_when_no_subscribers(
     make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
@@ -205,7 +201,6 @@ async def test_background_poll_skips_when_no_subscribers(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_stop_cancels_background_tasks_and_tears_down_controllers(
     make_settings: MakeSettingsFactory, _hermetic_lifecycle: None
 ) -> None:
@@ -249,7 +244,6 @@ async def test_stop_cancels_background_tasks_and_tears_down_controllers(
     assert db._executor is None
 
 
-@pytest.mark.asyncio
 async def test_stop_is_safe_without_start(make_settings: MakeSettingsFactory) -> None:
     """``stop()`` on a never-started instance doesn't crash.
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -334,7 +334,6 @@ def test_on_service_state_change_handles_none_properties(
     assert captured.count("unknown") >= 4  # 4 TXT fields all unknown
 
 
-@pytest.mark.asyncio
 async def test_run_prints_header_then_awaits_then_cleans_up(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -397,7 +396,6 @@ async def test_run_prints_header_then_awaits_then_cleans_up(
     assert "-" * 60 in captured
 
 
-@pytest.mark.asyncio
 async def test_run_verbose_flag_enables_debug_logging() -> None:
     """``-v`` flag flips the root + zeroconf loggers to DEBUG.
 

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -597,7 +597,6 @@ def test_load_device_from_storage_address_uses_storage_when_set(  # type: ignore
     assert device.address == "kitchen.lan"
 
 
-@pytest.mark.asyncio
 async def test_on_ip_change_persists_non_empty_value() -> None:
     """``_on_ip_change`` writes the IP to the metadata store synchronously."""
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -233,7 +233,6 @@ def _make_fake_proc(
     return proc, reader, stdin_capture
 
 
-@pytest.mark.asyncio
 async def test_validate_locked_returns_result_payload(tmp_path: Path) -> None:
     """Happy-path round trip: send validate, receive ``result``.
 
@@ -269,7 +268,6 @@ async def test_validate_locked_returns_result_payload(tmp_path: Path) -> None:
     assert b'"file":"kitchen.yaml"' in stdin_capture[0]
 
 
-@pytest.mark.asyncio
 async def test_validate_locked_handles_read_file_round_trip(tmp_path: Path) -> None:
     """``read_file`` is answered with the in-memory buffer, then result returns.
 
@@ -322,7 +320,6 @@ async def test_validate_locked_handles_read_file_round_trip(tmp_path: Path) -> N
     assert b"esphome" in stdin_capture[1]
 
 
-@pytest.mark.asyncio
 async def test_validate_locked_raises_when_subprocess_closes_stdout(
     tmp_path: Path,
 ) -> None:
@@ -349,7 +346,6 @@ async def test_validate_locked_raises_when_subprocess_closes_stdout(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_stop_terminates_all_sessions(tmp_path: Path) -> None:
     """``stop()`` walks every session and clears the registry.
 
@@ -383,7 +379,6 @@ def test_init_sets_default_state() -> None:
     assert controller._esphome_cmd == []
 
 
-@pytest.mark.asyncio
 async def test_start_resolves_esphome_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -412,7 +407,6 @@ async def test_start_resolves_esphome_command(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_ensure_subprocess_no_op_when_proc_already_running(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -449,7 +443,6 @@ async def test_ensure_subprocess_no_op_when_proc_already_running(
     assert session.proc is proc
 
 
-@pytest.mark.asyncio
 async def test_ensure_subprocess_spawns_and_drains_version_line(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -480,7 +473,6 @@ async def test_ensure_subprocess_spawns_and_drains_version_line(
     assert await proc.stdout.readline() == b""
 
 
-@pytest.mark.asyncio
 async def test_ensure_subprocess_terminates_session_and_raises_on_startup_timeout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -530,7 +522,6 @@ async def test_ensure_subprocess_terminates_session_and_raises_on_startup_timeou
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_terminate_subprocess_no_op_when_session_proc_is_none(
     tmp_path: Path,
 ) -> None:
@@ -541,7 +532,6 @@ async def test_terminate_subprocess_no_op_when_session_proc_is_none(
     await controller._terminate_subprocess(session)
 
 
-@pytest.mark.asyncio
 async def test_terminate_subprocess_no_op_when_proc_already_exited(
     tmp_path: Path,
 ) -> None:
@@ -558,7 +548,6 @@ async def test_terminate_subprocess_no_op_when_proc_already_exited(
     proc.kill.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_terminate_subprocess_sends_exit_and_waits(tmp_path: Path) -> None:
     """Happy path: write ``{"type": "exit"}``, drain, close stdin, wait."""
     controller = _make_controller(tmp_path)
@@ -577,7 +566,6 @@ async def test_terminate_subprocess_sends_exit_and_waits(tmp_path: Path) -> None
     assert session.proc is None
 
 
-@pytest.mark.asyncio
 async def test_terminate_subprocess_escalates_through_terminate_then_kill(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -623,7 +611,6 @@ async def test_terminate_subprocess_escalates_through_terminate_then_kill(
     assert kill_quietly_calls == [proc]
 
 
-@pytest.mark.asyncio
 async def test_terminate_subprocess_swallows_stdin_write_failure(
     tmp_path: Path,
 ) -> None:
@@ -686,7 +673,6 @@ def test_resolve_file_returns_empty_when_requested_path_unresolvable(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_validate_locked_skips_unparseable_lines(tmp_path: Path) -> None:
     """A malformed JSON line is dropped; the loop reads the next line.
 
@@ -717,7 +703,6 @@ async def test_validate_locked_skips_unparseable_lines(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_creates_session_and_delegates(
     tmp_path: Path,
 ) -> None:
@@ -746,7 +731,6 @@ async def test_validate_yaml_creates_session_and_delegates(
     assert controller._captured_session is controller._sessions["kitchen.yaml"]  # type: ignore[attr-defined]
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_terminates_session_on_timeout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -782,7 +766,6 @@ async def test_validate_yaml_terminates_session_on_timeout(
     terminated.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_terminates_session_on_runtime_error(
     tmp_path: Path,
 ) -> None:
@@ -807,7 +790,6 @@ async def test_validate_yaml_terminates_session_on_runtime_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_caches_result_for_repeated_content(tmp_path: Path) -> None:
     """A second call with identical content returns the cached result.
 
@@ -835,7 +817,6 @@ async def test_validate_yaml_caches_result_for_repeated_content(tmp_path: Path) 
     assert len(calls) == 1
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_cache_misses_on_different_content(tmp_path: Path) -> None:
     """Distinct content bypasses the cache and re-validates."""
     controller = _make_controller(tmp_path)
@@ -857,7 +838,6 @@ async def test_validate_yaml_cache_misses_on_different_content(tmp_path: Path) -
     assert calls == ["esphome:\n  name: kitchen\n", "esphome:\n  name: kitchen-2\n"]
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_cache_expires_after_ttl(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -884,7 +864,6 @@ async def test_validate_yaml_cache_expires_after_ttl(
     assert len(calls) == 2
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_cache_is_per_configuration(tmp_path: Path) -> None:
     """Same content under a different configuration doesn't share the cache."""
     controller = _make_controller(tmp_path)
@@ -903,7 +882,6 @@ async def test_validate_yaml_cache_is_per_configuration(tmp_path: Path) -> None:
     assert {c[0] for c in calls} == {"kitchen.yaml", "bedroom.yaml"}
 
 
-@pytest.mark.asyncio
 async def test_validate_yaml_inner_lock_recheck_coalesces_concurrent_calls(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_helpers_api.py
+++ b/tests/test_helpers_api.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from esphome_device_builder.helpers.api import api_command, collect_api_commands
 
 
@@ -139,7 +137,6 @@ def test_collect_api_commands_handles_duplicate_command_names_last_wins() -> Non
     assert handlers["ns/dup"].__name__ == "bbb"
 
 
-@pytest.mark.asyncio
 async def test_collect_api_commands_returns_callable_bound_methods() -> None:
     """Each entry is awaitable and bound to the original instance.
 

--- a/tests/test_helpers_async.py
+++ b/tests/test_helpers_async.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from esphome_device_builder.helpers.async_ import create_eager_task
 
 
-@pytest.mark.asyncio
 async def test_eager_task_runs_synchronously_until_first_await() -> None:
     ran: list[str] = []
 
@@ -25,7 +22,6 @@ async def test_eager_task_runs_synchronously_until_first_await() -> None:
     assert ran == ["before", "after"]
 
 
-@pytest.mark.asyncio
 async def test_eager_task_completes_without_loop_turn() -> None:
     async def coro() -> int:
         return 42
@@ -35,7 +31,6 @@ async def test_eager_task_completes_without_loop_turn() -> None:
     assert task.result() == 42
 
 
-@pytest.mark.asyncio
 async def test_eager_task_sets_name() -> None:
     async def coro() -> None:
         return None
@@ -45,7 +40,6 @@ async def test_eager_task_sets_name() -> None:
     await task
 
 
-@pytest.mark.asyncio
 async def test_eager_task_uses_explicit_loop() -> None:
     loop = asyncio.get_running_loop()
 

--- a/tests/test_helpers_process.py
+++ b/tests/test_helpers_process.py
@@ -123,7 +123,6 @@ def test_kill_quietly_calls_kill_when_alive(fake_proc: _FakeProc) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_terminate_subtree_with_grace_no_op_on_already_exited(
     fake_proc: _FakeProc,
 ) -> None:
@@ -134,7 +133,6 @@ async def test_terminate_subtree_with_grace_no_op_on_already_exited(
 
 
 @posix_only
-@pytest.mark.asyncio
 async def test_terminate_subtree_with_grace_sigterm_then_exit_no_kill(
     fake_proc: _FakeProc,
     fake_signal_group: _FakeSignalGroup,
@@ -153,7 +151,6 @@ async def test_terminate_subtree_with_grace_sigterm_then_exit_no_kill(
 
 
 @posix_only
-@pytest.mark.asyncio
 async def test_terminate_subtree_with_grace_escalates_to_sigkill_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
     fake_proc: _FakeProc,
@@ -193,7 +190,6 @@ async def test_terminate_subtree_with_grace_escalates_to_sigkill_on_timeout(
 
 
 @posix_only
-@pytest.mark.asyncio
 async def test_terminate_subtree_with_grace_returns_when_sigterm_undelivered(
     monkeypatch: pytest.MonkeyPatch,
     fake_proc: _FakeProc,
@@ -222,7 +218,6 @@ async def test_terminate_subtree_with_grace_returns_when_sigterm_undelivered(
 
 
 @windows_only
-@pytest.mark.asyncio
 async def test_terminate_subtree_with_grace_falls_back_to_proc_kill_on_taskkill_failure(
     monkeypatch: pytest.MonkeyPatch,
     fake_proc: _FakeProc,

--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -67,20 +67,17 @@ async def _drain_loop_until(predicate: Callable[[], bool], timeout: float = 1.0)
     raise AssertionError(msg)
 
 
-@pytest.mark.asyncio
 async def test_async_load_returns_none_when_file_missing(store: Store[bytes]) -> None:
     """A non-existent file yields ``None`` rather than raising."""
     assert await store.async_load() is None
 
 
-@pytest.mark.asyncio
 async def test_async_load_decodes_existing_file(store_path: Path, store: Store[bytes]) -> None:
     """An existing file is read + handed through the decoder."""
     store_path.write_bytes(b"hello")
     assert await store.async_load() == b"hello"
 
 
-@pytest.mark.asyncio
 async def test_async_delay_save_writes_after_delay(store_path: Path, store: Store[bytes]) -> None:
     """A scheduled save lands on disk after the delay elapses."""
     store.async_delay_save(lambda: b"delayed", delay=0.05)
@@ -91,7 +88,6 @@ async def test_async_delay_save_writes_after_delay(store_path: Path, store: Stor
     assert store_path.read_bytes() == b"delayed"
 
 
-@pytest.mark.asyncio
 async def test_async_delay_save_collapses_within_window(
     store_path: Path, store: Store[bytes]
 ) -> None:
@@ -117,7 +113,6 @@ async def test_async_delay_save_collapses_within_window(
     assert store_path.read_bytes() == b"final"
 
 
-@pytest.mark.asyncio
 async def test_async_delay_save_extends_deadline_on_later_call(
     store_path: Path, store: Store[bytes]
 ) -> None:
@@ -140,7 +135,6 @@ async def test_async_delay_save_extends_deadline_on_later_call(
     assert store_path.read_bytes() == b"late"
 
 
-@pytest.mark.asyncio
 async def test_async_delay_save_earlier_call_replaces_handle(
     store_path: Path, store: Store[bytes]
 ) -> None:
@@ -165,7 +159,6 @@ async def test_async_delay_save_earlier_call_replaces_handle(
     assert store_path.read_bytes() == b"earlier"
 
 
-@pytest.mark.asyncio
 async def test_async_save_now_flushes_pending_save(store_path: Path, store: Store[bytes]) -> None:
     """``async_save_now`` cancels the timer + writes immediately."""
     store.async_delay_save(lambda: b"pending", delay=10.0)
@@ -174,7 +167,6 @@ async def test_async_save_now_flushes_pending_save(store_path: Path, store: Stor
     assert store_path.read_bytes() == b"pending"
 
 
-@pytest.mark.asyncio
 async def test_async_save_now_is_noop_when_empty(store_path: Path, store: Store[bytes]) -> None:
     """Calling on an empty store is idempotent."""
     await store.async_save_now()
@@ -182,7 +174,6 @@ async def test_async_save_now_is_noop_when_empty(store_path: Path, store: Store[
     assert not store_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
     """Concurrent in-flight write completes before the final flush issues.
 
@@ -227,7 +218,6 @@ async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
     assert store_path.read_bytes() == b"second"
 
 
-@pytest.mark.asyncio
 async def test_write_failure_logged_and_swallowed(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -264,7 +254,6 @@ async def test_write_failure_logged_and_swallowed(
     assert str(store_path) in matching[0].getMessage()
 
 
-@pytest.mark.asyncio
 async def test_default_name_falls_back_to_path(tmp_path: Path) -> None:
     """Omitting *name* derives a stand-in from the store path."""
     store_path = tmp_path / "data.json"
@@ -277,7 +266,6 @@ async def test_default_name_falls_back_to_path(tmp_path: Path) -> None:
     assert str(store_path) in store._name
 
 
-@pytest.mark.asyncio
 async def test_data_func_called_at_flush_not_scheduling(
     store_path: Path, store: Store[bytes]
 ) -> None:
@@ -293,7 +281,6 @@ async def test_data_func_called_at_flush_not_scheduling(
     assert store_path.read_bytes() == b"after-mutation"
 
 
-@pytest.mark.asyncio
 async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
     """The store creates missing parent directories rather than failing."""
     store_path = tmp_path / "subdir" / "nested" / "data.json"
@@ -312,7 +299,6 @@ async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
-@pytest.mark.asyncio
 async def test_default_mode_is_owner_only(tmp_path: Path) -> None:
     """The default ``mode=0o600`` keeps persisted state owner-only.
 
@@ -333,7 +319,6 @@ async def test_default_mode_is_owner_only(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
-@pytest.mark.asyncio
 async def test_explicit_mode_is_applied(tmp_path: Path) -> None:
     """Caller-supplied *mode* lands on the persisted file.
 
@@ -354,7 +339,6 @@ async def test_explicit_mode_is_applied(tmp_path: Path) -> None:
     assert stat.S_IMODE(store_path.stat().st_mode) == 0o644
 
 
-@pytest.mark.asyncio
 async def test_atomic_write_cleans_up_tempfile_on_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -387,7 +371,6 @@ async def test_atomic_write_cleans_up_tempfile_on_error(
     assert not list(tmp_path.glob("data.json.*.tmp"))
 
 
-@pytest.mark.asyncio
 async def test_constructor_registers_shutdown_callback(
     recorder: _Recorder, store: Store[bytes], store_path: Path
 ) -> None:
@@ -404,7 +387,6 @@ async def test_constructor_registers_shutdown_callback(
     assert store_path.read_bytes() == b"via-shutdown"
 
 
-@pytest.mark.asyncio
 async def test_lifecycle_walk_flushes_pending_saves_across_stores(
     tmp_path: Path,
 ) -> None:
@@ -446,7 +428,6 @@ async def test_lifecycle_walk_flushes_pending_saves_across_stores(
     assert peers_path.read_bytes() == b"peers-final"
 
 
-@pytest.mark.asyncio
 async def test_save_now_skips_when_no_pending_data_after_drain(
     store_path: Path, store: Store[bytes]
 ) -> None:
@@ -458,7 +439,6 @@ async def test_save_now_skips_when_no_pending_data_after_drain(
     assert store_path.read_bytes() == b"v"
 
 
-@pytest.mark.asyncio
 async def test_extend_then_save_now_picks_up_latest(store_path: Path, store: Store[bytes]) -> None:
     """A flush after multiple extending calls writes the latest state once."""
     store.async_delay_save(lambda: b"a", delay=10.0)
@@ -468,7 +448,6 @@ async def test_extend_then_save_now_picks_up_latest(store_path: Path, store: Sto
     assert store_path.read_bytes() == b"c"
 
 
-@pytest.mark.asyncio
 async def test_handle_write_returns_early_when_data_func_already_drained(
     recorder: _Recorder, store: Store[bytes], store_path: Path
 ) -> None:
@@ -485,7 +464,6 @@ async def test_handle_write_returns_early_when_data_func_already_drained(
     assert not store_path.exists()
 
 
-@pytest.mark.asyncio
 async def test_load_propagates_decoder_errors(tmp_path: Path) -> None:
     """A corrupt file surfaces the decoder exception rather than masking.
 
@@ -511,7 +489,6 @@ async def test_load_propagates_decoder_errors(tmp_path: Path) -> None:
         await store.async_load()
 
 
-@pytest.mark.asyncio
 async def test_path_property_exposes_store_path(store_path: Path, store: Store[bytes]) -> None:
     """The ``path`` property surfaces the store's on-disk location."""
     assert store.path == store_path

--- a/tests/test_mdns_api_encryption.py
+++ b/tests/test_mdns_api_encryption.py
@@ -17,8 +17,6 @@ Three states matter for the apply path:
 
 from __future__ import annotations
 
-import pytest
-
 from esphome_device_builder.models import EventType
 
 from .conftest import (
@@ -95,7 +93,6 @@ def test_apply_api_encryption_dedupes_repeated_empty() -> None:
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_updates_device_and_fires_event() -> None:
     """Callback writes the value onto the in-memory device + fires DEVICE_UPDATED."""
     device = make_device(api_encryption_active=None)
@@ -107,7 +104,6 @@ async def test_on_api_encryption_change_updates_device_and_fires_event() -> None
     assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_records_empty_string() -> None:
     """Empty string flips ``None`` → ``""`` and fires the event.
 
@@ -126,7 +122,6 @@ async def test_on_api_encryption_change_records_empty_string() -> None:
     assert len(captured) == 1
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_skips_when_same() -> None:
     """No-op when the in-memory device already has the announced value AND ``api_encrypted`` agrees.
 
@@ -152,7 +147,6 @@ async def test_on_api_encryption_change_skips_when_same() -> None:
     assert captured == []
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_promotes_api_encrypted_when_yaml_missed_it() -> None:
     """Truthy mDNS broadcast flips ``api_encrypted=True`` when YAML missed it.
 
@@ -175,7 +169,6 @@ async def test_on_api_encryption_change_promotes_api_encrypted_when_yaml_missed_
     assert len(captured) == 1
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_promotion_fires_even_when_active_unchanged() -> None:
     """Repeat truthy broadcast still promotes ``api_encrypted`` if YAML scan reset it.
 
@@ -202,7 +195,6 @@ async def test_on_api_encryption_change_promotion_fires_even_when_active_unchang
     assert len(captured) == 1
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_empty_does_not_clear_api_encrypted() -> None:
     """Wire-confirmed-plaintext doesn't *demote* a YAML-claimed encryption.
 
@@ -230,7 +222,6 @@ async def test_on_api_encryption_change_empty_does_not_clear_api_encrypted() -> 
     assert len(captured) == 1
 
 
-@pytest.mark.asyncio
 async def test_on_api_encryption_change_unknown_device_is_noop() -> None:
     """A stray callback for a name we don't track must not raise or fire."""
     controller, captured = make_devices_controller_with_bus([])

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.models import Device, EventType
 
@@ -134,7 +132,6 @@ def test_apply_config_hash_no_callback_silently_drops() -> None:
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
     """The full pipe: callback updates the in-memory device + fires DEVICE_UPDATED."""
     device = _device(deployed_config_hash="")
@@ -146,7 +143,6 @@ async def test_on_config_hash_change_updates_device_and_fires_event() -> None:
     assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
 
 
-@pytest.mark.asyncio
 async def test_on_config_hash_change_skips_when_same() -> None:
     """No-op when in-memory device already has the announced hash."""
     device = _device(deployed_config_hash="1a2b3c4d")
@@ -157,7 +153,6 @@ async def test_on_config_hash_change_skips_when_same() -> None:
     assert captured == []
 
 
-@pytest.mark.asyncio
 async def test_on_config_hash_change_unknown_device_is_noop() -> None:
     """A stray callback for an unknown device must not raise or fire events."""
     controller, captured = make_devices_controller_with_bus([])
@@ -167,7 +162,6 @@ async def test_on_config_hash_change_unknown_device_is_noop() -> None:
     assert captured == []
 
 
-@pytest.mark.asyncio
 async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None:
     """Hashes don't match → ``has_pending_changes`` flips True."""
     device = _device(
@@ -183,7 +177,6 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None
     assert device.has_pending_changes is True
 
 
-@pytest.mark.asyncio
 async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
     """Hashes match → ``has_pending_changes`` flips False."""
     device = _device(
@@ -199,7 +192,6 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
     assert device.has_pending_changes is False
 
 
-@pytest.mark.asyncio
 async def test_on_config_hash_change_leaves_pending_alone_without_expected_hash() -> None:
     """No expected hash on file → don't touch has_pending_changes (mtime fallback owns it)."""
     device = _device(

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
 from esphome_device_builder.models import Device, EventType
 
@@ -99,7 +97,6 @@ def test_apply_version_no_callback_silently_drops() -> None:
 # ----------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_on_version_change_updates_device_fires_event_and_persists(
     monkeypatch: Any,
 ) -> None:
@@ -119,7 +116,6 @@ async def test_on_version_change_updates_device_fires_event_and_persists(
     assert controller._metadata_store.get(device.configuration) == {"deployed_version": "2026.5.0"}
 
 
-@pytest.mark.asyncio
 async def test_on_version_change_skips_when_same() -> None:
     """No-op when in-memory device already has the announced version."""
     device = _device(deployed_version="2026.5.0")
@@ -134,7 +130,6 @@ async def test_on_version_change_skips_when_same() -> None:
     assert scheduled == []
 
 
-@pytest.mark.asyncio
 async def test_on_version_change_marks_update_available_when_behind() -> None:
     """A device on an older version than the dashboard → ``update_available`` flips on."""
     device = _device(current_version="2026.5.0", deployed_version="2026.4.0")

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -1375,7 +1375,6 @@ async def test_run_reconnects_on_connect_and_listen_failure(
     assert monitor._last_seen == {}
 
 
-@pytest.mark.asyncio
 async def test_run_collapses_repeat_unreachable_errors_to_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1437,7 +1436,6 @@ async def test_run_collapses_repeat_unreachable_errors_to_debug(
         assert record.exc_info is None
 
 
-@pytest.mark.asyncio
 async def test_run_resets_log_gate_after_successful_connect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1526,7 +1524,6 @@ async def test_run_resets_log_gate_after_successful_connect(
     assert len(debugs) == 1, [r.message for r in debugs]
 
 
-@pytest.mark.asyncio
 async def test_run_loud_logs_unexpected_after_expected_failure(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1591,7 +1588,6 @@ async def test_run_loud_logs_unexpected_after_expected_failure(
     assert errors[0].exc_info is not None
 
 
-@pytest.mark.asyncio
 async def test_run_collapses_repeat_unexpected_errors_to_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -20,8 +20,6 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor, shared
 from esphome_device_builder.models import Device, DeviceState
 
@@ -77,7 +75,6 @@ def _make_monitor(
     return monitor, fake_zc.async_resolve_host
 
 
-@pytest.mark.asyncio
 async def test_non_api_device_marked_online_when_mdns_resolves() -> None:
     """A web-server-only YAML flips ONLINE when mDNS resolves its hostname.
 
@@ -95,7 +92,6 @@ async def test_non_api_device_marked_online_when_mdns_resolves() -> None:
     resolver.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_api_device_skipped() -> None:
     """API-loaded devices go through the browser path, not the resolve fallback.
 
@@ -112,7 +108,6 @@ async def test_api_device_skipped() -> None:
     assert devices[0].state == DeviceState.UNKNOWN
 
 
-@pytest.mark.asyncio
 async def test_uncompiled_device_skipped() -> None:
     """Devices with empty ``loaded_integrations`` skip the resolve.
 
@@ -130,7 +125,6 @@ async def test_uncompiled_device_skipped() -> None:
     resolver.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_non_local_hostname_skipped() -> None:
     """Resolve only kicks in for ``.local`` hostnames — DNS is the right tool elsewhere."""
     devices = [_device(address="device.example.com", loaded_integrations=["mqtt"])]
@@ -141,7 +135,6 @@ async def test_non_local_hostname_skipped() -> None:
     resolver.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_resolve_miss_is_silent_no_offline_branch_by_design() -> None:
     """A miss is silent — ONLY trust mDNS for ONLINE, never for OFFLINE.
 
@@ -167,7 +160,6 @@ async def test_resolve_miss_is_silent_no_offline_branch_by_design() -> None:
     assert monitor.priority_for("kitchen") == "unknown"
 
 
-@pytest.mark.asyncio
 async def test_resolve_exception_does_not_propagate() -> None:
     """A zeroconf exception on one host doesn't poison the others.
 
@@ -201,7 +193,6 @@ async def test_resolve_exception_does_not_propagate() -> None:
     assert kitchen.state == DeviceState.UNKNOWN
 
 
-@pytest.mark.asyncio
 async def test_no_zeroconf_is_a_noop() -> None:
     """Pre-start (or zeroconf-failed) sweep must not raise."""
     devices = [_device(loaded_integrations=["web_server"])]
@@ -213,7 +204,6 @@ async def test_no_zeroconf_is_a_noop() -> None:
     assert devices[0].state == DeviceState.UNKNOWN
 
 
-@pytest.mark.asyncio
 async def test_already_online_via_higher_priority_skipped() -> None:
     """A device claimed by mDNS / MQTT already doesn't get re-resolved.
 
@@ -231,7 +221,6 @@ async def test_already_online_via_higher_priority_skipped() -> None:
     resolver.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_resolve_hit_locks_out_ping() -> None:
     """A resolve hit claims ``mdns`` priority and ICMP stops.
 
@@ -254,7 +243,6 @@ async def test_resolve_hit_locks_out_ping() -> None:
     assert shared.should_ping(monitor, devices[0]) is False
 
 
-@pytest.mark.asyncio
 async def test_offline_via_ping_still_resolved() -> None:
     """A device flipped OFFLINE by ping is still a resolve candidate.
 
@@ -273,7 +261,6 @@ async def test_offline_via_ping_still_resolved() -> None:
     assert devices[0].state == DeviceState.ONLINE
 
 
-@pytest.mark.asyncio
 async def test_resolve_picks_ipv4_for_apply_ip() -> None:
     """Active resolve forwards every IP; primary picks IPv4 when present.
 
@@ -294,7 +281,6 @@ async def test_resolve_picks_ipv4_for_apply_ip() -> None:
     assert devices[0].ip_addresses == ["fe80::1%en0", "192.168.1.42", "fe80::2%en0"]
 
 
-@pytest.mark.asyncio
 async def test_no_candidates_skips_zeroconf_call() -> None:
     """All API-loaded fleet → no resolve work.
 
@@ -311,7 +297,6 @@ async def test_no_candidates_skips_zeroconf_call() -> None:
     resolver.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_multiple_devices_resolve_in_parallel(monkeypatch: Any) -> None:
     """All non-API devices resolve in a single ``asyncio.gather`` call.
 

--- a/tests/test_onboarding_controller.py
+++ b/tests/test_onboarding_controller.py
@@ -50,7 +50,6 @@ def _write_secrets(config_dir: Path, content: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_state_pending_for_missing_secrets(tmp_path: Path) -> None:
     """No ``secrets.yaml`` ⇒ wifi step pending, version baseline."""
     controller = _make_controller(tmp_path)
@@ -62,7 +61,6 @@ async def test_get_state_pending_for_missing_secrets(tmp_path: Path) -> None:
     assert state.steps[0].status == OnboardingStepStatus.PENDING
 
 
-@pytest.mark.asyncio
 async def test_get_state_pending_for_empty_string_secrets(tmp_path: Path) -> None:
     """Existing-install bootstrap with ``wifi_ssid: ""`` ⇒ still pending."""
     _write_secrets(tmp_path, 'wifi_ssid: ""\nwifi_password: ""\n')
@@ -71,7 +69,6 @@ async def test_get_state_pending_for_empty_string_secrets(tmp_path: Path) -> Non
     assert state.steps[0].status == OnboardingStepStatus.PENDING
 
 
-@pytest.mark.asyncio
 async def test_get_state_pending_for_placeholder_secrets(tmp_path: Path) -> None:
     """Fresh-install bootstrap with the placeholder ⇒ still pending."""
     _write_secrets(
@@ -83,7 +80,6 @@ async def test_get_state_pending_for_placeholder_secrets(tmp_path: Path) -> None
     assert state.steps[0].status == OnboardingStepStatus.PENDING
 
 
-@pytest.mark.asyncio
 async def test_get_state_done_for_real_secrets(tmp_path: Path) -> None:
     _write_secrets(tmp_path, "wifi_ssid: home_network\nwifi_password: hunter2\n")
     controller = _make_controller(tmp_path)
@@ -96,7 +92,6 @@ async def test_get_state_done_for_real_secrets(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_writes_to_secrets_yaml(tmp_path: Path) -> None:
     """The setter updates the file and the next get_state reflects it."""
     _write_secrets(
@@ -111,7 +106,6 @@ async def test_set_wifi_credentials_writes_to_secrets_yaml(tmp_path: Path) -> No
     assert 'wifi_password: "hunter2"' in content
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_preserves_other_secrets_and_comments(
     tmp_path: Path,
 ) -> None:
@@ -136,7 +130,6 @@ async def test_set_wifi_credentials_preserves_other_secrets_and_comments(
     assert 'wifi_password: "secret"' in content
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_creates_file_when_missing(tmp_path: Path) -> None:
     """User who deleted secrets.yaml between bootstrap and onboarding."""
     controller = _make_controller(tmp_path)
@@ -146,7 +139,6 @@ async def test_set_wifi_credentials_creates_file_when_missing(tmp_path: Path) ->
     assert 'wifi_password: "secret"' in content
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_preserves_ssid_whitespace(tmp_path: Path) -> None:
     """IEEE 802.11 allows leading/trailing whitespace in SSIDs.
 
@@ -160,7 +152,6 @@ async def test_set_wifi_credentials_preserves_ssid_whitespace(tmp_path: Path) ->
     assert 'wifi_ssid: "  MyNetwork  "' in content
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_quotes_double_quotes_safely(
     tmp_path: Path,
 ) -> None:
@@ -171,14 +162,12 @@ async def test_set_wifi_credentials_quotes_double_quotes_safely(
     assert r'wifi_ssid: "Net\"With\"Quotes"' in content
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rejects_empty_ssid(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     with pytest.raises(CommandError, match="SSID can't be empty"):
         await controller.set_wifi_credentials(ssid="   ", password="p")
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rejects_non_string_ssid(tmp_path: Path) -> None:
     """A misbehaving client sending a number / null gets a clean error.
 
@@ -191,21 +180,18 @@ async def test_set_wifi_credentials_rejects_non_string_ssid(tmp_path: Path) -> N
         await controller.set_wifi_credentials(ssid=42, password="p")  # type: ignore[arg-type]
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rejects_non_string_password(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     with pytest.raises(CommandError, match="Password must be a string"):
         await controller.set_wifi_credentials(ssid="MyAP", password=None)  # type: ignore[arg-type]
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rejects_oversize_ssid(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     with pytest.raises(CommandError, match="32 characters"):
         await controller.set_wifi_credentials(ssid="A" * 33, password="p")
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rejects_oversize_password(
     tmp_path: Path,
 ) -> None:
@@ -214,7 +200,6 @@ async def test_set_wifi_credentials_rejects_oversize_password(
         await controller.set_wifi_credentials(ssid="MyAP", password="P" * 65)
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_accepts_empty_password(tmp_path: Path) -> None:
     """Open networks have empty passwords — must not be rejected."""
     controller = _make_controller(tmp_path)
@@ -227,7 +212,6 @@ async def test_set_wifi_credentials_accepts_empty_password(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_mark_acknowledged_persists_current_version(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     state = await controller.mark_acknowledged()
@@ -237,7 +221,6 @@ async def test_mark_acknowledged_persists_current_version(tmp_path: Path) -> Non
     assert state2.completed_version == ONBOARDING_VERSION
 
 
-@pytest.mark.asyncio
 async def test_mark_acknowledged_is_idempotent(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     await controller.mark_acknowledged()
@@ -245,7 +228,6 @@ async def test_mark_acknowledged_is_idempotent(tmp_path: Path) -> None:
     assert state.completed_version == ONBOARDING_VERSION
 
 
-@pytest.mark.asyncio
 async def test_mark_acknowledged_does_not_downgrade_a_higher_stored_version(
     tmp_path: Path,
 ) -> None:
@@ -273,7 +255,6 @@ async def test_mark_acknowledged_does_not_downgrade_a_higher_stored_version(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "ssid",
     [
@@ -298,7 +279,6 @@ async def test_set_wifi_credentials_rejects_newlines_in_ssid(tmp_path: Path, ssi
         await controller.set_wifi_credentials(ssid=ssid, password="p")
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rejects_newlines_in_password(
     tmp_path: Path,
 ) -> None:
@@ -307,7 +287,6 @@ async def test_set_wifi_credentials_rejects_newlines_in_password(
         await controller.set_wifi_credentials(ssid="MyAP", password="p\nass")
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_allows_tab_in_value(tmp_path: Path) -> None:
     """Allow TAB through — don't over-block.
 
@@ -319,7 +298,6 @@ async def test_set_wifi_credentials_allows_tab_in_value(tmp_path: Path) -> None:
     assert state.steps[0].status == OnboardingStepStatus.DONE
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_preserves_inline_comments(
     tmp_path: Path,
 ) -> None:
@@ -341,7 +319,6 @@ async def test_set_wifi_credentials_preserves_inline_comments(
     assert 'wifi_password: "newpw"  # WPA2' in content
 
 
-@pytest.mark.asyncio
 async def test_set_wifi_credentials_rewrites_duplicate_keys(
     tmp_path: Path,
 ) -> None:
@@ -375,7 +352,6 @@ async def test_set_wifi_credentials_rewrites_duplicate_keys(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_get_state_pending_for_malformed_secrets_yaml(tmp_path: Path) -> None:
     """Treat malformed YAML as ``unconfigured`` instead of crashing.
 

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -88,7 +88,6 @@ async def _drive_until(condition: Callable[[], object], *, timeout: float = 0.5)
     await asyncio.wait_for(_spin(), timeout=timeout)
 
 
-@pytest.mark.asyncio
 async def test_ping_loop_runs_unconditionally_without_presence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -114,7 +113,6 @@ async def test_ping_loop_runs_unconditionally_without_presence(
     assert counts["resolves"] >= 2
 
 
-@pytest.mark.asyncio
 async def test_ping_loop_parks_until_first_subscriber(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -149,7 +147,6 @@ async def test_ping_loop_parks_until_first_subscriber(
     assert counts["sweeps"] >= 1
 
 
-@pytest.mark.asyncio
 async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -188,7 +185,6 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
     assert counts["sweeps"] <= sweeps_at_disconnect + 1
 
 
-@pytest.mark.asyncio
 async def test_subscribe_events_holds_presence_for_stream_lifetime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -223,7 +219,6 @@ async def test_subscribe_events_holds_presence_for_stream_lifetime(
     assert counts["outside_after"] == 0, "presence count must drop back to 0 after stream exit"
 
 
-@pytest.mark.asyncio
 async def test_subscriber_arrival_mid_idle_bails_within_a_tick(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -70,7 +70,6 @@ def _capture_apply(
     return calls
 
 
-@pytest.mark.asyncio
 async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None:
     """A cached service info applies inline; no task is spawned."""
     monitor = _make_monitor()
@@ -89,7 +88,6 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
     assert not monitor._tasks
 
 
-@pytest.mark.asyncio
 async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None:
     """``service_name`` overrides the lookup but apply still keys by ``device_name``.
 
@@ -125,7 +123,6 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
     assert apply_calls == [("my-living-room", fake_info)]
 
 
-@pytest.mark.asyncio
 async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     """Cache miss → fire-and-forget resolve task tracked in ``_tasks``."""
     monitor = _make_monitor()
@@ -172,7 +169,6 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
     assert not monitor._tasks
 
 
-@pytest.mark.asyncio
 async def test_apply_service_info_claims_online() -> None:
     """``_apply_service_info`` flips the device ONLINE under the mDNS source.
 
@@ -214,7 +210,6 @@ async def test_apply_service_info_claims_online() -> None:
     ]
 
 
-@pytest.mark.asyncio
 async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
     """A populated ``mac`` TXT lands at ``apply_mac_address``.
 

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -109,7 +109,6 @@ def test_probe_device_ping_herd_collapses_to_single_set() -> None:
     assert monitor._tasks == set()
 
 
-@pytest.mark.asyncio
 async def test_wake_bails_idle_wait_early(monkeypatch: pytest.MonkeyPatch) -> None:
     """A wake fired during the idle wait re-runs the sweep without paying ``_PING_INTERVAL``."""
     _patch_loop_for_wake_tests(monkeypatch)
@@ -126,7 +125,6 @@ async def test_wake_bails_idle_wait_early(monkeypatch: pytest.MonkeyPatch) -> No
         assert sweeps.count == 2
 
 
-@pytest.mark.asyncio
 async def test_wake_during_sweep_triggers_followup(monkeypatch: pytest.MonkeyPatch) -> None:
     """A wake fired mid-sweep survives the pre-sweep ``_wake.clear()`` to drive one follow-up."""
     _patch_loop_for_wake_tests(monkeypatch)

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -121,7 +121,6 @@ def _all_app_frames(session: Any) -> list[dict[str, Any]]:
         {"type": "download_artifacts", "job_id": 12345},
     ],
 )
-@pytest.mark.asyncio
 async def test_download_artifacts_malformed_terminates(broken_frame: dict[str, Any]) -> None:
     """A malformed ``download_artifacts`` frame terminates the session, no end frame."""
     sender = _make_sender()
@@ -133,7 +132,6 @@ async def test_download_artifacts_malformed_terminates(broken_frame: dict[str, A
     session.send_app_frame.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_unknown_job_rejected(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -163,7 +161,6 @@ async def test_download_artifacts_unknown_job_rejected(
     assert "another" in log_text  # the receiver's known job_ids
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_job_not_completed_rejected(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -191,7 +188,6 @@ async def test_download_artifacts_job_not_completed_rejected(
     assert "running" in log_text.lower()
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_duplicate_rejected_without_terminate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -209,7 +205,6 @@ async def test_download_artifacts_duplicate_rejected_without_terminate(
     assert payload["reason"] == "duplicate_download"
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_build_dir_missing_rejected(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -249,7 +244,6 @@ async def test_download_artifacts_build_dir_missing_rejected(
     assert "StorageJSON sidecar missing" in log_text
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_pack_failed_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -273,7 +267,6 @@ async def test_download_artifacts_pack_failed_rejected(
     assert payload["reason"] == "pack_failed"
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_happy_path_streams_start_chunk_end(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -308,7 +301,6 @@ async def test_download_artifacts_happy_path_streams_start_chunk_end(
     assert session.dashboard_id not in sender._inflight
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_clears_inflight_on_reject(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -381,7 +381,6 @@ def _patch_probe_internals(
     return cancel, spawn
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -416,7 +415,6 @@ async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     assert pin not in controller.offloader.state.rebind_probe_until
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_pin_mismatch_does_not_mutate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -457,7 +455,6 @@ async def test_rebind_probe_pin_mismatch_does_not_mutate(
     assert controller.offloader.state.rebind_probe_until[pin] == 9999.0
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_unreachable_does_not_mutate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -490,7 +487,6 @@ async def test_rebind_probe_unreachable_does_not_mutate(
     assert controller.offloader.state.rebind_probe_until[pin] == 9999.0
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_skips_when_pairing_replaced_mid_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -523,7 +519,6 @@ async def test_rebind_probe_skips_when_pairing_replaced_mid_probe(
     spawn.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_skips_when_pairing_status_flips_mid_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -560,7 +555,6 @@ async def test_rebind_probe_skips_when_pairing_status_flips_mid_probe(
     spawn.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_unexpected_exception_clears_cooldown(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -589,7 +583,6 @@ async def test_rebind_probe_unexpected_exception_clears_cooldown(
     assert pin not in controller.offloader.state.rebind_probe_until
 
 
-@pytest.mark.asyncio
 async def test_rebind_probe_skips_when_pairing_unpaired_mid_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -672,7 +665,6 @@ def test_maybe_schedule_rebind_probe_skips_pending(tmp_path: Path) -> None:
     assert controller.offloader._tasks == set()
 
 
-@pytest.mark.asyncio
 async def test_maybe_schedule_rebind_probe_dedupes_within_cooldown(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -748,7 +740,6 @@ def test_maybe_schedule_rebind_probe_skips_without_priv(tmp_path: Path) -> None:
 # failure mode the probe can return.
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_match_mutates_pairing_and_fires_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -783,7 +774,6 @@ async def test_edit_pairing_endpoint_match_mutates_pairing_and_fires_event(
     assert summary.pin_sha256 == pin
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_pin_mismatch_raises_precondition_failed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -817,7 +807,6 @@ async def test_edit_pairing_endpoint_pin_mismatch_raises_precondition_failed(
     spawn.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_unreachable_raises_unavailable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -844,7 +833,6 @@ async def test_edit_pairing_endpoint_unreachable_raises_unavailable(
     spawn.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_unknown_pin_raises_not_found(tmp_path: Path) -> None:
     """A pin with no stored pairing raises NOT_FOUND before the probe runs."""
     controller = _make_controller(config_dir=tmp_path)
@@ -859,7 +847,6 @@ async def test_edit_pairing_endpoint_unknown_pin_raises_not_found(tmp_path: Path
     assert exc_info.value.code is ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_pending_pairing_raises_precondition_failed(
     tmp_path: Path,
 ) -> None:
@@ -885,7 +872,6 @@ async def test_edit_pairing_endpoint_pending_pairing_raises_precondition_failed(
     assert "pending" in str(exc_info.value).lower()
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_same_endpoint_raises_precondition_failed(
     tmp_path: Path,
 ) -> None:
@@ -908,7 +894,6 @@ async def test_edit_pairing_endpoint_same_endpoint_raises_precondition_failed(
     assert exc_info.value.code is ErrorCode.PRECONDITION_FAILED
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_raises_not_found_when_pairing_replaced_mid_probe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -952,7 +937,6 @@ async def test_edit_pairing_endpoint_raises_not_found_when_pairing_replaced_mid_
     spawn.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_without_priv_raises_precondition_failed(
     tmp_path: Path,
 ) -> None:
@@ -977,7 +961,6 @@ async def test_edit_pairing_endpoint_without_priv_raises_precondition_failed(
     assert exc_info.value.code is ErrorCode.PRECONDITION_FAILED
 
 
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_status_changed_mid_probe_raises_precondition_failed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1040,7 +1023,6 @@ async def test_edit_pairing_endpoint_status_changed_mid_probe_raises_preconditio
         {"pin_sha256": "a" * 64, "hostname": "a.local", "port": True},
     ],
 )
-@pytest.mark.asyncio
 async def test_edit_pairing_endpoint_invalid_args_rejected_before_lookup(
     tmp_path: Path, kwargs: dict[str, Any]
 ) -> None:
@@ -1226,7 +1208,6 @@ def test_hosts_snapshot_empty_when_no_peers(tmp_path: Path) -> None:
     assert controller.offloader.hosts_snapshot() == []
 
 
-@pytest.mark.asyncio
 async def test_get_settings_defaults_when_unset(tmp_path: Path) -> None:
     """A fresh dashboard with no metadata returns ``enabled=True``.
 
@@ -1242,7 +1223,6 @@ async def test_get_settings_defaults_when_unset(tmp_path: Path) -> None:
     assert settings == RemoteBuildSettingsView(enabled=True)
 
 
-@pytest.mark.asyncio
 async def test_set_settings_round_trips(tmp_path: Path) -> None:
     """Setting ``enabled=True`` persists and is read back by ``get_settings``."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1252,7 +1232,6 @@ async def test_set_settings_round_trips(tmp_path: Path) -> None:
     assert read == RemoteBuildSettingsView(enabled=True)
 
 
-@pytest.mark.asyncio
 async def test_set_settings_rejects_non_bool(tmp_path: Path) -> None:
     """
     Non-boolean ``enabled`` raises ``INVALID_ARGS``, doesn't coerce.
@@ -1274,7 +1253,6 @@ async def test_set_settings_rejects_non_bool(tmp_path: Path) -> None:
     assert settings.enabled is True
 
 
-@pytest.mark.asyncio
 async def test_set_settings_round_trips_cleanup_ttl(tmp_path: Path) -> None:
     """``cleanup_ttl_seconds`` persists alongside ``enabled``."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1284,7 +1262,6 @@ async def test_set_settings_round_trips_cleanup_ttl(tmp_path: Path) -> None:
     assert read.cleanup_ttl_seconds == 7200
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "bad_value",
     [
@@ -1310,7 +1287,6 @@ async def test_set_settings_rejects_non_int_cleanup_ttl(tmp_path: Path, bad_valu
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "out_of_range",
     [
@@ -1335,7 +1311,6 @@ async def test_set_settings_rejects_out_of_range_cleanup_ttl(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_start_skips_when_devices_controller_missing(tmp_path: Path) -> None:
     """``start`` is a no-op when ``DevicesController`` hasn't been set."""
     db = MagicMock()
@@ -1351,7 +1326,6 @@ async def test_start_skips_when_devices_controller_missing(tmp_path: Path) -> No
     assert controller.offloader.state.browser is None
 
 
-@pytest.mark.asyncio
 async def test_start_skips_when_zeroconf_unavailable(tmp_path: Path) -> None:
     """``start`` is a no-op when zeroconf failed to bind."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1360,7 +1334,6 @@ async def test_start_skips_when_zeroconf_unavailable(tmp_path: Path) -> None:
     assert controller.offloader.state.browser is None
 
 
-@pytest.mark.asyncio
 async def test_start_leaves_peer_link_resolver_none_when_devices_controller_missing(
     tmp_path: Path,
 ) -> None:
@@ -1385,7 +1358,6 @@ async def test_start_leaves_peer_link_resolver_none_when_devices_controller_miss
     assert controller.offloader.state.peer_link_resolver is None
 
 
-@pytest.mark.asyncio
 async def test_start_leaves_peer_link_resolver_none_when_zeroconf_failed_to_bind(
     tmp_path: Path,
 ) -> None:
@@ -1403,7 +1375,6 @@ async def test_start_leaves_peer_link_resolver_none_when_zeroconf_failed_to_bind
     assert controller.offloader.state.peer_link_resolver is None
 
 
-@pytest.mark.asyncio
 async def test_start_swallows_peer_link_resolver_construction_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1438,7 +1409,6 @@ async def test_start_swallows_peer_link_resolver_construction_errors(
         await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_stop_swallows_peer_link_resolver_close_failures(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -1470,7 +1440,6 @@ async def test_stop_swallows_peer_link_resolver_close_failures(
     assert any("peer-link resolver close failed" in r.message for r in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_start_constructs_peer_link_resolver_when_zeroconf_is_up(
     tmp_path: Path,
 ) -> None:
@@ -1495,7 +1464,6 @@ async def test_start_constructs_peer_link_resolver_when_zeroconf_is_up(
         assert controller.offloader.state.peer_link_resolver is None
 
 
-@pytest.mark.asyncio
 async def test_start_swallows_browser_construction_errors(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1516,7 +1484,6 @@ async def test_start_swallows_browser_construction_errors(
     assert controller.offloader.state.browser is None
 
 
-@pytest.mark.asyncio
 async def test_start_captures_own_instance_name(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1545,7 +1512,6 @@ async def test_start_captures_own_instance_name(
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_start_skips_self_capture_when_advertiser_unregistered(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1570,7 +1536,6 @@ async def test_start_skips_self_capture_when_advertiser_unregistered(
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_start_skips_self_capture_when_no_advertiser(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1590,7 +1555,6 @@ async def test_start_skips_self_capture_when_no_advertiser(
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_stop_swallows_browser_cancel_errors(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1608,7 +1572,6 @@ async def test_stop_swallows_browser_cancel_errors(
     assert controller.offloader.state.browser is None
 
 
-@pytest.mark.asyncio
 async def test_on_service_state_change_spawns_resolve_task_on_cache_miss(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1639,7 +1602,6 @@ async def test_on_service_state_change_spawns_resolve_task_on_cache_miss(
     assert event_type is EventType.REMOTE_BUILD_HOST_ADDED
 
 
-@pytest.mark.asyncio
 async def test_resolve_and_apply_swallows_errors(tmp_path: Path) -> None:
     """A resolve-side exception leaves the peer map untouched."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1649,7 +1611,6 @@ async def test_resolve_and_apply_swallows_errors(tmp_path: Path) -> None:
     assert controller.offloader.state.peers == {}
 
 
-@pytest.mark.asyncio
 async def test_resolve_and_apply_skips_when_resolution_returns_false(tmp_path: Path) -> None:
     """An ``async_request`` that returns ``False`` (timeout) doesn't add a peer."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1659,7 +1620,6 @@ async def test_resolve_and_apply_skips_when_resolution_returns_false(tmp_path: P
     assert controller.offloader.state.peers == {}
 
 
-@pytest.mark.asyncio
 async def test_stop_drains_resolve_tasks(tmp_path: Path) -> None:
     """In-flight resolve tasks are cancelled and the set is cleared."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1813,7 +1773,6 @@ def _stub_identity_db(
     return reload_mock
 
 
-@pytest.mark.asyncio
 async def test_get_identity_returns_dashboard_id_pin_and_versions(tmp_path: Path) -> None:
     """``get_identity`` projects the persistent identity into the wire shape."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1832,7 +1791,6 @@ async def test_get_identity_returns_dashboard_id_pin_and_versions(tmp_path: Path
     assert view.esphome_version
 
 
-@pytest.mark.asyncio
 async def test_get_identity_lazy_creates_peer_link_key_on_first_call(tmp_path: Path) -> None:
     """``get_identity`` writes the X25519 peer-link key to disk if it's missing."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1853,7 +1811,6 @@ async def test_get_identity_lazy_creates_peer_link_key_on_first_call(tmp_path: P
     assert not (tmp_path / ".device-builder-key.pem").exists()
 
 
-@pytest.mark.asyncio
 async def test_get_identity_reflects_listener_bound_state(tmp_path: Path) -> None:
     """``listener_bound`` reads the dashboard's runner state."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1866,7 +1823,6 @@ async def test_get_identity_reflects_listener_bound_state(tmp_path: Path) -> Non
     assert unbound_view.listener_bound is False
 
 
-@pytest.mark.asyncio
 async def test_get_identity_does_not_leak_cert_or_key_pem(tmp_path: Path) -> None:
     """Wire shape is the declared fields only — no PEM bytes."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1885,7 +1841,6 @@ async def test_get_identity_does_not_leak_cert_or_key_pem(tmp_path: Path) -> Non
     assert "key_pem" not in encoded
 
 
-@pytest.mark.asyncio
 async def test_get_identity_is_idempotent_across_calls(tmp_path: Path) -> None:
     """Two calls return the same identity (no rotation triggered by reads)."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1895,7 +1850,6 @@ async def test_get_identity_is_idempotent_across_calls(tmp_path: Path) -> None:
     assert first == second
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_changes_pin_sha256(tmp_path: Path) -> None:
     """A rotate produces a different ``pin_sha256`` than the previous identity."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1909,7 +1863,6 @@ async def test_rotate_identity_changes_pin_sha256(tmp_path: Path) -> None:
     assert rotated.dashboard_id == pre.dashboard_id
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_calls_reload_hook_with_new_pin(tmp_path: Path) -> None:
     """The rotate hands the new pin off to the dashboard for listener rebuild."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1918,7 +1871,6 @@ async def test_rotate_identity_calls_reload_hook_with_new_pin(tmp_path: Path) ->
     reload_mock.assert_awaited_once_with(pin_sha256=rotated.pin_sha256)
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_persists_to_disk(tmp_path: Path) -> None:
     """The new cert + key land on disk so a fresh ``get_identity`` agrees."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1931,7 +1883,6 @@ async def test_rotate_identity_persists_to_disk(tmp_path: Path) -> None:
     assert reread.pin_sha256 == rotated.pin_sha256
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_response_omits_cert_pem(tmp_path: Path) -> None:
     """Rotate's wire response also redacts cert + key bytes."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1946,7 +1897,6 @@ async def test_rotate_identity_response_omits_cert_pem(tmp_path: Path) -> None:
     assert "key_pem" not in encoded
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_surfaces_listener_bound_from_reload(tmp_path: Path) -> None:
     """``IdentityView.listener_bound`` reflects the rebuild's outcome."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1959,7 +1909,6 @@ async def test_rotate_identity_surfaces_listener_bound_from_reload(tmp_path: Pat
     assert view.listener_bound is False
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_fires_event_on_bus(tmp_path: Path) -> None:
     """A successful rotate fires ``REMOTE_BUILD_IDENTITY_ROTATED``."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1975,7 +1924,6 @@ async def test_rotate_identity_fires_event_on_bus(tmp_path: Path) -> None:
     }
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:
     """A second concurrent ``rotate_identity`` raises ``ALREADY_EXISTS``."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2006,7 +1954,6 @@ async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:
     assert isinstance(first_result, IdentityView)
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_in_flight_flag_tracks_shielded_work(tmp_path: Path) -> None:
     """A cancelled awaiter doesn't release the flag while the shielded reload still runs."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2044,7 +1991,6 @@ async def test_rotate_identity_in_flight_flag_tracks_shielded_work(tmp_path: Pat
     assert reload_calls == 1
 
 
-@pytest.mark.asyncio
 async def test_rotate_identity_clears_in_flight_flag_on_failure(tmp_path: Path) -> None:
     """A failed reload still clears the flag so the next rotate isn't stuck rejected."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2314,7 +2260,6 @@ def test_stored_peer_refresh_from_pair_request_updates_all_documented_fields() -
     assert peer.dashboard_id == "alpha"
 
 
-@pytest.mark.asyncio
 async def test_start_seeds_approved_peers_dict_from_disk(tmp_path: Path) -> None:
     """``start()`` loads APPROVED peers off disk into ``_approved_peers``.
 
@@ -2364,7 +2309,6 @@ async def test_start_seeds_approved_peers_dict_from_disk(tmp_path: Path) -> None
     assert loaded.peer_ip == "172.16.5.42"
 
 
-@pytest.mark.asyncio
 async def test_start_recovers_to_empty_on_corrupt_peers_file(tmp_path: Path) -> None:
     """A corrupt ``.receiver_peers.json`` doesn't crash startup; dict stays empty.
 
@@ -2386,7 +2330,6 @@ async def test_start_recovers_to_empty_on_corrupt_peers_file(tmp_path: Path) -> 
     assert controller.receiver.state.approved_peers == {}
 
 
-@pytest.mark.asyncio
 async def test_start_loads_legacy_peers_file_without_peer_ip(tmp_path: Path) -> None:
     """A ``.receiver_peers.json`` written before ``peer_ip`` was added loads cleanly.
 
@@ -2416,7 +2359,6 @@ async def test_start_loads_legacy_peers_file_without_peer_ip(tmp_path: Path) -> 
     assert controller.receiver.state.approved_peers["alpha"].peer_ip == ""
 
 
-@pytest.mark.asyncio
 async def test_approve_peer_promotes_pending_to_approved(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2432,7 +2374,6 @@ async def test_approve_peer_promotes_pending_to_approved(tmp_path: Path) -> None
     assert controller.receiver.state.approved_peers["alpha"].dashboard_id == "alpha"
 
 
-@pytest.mark.asyncio
 async def test_approve_peer_fires_pair_status_changed(tmp_path: Path) -> None:
     """Approval fires ``REMOTE_BUILD_PAIR_STATUS_CHANGED`` with status=approved."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2448,7 +2389,6 @@ async def test_approve_peer_fires_pair_status_changed(tmp_path: Path) -> None:
     assert payload == {"dashboard_id": "alpha", "status": "approved"}
 
 
-@pytest.mark.asyncio
 async def test_approve_peer_unknown_returns_not_found(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2460,7 +2400,6 @@ async def test_approve_peer_unknown_returns_not_found(tmp_path: Path) -> None:
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_approve_peer_already_approved_returns_invalid_args(tmp_path: Path) -> None:
     """Re-approving an already-APPROVED peer is rejected, not silently re-fired."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2474,7 +2413,6 @@ async def test_approve_peer_already_approved_returns_invalid_args(tmp_path: Path
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_approve_peer_rejects_invalid_dashboard_id(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2485,7 +2423,6 @@ async def test_approve_peer_rejects_invalid_dashboard_id(tmp_path: Path) -> None
     assert exc.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_approve_peer_rejects_non_string_dashboard_id(tmp_path: Path) -> None:
     """Non-string ``dashboard_id`` is rejected up front, not silently coerced."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2498,7 +2435,6 @@ async def test_approve_peer_rejects_non_string_dashboard_id(tmp_path: Path) -> N
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_remove_peer_drops_pending_and_fires_removed(tmp_path: Path) -> None:
     """Removing a PENDING peer fires ``status="removed"``.
 
@@ -2523,7 +2459,6 @@ async def test_remove_peer_drops_pending_and_fires_removed(tmp_path: Path) -> No
     assert payload == {"dashboard_id": "alpha", "status": "removed"}
 
 
-@pytest.mark.asyncio
 async def test_remove_peer_drops_approved_and_fires_event(tmp_path: Path) -> None:
     """Removing an APPROVED peer is revocation; fires the removed event."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2540,7 +2475,6 @@ async def test_remove_peer_drops_approved_and_fires_event(tmp_path: Path) -> Non
     assert payload == {"dashboard_id": "alpha", "status": "removed"}
 
 
-@pytest.mark.asyncio
 async def test_remove_peer_keeps_other_rows(tmp_path: Path) -> None:
     """``remove_peer`` only touches the matching dashboard_id."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2553,7 +2487,6 @@ async def test_remove_peer_keeps_other_rows(tmp_path: Path) -> None:
     assert {peer.dashboard_id for peer in view.peers} == {"keep"}
 
 
-@pytest.mark.asyncio
 async def test_remove_peer_unknown_returns_not_found(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2568,13 +2501,11 @@ async def test_remove_peer_unknown_returns_not_found(tmp_path: Path) -> None:
 # --- pairing window ---
 
 
-@pytest.mark.asyncio
 async def test_pairing_window_starts_closed(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     assert controller.receiver.is_pairing_window_open() is False
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_window_open_opens_and_fires(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2596,7 +2527,6 @@ async def test_set_pairing_window_open_opens_and_fires(tmp_path: Path) -> None:
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_window_close_closes_and_fires(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2617,7 +2547,6 @@ async def test_set_pairing_window_close_closes_and_fires(tmp_path: Path) -> None
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_window_close_while_already_closed_is_silent(tmp_path: Path) -> None:
     """A close from a client that wasn't extending must not fire."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2629,7 +2558,6 @@ async def test_set_pairing_window_close_while_already_closed_is_silent(tmp_path:
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_window_extend_refreshes_deadline_and_fires(tmp_path: Path) -> None:
     """
     Repeat ``open=true`` advances the client's timestamp and fires the event.
@@ -2676,7 +2604,6 @@ async def test_set_pairing_window_extend_refreshes_deadline_and_fires(tmp_path: 
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_pairing_window_two_clients_refcount(tmp_path: Path) -> None:
     """Two tabs / two users: window stays open until the LAST client closes."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2703,7 +2630,6 @@ async def test_pairing_window_two_clients_refcount(tmp_path: Path) -> None:
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_pairing_window_close_from_non_extender_does_not_fire(tmp_path: Path) -> None:
     """A spurious open=False from a client that wasn't extending is a no-op."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2720,7 +2646,6 @@ async def test_pairing_window_close_from_non_extender_does_not_fire(tmp_path: Pa
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_window_rejects_non_bool(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -2731,7 +2656,6 @@ async def test_set_pairing_window_rejects_non_bool(tmp_path: Path) -> None:
     assert exc.value.code is ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_pairing_window_auto_closes_when_clients_age_out(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2782,7 +2706,6 @@ async def test_pairing_window_auto_closes_when_clients_age_out(
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_stop_cancels_pairing_window_handle(tmp_path: Path) -> None:
     """``controller.stop()`` cleans up the auto-close TimerHandle."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2796,7 +2719,6 @@ async def test_stop_cancels_pairing_window_handle(tmp_path: Path) -> None:
     assert controller.receiver.is_pairing_window_open() is False
 
 
-@pytest.mark.asyncio
 async def test_explicit_close_cancels_handle_no_duplicate_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2859,7 +2781,6 @@ async def test_explicit_close_cancels_handle_no_duplicate_event(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_creates_pending_row(tmp_path: Path) -> None:
     """First pair_request from a previously-unknown dashboard_id creates PENDING."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2886,7 +2807,6 @@ async def test_record_pair_request_creates_pending_row(tmp_path: Path) -> None:
     assert pending.label == "alpha"
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_fires_event(tmp_path: Path) -> None:
     """Creating a PENDING row fires REMOTE_BUILD_PAIR_REQUEST_RECEIVED."""
     controller = _make_controller(config_dir=tmp_path)
@@ -2927,7 +2847,6 @@ async def test_record_pair_request_fires_event(tmp_path: Path) -> None:
     assert stored.peer_ip == "192.168.1.10"
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path) -> None:
     """
     Re-pair from same dashboard_id + same pubkey refreshes label / peer_ip / paired_at.
@@ -2979,7 +2898,6 @@ async def test_record_pair_request_refreshes_existing_pending_row(tmp_path: Path
     assert controller.receiver.state.approved_peers == {}
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_pending_pubkey_mismatch_returns_rejected(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -3060,7 +2978,6 @@ async def test_record_pair_request_pending_pubkey_mismatch_returns_rejected(
     )
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_already_approved_same_pin_returns_approved(
     tmp_path: Path,
 ) -> None:
@@ -3103,7 +3020,6 @@ async def test_record_pair_request_already_approved_same_pin_returns_approved(
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_unknown_dashboard_id_closed_window_returns_no_pairing_window(
     tmp_path: Path,
 ) -> None:
@@ -3137,7 +3053,6 @@ async def test_record_pair_request_unknown_dashboard_id_closed_window_returns_no
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_already_approved_bypasses_closed_window(
     tmp_path: Path,
 ) -> None:
@@ -3178,7 +3093,6 @@ async def test_record_pair_request_already_approved_bypasses_closed_window(
     assert response is IntentResponse.APPROVED
 
 
-@pytest.mark.asyncio
 async def test_record_pair_request_already_approved_different_pin_returns_rejected(
     tmp_path: Path,
 ) -> None:
@@ -3226,7 +3140,6 @@ async def test_record_pair_request_already_approved_different_pin_returns_reject
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_session_approved_returns_ok(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -3248,7 +3161,6 @@ async def test_lookup_peer_for_session_approved_returns_ok(tmp_path: Path) -> No
     assert response == "ok"
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_session_pending_returns_pending(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -3270,7 +3182,6 @@ async def test_lookup_peer_for_session_pending_returns_pending(tmp_path: Path) -
     assert response == "pending"
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_session_unknown_returns_rejected(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -3282,7 +3193,6 @@ async def test_lookup_peer_for_session_unknown_returns_rejected(tmp_path: Path) 
     assert response == "rejected"
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_session_pin_mismatch_returns_rejected(tmp_path: Path) -> None:
     """
     Stored row exists but pin doesn't match the handshake's pubkey hash.
@@ -3313,7 +3223,6 @@ async def test_lookup_peer_for_session_pin_mismatch_returns_rejected(tmp_path: P
     assert response == "rejected"
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_status_mirrors_session_but_uses_approved_string(
     tmp_path: Path,
 ) -> None:
@@ -3342,7 +3251,6 @@ async def test_lookup_peer_for_status_mirrors_session_but_uses_approved_string(
     assert session_response == "ok"
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_status_unknown_returns_rejected(tmp_path: Path) -> None:
     """A removed/rejected peer (or one that never existed) returns rejected."""
     controller = _make_controller(config_dir=tmp_path)
@@ -3355,7 +3263,6 @@ async def test_lookup_peer_for_status_unknown_returns_rejected(tmp_path: Path) -
     assert response == "rejected"
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_status_long_polls_until_approve_fires(
     tmp_path: Path,
 ) -> None:
@@ -3402,7 +3309,6 @@ async def test_lookup_peer_for_status_long_polls_until_approve_fires(
     assert response is IntentResponse.APPROVED
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_status_long_poll_ignores_other_dashboard_ids(
     tmp_path: Path,
 ) -> None:
@@ -3787,7 +3693,6 @@ def _make_session_stub(dashboard_id: str) -> AsyncMock:
     return session
 
 
-@pytest.mark.asyncio
 async def test_on_firmware_queue_transition_broadcasts_to_every_session(
     tmp_path: Path,
 ) -> None:
@@ -3864,7 +3769,6 @@ def test_on_firmware_queue_transition_skips_when_firmware_missing(
     controller.offloader._db.create_background_task.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_broadcast_queue_status_continues_past_failed_session(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -4050,7 +3954,6 @@ def test_get_artifacts_download_sender_returns_installed_sender(tmp_path: Path) 
     assert controller.receiver.get_artifacts_download_sender() is installed
 
 
-@pytest.mark.asyncio
 async def test_run_cleanup_loop_reclaims_cold_subtree_and_skips_in_flight(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4114,7 +4017,6 @@ async def test_run_cleanup_loop_reclaims_cold_subtree_and_skips_in_flight(
     assert not cold.subtree(tmp_path).exists()
 
 
-@pytest.mark.asyncio
 async def test_run_cleanup_loop_logs_per_cycle_exception_and_continues(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4167,7 +4069,6 @@ async def test_run_cleanup_loop_logs_per_cycle_exception_and_continues(
     assert sweep_calls == 2
 
 
-@pytest.mark.asyncio
 async def test_run_cleanup_loop_short_circuits_when_firmware_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4319,7 +4220,6 @@ def test_remote_builds_enabled_default_is_true(tmp_path: Path) -> None:
     assert controller.offloader.build_scheduler_snapshot().remote_builds_enabled is True
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_toggles_master_and_fires_event(tmp_path: Path) -> None:
     """
     ``set_offloader_settings(remote_builds_enabled=False)`` flips the toggle + fires the event.
@@ -4344,7 +4244,6 @@ async def test_set_offloader_settings_toggles_master_and_fires_event(tmp_path: P
     assert captured == [{"remote_builds_enabled": False}]
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_rejects_non_bool(tmp_path: Path) -> None:
     """Truthy non-bool inputs raise ``INVALID_ARGS`` rather than coerce.
 
@@ -4361,7 +4260,6 @@ async def test_set_offloader_settings_rejects_non_bool(tmp_path: Path) -> None:
     assert controller.offloader.state.remote_builds_enabled is True
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_enabled_flips_field_and_fires_event(tmp_path: Path) -> None:
     """
     ``set_pairing_enabled(pin, False)`` flips ``StoredPairing.enabled`` + fires the event.
@@ -4391,7 +4289,6 @@ async def test_set_pairing_enabled_flips_field_and_fires_event(tmp_path: Path) -
     assert captured == [{"pin_sha256": pairing.pin_sha256, "enabled": False}]
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_enabled_rejects_unknown_pin(tmp_path: Path) -> None:
     """An unknown pin raises ``NOT_FOUND`` instead of silently no-op'ing.
 
@@ -4405,7 +4302,6 @@ async def test_set_pairing_enabled_rejects_unknown_pin(tmp_path: Path) -> None:
     assert exc.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_set_pairing_enabled_rejects_non_bool(tmp_path: Path) -> None:
     """Strict ``bool`` validation matches the master-toggle command."""
     controller = _make_controller(config_dir=tmp_path)
@@ -4422,7 +4318,6 @@ async def test_set_pairing_enabled_rejects_non_bool(tmp_path: Path) -> None:
     assert pairing.enabled is True
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_flips_version_match_policy(tmp_path: Path) -> None:
     """Setting the policy fires the new event and updates the snapshot."""
     controller = _make_controller(config_dir=tmp_path, real_bus=True)
@@ -4441,7 +4336,6 @@ async def test_set_offloader_settings_flips_version_match_policy(tmp_path: Path)
     assert captured == [{"version_match_policy": VersionMatchPolicy.EXACT_REQUIRED}]
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_rejects_unknown_policy(tmp_path: Path) -> None:
     """An unknown wire value raises ``INVALID_ARGS`` and leaves state untouched."""
     controller = _make_controller(config_dir=tmp_path)
@@ -4451,7 +4345,6 @@ async def test_set_offloader_settings_rejects_unknown_policy(tmp_path: Path) -> 
     assert controller.offloader.state.version_match_policy is VersionMatchPolicy.ANY
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_rejects_non_string_policy(tmp_path: Path) -> None:
     """A non-string ``version_match_policy`` (e.g. ``int``, ``bool``) raises INVALID_ARGS."""
     controller = _make_controller(config_dir=tmp_path)
@@ -4461,7 +4354,6 @@ async def test_set_offloader_settings_rejects_non_string_policy(tmp_path: Path) 
     assert controller.offloader.state.version_match_policy is VersionMatchPolicy.ANY
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_no_op_when_value_unchanged(tmp_path: Path) -> None:
     """Re-supplying the current value fires no event and schedules no save.
 
@@ -4485,7 +4377,6 @@ async def test_set_offloader_settings_no_op_when_value_unchanged(tmp_path: Path)
     save.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_rejects_atomically_on_bad_policy(tmp_path: Path) -> None:
     """A bad policy doesn't half-apply a paired valid ``remote_builds_enabled`` flip."""
     controller = _make_controller(config_dir=tmp_path, real_bus=True)
@@ -4506,7 +4397,6 @@ async def test_set_offloader_settings_rejects_atomically_on_bad_policy(tmp_path:
     assert captured == []
 
 
-@pytest.mark.asyncio
 async def test_set_offloader_settings_rejects_all_none_args(tmp_path: Path) -> None:
     """Passing neither flag raises INVALID_ARGS rather than silently no-op'ing."""
     controller = _make_controller(config_dir=tmp_path)
@@ -4515,7 +4405,6 @@ async def test_set_offloader_settings_rejects_all_none_args(tmp_path: Path) -> N
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_build_scheduler_snapshot_resolves_esphome_version_per_call(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4529,7 +4418,6 @@ async def test_build_scheduler_snapshot_resolves_esphome_version_per_call(
     assert second.offloader_esphome_version == "2026.6.0"
 
 
-@pytest.mark.asyncio
 async def test_get_offloader_settings_returns_master_plus_pairings(tmp_path: Path) -> None:
     """The view bundles the master toggle with the pairings snapshot.
 

--- a/tests/test_remote_build_job_fanout.py
+++ b/tests/test_remote_build_job_fanout.py
@@ -121,7 +121,6 @@ def _seed_via_queued(bus: EventBus, job: FirmwareJob) -> None:
         (EventType.JOB_CANCELLED, JobStatus.CANCELLED, "cancelled"),
     ],
 )
-@pytest.mark.asyncio
 async def test_lifecycle_event_fans_out_as_job_state_changed(
     event_type: EventType, status_field: JobStatus, expected_status: str
 ) -> None:
@@ -147,7 +146,6 @@ async def test_lifecycle_event_fans_out_as_job_state_changed(
     assert frame["error_message"] == ""
 
 
-@pytest.mark.asyncio
 async def test_failed_event_carries_error_message() -> None:
     """``failed`` carries ``FirmwareJob.error`` on the wire so the offloader can surface it."""
     bus = EventBus()
@@ -168,7 +166,6 @@ async def test_failed_event_carries_error_message() -> None:
     assert frame["error_message"] == "compile failed: bad pin"
 
 
-@pytest.mark.asyncio
 async def test_local_job_does_not_fan_out() -> None:
     """A local-only job (``remote_peer=""``) is skipped at the listener."""
     bus = EventBus()
@@ -189,7 +186,6 @@ async def test_local_job_does_not_fan_out() -> None:
     session.send_app_frame.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_lifecycle_skips_when_session_gone() -> None:
     """A fan-out for a peer whose session has unregistered is skipped silently."""
     bus = EventBus()
@@ -209,7 +205,6 @@ async def test_lifecycle_skips_when_session_gone() -> None:
     assert controller.background_tasks == []
 
 
-@pytest.mark.asyncio
 async def test_job_queued_caches_correlation_and_fans_out_queued_frame() -> None:
     """``JOB_QUEUED`` populates the cache AND fans out a ``queued`` wire frame.
 
@@ -238,7 +233,6 @@ async def test_job_queued_caches_correlation_and_fans_out_queued_frame() -> None
     assert fanout._remote_jobs == {job.job_id: ("alpha", "wire-job")}
 
 
-@pytest.mark.asyncio
 async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -277,7 +271,6 @@ async def test_queued_with_missing_remote_job_id_logs_and_skips_cache(
     assert any("missing remote_job_id" in msg for msg in debug_calls)
 
 
-@pytest.mark.asyncio
 async def test_terminal_event_drops_cache_entry() -> None:
     """A terminal event (completed / failed / cancelled) drops the cache entry.
 
@@ -307,7 +300,6 @@ async def test_terminal_event_drops_cache_entry() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_job_output_fans_out_as_job_output_frame() -> None:
     """``JOB_OUTPUT`` for a cached remote-peer job sends a ``job_output`` frame."""
     bus = EventBus()
@@ -331,7 +323,6 @@ async def test_job_output_fans_out_as_job_output_frame() -> None:
     assert frame["line"] == "Compiling .pioenvs/...\n"
 
 
-@pytest.mark.asyncio
 async def test_job_output_skips_local_job() -> None:
     """A local job's JOB_QUEUED never enters the cache, so its JOB_OUTPUT is skipped."""
     bus = EventBus()
@@ -354,7 +345,6 @@ async def test_job_output_skips_local_job() -> None:
     assert local_job.job_id not in fanout._remote_jobs
 
 
-@pytest.mark.asyncio
 async def test_job_output_skips_when_session_gone() -> None:
     """``JOB_OUTPUT`` for a cached job whose session unregistered is silently dropped."""
     bus = EventBus()
@@ -370,7 +360,6 @@ async def test_job_output_skips_when_session_gone() -> None:
     assert controller.background_tasks == []
 
 
-@pytest.mark.asyncio
 async def test_job_output_skips_unknown_job_id() -> None:
     """``JOB_OUTPUT`` for an unseen ``job_id`` (no JOB_QUEUED before) is silently dropped."""
     bus = EventBus()
@@ -390,7 +379,6 @@ async def test_job_output_skips_unknown_job_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_stop_detaches_listeners() -> None:
     """``stop()`` removes every listener registered by ``start()``.
 
@@ -411,7 +399,6 @@ async def test_stop_detaches_listeners() -> None:
     session.send_app_frame.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_send_app_frame_failure_is_swallowed() -> None:
     """A ``send_app_frame`` raise doesn't propagate out of the fan-out task."""
     bus = EventBus()

--- a/tests/test_remote_build_listener.py
+++ b/tests/test_remote_build_listener.py
@@ -47,7 +47,6 @@ from .conftest import MakeSettingsFactory
 from .conftest import RemoteBuildTestHandles as RemoteBuildController
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_skips_when_explicitly_disabled(
     tmp_path: Path,
 ) -> None:
@@ -79,7 +78,6 @@ async def test_maybe_start_remote_build_site_skips_when_explicitly_disabled(
     assert db._remote_build_runner is None
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_binds_by_default_on_fresh_install(
     tmp_path: Path,
 ) -> None:
@@ -111,7 +109,6 @@ async def test_maybe_start_remote_build_site_binds_by_default_on_fresh_install(
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_binds_when_enabled(tmp_path: Path) -> None:
     """
     Flipping ``enabled=True`` makes the lifecycle hook bind the listener.
@@ -147,7 +144,6 @@ async def test_maybe_start_remote_build_site_binds_when_enabled(tmp_path: Path) 
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_fails_soft_on_bind_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -195,7 +191,6 @@ async def test_maybe_start_remote_build_site_fails_soft_on_bind_error(
     monkeypatch.setattr(web.TCPSite, "start", real_start)
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_refuses_port_zero_with_multi_host(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -247,7 +242,6 @@ async def test_maybe_start_remote_build_site_refuses_port_zero_with_multi_host(
     assert refusal_logged, "expected the operator-facing refusal on the fail-soft log's exc_info"
 
 
-@pytest.mark.asyncio
 async def test_strip_server_header_middleware_overrides_to_empty(tmp_path: Path) -> None:
     """
     The Server header is overridden to empty string.
@@ -266,7 +260,6 @@ async def test_strip_server_header_middleware_overrides_to_empty(tmp_path: Path)
     assert response.headers["Server"] == ""
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_updates_advertiser_on_success(
     tmp_path: Path,
 ) -> None:
@@ -313,7 +306,6 @@ async def test_maybe_start_remote_build_site_updates_advertiser_on_success(
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_start_registers_advertiser_with_all_txt_keys_in_one_announce(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -365,7 +357,6 @@ async def test_start_registers_advertiser_with_all_txt_keys_in_one_announce(
         await db.stop()
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_against_unregistered_advertiser_stages_only(
     tmp_path: Path,
 ) -> None:
@@ -422,7 +413,6 @@ async def test_maybe_start_remote_build_site_against_unregistered_advertiser_sta
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_advertises_actual_port_for_ephemeral(
     tmp_path: Path,
 ) -> None:
@@ -471,7 +461,6 @@ async def test_maybe_start_remote_build_site_advertises_actual_port_for_ephemera
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_skips_ha_addon_without_persisted_opt_in(
     tmp_path: Path,
 ) -> None:
@@ -497,7 +486,6 @@ async def test_maybe_start_remote_build_site_skips_ha_addon_without_persisted_op
     assert db._remote_build_runner is None
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_binds_ha_addon_after_explicit_opt_in(
     tmp_path: Path,
 ) -> None:
@@ -537,7 +525,6 @@ async def test_maybe_start_remote_build_site_binds_ha_addon_after_explicit_opt_i
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_maybe_start_remote_build_site_respects_ha_addon_explicit_disable(
     tmp_path: Path,
 ) -> None:
@@ -573,7 +560,6 @@ async def test_maybe_start_remote_build_site_respects_ha_addon_explicit_disable(
     assert db._remote_build_runner is None
 
 
-@pytest.mark.asyncio
 async def test_reload_remote_build_identity_no_op_when_listener_unbound(
     tmp_path: Path,
 ) -> None:
@@ -608,7 +594,6 @@ async def test_reload_remote_build_identity_no_op_when_listener_unbound(
     assert listener_bound is False
 
 
-@pytest.mark.asyncio
 async def test_reload_remote_build_identity_rebuilds_listener(tmp_path: Path) -> None:
     """
     Rotation while the listener is bound: tear down + rebuild against the new cert.
@@ -655,7 +640,6 @@ async def test_reload_remote_build_identity_rebuilds_listener(tmp_path: Path) ->
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_reload_remote_build_identity_clears_advertiser_when_rebuild_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -727,7 +711,6 @@ async def test_reload_remote_build_identity_clears_advertiser_when_rebuild_fails
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_reload_remote_build_identity_advertiser_refresh_failure_is_swallowed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -769,7 +752,6 @@ async def test_reload_remote_build_identity_advertiser_refresh_failure_is_swallo
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_apply_remote_build_enabled_binds_when_disk_says_true(tmp_path: Path) -> None:
     """Convergence: disk ``enabled=True`` + listener absent → bind."""
     loop = asyncio.get_running_loop()
@@ -797,7 +779,6 @@ async def test_apply_remote_build_enabled_binds_when_disk_says_true(tmp_path: Pa
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_apply_remote_build_enabled_tears_down_when_disk_says_false(
     tmp_path: Path,
 ) -> None:
@@ -845,7 +826,6 @@ async def test_apply_remote_build_enabled_tears_down_when_disk_says_false(
     advertiser.unregister.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_apply_remote_build_enabled_no_op_before_loop_set(tmp_path: Path) -> None:
     """No-op when the dashboard hasn't finished startup yet (``loop is None``)."""
     settings = DashboardSettings(config_dir=tmp_path)
@@ -861,7 +841,6 @@ async def test_apply_remote_build_enabled_no_op_before_loop_set(tmp_path: Path) 
     assert bound is False
 
 
-@pytest.mark.asyncio
 async def test_apply_remote_build_enabled_idempotent_when_already_off(tmp_path: Path) -> None:
     """Disk ``enabled=False`` + listener absent → no-op (no advertiser touch)."""
     settings = DashboardSettings(config_dir=tmp_path)
@@ -881,7 +860,6 @@ async def test_apply_remote_build_enabled_idempotent_when_already_off(tmp_path: 
     advertiser.refresh.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_apply_remote_build_enabled_idempotent_when_already_on(tmp_path: Path) -> None:
     """Disk ``enabled=True`` + listener bound → no-op (no rebind, no advertiser churn)."""
     loop = asyncio.get_running_loop()
@@ -915,7 +893,6 @@ async def test_apply_remote_build_enabled_idempotent_when_already_on(tmp_path: P
             await db._remote_build_runner.cleanup()
 
 
-@pytest.mark.asyncio
 async def test_set_settings_live_rebinds_listener(tmp_path: Path) -> None:
     """End-to-end: ``set_settings(enabled=True)`` flips disk + binds the listener."""
     settings = DashboardSettings(config_dir=tmp_path)

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -135,7 +135,6 @@ async def _wait_until(condition: Callable[[], bool], *, timeout: float = 2.0) ->
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_dispatch_preview_returns_ok(tmp_path: Path) -> None:
     """``intent="preview"`` doesn't hit the controller; just returns OK."""
     controller = _make_controller(config_dir=tmp_path)
@@ -157,7 +156,6 @@ async def test_dispatch_preview_returns_ok(tmp_path: Path) -> None:
     controller.offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_pair_request_open_window_creates_pending(tmp_path: Path) -> None:
     """``intent="pair_request"`` while window open creates the row + fires event."""
     controller = _make_controller(config_dir=tmp_path)
@@ -188,7 +186,6 @@ async def test_dispatch_pair_request_open_window_creates_pending(tmp_path: Path)
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_pair_request_closed_window_returns_no_pairing_window(
     tmp_path: Path,
 ) -> None:
@@ -216,7 +213,6 @@ async def test_dispatch_pair_request_closed_window_returns_no_pairing_window(
     assert controller.receiver.state.pending_peers == {}
 
 
-@pytest.mark.asyncio
 async def test_dispatch_peer_link_approved_returns_ok(tmp_path: Path) -> None:
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
@@ -248,7 +244,6 @@ async def test_dispatch_peer_link_approved_returns_ok(tmp_path: Path) -> None:
     assert response is IntentResponse.OK
 
 
-@pytest.mark.asyncio
 async def test_dispatch_pair_request_empty_dashboard_id_returns_rejected(tmp_path: Path) -> None:
     """
     pair_request with no dashboard_id is REJECTED before any controller mutation.
@@ -282,7 +277,6 @@ async def test_dispatch_pair_request_empty_dashboard_id_returns_rejected(tmp_pat
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_pair_request_malformed_dashboard_id_returns_rejected(
     tmp_path: Path,
 ) -> None:
@@ -320,7 +314,6 @@ async def test_dispatch_pair_request_malformed_dashboard_id_returns_rejected(
     await controller.stop()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_pair_status_unknown_after_window_close_returns_rejected(
     tmp_path: Path,
 ) -> None:
@@ -381,7 +374,6 @@ def _binary_msg(data: bytes) -> WSMessage:
     return WSMessage(type=WSMsgType.BINARY, data=data, extra=None)
 
 
-@pytest.mark.asyncio
 async def test_read_handshake_message_timeout_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -403,7 +395,6 @@ async def test_read_handshake_message_timeout_returns_none(
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_read_handshake_message_non_binary_frame_returns_none() -> None:
     """A TEXT frame on the binary channel is rejected without crashing the session."""
     session = PeerLinkNoiseSession.responder(secrets.token_bytes(32))
@@ -414,7 +405,6 @@ async def test_read_handshake_message_non_binary_frame_returns_none() -> None:
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_read_handshake_message_noise_error_returns_none() -> None:
     """Garbage bytes that don't decode as a Noise frame log a warning and return None."""
     session = PeerLinkNoiseSession.responder(secrets.token_bytes(32))
@@ -428,7 +418,6 @@ async def test_read_handshake_message_noise_error_returns_none() -> None:
     assert result is None
 
 
-@pytest.mark.asyncio
 async def test_send_bytes_safely_connection_reset_returns_false() -> None:
     """``ConnectionResetError`` (peer hung up) returns False without escalating the log."""
     ws = _make_ws_stub()
@@ -438,7 +427,6 @@ async def test_send_bytes_safely_connection_reset_returns_false() -> None:
     assert result is False
 
 
-@pytest.mark.asyncio
 async def test_send_bytes_safely_other_exception_returns_false() -> None:
     """Other transport errors are debug-logged and the function returns False."""
     ws = _make_ws_stub()
@@ -448,7 +436,6 @@ async def test_send_bytes_safely_other_exception_returns_false() -> None:
     assert result is False
 
 
-@pytest.mark.asyncio
 async def test_send_handshake_message_noise_error_returns_false() -> None:
     """A noise-side write failure returns False without touching the WS."""
     ws = _make_ws_stub()
@@ -460,7 +447,6 @@ async def test_send_handshake_message_noise_error_returns_false() -> None:
     ws.send_bytes.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_send_response_encrypt_error_skips_send() -> None:
     """``encrypt`` failing post-handshake logs a warning and skips ``send_bytes``."""
     ws = _make_ws_stub()
@@ -471,7 +457,6 @@ async def test_send_response_encrypt_error_skips_send() -> None:
     ws.send_bytes.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_send_response_advertises_esphome_version() -> None:
     """The ``intent_response`` body carries the receiver's esphome version.
 
@@ -503,7 +488,6 @@ async def test_send_response_advertises_esphome_version() -> None:
     }
 
 
-@pytest.mark.asyncio
 async def test_drive_session_msg1_timeout_returns_quietly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -525,7 +509,6 @@ async def test_drive_session_msg1_timeout_returns_quietly(
     ws.send_bytes.assert_not_awaited()
 
 
-@pytest.mark.asyncio
 async def test_handler_logs_unexpected_exception(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -608,7 +591,6 @@ def test_normalize_label_non_string_returns_empty() -> None:
     assert _normalize_label(None) == ""
 
 
-@pytest.mark.asyncio
 async def test_drive_session_msg2_send_failure_short_circuits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -631,7 +613,6 @@ async def test_drive_session_msg2_send_failure_short_circuits(
     assert ws.receive.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_drive_session_unknown_intent_msg3_read_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -662,7 +643,6 @@ async def test_drive_session_unknown_intent_msg3_read_failure(
     assert ws.send_bytes.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_drive_session_unknown_intent_msg2_send_failure() -> None:
     """Unknown intent + msg2 send fails → driver bails before reading msg3."""
     controller = MagicMock(spec=ReceiverController)
@@ -680,7 +660,6 @@ async def test_drive_session_unknown_intent_msg2_send_failure() -> None:
     assert ws.receive.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_drive_session_happy_path_msg3_read_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -710,7 +689,6 @@ async def test_drive_session_happy_path_msg3_read_failure(
     assert ws.send_bytes.await_count == 1
 
 
-@pytest.mark.asyncio
 async def test_drive_session_handshake_not_complete_logs_and_returns(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -864,7 +842,6 @@ def _decode_intent_response(session: PeerLinkNoiseSession, encrypted: bytes) -> 
     return _json.loads(session.decrypt(encrypted))["intent_response"]
 
 
-@pytest.mark.asyncio
 async def test_e2e_preview_round_trip(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -886,7 +863,6 @@ async def test_e2e_preview_round_trip(
     assert round_trip.session.remote_static_pub == receiver_static_pub
 
 
-@pytest.mark.asyncio
 async def test_e2e_pair_request_open_window_creates_row(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -918,7 +894,6 @@ async def test_e2e_pair_request_open_window_creates_row(
     assert pending.pin_sha256 == pin_sha256_for_pubkey(round_trip.initiator_static_pub)
 
 
-@pytest.mark.asyncio
 async def test_e2e_pair_request_closed_window_returns_no_pairing_window(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -941,7 +916,6 @@ async def test_e2e_pair_request_closed_window_returns_no_pairing_window(
     assert controller.receiver.state.pending_peers == {}
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_approved_returns_ok(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -984,7 +958,6 @@ async def test_e2e_peer_link_approved_returns_ok(
     assert _decode_intent_response(session, encrypted) == IntentResponse.OK
 
 
-@pytest.mark.asyncio
 async def test_e2e_unknown_intent_completes_handshake_then_rejects(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1003,7 +976,6 @@ async def test_e2e_unknown_intent_completes_handshake_then_rejects(
     )
 
 
-@pytest.mark.asyncio
 async def test_e2e_non_dict_msg3_payload_treated_as_empty(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1030,7 +1002,6 @@ async def test_e2e_non_dict_msg3_payload_treated_as_empty(
     assert _decode_intent_response(session, encrypted) == IntentResponse.REJECTED
 
 
-@pytest.mark.asyncio
 async def test_e2e_garbage_msg1_payload_handled_gracefully(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1126,7 +1097,6 @@ def _decode_app_frame(session: PeerLinkNoiseSession, encrypted: bytes) -> dict[s
     return parsed
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_session_stays_open_after_intent_response(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1158,7 +1128,6 @@ async def test_e2e_peer_link_session_stays_open_after_intent_response(
         await ws.close()
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_session_responds_to_offloader_ping(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1191,7 +1160,6 @@ async def test_e2e_peer_link_session_responds_to_offloader_ping(
     assert pong["nonce"] == 42
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_session_kicks_old_on_duplicate_connect(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1239,7 +1207,6 @@ async def test_e2e_peer_link_session_kicks_old_on_duplicate_connect(
         await new_ws.close()
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_session_unregistered_on_peer_close(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1263,7 +1230,6 @@ async def test_e2e_peer_link_session_unregistered_on_peer_close(
     await _wait_until(lambda: "alpha" not in controller.receiver.state.peer_link_sessions)
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_session_drained_on_controller_stop(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1305,7 +1271,6 @@ async def test_e2e_peer_link_session_drained_on_controller_stop(
         await ws.close()
 
 
-@pytest.mark.asyncio
 async def test_e2e_peer_link_session_oversize_frame_terminates(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
 ) -> None:
@@ -1388,7 +1353,6 @@ def _install_stub_submit_job_receiver(
     return firmware_stub, queued_jobs
 
 
-@pytest.mark.asyncio
 async def test_e2e_submit_job_dispatches_to_receiver(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
     monkeypatch: pytest.MonkeyPatch,
@@ -1531,7 +1495,6 @@ def _make_unit_session(noise: PeerLinkNoiseSession) -> tuple[PeerLinkSession, _F
     ), ws
 
 
-@pytest.mark.asyncio
 async def test_peer_link_session_send_app_frame_is_serialised(tmp_path: Path) -> None:
     """The session's send lock keeps concurrent encrypts from interleaving.
 
@@ -1557,7 +1520,6 @@ async def test_peer_link_session_send_app_frame_is_serialised(tmp_path: Path) ->
     assert {entry["n"] for entry in decoded} == {1, 2}
 
 
-@pytest.mark.asyncio
 async def test_peer_link_session_terminate_idempotent(tmp_path: Path) -> None:
     """Calling ``terminate`` twice doesn't double-send the frame or double-close the WS."""
     _initiator, responder = _noise_pair()
@@ -1569,7 +1531,6 @@ async def test_peer_link_session_terminate_idempotent(tmp_path: Path) -> None:
     assert ws.closes == 1
 
 
-@pytest.mark.asyncio
 async def test_send_app_frame_short_circuits_after_terminate(tmp_path: Path) -> None:
     """A late ``send_app_frame`` after ``terminate`` returns False without a wire frame.
 
@@ -1593,7 +1554,6 @@ async def test_send_app_frame_short_circuits_after_terminate(tmp_path: Path) -> 
     assert len(ws.sends) == 1
 
 
-@pytest.mark.asyncio
 async def test_register_peer_link_session_kicks_existing(tmp_path: Path) -> None:
     """Registering a new session for the same dashboard_id terminates the existing one."""
     controller = _make_controller(config_dir=tmp_path)
@@ -1617,7 +1577,6 @@ async def test_register_peer_link_session_kicks_existing(tmp_path: Path) -> None
     new.terminate.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_register_peer_link_session_pushes_initial_queue_status(tmp_path: Path) -> None:
     """A freshly-registered session gets a one-shot ``queue_status`` frame.
 
@@ -1650,7 +1609,6 @@ async def test_register_peer_link_session_pushes_initial_queue_status(tmp_path: 
     )
 
 
-@pytest.mark.asyncio
 async def test_register_peer_link_session_skips_initial_queue_status_when_firmware_missing(
     tmp_path: Path,
 ) -> None:
@@ -1677,7 +1635,6 @@ async def test_register_peer_link_session_skips_initial_queue_status_when_firmwa
     session.send_app_frame.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_register_peer_link_session_swallows_snapshot_exception(tmp_path: Path) -> None:
     """A ``queue_status_snapshot`` raise mustn't poison session registration.
 
@@ -1708,7 +1665,6 @@ async def test_register_peer_link_session_swallows_snapshot_exception(tmp_path: 
     assert controller.receiver.state.peer_link_sessions["alpha"] is session
 
 
-@pytest.mark.asyncio
 async def test_register_peer_link_session_swallows_send_app_frame_exception(
     tmp_path: Path,
 ) -> None:
@@ -1773,7 +1729,6 @@ def test_unregister_peer_link_session_removes_when_current(tmp_path: Path) -> No
     assert controller.receiver.state.peer_link_sessions == {}
 
 
-@pytest.mark.asyncio
 async def test_send_app_frame_returns_false_on_unserialisable_payload(tmp_path: Path) -> None:
     """A payload with a non-JSON-encodable value short-circuits before encrypting."""
     _initiator, responder = _noise_pair()
@@ -1785,7 +1740,6 @@ async def test_send_app_frame_returns_false_on_unserialisable_payload(tmp_path: 
     assert ws.sends == []
 
 
-@pytest.mark.asyncio
 async def test_send_app_frame_returns_false_on_noise_encrypt_failure(tmp_path: Path) -> None:
     """A Noise-side failure surfaces as ``False``, not an unhandled exception.
 
@@ -1812,7 +1766,6 @@ async def test_send_app_frame_returns_false_on_noise_encrypt_failure(tmp_path: P
     assert ws.sends == []
 
 
-@pytest.mark.asyncio
 async def test_peer_link_channel_send_terminate_swallows_aiohttp_close_error(
     tmp_path: Path,
 ) -> None:
@@ -1871,7 +1824,6 @@ def _text_msg(data: str) -> WSMessage:
     return WSMessage(type=WSMsgType.TEXT, data=data, extra="")
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_terminates_on_text_frame(tmp_path: Path) -> None:
     """A TEXT message (not BINARY) triggers ``terminate{malformed_frame}``."""
     initiator, responder = _noise_pair()
@@ -1889,7 +1841,6 @@ async def test_receive_loop_terminates_on_text_frame(tmp_path: Path) -> None:
     assert decoded["reason"] == TerminateReason.MALFORMED_FRAME.value
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_terminates_on_undecryptable_frame(tmp_path: Path) -> None:
     """Random bytes that fail Noise decrypt trigger ``terminate{malformed_frame}``."""
     _initiator, responder = _noise_pair()
@@ -1907,7 +1858,6 @@ async def test_receive_loop_terminates_on_undecryptable_frame(tmp_path: Path) ->
     assert len(ws.sends) == 1
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_terminates_on_non_object_json(tmp_path: Path) -> None:
     """Encrypted JSON that isn't an object (e.g. a list) triggers terminate."""
     initiator, responder = _noise_pair()
@@ -1922,7 +1872,6 @@ async def test_receive_loop_terminates_on_non_object_json(tmp_path: Path) -> Non
     assert len(ws.sends) == 1
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_routes_cancel_job_to_controller(tmp_path: Path) -> None:
     """A ``cancel_job`` Noise frame routes through ``controller.receiver.handle_cancel_job``."""
     initiator, responder = _noise_pair()
@@ -1940,7 +1889,6 @@ async def test_receive_loop_routes_cancel_job_to_controller(tmp_path: Path) -> N
     assert call_frame == {"type": "cancel_job", "job_id": "j-1"}
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_routes_download_artifacts_to_sender(tmp_path: Path) -> None:
     """A ``download_artifacts`` Noise frame routes through the artifacts-download sender."""
     initiator, responder = _noise_pair()
@@ -1962,7 +1910,6 @@ async def test_receive_loop_routes_download_artifacts_to_sender(tmp_path: Path) 
     assert call_frame == payload
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_pong_updates_last_pong_at(tmp_path: Path) -> None:
     """A ``pong`` frame from the peer bumps ``session.last_pong_at``."""
     initiator, responder = _noise_pair()
@@ -1978,7 +1925,6 @@ async def test_receive_loop_pong_updates_last_pong_at(tmp_path: Path) -> None:
     assert ws.sends == []
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_peer_terminate_exits_cleanly(tmp_path: Path) -> None:
     """A peer-side ``terminate`` exits the loop without sending our own."""
     initiator, responder = _noise_pair()
@@ -1995,7 +1941,6 @@ async def test_receive_loop_peer_terminate_exits_cleanly(tmp_path: Path) -> None
     assert session._closing is True
 
 
-@pytest.mark.asyncio
 async def test_receive_loop_unknown_app_frame_type_logged_and_ignored(tmp_path: Path) -> None:
     """An unknown ``type`` field in a well-formed encrypted frame is logged at debug, not fatal.
 
@@ -2024,7 +1969,6 @@ async def test_receive_loop_unknown_app_frame_type_logged_and_ignored(tmp_path: 
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_run_peer_link_heartbeat_terminates_on_pong_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -2062,7 +2006,6 @@ async def test_run_peer_link_heartbeat_terminates_on_pong_timeout(
     assert deaths == [True]
 
 
-@pytest.mark.asyncio
 async def test_run_peer_link_heartbeat_terminates_on_send_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -2087,7 +2030,6 @@ async def test_run_peer_link_heartbeat_terminates_on_send_failure(
     assert deaths == [True]
 
 
-@pytest.mark.asyncio
 async def test_run_peer_link_session_heartbeat_closures_route_to_session(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2178,7 +2120,6 @@ async def test_run_peer_link_session_heartbeat_closures_route_to_session(
     await asyncio.gather(run_task, return_exceptions=True)
 
 
-@pytest.mark.asyncio
 async def test_run_peer_link_heartbeat_propagates_cancellation(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -2240,7 +2181,6 @@ def _cancel_session(dashboard_id: str = "alpha") -> Any:
     return session
 
 
-@pytest.mark.asyncio
 async def test_handle_cancel_job_routes_to_firmware_cancel(tmp_path: Path) -> None:
     """Happy path: resolve offloader job_id → firmware job_id → fire ``firmware.cancel``."""
     controller = _make_receiver_with_fanout(tmp_path)
@@ -2254,7 +2194,6 @@ async def test_handle_cancel_job_routes_to_firmware_cancel(tmp_path: Path) -> No
     controller.offloader._db.firmware.cancel.assert_awaited_once_with(job_id="fw-abc")
 
 
-@pytest.mark.asyncio
 async def test_handle_cancel_job_unknown_remote_job_drops_silently(tmp_path: Path) -> None:
     """No matching correlation entry: drop without raising or calling firmware.cancel."""
     controller = _make_receiver_with_fanout(tmp_path)
@@ -2265,7 +2204,6 @@ async def test_handle_cancel_job_unknown_remote_job_drops_silently(tmp_path: Pat
     controller.offloader._db.firmware.cancel.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_handle_cancel_job_pin_to_wrong_session_no_cancel(tmp_path: Path) -> None:
     """A cancel_job arriving on a different session than the submit-time peer is dropped.
 
@@ -2285,7 +2223,6 @@ async def test_handle_cancel_job_pin_to_wrong_session_no_cancel(tmp_path: Path) 
     controller.offloader._db.firmware.cancel.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_handle_cancel_job_malformed_frame_drops_silently(tmp_path: Path) -> None:
     """A cancel_job frame missing ``job_id`` is dropped without raising."""
     controller = _make_receiver_with_fanout(tmp_path)
@@ -2296,7 +2233,6 @@ async def test_handle_cancel_job_malformed_frame_drops_silently(tmp_path: Path) 
     controller.offloader._db.firmware.cancel.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_handle_cancel_job_before_controller_started_drops_silently(
     tmp_path: Path,
 ) -> None:
@@ -2319,7 +2255,6 @@ async def test_handle_cancel_job_before_controller_started_drops_silently(
     controller.offloader._db.firmware.cancel.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_handle_cancel_job_swallows_firmware_command_error(tmp_path: Path) -> None:
     """A ``CommandError`` from ``firmware.cancel`` (e.g. already-terminal) is swallowed."""
     controller = _make_receiver_with_fanout(tmp_path)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -159,7 +159,6 @@ async def receiver_server(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_preview_pair_returns_receivers_pin(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     tmp_path: Path,
@@ -177,7 +176,6 @@ async def test_preview_pair_returns_receivers_pin(
     assert pin == expected_pin
 
 
-@pytest.mark.asyncio
 async def test_preview_pair_does_not_persist_state_on_receiver(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -205,7 +203,6 @@ async def test_preview_pair_does_not_persist_state_on_receiver(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_preview_pair_connection_refused_raises_client_error(
     tmp_path: Path,
     bound_unused_tcp_port: int,
@@ -220,7 +217,6 @@ async def test_preview_pair_connection_refused_raises_client_error(
         )
 
 
-@pytest.mark.asyncio
 async def test_drive_initiator_round_trip_timeout_raises_client_error() -> None:
     """A hung TCP socket trips the WS handshake timeout, surfaced as PeerLinkClientError.
 
@@ -254,7 +250,6 @@ async def test_drive_initiator_round_trip_timeout_raises_client_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_preview_pair_rejects_garbage_post_handshake_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -302,7 +297,6 @@ async def test_preview_pair_rejects_garbage_post_handshake_frame(
         await server.close()
 
 
-@pytest.mark.asyncio
 async def test_preview_pair_non_ok_intent_response_raises_client_error() -> None:
     """Receiver's preview returns a non-OK intent_response → PeerLinkClientError.
 
@@ -345,7 +339,6 @@ async def test_preview_pair_non_ok_intent_response_raises_client_error() -> None
         await server.close()
 
 
-@pytest.mark.asyncio
 async def test_drive_initiator_round_trip_non_object_response_raises_client_error() -> None:
     """Receiver's response decrypts to a JSON value that isn't a dict → PeerLinkClientError.
 
@@ -386,7 +379,6 @@ async def test_drive_initiator_round_trip_non_object_response_raises_client_erro
         await server.close()
 
 
-@pytest.mark.asyncio
 async def test_drive_initiator_round_trip_missing_intent_response_raises_client_error() -> None:
     """Response object without an ``intent_response`` string field → PeerLinkClientError.
 
@@ -425,7 +417,6 @@ async def test_drive_initiator_round_trip_missing_intent_response_raises_client_
         await server.close()
 
 
-@pytest.mark.asyncio
 async def test_drive_initiator_round_trip_handshake_not_complete_raises_client_error(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
@@ -482,7 +473,6 @@ async def test_drive_initiator_round_trip_handshake_not_complete_raises_client_e
         )
 
 
-@pytest.mark.asyncio
 async def test_drive_initiator_round_trip_short_msg2_raises_noise_handshake_failed() -> None:
     """A msg2 too short to parse → ``NoiseValueError`` → PeerLinkClientError.
 
@@ -558,7 +548,6 @@ def test_build_ws_url_rejects_pathological_host() -> None:
         _build_ws_url("evil/path", 6055)
 
 
-@pytest.mark.asyncio
 async def test_drive_initiator_round_trip_maps_pathological_host_to_client_error() -> None:
     """A pathological host typed in the hostname field maps to PeerLinkClientError.
 
@@ -585,7 +574,6 @@ async def test_drive_initiator_round_trip_maps_pathological_host_to_client_error
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_request_pair_open_window_returns_pending(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -617,7 +605,6 @@ async def test_request_pair_open_window_returns_pending(
     assert peers[0].status is PeerStatus.PENDING
 
 
-@pytest.mark.asyncio
 async def test_request_pair_closed_window_returns_no_pairing_window(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -636,7 +623,6 @@ async def test_request_pair_closed_window_returns_no_pairing_window(
     assert result.status is IntentResponse.NO_PAIRING_WINDOW
 
 
-@pytest.mark.asyncio
 async def test_request_pair_unknown_intent_response_raises_client_error() -> None:
     """A wire ``intent_response`` outside the known enum surfaces as PeerLinkClientError.
 
@@ -721,7 +707,6 @@ async def _saved_pairings(offloader: OffloaderController) -> list[StoredPairing]
     return list(saved.pairings) if saved is not None else []
 
 
-@pytest.mark.asyncio
 async def test_controller_preview_pair_returns_receiver_pin(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     offloader_controller_dir: Path,
@@ -743,7 +728,6 @@ async def test_controller_preview_pair_returns_receiver_pin(
     assert await _saved_pairings(offloader) == []
 
 
-@pytest.mark.asyncio
 async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
     bound_unused_tcp_port: int,
@@ -760,7 +744,6 @@ async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
     assert exc.value.code == ErrorCode.UNAVAILABLE
 
 
-@pytest.mark.asyncio
 async def test_controller_request_pair_persists_pending_row(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     offloader_controller_dir: Path,
@@ -792,7 +775,6 @@ async def test_controller_request_pair_persists_pending_row(
     assert expected_pin in offloader.state.pairings
 
 
-@pytest.mark.asyncio
 async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     offloader_controller_dir: Path,
@@ -821,7 +803,6 @@ async def test_controller_request_pair_pin_mismatch_raises_precondition_failed(
     assert await _saved_pairings(offloader) == []
 
 
-@pytest.mark.asyncio
 async def test_controller_request_pair_closed_window_raises_no_pairing_window(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     offloader_controller_dir: Path,
@@ -844,7 +825,6 @@ async def test_controller_request_pair_closed_window_raises_no_pairing_window(
     assert exc.value.code == ErrorCode.NO_PAIRING_WINDOW
 
 
-@pytest.mark.asyncio
 async def test_controller_request_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
     bound_unused_tcp_port: int,
@@ -864,7 +844,6 @@ async def test_controller_request_pair_unavailable_on_unreachable_receiver(
     assert exc.value.code == ErrorCode.UNAVAILABLE
 
 
-@pytest.mark.asyncio
 async def test_controller_request_pair_unexpected_status_raises_internal_error(
     offloader_controller_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -949,7 +928,6 @@ def _stub_pairing(
     )
 
 
-@pytest.mark.asyncio
 async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     offloader_controller_dir: Path,
 ) -> None:
@@ -987,7 +965,6 @@ async def test_unpair_drops_pending_dict_entry_and_cancels_listener(
     assert listener.cancelled()
 
 
-@pytest.mark.asyncio
 async def test_unpair_drops_persisted_row(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1022,7 +999,6 @@ async def test_unpair_drops_persisted_row(
     assert saved.pairings == []
 
 
-@pytest.mark.asyncio
 async def test_unpair_unknown_returns_removed_false_idempotent(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1035,7 +1011,6 @@ async def test_unpair_unknown_returns_removed_false_idempotent(
     assert result == {"removed": False}
 
 
-@pytest.mark.asyncio
 async def test_pairings_snapshot_returns_ram_dict(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1072,7 +1047,6 @@ async def test_pairings_snapshot_returns_ram_dict(
     assert by_host["approved.local"].status is PeerStatus.APPROVED
 
 
-@pytest.mark.asyncio
 async def test_pairings_snapshot_marks_open_link_as_connected(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1113,7 +1087,6 @@ async def test_pairings_snapshot_marks_open_link_as_connected(
     assert rows["b.local"].connected is False
 
 
-@pytest.mark.asyncio
 async def test_offloader_peer_link_event_listeners_update_open_set(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1193,7 +1166,6 @@ def test_extract_receiver_esphome_version_branches(response: dict[str, Any], exp
     assert _extract_receiver_esphome_version(response) == expected
 
 
-@pytest.mark.asyncio
 async def test_peer_link_opened_refreshes_stored_pairing_version(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1275,7 +1247,6 @@ async def test_peer_link_opened_refreshes_stored_pairing_version(
     assert len(save_calls) == 2
 
 
-@pytest.mark.asyncio
 async def test_peer_link_opened_for_unknown_pin_is_silent_no_op(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1304,7 +1275,6 @@ async def test_peer_link_opened_for_unknown_pin_is_silent_no_op(
     assert len(save_calls) == 0
 
 
-@pytest.mark.asyncio
 async def test_start_seeds_pairings_dict_from_disk(
     offloader_controller_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1373,7 +1343,6 @@ async def test_start_seeds_pairings_dict_from_disk(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_approved_promotes_and_fires(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1409,7 +1378,6 @@ async def test_apply_pair_status_result_approved_promotes_and_fires(
     assert payload["status"] == "approved"
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_removed(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1458,7 +1426,6 @@ async def test_apply_pair_status_result_approved_pin_drift_drops_and_fires_remov
     assert second_payload["status"] == "removed"
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1497,7 +1464,6 @@ async def test_apply_pair_status_result_rejected_drops_and_fires_removed(
     assert second_payload["status"] == "removed"
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_pin_drift_seeds_offloader_alert(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1537,7 +1503,6 @@ async def test_apply_pair_status_result_pin_drift_seeds_offloader_alert(
     assert alert["fired_at"] > 0
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_rejected_seeds_offloader_alert(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1572,7 +1537,6 @@ async def test_apply_pair_status_result_rejected_seeds_offloader_alert(
     assert alert["fired_at"] > 0
 
 
-@pytest.mark.asyncio
 async def test_unpair_clears_offloader_alert_and_fires_dismissed(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1601,7 +1565,6 @@ async def test_unpair_clears_offloader_alert_and_fires_dismissed(
     assert EventType.OFFLOADER_PAIR_ALERT_DISMISSED in fire_event_types
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_unexpected_status_logs_and_continues(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1629,7 +1592,6 @@ async def test_apply_pair_status_result_unexpected_status_logs_and_continues(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_apply_pair_status_result_approved_after_unpair_does_not_resurrect_row(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1666,7 +1628,6 @@ async def test_apply_pair_status_result_approved_after_unpair_does_not_resurrect
     offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_unpair_cancels_listener_before_disk_transaction(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1698,7 +1659,6 @@ async def test_unpair_cancels_listener_before_disk_transaction(
     assert key not in offloader.state.pair_status_listeners
 
 
-@pytest.mark.asyncio
 async def test_unpair_fires_offloader_pair_status_changed_removed(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1729,7 +1689,6 @@ async def test_unpair_fires_offloader_pair_status_changed_removed(
     }
 
 
-@pytest.mark.asyncio
 async def test_request_pair_clears_offloader_alert_for_same_receiver(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1820,7 +1779,6 @@ async def test_request_pair_clears_offloader_alert_for_same_receiver(
         await asyncio.gather(listener, return_exceptions=True)
 
 
-@pytest.mark.asyncio
 async def test_unpair_does_not_fire_event_when_nothing_to_remove(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1837,7 +1795,6 @@ async def test_unpair_does_not_fire_event_when_nothing_to_remove(
     offloader._db.bus.fire.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_request_pair_repair_then_unpair_clean_state(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1964,7 +1921,6 @@ async def test_request_pair_repair_then_unpair_clean_state(
     assert offloader.state.pair_status_listeners == {}
 
 
-@pytest.mark.asyncio
 async def test_spawn_pair_status_listener_is_idempotent_on_running_task(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1991,7 +1947,6 @@ async def test_spawn_pair_status_listener_is_idempotent_on_running_task(
     await existing
 
 
-@pytest.mark.asyncio
 async def test_cancel_pair_status_listener_noop_when_absent(
     offloader_controller_dir: Path,
 ) -> None:
@@ -2003,7 +1958,6 @@ async def test_cancel_pair_status_listener_noop_when_absent(
     offloader._cancel_pair_status_listener("a" * 64)
 
 
-@pytest.mark.asyncio
 async def test_request_pair_repair_against_pending_cancels_old_listener(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2076,7 +2030,6 @@ async def test_request_pair_repair_against_pending_cancels_old_listener(
     assert key_old not in offloader.state.pairings
 
 
-@pytest.mark.asyncio
 async def test_request_pair_already_approved_persists_to_disk(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     offloader_controller_dir: Path,
@@ -2133,7 +2086,6 @@ async def test_request_pair_already_approved_persists_to_disk(
     assert offloader.state.pairings[expected_pin].status is PeerStatus.APPROVED
 
 
-@pytest.mark.asyncio
 async def test_lookup_peer_for_status_pending_dict_pin_mismatch_returns_rejected(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -2168,7 +2120,6 @@ async def test_lookup_peer_for_status_pending_dict_pin_mismatch_returns_rejected
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_await_pair_status_returns_approved_when_receiver_approved(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     offloader_controller_dir: Path,
@@ -2212,7 +2163,6 @@ async def test_await_pair_status_returns_approved_when_receiver_approved(
     assert result.pin_sha256 == expected_pin
 
 
-@pytest.mark.asyncio
 async def test_await_pair_status_unknown_dashboard_id_returns_rejected(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -2246,7 +2196,6 @@ def _seed_approved_peer_sync(
     )
 
 
-@pytest.mark.asyncio
 async def test_await_pair_status_unknown_intent_response_raises_client_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2278,7 +2227,6 @@ async def test_await_pair_status_unknown_intent_response_raises_client_error(
         )
 
 
-@pytest.mark.asyncio
 async def test_stop_cancels_pair_status_listeners(
     offloader_controller_dir: Path,
 ) -> None:
@@ -2304,7 +2252,6 @@ async def test_stop_cancels_pair_status_listeners(
     assert offloader.state.pair_status_listeners == {}
 
 
-@pytest.mark.asyncio
 async def test_pair_status_listener_loop_backs_off_on_transport_error(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2372,7 +2319,6 @@ async def test_pair_status_listener_loop_backs_off_on_transport_error(
     assert offloader.state.pairings[pin].status is PeerStatus.APPROVED
 
 
-@pytest.mark.asyncio
 async def test_pair_status_listener_loop_backs_off_on_unexpected_status(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2607,7 +2553,6 @@ async def _seed_approved_peer_for_initiator(
     )
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_fires_opened_after_handshake(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -2641,7 +2586,6 @@ async def test_peer_link_client_fires_opened_after_handshake(
         await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_fires_closed_on_cancel(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -2679,7 +2623,6 @@ async def test_peer_link_client_fires_closed_on_cancel(
     assert closed[-1]["reason"] == "client_stopped"
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_orphans_on_superseded(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -2751,7 +2694,6 @@ async def test_peer_link_client_orphans_on_superseded(
             await cancel_and_drain(task1)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_reconnects_on_transport_error(
     monkeypatch: pytest.MonkeyPatch,
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
@@ -2813,7 +2755,6 @@ async def test_peer_link_client_reconnects_on_transport_error(
         await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_send_ping_routes_through_channel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2868,7 +2809,6 @@ async def test_run_session_loops_send_ping_routes_through_channel(
     await drive_task
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_returns_heartbeat_timeout_when_dead(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2919,7 +2859,6 @@ async def test_run_session_loops_returns_heartbeat_timeout_when_dead(
     assert close_reason == "heartbeat_timeout"
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_backoff_advances_when_session_never_opens(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3013,7 +2952,6 @@ def test_peer_link_client_exposes_receiver_coordinates() -> None:
     assert client.receiver_port == 6055
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_returns_transport_error_on_type_error(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
@@ -3060,7 +2998,6 @@ async def test_peer_link_client_returns_transport_error_on_type_error(
         await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_returns_transport_error_on_noise_failure(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
@@ -3105,7 +3042,6 @@ async def test_peer_link_client_returns_transport_error_on_noise_failure(
         await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_close_event_carries_error_detail_on_noise_failure(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     monkeypatch: pytest.MonkeyPatch,
@@ -3165,7 +3101,6 @@ async def test_peer_link_client_close_event_carries_error_detail_on_noise_failur
         await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
 ) -> None:
@@ -3199,7 +3134,6 @@ async def test_peer_link_client_auth_rejected_when_dashboard_id_unknown(
         await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,
@@ -3308,7 +3242,6 @@ async def test_peer_link_client_pin_mismatch_aborts_and_orphans(
             await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_self_loopback_logs_error_and_retries(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,
@@ -3365,7 +3298,6 @@ async def test_peer_link_client_self_loopback_logs_error_and_retries(
             await cancel_and_drain(task)
 
 
-@pytest.mark.asyncio
 async def test_skip_hosts_resolver_strips_skipped_entries_live() -> None:
     """``_SkipHostsResolver.resolve`` filters skipped entries, picking up live edits."""
     inner = MagicMock()
@@ -3386,7 +3318,6 @@ async def test_skip_hosts_resolver_strips_skipped_entries_live() -> None:
     assert await wrapper.resolve("x", 6055) == []
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_responds_to_peer_ping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3448,7 +3379,6 @@ async def test_run_session_loops_responds_to_peer_ping(
     assert reason == "peer_hung_up"
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_bumps_last_pong_on_pong(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3511,7 +3441,6 @@ async def test_run_session_loops_bumps_last_pong_on_pong(
     # left ``last_pong_at`` at the initial value).
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_returns_transport_error_on_malformed_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3556,7 +3485,6 @@ async def test_run_session_loops_returns_transport_error_on_malformed_frame(
     assert reason == "transport_error"
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_ignores_unknown_msg_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3610,7 +3538,6 @@ async def test_run_session_loops_ignores_unknown_msg_type(
     assert reason == "peer_hung_up"
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_on_dead_swallows_aiohttp_close_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3684,7 +3611,6 @@ def _prime_offloader_identity_for_spawn(controller: OffloaderController) -> None
     controller.state.offloader_peer_link_priv = secrets.token_bytes(32)
 
 
-@pytest.mark.asyncio
 async def test_await_pair_status_flip_self_removes_listener_on_terminal_exit(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3724,7 +3650,6 @@ async def test_await_pair_status_flip_self_removes_listener_on_terminal_exit(
     assert pin not in offloader.state.pair_status_listeners
 
 
-@pytest.mark.asyncio
 async def test_spawn_peer_link_client_idempotent_when_task_running(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3762,7 +3687,6 @@ async def test_spawn_peer_link_client_idempotent_when_task_running(
     await cancel_and_drain(first_handle.task)
 
 
-@pytest.mark.asyncio
 async def test_cancel_peer_link_client_cancels_running_task(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3798,7 +3722,6 @@ async def test_cancel_peer_link_client_cancels_running_task(
         await handle.task
 
 
-@pytest.mark.asyncio
 async def test_stop_drains_peer_link_clients(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3851,7 +3774,6 @@ async def test_stop_drains_peer_link_clients(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_fires_queue_status_event_on_inbound_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3943,7 +3865,6 @@ async def test_run_session_loops_fires_queue_status_event_on_inbound_frame(
         "bool-queue-depth",
     ],
 )
-@pytest.mark.asyncio
 async def test_run_session_loops_drops_malformed_queue_status(
     monkeypatch: pytest.MonkeyPatch,
     frame_body: dict[str, Any],
@@ -4005,7 +3926,6 @@ async def test_run_session_loops_drops_malformed_queue_status(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_fires_offloader_job_state_changed_on_inbound_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4055,7 +3975,6 @@ async def test_run_session_loops_fires_offloader_job_state_changed_on_inbound_fr
     ],
     ids=["invalid-status", "missing-error_message", "non-string-job_id"],
 )
-@pytest.mark.asyncio
 async def test_run_session_loops_drops_malformed_job_state_changed(
     monkeypatch: pytest.MonkeyPatch,
     frame_body: dict[str, Any],
@@ -4072,7 +3991,6 @@ async def test_run_session_loops_drops_malformed_job_state_changed(
     assert len(captured) == 0
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_fires_offloader_job_output_on_inbound_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4100,7 +4018,6 @@ async def test_run_session_loops_fires_offloader_job_output_on_inbound_frame(
     }
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_resolves_submit_job_ack_future(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4125,7 +4042,6 @@ async def test_run_session_loops_resolves_submit_job_ack_future(
     assert ack == frame
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_finally_drains_pending_submit_acks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4145,7 +4061,6 @@ async def test_run_session_loops_finally_drains_pending_submit_acks(
         await pending
 
 
-@pytest.mark.asyncio
 async def test_submit_job_raises_no_session_error_when_session_closed() -> None:
     """:meth:`submit_job` without a live session raises :class:`PeerLinkNoSessionError`."""
     client = _make_offloader_client(EventBus())
@@ -4159,7 +4074,6 @@ async def test_submit_job_raises_no_session_error_when_session_closed() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_submit_job_sends_header_chunks_and_returns_ack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4242,7 +4156,6 @@ async def test_submit_job_sends_header_chunks_and_returns_ack(
     assert [c["is_last"] for c in chunks] == [False, False, True]
 
 
-@pytest.mark.asyncio
 async def test_submit_job_times_out_when_no_ack_arrives(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4271,7 +4184,6 @@ async def test_submit_job_times_out_when_no_ack_arrives(
             )
 
 
-@pytest.mark.asyncio
 async def test_submit_job_rejects_duplicate_job_id() -> None:
     """A second :meth:`submit_job` with an in-flight ``job_id`` raises immediately."""
     client = _make_offloader_client(EventBus())
@@ -4339,7 +4251,6 @@ def _seed_open_peer_link_client(
     return client
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_returns_ack_on_accept(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4401,7 +4312,6 @@ async def test_controller_submit_job_returns_ack_on_accept(
     assert captured_args["bundle_bytes"] == b"bundle-bytes"
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_passes_through_reject_reason(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4453,7 +4363,6 @@ async def test_controller_submit_job_passes_through_reject_reason(
     assert result["reason"] == "queue_rejected"
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_invalid_target_raises_invalid_args(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4469,7 +4378,6 @@ async def test_controller_submit_job_invalid_target_raises_invalid_args(
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_unknown_pairing_raises_not_found(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4488,7 +4396,6 @@ async def test_controller_submit_job_unknown_pairing_raises_not_found(
     assert exc_info.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_pending_pairing_raises_precondition_failed(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4509,7 +4416,6 @@ async def test_controller_submit_job_pending_pairing_raises_precondition_failed(
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_no_session_raises_precondition_failed(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4534,7 +4440,6 @@ async def test_controller_submit_job_no_session_raises_precondition_failed(
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_timeout_maps_to_unavailable(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4579,7 +4484,6 @@ async def test_controller_submit_job_timeout_maps_to_unavailable(
     assert exc_info.value.code == ErrorCode.UNAVAILABLE
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_empty_configuration_raises_invalid_args(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4595,7 +4499,6 @@ async def test_controller_submit_job_empty_configuration_raises_invalid_args(
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_rejects_path_traversal(
     make_settings: MakeSettingsFactory,
 ) -> None:
@@ -4640,7 +4543,6 @@ async def test_controller_submit_job_rejects_path_traversal(
     ],
     ids=["missing-accepted", "non-bool-accepted", "missing-job_id"],
 )
-@pytest.mark.asyncio
 async def test_dispatch_submit_job_ack_drops_malformed(
     monkeypatch: pytest.MonkeyPatch,
     frame_body: dict[str, Any],
@@ -4654,7 +4556,6 @@ async def test_dispatch_submit_job_ack_drops_malformed(
     assert not fut.done()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_submit_job_ack_drops_with_no_pending_future() -> None:
     """An ack frame with no matching future is dropped silently."""
     bus = EventBus()
@@ -4666,7 +4567,6 @@ async def test_dispatch_submit_job_ack_drops_with_no_pending_future() -> None:
     # branch is exercised; absence of a raise is the assertion.
 
 
-@pytest.mark.asyncio
 async def test_dispatch_submit_job_ack_drops_already_done_future() -> None:
     """An ack frame for an already-resolved future is dropped silently."""
     bus = EventBus()
@@ -4681,7 +4581,6 @@ async def test_dispatch_submit_job_ack_drops_already_done_future() -> None:
     assert fut.result()["accepted"] is True
 
 
-@pytest.mark.asyncio
 async def test_dispatch_job_output_drops_malformed_frame() -> None:
     """Missing required field on job_output is dropped silently."""
     bus = EventBus()
@@ -4701,7 +4600,6 @@ async def test_dispatch_job_output_drops_malformed_frame() -> None:
     assert len(captured) == 0
 
 
-@pytest.mark.asyncio
 async def test_dispatch_job_output_drops_invalid_stream_literal() -> None:
     """A stream value outside ``{stdout, stderr}`` is dropped."""
     bus = EventBus()
@@ -4722,7 +4620,6 @@ async def test_dispatch_job_output_drops_invalid_stream_literal() -> None:
     assert len(captured) == 0
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_yaml_invalid_maps_to_invalid_args(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4764,7 +4661,6 @@ async def test_controller_submit_job_yaml_invalid_maps_to_invalid_args(
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_missing_yaml_maps_to_not_found(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4802,7 +4698,6 @@ async def test_controller_submit_job_missing_yaml_maps_to_not_found(
     assert exc_info.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_orphaned_client_raises_precondition_failed(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4844,7 +4739,6 @@ async def test_controller_submit_job_orphaned_client_raises_precondition_failed(
     assert "orphaned" in exc_info.value.message
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_session_closed_branch_in_lookup(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4898,7 +4792,6 @@ async def test_controller_submit_job_session_closed_branch_in_lookup(
         await asyncio.gather(task, return_exceptions=True)
 
 
-@pytest.mark.asyncio
 async def test_controller_submit_job_no_session_during_send_maps_to_precondition_failed(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4985,7 +4878,6 @@ def _fire_offloader_job_state(
     offloader._on_offloader_job_state_changed(MagicMock(data=data))
 
 
-@pytest.mark.asyncio
 async def test_offloader_remote_jobs_cache_seeded_on_running_event(
     offloader_controller_dir: Path,
 ) -> None:
@@ -4999,7 +4891,6 @@ async def test_offloader_remote_jobs_cache_seeded_on_running_event(
 
 
 @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
-@pytest.mark.asyncio
 async def test_offloader_remote_jobs_cache_drops_on_terminal_event(
     offloader_controller_dir: Path,
     status: str,
@@ -5012,7 +4903,6 @@ async def test_offloader_remote_jobs_cache_drops_on_terminal_event(
     assert offloader.offloader_remote_jobs_snapshot() == []
 
 
-@pytest.mark.asyncio
 async def test_offloader_remote_jobs_cache_cleared_on_unpair(
     offloader_controller_dir: Path,
 ) -> None:
@@ -5039,7 +4929,6 @@ async def test_offloader_remote_jobs_cache_cleared_on_unpair(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_cancel_job_sends_frame_through_channel() -> None:
     """:meth:`PeerLinkClient.cancel_job` writes a ``cancel_job`` frame on the wire."""
     initiator, responder = _build_handshake_pair()
@@ -5060,7 +4949,6 @@ async def test_peer_link_client_cancel_job_sends_frame_through_channel() -> None
     assert captured == [{"type": "cancel_job", "job_id": "j-1"}]
 
 
-@pytest.mark.asyncio
 async def test_peer_link_client_cancel_job_raises_when_session_closed() -> None:
     """``cancel_job`` without a live session raises :class:`PeerLinkNoSessionError`."""
     client = _make_offloader_client(EventBus())
@@ -5069,7 +4957,6 @@ async def test_peer_link_client_cancel_job_raises_when_session_closed() -> None:
         await client.cancel_job(job_id="j-1")
 
 
-@pytest.mark.asyncio
 async def test_controller_cancel_job_dispatches_via_client(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5104,7 +4991,6 @@ async def test_controller_cancel_job_dispatches_via_client(
     assert captured_kwargs == {"job_id": "j-1"}
 
 
-@pytest.mark.asyncio
 async def test_controller_cancel_job_empty_job_id_raises_invalid_args(
     offloader_controller_dir: Path,
 ) -> None:
@@ -5116,7 +5002,6 @@ async def test_controller_cancel_job_empty_job_id_raises_invalid_args(
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_controller_cancel_job_unknown_pairing_raises_not_found(
     offloader_controller_dir: Path,
 ) -> None:
@@ -5128,7 +5013,6 @@ async def test_controller_cancel_job_unknown_pairing_raises_not_found(
     assert exc_info.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_controller_cancel_job_no_session_raises_precondition_failed(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5161,7 +5045,6 @@ async def test_controller_cancel_job_no_session_raises_precondition_failed(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_raises_no_session_error_when_session_closed() -> None:
     """:meth:`download_artifacts` without a live session raises :class:`PeerLinkNoSessionError`."""
     client = _make_offloader_client(EventBus())
@@ -5170,7 +5053,6 @@ async def test_download_artifacts_raises_no_session_error_when_session_closed() 
         await client.download_artifacts(job_id="j-1")
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_rejects_duplicate_job_id_on_same_session() -> None:
     """A second concurrent download on the same job_id raises :class:`PeerLinkNoSessionError`."""
     client = _make_offloader_client(EventBus())
@@ -5182,7 +5064,6 @@ async def test_download_artifacts_rejects_duplicate_job_id_on_same_session() -> 
         await client.download_artifacts(job_id="already-running")
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_resolves_future_with_tarball_and_offset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5226,7 +5107,6 @@ async def test_dispatch_artifacts_resolves_future_with_tarball_and_offset(
     assert result.firmware_offset == "0x10000"
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_end_rejected_resolves_future_with_reason(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5249,7 +5129,6 @@ async def test_dispatch_artifacts_end_rejected_resolves_future_with_reason(
     assert exc_info.value.reason == "build_dir_missing"
 
 
-@pytest.mark.asyncio
 async def test_run_session_loops_drains_pending_artifacts_downloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5283,7 +5162,6 @@ def _seed_artifacts_state(
     return fut, state
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_start_drops_malformed_frame() -> None:
     """A frame missing ``firmware_offset`` is logged + dropped (state untouched)."""
     client = _make_offloader_client(EventBus())
@@ -5297,7 +5175,6 @@ async def test_dispatch_artifacts_start_drops_malformed_frame() -> None:
     assert not fut.done()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_start_unknown_job_id_dropped() -> None:
     """A start frame for a job nobody asked for is logged + dropped."""
     client = _make_offloader_client(EventBus())
@@ -5317,7 +5194,6 @@ async def test_dispatch_artifacts_start_unknown_job_id_dropped() -> None:
     assert "stranger" not in client._artifacts_downloads
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_start_invalid_header_resolves_future_with_error() -> None:
     """A start header that ``BundleAssembler`` rejects resolves the future with an error."""
     client = _make_offloader_client(EventBus())
@@ -5341,7 +5217,6 @@ async def test_dispatch_artifacts_start_invalid_header_resolves_future_with_erro
     assert exc_info.value.reason == "invalid_start_header"
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_chunk_drops_malformed_frame() -> None:
     """A chunk frame missing ``data_b64`` is logged + dropped without resolving."""
     client = _make_offloader_client(EventBus())
@@ -5354,7 +5229,6 @@ async def test_dispatch_artifacts_chunk_drops_malformed_frame() -> None:
     assert not fut.done()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_chunk_drops_when_no_assembler_yet() -> None:
     """A chunk frame arriving before ``artifacts_start`` is logged + dropped."""
     client = _make_offloader_client(EventBus())
@@ -5374,7 +5248,6 @@ async def test_dispatch_artifacts_chunk_drops_when_no_assembler_yet() -> None:
     assert not fut.done()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_chunk_assembler_error_resolves_future() -> None:
     """A chunk that drives the assembler past its bounds resolves the future with an error."""
     payload = b"hello"
@@ -5408,7 +5281,6 @@ async def test_dispatch_artifacts_chunk_assembler_error_resolves_future() -> Non
         await fut
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_end_drops_malformed_frame() -> None:
     """An ``artifacts_end`` missing ``accepted`` is logged + dropped."""
     client = _make_offloader_client(EventBus())
@@ -5419,7 +5291,6 @@ async def test_dispatch_artifacts_end_drops_malformed_frame() -> None:
     assert not fut.done()
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_end_skips_already_resolved_future() -> None:
     """A late ``artifacts_end`` for a future that's already done is a no-op."""
     client = _make_offloader_client(EventBus())
@@ -5432,7 +5303,6 @@ async def test_dispatch_artifacts_end_skips_already_resolved_future() -> None:
     )
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_end_accept_without_start_resolves_with_missing_start() -> None:
     """``artifacts_end{accepted:true}`` with no prior start fires ``missing_start``."""
     client = _make_offloader_client(EventBus())
@@ -5448,7 +5318,6 @@ async def test_dispatch_artifacts_end_accept_without_start_resolves_with_missing
     assert exc_info.value.reason == "missing_start"
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_returns_result_on_full_round_trip() -> None:
     """End-to-end :meth:`download_artifacts` returns the assembled :class:`DownloadArtifactsResult`.
 
@@ -5504,7 +5373,6 @@ async def test_download_artifacts_returns_result_on_full_round_trip() -> None:
     assert "happy-path" not in client._artifacts_downloads
 
 
-@pytest.mark.asyncio
 async def test_download_artifacts_send_failure_raises_session_lost() -> None:
     """``send_frame`` returning ``False`` mid-request raises :class:`SubmitJobSessionLostError`."""
     client = _make_offloader_client(EventBus())
@@ -5522,7 +5390,6 @@ async def test_download_artifacts_send_failure_raises_session_lost() -> None:
     assert "lost-session" not in client._artifacts_downloads
 
 
-@pytest.mark.asyncio
 async def test_dispatch_artifacts_end_finalise_failure_resolves_with_error() -> None:
     """A SHA mismatch at finalise resolves the future with the assembler's error code."""
     payload = b"hello world"
@@ -5589,7 +5456,6 @@ def _make_test_tarball(*, idedata_extras: list[dict[str, str]] | None = None) ->
     return buf.getvalue()
 
 
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_returns_unpacked_response(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5636,7 +5502,6 @@ async def test_controller_download_artifacts_returns_unpacked_response(
     assert result["idedata"]["extra"]["flash_images"][0]["path"] == "bootloader.bin"
 
 
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_empty_job_id_raises_invalid_args(
     offloader_controller_dir: Path,
 ) -> None:
@@ -5648,7 +5513,6 @@ async def test_controller_download_artifacts_empty_job_id_raises_invalid_args(
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
 
 
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_unknown_pairing_raises_not_found(
     offloader_controller_dir: Path,
 ) -> None:
@@ -5660,7 +5524,6 @@ async def test_controller_download_artifacts_unknown_pairing_raises_not_found(
     assert exc_info.value.code == ErrorCode.NOT_FOUND
 
 
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_no_session_raises_precondition_failed(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5688,7 +5551,6 @@ async def test_controller_download_artifacts_no_session_raises_precondition_fail
     assert exc_info.value.code == ErrorCode.PRECONDITION_FAILED
 
 
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_session_lost_maps_to_unavailable(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5727,7 +5589,6 @@ async def test_controller_download_artifacts_session_lost_maps_to_unavailable(
         ("entirely_unknown_reason", ErrorCode.UNAVAILABLE),
     ],
 )
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_maps_receiver_reasons(
     reason: str,
     expected_code: ErrorCode,
@@ -5758,7 +5619,6 @@ async def test_controller_download_artifacts_maps_receiver_reasons(
     assert exc_info.value.code == expected_code
 
 
-@pytest.mark.asyncio
 async def test_controller_download_artifacts_malformed_tarball_maps_to_invalid_args(
     offloader_controller_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -5791,7 +5651,6 @@ async def test_controller_download_artifacts_malformed_tarball_maps_to_invalid_a
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_receiver_logs_accept_and_handshake_ok_on_preview_session(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,
@@ -5821,7 +5680,6 @@ async def test_receiver_logs_accept_and_handshake_ok_on_preview_session(
     assert "intent=preview" in handshake[-1].getMessage()
 
 
-@pytest.mark.asyncio
 async def test_run_one_session_logs_connected_peer_after_tcp_connect(
     receiver_server: tuple[TestServer, ReceiverController, str, bytes],
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_remote_build_submit_job.py
+++ b/tests/test_remote_build_submit_job.py
@@ -211,7 +211,6 @@ def test_validate_configuration_filename_rejects_malicious_inputs(filename: str)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_submit_job_duplicate_header_rejected(tmp_path: Path) -> None:
     """A second header on a session with one in-flight rejects ``duplicate_submit``."""
     receiver = _make_receiver(tmp_path)
@@ -228,7 +227,6 @@ async def test_submit_job_duplicate_header_rejected(tmp_path: Path) -> None:
     assert payload["job_id"] == "second"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "broken_frame",
     [
@@ -268,7 +266,6 @@ async def test_submit_job_duplicate_header_rejected(tmp_path: Path) -> None:
         },
     ],
 )
-@pytest.mark.asyncio
 async def test_submit_job_malformed_header_terminates(
     tmp_path: Path, broken_frame: dict[str, Any]
 ) -> None:
@@ -319,7 +316,6 @@ async def test_submit_job_malformed_header_terminates(
         },
     ],
 )
-@pytest.mark.asyncio
 async def test_submit_job_chunk_malformed_terminates(
     tmp_path: Path, broken_chunk: dict[str, Any]
 ) -> None:
@@ -337,7 +333,6 @@ async def test_submit_job_chunk_malformed_terminates(
     session.terminate.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_invalid_target_rejected(tmp_path: Path) -> None:
     """A header with ``target`` outside compile/upload rejects ``invalid_header``."""
     receiver = _make_receiver(tmp_path)
@@ -350,7 +345,6 @@ async def test_submit_job_invalid_target_rejected(tmp_path: Path) -> None:
     assert payload["reason"] == "invalid_header"
 
 
-@pytest.mark.asyncio
 async def test_submit_job_path_traversal_filename_rejected(tmp_path: Path) -> None:
     """A ``configuration_filename`` with path traversal rejects ``invalid_header``."""
     receiver = _make_receiver(tmp_path)
@@ -363,7 +357,6 @@ async def test_submit_job_path_traversal_filename_rejected(tmp_path: Path) -> No
     assert payload["reason"] == "invalid_header"
 
 
-@pytest.mark.asyncio
 async def test_submit_job_oversized_bundle_rejected(tmp_path: Path) -> None:
     """A header announcing a bundle past ``BUNDLE_MAX_TOTAL_BYTES`` rejects via the assembler."""
     receiver = _make_receiver(tmp_path)
@@ -390,7 +383,6 @@ async def test_submit_job_oversized_bundle_rejected(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_submit_job_chunk_no_inflight_rejected(tmp_path: Path) -> None:
     """A chunk frame without a preceding header rejects ``no_inflight_submit``."""
     receiver = _make_receiver(tmp_path)
@@ -411,7 +403,6 @@ async def test_submit_job_chunk_no_inflight_rejected(tmp_path: Path) -> None:
     session.terminate.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_chunk_job_id_mismatch_rejected(tmp_path: Path) -> None:
     """A chunk with the wrong ``job_id`` rejects ``job_id_mismatch``."""
     receiver = _make_receiver(tmp_path)
@@ -429,7 +420,6 @@ async def test_submit_job_chunk_job_id_mismatch_rejected(tmp_path: Path) -> None
     assert payload["reason"] == "job_id_mismatch"
 
 
-@pytest.mark.asyncio
 async def test_submit_job_chunk_decode_failure_terminates_session(tmp_path: Path) -> None:
     """Garbage base64 in a chunk rejects ``chunk_decode_failed`` AND terminates the session."""
     receiver = _make_receiver(tmp_path)
@@ -451,7 +441,6 @@ async def test_submit_job_chunk_decode_failure_terminates_session(tmp_path: Path
     session.terminate.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_chunk_out_of_order_terminates_session(tmp_path: Path) -> None:
     """An out-of-order chunk index rejects + terminates (wire-level misbehaviour)."""
     receiver = _make_receiver(tmp_path)
@@ -469,7 +458,6 @@ async def test_submit_job_chunk_out_of_order_terminates_session(tmp_path: Path) 
     session.terminate.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_chunk_hash_mismatch_recoverable(tmp_path: Path) -> None:
     """A bundle whose assembled hash mismatches rejects ``hash_mismatch`` *without* terminating."""
     receiver = _make_receiver(tmp_path)
@@ -505,7 +493,6 @@ async def test_submit_job_chunk_hash_mismatch_recoverable(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_submit_job_happy_path_extracts_and_queues(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -563,7 +550,6 @@ async def test_submit_job_happy_path_extracts_and_queues(
     firmware._enqueue.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_happy_path_with_relative_config_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -616,7 +602,6 @@ async def test_submit_job_happy_path_with_relative_config_dir(
     firmware._enqueue.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_clean_target_creates_clean_job(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -671,7 +656,6 @@ async def test_submit_job_clean_target_creates_clean_job(
     firmware._enqueue.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_carries_display_fields_through_to_firmware_job(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -739,7 +723,6 @@ async def test_submit_job_carries_display_fields_through_to_firmware_job(
     assert job.remote_peer_label == "MacBook Pro"
 
 
-@pytest.mark.asyncio
 async def test_submit_job_malformed_display_fields_coerce_to_empty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -798,7 +781,6 @@ async def test_submit_job_malformed_display_fields_coerce_to_empty(
     assert job.device_friendly_name == ""
 
 
-@pytest.mark.asyncio
 async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -867,7 +849,6 @@ async def test_submit_job_missing_display_fields_falls_through_to_empty_strings(
     assert job.remote_peer_label == ""
 
 
-@pytest.mark.asyncio
 async def test_submit_job_bundle_path_survives_prepare_bundle_wipe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -938,7 +919,6 @@ async def test_submit_job_bundle_path_survives_prepare_bundle_wipe(
     assert "reason" not in payload
 
 
-@pytest.mark.asyncio
 async def test_submit_job_intermediate_chunk_no_ack(tmp_path: Path) -> None:
     """A non-final chunk feeds the assembler silently; no ack until ``is_last``.
 
@@ -963,7 +943,6 @@ async def test_submit_job_intermediate_chunk_no_ack(tmp_path: Path) -> None:
     session.terminate.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -998,7 +977,6 @@ async def test_submit_job_path_traversal_dashboard_id_caught_at_extract(
     firmware._enqueue.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_enqueue_failure_rejects(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1024,7 +1002,6 @@ async def test_submit_job_enqueue_failure_rejects(
     session.terminate.assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_submit_job_extract_failure_rejects_without_terminate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1060,7 +1037,6 @@ async def test_submit_job_extract_failure_rejects_without_terminate(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_discard_session_drops_inflight(tmp_path: Path) -> None:
     """A discarded session forgets its in-flight upload."""
     receiver = _make_receiver(tmp_path)

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from esphome_device_builder.models import Device, DeviceState
 
 from .conftest import (
@@ -54,7 +52,6 @@ def test_state_change_fans_out_to_every_matching_device() -> None:
     assert targeted == ["kitchen (1).yaml", "kitchen.yaml"]
 
 
-@pytest.mark.asyncio
 async def test_ip_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", ip="")
     b = _device("kitchen (1).yaml", ip="")
@@ -76,7 +73,6 @@ async def test_ip_change_fans_out_to_every_matching_device() -> None:
     ]
 
 
-@pytest.mark.asyncio
 async def test_version_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", current_version="2026.5.0", deployed_version="")
     b = _device("kitchen (1).yaml", current_version="2026.5.0", deployed_version="")
@@ -96,7 +92,6 @@ async def test_version_change_fans_out_to_every_matching_device() -> None:
     ]
 
 
-@pytest.mark.asyncio
 async def test_config_hash_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", expected_config_hash="abcd1234", deployed_config_hash="")
     b = _device(
@@ -119,7 +114,6 @@ async def test_config_hash_change_fans_out_to_every_matching_device() -> None:
     assert len(captured) == 2
 
 
-@pytest.mark.asyncio
 async def test_api_encryption_change_fans_out_to_every_matching_device() -> None:
     a = _device("kitchen.yaml", api_encryption_active=None)
     b = _device("kitchen (1).yaml", api_encryption_active=None)

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -186,7 +186,6 @@ async def _stop_and_drain(monitor: DeviceStateMonitor) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_stop_cancels_every_async_resource(monkeypatch: pytest.MonkeyPatch) -> None:
     """``start`` → ``stop`` cancels the ping task, browser, in-flight resolves, and zeroconf.
 
@@ -217,7 +216,6 @@ async def test_stop_cancels_every_async_resource(monkeypatch: pytest.MonkeyPatch
     assert in_flight.cancelled() or in_flight.done()
 
 
-@pytest.mark.asyncio
 async def test_stop_swallows_browser_cancel_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -237,7 +235,6 @@ async def test_stop_swallows_browser_cancel_exception(
     assert monitor._mdns._mdns_browser is None
 
 
-@pytest.mark.asyncio
 async def test_stop_swallows_zeroconf_close_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -256,7 +253,6 @@ async def test_stop_swallows_zeroconf_close_exception(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_start_falls_back_when_zeroconf_construct_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -289,7 +285,6 @@ async def test_start_falls_back_when_zeroconf_construct_fails(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_start_continues_when_browser_construct_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -333,7 +328,6 @@ async def test_start_continues_when_browser_construct_fails(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_dispatch_removed_event_flips_offline_clears_ip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -356,7 +350,6 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_removed_event_clears_reachability_tracker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -393,7 +386,6 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -441,7 +433,6 @@ async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -475,7 +466,6 @@ async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_with_explicit_empty_api_encryption_pushes_empty_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -510,7 +500,6 @@ async def test_dispatch_added_with_explicit_empty_api_encryption_pushes_empty_st
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_without_api_encryption_txt_preserves_last_known(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -553,7 +542,6 @@ async def test_dispatch_added_without_api_encryption_txt_preserves_last_known(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -588,7 +576,6 @@ async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_api_encryption_absent_with_other_content_clears_to_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -640,7 +627,6 @@ async def test_dispatch_added_api_encryption_absent_with_other_content_clears_to
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_api_encryption_bare_key_pushes_empty_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -731,7 +717,6 @@ async def test_dispatch_added_api_encryption_bare_key_pushes_empty_string(
     ],
     ids=lambda v: v if isinstance(v, str) else "",
 )
-@pytest.mark.asyncio
 async def test_dispatch_added_sparse_announce_preserves_last_known(
     device_field: str,
     txt_key: str,
@@ -772,7 +757,6 @@ async def test_dispatch_added_sparse_announce_preserves_last_known(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_cache_miss_resolves_and_applies(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -810,7 +794,6 @@ async def test_dispatch_added_cache_miss_resolves_and_applies(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_cache_miss_skips_apply_when_request_returns_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -842,7 +825,6 @@ async def test_dispatch_added_cache_miss_skips_apply_when_request_returns_false(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_added_cache_miss_swallows_resolve_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -875,7 +857,6 @@ async def test_dispatch_added_cache_miss_swallows_resolve_exception(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_skips_unconfigured_devices(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -935,7 +916,6 @@ def _build_discovered(name: str, **overrides: Any) -> Any:
     return discovered
 
 
-@pytest.mark.asyncio
 async def test_dispatch_http_service_added_records_url_and_refires_importable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -972,7 +952,6 @@ async def test_dispatch_http_service_added_records_url_and_refires_importable(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_http_service_added_skips_when_no_importable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1004,7 +983,6 @@ async def test_dispatch_http_service_added_skips_when_no_importable(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_http_service_removed_clears_url_and_refires(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1039,7 +1017,6 @@ async def test_dispatch_http_service_removed_clears_url_and_refires(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_http_service_removed_for_untracked_is_noop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1060,7 +1037,6 @@ async def test_dispatch_http_service_removed_for_untracked_is_noop(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_dispatch_http_service_added_cache_miss_resolves_and_applies(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1231,7 +1207,6 @@ def _shrink_ping_intervals(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ping_module, "_PING_INTERVAL", 0.001)
 
 
-@pytest.mark.asyncio
 async def test_start_drives_ping_pipeline_to_online_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1261,7 +1236,6 @@ async def test_start_drives_ping_pipeline_to_online_state(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_start_disables_sweep_when_privilege_probe_returns_none(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1288,7 +1262,6 @@ async def test_start_disables_sweep_when_privilege_probe_returns_none(
     assert any("privileges are insufficient" in rec.message for rec in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_start_with_icmplib_unavailable_skips_dns_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1313,7 +1286,6 @@ async def test_start_with_icmplib_unavailable_skips_dns_resolution(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_start_marks_offline_on_icmp_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1346,7 +1318,6 @@ async def test_start_marks_offline_on_icmp_exception(
         await _stop_and_drain(monitor)
 
 
-@pytest.mark.asyncio
 async def test_start_skips_ping_for_cached_dns_failures(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1381,7 +1352,6 @@ async def test_start_skips_ping_for_cached_dns_failures(
     assert any("cached DNS failure" in rec.message for rec in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_start_logs_ping_count_at_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1408,7 +1378,6 @@ async def test_start_logs_ping_count_at_debug(
     assert any("Pinging 1 devices" in rec.message for rec in caplog.records)
 
 
-@pytest.mark.asyncio
 async def test_repeat_sweep_with_unchanged_targets_logs_once(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1446,7 +1415,6 @@ async def test_repeat_sweep_with_unchanged_targets_logs_once(
     assert len(ping_logs) == 1
 
 
-@pytest.mark.asyncio
 async def test_dns_failure_flicker_does_not_re_emit_log(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -1495,7 +1463,6 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
     assert cache_calls["n"] >= 4
 
 
-@pytest.mark.asyncio
 async def test_start_skips_devices_without_address(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1581,7 +1548,6 @@ def test_get_cached_addresses_returns_none_when_addresses_empty(
     assert monitor.get_cached_addresses("kitchen.local") is None
 
 
-@pytest.mark.asyncio
 async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -191,7 +191,6 @@ def test_apply_with_no_tracker_does_not_raise() -> None:
     monitor.apply("kitchen", DeviceState.ONLINE, "mdns")
 
 
-@pytest.mark.asyncio
 async def test_ping_success_records_rtt_and_observation() -> None:
     """A successful ICMP probe captures ``min_rtt`` and stamps freshness."""
     devices = [_make_device()]
@@ -214,7 +213,6 @@ async def test_ping_success_records_rtt_and_observation() -> None:
     assert snap["ping_last_seen_seconds_ago"] is not None
 
 
-@pytest.mark.asyncio
 async def test_ping_failure_does_not_record_rtt() -> None:
     """An unreachable host leaves the rtt slot null — no "0 ms" lie."""
     devices = [_make_device()]
@@ -237,7 +235,6 @@ async def test_ping_failure_does_not_record_rtt() -> None:
     assert snap["ping_last_seen_seconds_ago"] is None
 
 
-@pytest.mark.asyncio
 async def test_ping_retry_absorbs_transient_miss() -> None:
     """First-shot miss → retry with multiple packets → ONLINE, not OFFLINE."""
     devices = [_make_device(state=DeviceState.ONLINE)]
@@ -266,7 +263,6 @@ async def test_ping_retry_absorbs_transient_miss() -> None:
     assert snap["ping_rtt_ms"] == 7.5
 
 
-@pytest.mark.asyncio
 async def test_ping_retry_still_offline_when_retry_also_misses() -> None:
     """Both probes miss → OFFLINE. Retry doesn't mask a genuinely-gone device."""
     devices = [_make_device(state=DeviceState.ONLINE)]
@@ -289,7 +285,6 @@ async def test_ping_retry_still_offline_when_retry_also_misses() -> None:
     assert snap["ping_rtt_ms"] is None
 
 
-@pytest.mark.asyncio
 async def test_ping_no_retry_when_first_probe_succeeds() -> None:
     """Healthy path stays a single packet; the retry is opt-in on miss."""
     devices = [_make_device()]
@@ -306,7 +301,6 @@ async def test_ping_no_retry_when_first_probe_succeeds() -> None:
     fake_ping.assert_awaited_once()
 
 
-@pytest.mark.asyncio
 async def test_ping_no_retry_when_already_offline() -> None:
     """Already-OFFLINE devices skip the retry — the miss just confirms the state."""
     devices = [_make_device(state=DeviceState.OFFLINE)]
@@ -324,7 +318,6 @@ async def test_ping_no_retry_when_already_offline() -> None:
     assert devices[0].state == DeviceState.OFFLINE
 
 
-@pytest.mark.asyncio
 async def test_ping_retry_absorbs_transient_miss_when_unknown() -> None:
     """Cold-start UNKNOWN devices retry too; a single dropped packet can't flip OFFLINE.
 
@@ -350,7 +343,6 @@ async def test_ping_retry_absorbs_transient_miss_when_unknown() -> None:
     assert devices[0].state == DeviceState.ONLINE
 
 
-@pytest.mark.asyncio
 async def test_can_use_icmp_lib_with_privilege_picks_raw_when_available() -> None:
     """``SOCK_RAW`` probe succeeds; the loop runs in privileged mode."""
     fake_ping = AsyncMock(return_value=MagicMock())
@@ -364,7 +356,6 @@ async def test_can_use_icmp_lib_with_privilege_picks_raw_when_available() -> Non
     assert fake_ping.await_args_list[0].kwargs.get("privileged") is True
 
 
-@pytest.mark.asyncio
 async def test_can_use_icmp_lib_with_privilege_falls_back_to_dgram() -> None:
     """Raw socket denied; the probe falls back to unprivileged ``SOCK_DGRAM``."""
     fake_ping = AsyncMock(side_effect=[SocketPermissionError(True), MagicMock()])
@@ -378,7 +369,6 @@ async def test_can_use_icmp_lib_with_privilege_falls_back_to_dgram() -> None:
     assert fake_ping.await_args_list[1].kwargs.get("privileged") is False
 
 
-@pytest.mark.asyncio
 async def test_can_use_icmp_lib_with_privilege_returns_none_when_both_denied() -> None:
     """Both modes denied; probe returns ``None`` so ``run`` disables the sweep."""
     fake_ping = AsyncMock(side_effect=[SocketPermissionError(True), SocketPermissionError(False)])
@@ -391,7 +381,6 @@ async def test_can_use_icmp_lib_with_privilege_returns_none_when_both_denied() -
     assert fake_ping.await_count == 2
 
 
-@pytest.mark.asyncio
 async def test_can_use_icmp_lib_with_privilege_returns_none_when_icmplib_missing() -> None:
     """``icmp_ping`` is ``None`` (icmplib not installed) → probe returns ``None``."""
     with patch(
@@ -401,7 +390,6 @@ async def test_can_use_icmp_lib_with_privilege_returns_none_when_icmplib_missing
         assert await _can_use_icmp_lib_with_privilege() is None
 
 
-@pytest.mark.asyncio
 async def test_can_use_icmp_lib_with_privilege_returns_none_on_unexpected_oserror() -> None:
     """Non-permission ``OSError`` also degrades gracefully; the task doesn't die."""
     fake_ping = AsyncMock(side_effect=[OSError("EAFNOSUPPORT"), OSError("EAFNOSUPPORT")])
@@ -414,7 +402,6 @@ async def test_can_use_icmp_lib_with_privilege_returns_none_on_unexpected_oserro
     assert fake_ping.await_count == 2
 
 
-@pytest.mark.asyncio
 async def test_ping_device_uses_privileged_flag_from_probe() -> None:
     """``_ping_device`` forwards ``self._privileged`` to every ``icmp_ping`` call."""
     devices = [_make_device(state=DeviceState.UNKNOWN)]
@@ -434,7 +421,6 @@ async def test_ping_device_uses_privileged_flag_from_probe() -> None:
     assert fake_ping.await_args_list[1].kwargs.get("privileged") is False
 
 
-@pytest.mark.asyncio
 async def test_mdns_removed_clears_tracker_for_device() -> None:
     """A ``Removed`` mDNS event wipes every channel's history for the device.
 
@@ -470,7 +456,6 @@ async def test_mdns_removed_clears_tracker_for_device() -> None:
     assert snap["ping_rtt_ms"] is None
 
 
-@pytest.mark.asyncio
 async def test_mdns_removed_via_dispatch_clears_tracker() -> None:
     """The real browser-callback path (Removed) routes through to ``clear``.
 
@@ -1005,7 +990,6 @@ def test_get_mdns_cache_info_picks_latest_record() -> None:
     assert info.ttl_remaining_seconds == pytest.approx(115.0, abs=0.5)
 
 
-@pytest.mark.asyncio
 async def test_refresh_mdns_no_zeroconf_is_a_noop() -> None:
     """``refresh_mdns`` is silent when zeroconf failed to start.
 
@@ -1025,7 +1009,6 @@ async def test_refresh_mdns_no_zeroconf_is_a_noop() -> None:
     assert snap["mdns_last_seen_seconds_ago"] is None
 
 
-@pytest.mark.asyncio
 async def test_refresh_mdns_calls_resolve_host() -> None:
     """``refresh_mdns`` delegates to ``AsyncEsphomeZeroconf.async_resolve_host``.
 
@@ -1052,7 +1035,6 @@ async def test_refresh_mdns_calls_resolve_host() -> None:
     assert seen.count("kitchen") >= 1
 
 
-@pytest.mark.asyncio
 async def test_refresh_mdns_swallows_resolve_errors() -> None:
     """A resolve exception is logged but does not propagate.
 
@@ -1072,7 +1054,6 @@ async def test_refresh_mdns_swallows_resolve_errors() -> None:
     assert devices[0].state is DeviceState.UNKNOWN
 
 
-@pytest.mark.asyncio
 async def test_refresh_mdns_empty_resolve_no_state_change() -> None:
     """An empty resolve (device didn't respond) leaves state untouched.
 

--- a/tests/test_subprocess_stream.py
+++ b/tests/test_subprocess_stream.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
-
 from esphome_device_builder.helpers.subprocess import iter_lines_with_progress
 
 
@@ -34,7 +32,6 @@ async def _collect(stream: asyncio.StreamReader) -> list[str]:
     return [chunk async for chunk in iter_lines_with_progress(stream)]
 
 
-@pytest.mark.asyncio
 async def test_splits_on_newline() -> None:
     r"""The traditional `\n`-delimited case still works.
 
@@ -46,7 +43,6 @@ async def test_splits_on_newline() -> None:
     assert chunks == ["alpha\n", "beta\n", "gamma\n"]
 
 
-@pytest.mark.asyncio
 async def test_splits_on_carriage_return() -> None:
     r"""`\\r` flushes too — esptool's progress lines surface live.
 
@@ -59,7 +55,6 @@ async def test_splits_on_carriage_return() -> None:
     assert chunks == ["5%\r", "25%\r", "50%\r"]
 
 
-@pytest.mark.asyncio
 async def test_crlf_coalesces_to_single_chunk() -> None:
     r"""`\r\n` is one logical line ending, not two events.
 
@@ -75,7 +70,6 @@ async def test_crlf_coalesces_to_single_chunk() -> None:
     assert chunks == ["foo\r\n", "bar\n"]
 
 
-@pytest.mark.asyncio
 async def test_bare_cr_followed_by_data_is_overwrite() -> None:
     r"""A bare ``\r`` (no ``\n``) is the esptool-style overwrite case.
 
@@ -88,7 +82,6 @@ async def test_bare_cr_followed_by_data_is_overwrite() -> None:
     assert chunks == ["5%\r", "10%\r"]
 
 
-@pytest.mark.asyncio
 async def test_cr_at_end_of_read_defers_until_next_chunk() -> None:
     r"""A ``\r`` at the read boundary waits for the next byte.
 
@@ -108,7 +101,6 @@ async def test_cr_at_end_of_read_defers_until_next_chunk() -> None:
     assert chunks == ["foo\r\n", "bar\n"]
 
 
-@pytest.mark.asyncio
 async def test_eof_flushes_trailing_buffer() -> None:
     """A final chunk without a terminator still surfaces.
 
@@ -120,7 +112,6 @@ async def test_eof_flushes_trailing_buffer() -> None:
     assert chunks == ["clean\n", "incomplete"]
 
 
-@pytest.mark.asyncio
 async def test_handles_invalid_utf8_with_replace() -> None:
     """Bad bytes don't kill the stream — decode with `errors='replace'`.
 
@@ -136,14 +127,12 @@ async def test_handles_invalid_utf8_with_replace() -> None:
     assert "�" in chunks[1]  # replacement marker present
 
 
-@pytest.mark.asyncio
 async def test_empty_stream_yields_nothing() -> None:
     """Closing without writing anything is a no-op (no spurious empty chunk)."""
     chunks = await _collect(_stream(b""))
     assert chunks == []
 
 
-@pytest.mark.asyncio
 async def test_chunks_split_across_multiple_reads() -> None:
     """A line straddling two reads still emits as a single chunk.
 
@@ -162,7 +151,6 @@ async def test_chunks_split_across_multiple_reads() -> None:
     assert chunks == ["long line that arrives in two pieces\n"]
 
 
-@pytest.mark.asyncio
 async def test_realistic_esptool_progress_output() -> None:
     r"""End-to-end shape of an esptool progress stream.
 

--- a/tests/test_subscriber_presence.py
+++ b/tests/test_subscriber_presence.py
@@ -64,7 +64,6 @@ def test_subscriber_context_decrements_on_exception() -> None:
     assert p.has_subscribers() is False
 
 
-@pytest.mark.asyncio
 async def test_wait_for_subscriber_returns_immediately_when_open() -> None:
     """A subscriber already present means awaiting completes without parking."""
     p = SubscriberPresence()
@@ -74,7 +73,6 @@ async def test_wait_for_subscriber_returns_immediately_when_open() -> None:
         await asyncio.wait_for(p.wait_for_subscriber(), timeout=0.5)
 
 
-@pytest.mark.asyncio
 async def test_wait_for_subscriber_parks_until_first_subscriber() -> None:
     """An awaiter blocks while count is 0 and resumes on the 0→1 transition."""
     p = SubscriberPresence()
@@ -91,7 +89,6 @@ async def test_wait_for_subscriber_parks_until_first_subscriber() -> None:
         await asyncio.wait_for(waiter_task, timeout=0.5)
 
 
-@pytest.mark.asyncio
 async def test_wait_for_subscriber_parks_again_after_drop_to_zero() -> None:
     """A second awaiter created after the gate closed parks again.
 
@@ -120,7 +117,6 @@ async def test_wait_for_subscriber_parks_again_after_drop_to_zero() -> None:
         await asyncio.wait_for(waiter_task, timeout=0.5)
 
 
-@pytest.mark.asyncio
 async def test_wait_for_subscriber_wakes_every_awaiter_on_open() -> None:
     """Multiple awaiters all resume when the count first goes 0→1.
 
@@ -142,7 +138,6 @@ async def test_wait_for_subscriber_wakes_every_awaiter_on_open() -> None:
         await asyncio.wait_for(asyncio.gather(*waiters), timeout=0.5)
 
 
-@pytest.mark.asyncio
 async def test_wait_for_no_subscribers_returns_immediately_when_count_is_zero() -> None:
     """The mirror gate is open at startup (count == 0).
 
@@ -158,7 +153,6 @@ async def test_wait_for_no_subscribers_returns_immediately_when_count_is_zero() 
     await asyncio.wait_for(p.wait_for_no_subscribers(), timeout=0.5)
 
 
-@pytest.mark.asyncio
 async def test_wait_for_no_subscribers_parks_while_subscribers_present() -> None:
     """A subscriber holding the gate open blocks the no-subscriber waiter."""
     p = SubscriberPresence()
@@ -175,7 +169,6 @@ async def test_wait_for_no_subscribers_parks_while_subscribers_present() -> None
     await asyncio.wait_for(waiter_task, timeout=0.5)
 
 
-@pytest.mark.asyncio
 async def test_wait_for_no_subscribers_wakes_on_drop_to_zero() -> None:
     """Subscriber-drop wakes a parked no-subscribers waiter within one tick.
 

--- a/tests/test_ws_dispatch_branches.py
+++ b/tests/test_ws_dispatch_branches.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from esphome_device_builder.api.ws import WebSocketClient
 from esphome_device_builder.controllers.auth import AuthError
 from esphome_device_builder.helpers.api import CommandError
@@ -61,7 +59,6 @@ def test_token_property_returns_value_set_by_authenticator() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_send_result_invokes_to_dict_on_dataclass_results() -> None:
     """``send_result`` flattens ``to_dict``-shaped results before sending.
 
@@ -83,7 +80,6 @@ async def test_send_result_invokes_to_dict_on_dataclass_results() -> None:
     assert payload["message_id"] == "m1"
 
 
-@pytest.mark.asyncio
 async def test_send_event_serialises_eventmessage() -> None:
     """``send_event`` packages the event into the ``EventMessage`` envelope."""
     client, ws = _make_client()
@@ -101,7 +97,6 @@ async def test_send_event_serialises_eventmessage() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_handle_command_invalid_message_format() -> None:
     """A raw payload that fails ``CommandMessage.from_dict`` returns INVALID_MESSAGE.
 
@@ -119,7 +114,6 @@ async def test_handle_command_invalid_message_format() -> None:
     assert payload["message_id"] == ""
 
 
-@pytest.mark.asyncio
 async def test_handle_command_unknown_command_returns_typed_error() -> None:
     """Unrecognised commands surface as ``UNKNOWN_COMMAND``, not as a 500.
 
@@ -137,7 +131,6 @@ async def test_handle_command_unknown_command_returns_typed_error() -> None:
     assert "garbage/nonexistent" in payload["details"]
 
 
-@pytest.mark.asyncio
 async def test_handle_command_pre_auth_blocks_non_auth_commands() -> None:
     """A non-``auth`` command before authentication is refused with NOT_AUTHENTICATED.
 
@@ -158,7 +151,6 @@ async def test_handle_command_pre_auth_blocks_non_auth_commands() -> None:
     client.device_builder.command_handlers["devices/list"].assert_not_called()
 
 
-@pytest.mark.asyncio
 async def test_handle_command_passes_through_auth_error_code() -> None:
     """``AuthError`` from a handler keeps its own code/message verbatim.
 
@@ -179,7 +171,6 @@ async def test_handle_command_passes_through_auth_error_code() -> None:
     assert payload["details"] == "slow down"
 
 
-@pytest.mark.asyncio
 async def test_handle_command_passes_through_command_error_code() -> None:
     """``CommandError`` from a handler also keeps its own typed code."""
     client, ws = _make_client()
@@ -196,7 +187,6 @@ async def test_handle_command_passes_through_command_error_code() -> None:
     assert payload["details"] == "bad name"
 
 
-@pytest.mark.asyncio
 async def test_handle_command_unexpected_exception_becomes_internal_error() -> None:
     """A bare ``Exception`` from a handler is logged and surfaced as INTERNAL_ERROR.
 


### PR DESCRIPTION
# What does this implement/fix?

`asyncio_mode` is already set to `auto` in `pyproject.toml`, so every `@pytest.mark.asyncio` decorator was a no-op; this removes all 1139 of them along with the `import pytest` lines that existed only to apply the marker. No test behaviour changes, the full suite still collects (3991 tests) and async tests run fine under auto mode.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
