### PR TITLE
Make user-preference writes atomic to prevent lost updates

### DIFF
--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -593,12 +593,7 @@ def clear_volatile_device_metadata(config_dir: Path, filename: str) -> None:
 
 
 def _prefs_from_data(data: dict[str, Any]) -> UserPreferences:
-    """
-    Decode the ``_preferences`` blob, defaulting on a corrupt shape.
-
-    A hand-edited sidecar with a malformed prefs blob shouldn't
-    take the whole dashboard down.
-    """
+    """Decode the ``_preferences`` blob, returning defaults on a corrupt shape."""
     try:
         return UserPreferences.from_dict(data.get(_PREFS_KEY, {}))
     except (ValueError, TypeError, LookupError):
@@ -622,12 +617,9 @@ def mutate_preferences(
     """
     Atomic read-modify-write for user preferences.
 
-    Load the current prefs (defaults on a corrupt blob), call
-    *mutate* to produce the next state, and persist under one
-    ``metadata_transaction`` lock so a concurrent writer can't
-    read the same baseline and clobber the result. *mutate* either
-    returns the new prefs or mutates the passed object in place and
-    returns ``None``.
+    *mutate* receives the current prefs (defaults on a corrupt
+    blob) and returns the next state, or mutates it in place and
+    returns ``None``. Load and save share one lock.
     """
     with metadata_transaction(config_dir) as data:
         prefs = _prefs_from_data(data)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -610,6 +610,14 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
         data[_PREFS_KEY] = prefs.to_dict()
 
 
+def _prefs_from_data(data: dict[str, Any]) -> UserPreferences:
+    """Decode the ``_preferences`` blob, defaulting on a corrupt shape."""
+    try:
+        return UserPreferences.from_dict(data.get(_PREFS_KEY, {}))
+    except (ValueError, TypeError, LookupError):
+        return UserPreferences()
+
+
 def update_preferences(config_dir: Path, update_fields: dict[str, Any]) -> UserPreferences:
     """
     Merge *update_fields* into stored preferences under one lock.
@@ -617,18 +625,36 @@ def update_preferences(config_dir: Path, update_fields: dict[str, Any]) -> UserP
     Load, merge the partial update, validate, and save inside a
     single ``metadata_transaction`` so two concurrent partial
     updates can't both read the same baseline and clobber each
-    other's field. Defaults on a corrupt blob.
+    other's field. Defaults on a corrupt blob. Validates the
+    untrusted partial dict through ``from_dict``; for a
+    conditional in-place update use ``preferences_transaction``.
     """
     with metadata_transaction(config_dir) as data:
-        try:
-            current = UserPreferences.from_dict(data.get(_PREFS_KEY, {}))
-        except (ValueError, TypeError, LookupError):
-            current = UserPreferences()
-        merged = current.to_dict()
+        merged = _prefs_from_data(data).to_dict()
         merged.update(update_fields)
         updated = UserPreferences.from_dict(merged)
         data[_PREFS_KEY] = updated.to_dict()
         return updated
+
+
+@contextmanager
+def preferences_transaction(config_dir: Path) -> Iterator[UserPreferences]:
+    """
+    Atomic read-modify-write context for user preferences.
+
+    Yields the current :class:`UserPreferences` (defaults on a
+    corrupt blob). Mutate it in place; on a clean exit the blob is
+    persisted under the same ``metadata_transaction`` lock, so a
+    conditional update can't lose a concurrent writer's field.
+    Exceptions inside the block discard the pending mutation. Use
+    when the next state depends on reading the current one;
+    ``set_prefs`` uses ``update_preferences`` instead because it
+    validates an untrusted partial dict.
+    """
+    with metadata_transaction(config_dir) as data:
+        prefs = _prefs_from_data(data)
+        yield prefs
+        data[_PREFS_KEY] = prefs.to_dict()
 
 
 _REMOTE_BUILD_FAIL_SAFE = RemoteBuildSettings(enabled=False)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -10,7 +10,7 @@ import re
 import stat
 import tempfile
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -592,16 +592,22 @@ def clear_volatile_device_metadata(config_dir: Path, filename: str) -> None:
             data.pop(filename, None)
 
 
-def load_preferences(config_dir: Path) -> UserPreferences:
-    """Load user preferences, returning defaults for missing fields."""
-    raw = _load_metadata(config_dir).get(_PREFS_KEY, {})
+def _prefs_from_data(data: dict[str, Any]) -> UserPreferences:
+    """
+    Decode the ``_preferences`` blob, defaulting on a corrupt shape.
+
+    A hand-edited sidecar with a malformed prefs blob shouldn't
+    take the whole dashboard down.
+    """
     try:
-        return UserPreferences.from_dict(raw)
+        return UserPreferences.from_dict(data.get(_PREFS_KEY, {}))
     except (ValueError, TypeError, LookupError):
-        # mashumaro runtime-shape errors → defaults. Hand-edited
-        # sidecar with a malformed prefs blob shouldn't take the
-        # whole dashboard down.
         return UserPreferences()
+
+
+def load_preferences(config_dir: Path) -> UserPreferences:
+    """Load user preferences, returning defaults for missing or corrupt fields."""
+    return _prefs_from_data(_load_metadata(config_dir))
 
 
 def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
@@ -610,51 +616,34 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
         data[_PREFS_KEY] = prefs.to_dict()
 
 
-def _prefs_from_data(data: dict[str, Any]) -> UserPreferences:
-    """Decode the ``_preferences`` blob, defaulting on a corrupt shape."""
-    try:
-        return UserPreferences.from_dict(data.get(_PREFS_KEY, {}))
-    except (ValueError, TypeError, LookupError):
-        return UserPreferences()
-
-
-def update_preferences(config_dir: Path, update_fields: dict[str, Any]) -> UserPreferences:
+def mutate_preferences(
+    config_dir: Path, mutate: Callable[[UserPreferences], UserPreferences | None]
+) -> UserPreferences:
     """
-    Merge *update_fields* into stored preferences under one lock.
+    Atomic read-modify-write for user preferences.
 
-    Load, merge the partial update, validate, and save inside a
-    single ``metadata_transaction`` so two concurrent partial
-    updates can't both read the same baseline and clobber each
-    other's field. Defaults on a corrupt blob. Validates the
-    untrusted partial dict through ``from_dict``; for a
-    conditional in-place update use ``preferences_transaction``.
-    """
-    with metadata_transaction(config_dir) as data:
-        merged = _prefs_from_data(data).to_dict()
-        merged.update(update_fields)
-        updated = UserPreferences.from_dict(merged)
-        data[_PREFS_KEY] = updated.to_dict()
-        return updated
-
-
-@contextmanager
-def preferences_transaction(config_dir: Path) -> Iterator[UserPreferences]:
-    """
-    Atomic read-modify-write context for user preferences.
-
-    Yields the current :class:`UserPreferences` (defaults on a
-    corrupt blob). Mutate it in place; on a clean exit the blob is
-    persisted under the same ``metadata_transaction`` lock, so a
-    conditional update can't lose a concurrent writer's field.
-    Exceptions inside the block discard the pending mutation. Use
-    when the next state depends on reading the current one;
-    ``set_prefs`` uses ``update_preferences`` instead because it
-    validates an untrusted partial dict.
+    Load the current prefs (defaults on a corrupt blob), call
+    *mutate* to produce the next state, and persist under one
+    ``metadata_transaction`` lock so a concurrent writer can't
+    read the same baseline and clobber the result. *mutate* either
+    returns the new prefs or mutates the passed object in place and
+    returns ``None``.
     """
     with metadata_transaction(config_dir) as data:
         prefs = _prefs_from_data(data)
-        yield prefs
-        data[_PREFS_KEY] = prefs.to_dict()
+        result = mutate(prefs)
+        if result is None:
+            result = prefs
+        data[_PREFS_KEY] = result.to_dict()
+        return result
+
+
+def update_preferences(config_dir: Path, update_fields: dict[str, Any]) -> UserPreferences:
+    """Merge a validated partial dict into stored preferences atomically."""
+    return mutate_preferences(
+        config_dir,
+        lambda prefs: UserPreferences.from_dict({**prefs.to_dict(), **update_fields}),
+    )
 
 
 _REMOTE_BUILD_FAIL_SAFE = RemoteBuildSettings(enabled=False)

--- a/esphome_device_builder/controllers/config.py
+++ b/esphome_device_builder/controllers/config.py
@@ -610,6 +610,27 @@ def save_preferences(config_dir: Path, prefs: UserPreferences) -> None:
         data[_PREFS_KEY] = prefs.to_dict()
 
 
+def update_preferences(config_dir: Path, update_fields: dict[str, Any]) -> UserPreferences:
+    """
+    Merge *update_fields* into stored preferences under one lock.
+
+    Load, merge the partial update, validate, and save inside a
+    single ``metadata_transaction`` so two concurrent partial
+    updates can't both read the same baseline and clobber each
+    other's field. Defaults on a corrupt blob.
+    """
+    with metadata_transaction(config_dir) as data:
+        try:
+            current = UserPreferences.from_dict(data.get(_PREFS_KEY, {}))
+        except (ValueError, TypeError, LookupError):
+            current = UserPreferences()
+        merged = current.to_dict()
+        merged.update(update_fields)
+        updated = UserPreferences.from_dict(merged)
+        data[_PREFS_KEY] = updated.to_dict()
+        return updated
+
+
 _REMOTE_BUILD_FAIL_SAFE = RemoteBuildSettings(enabled=False)
 
 
@@ -1370,18 +1391,8 @@ class ConfigController:
         """
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
-
-        # Load current, merge with provided fields, validate, save
-        current = await loop.run_in_executor(None, load_preferences, config_dir)
         update_fields = {k: v for k, v in kwargs.items() if k not in ("client", "message_id")}
-
-        # Merge into current preferences
-        current_dict = current.to_dict()
-        current_dict.update(update_fields)
-        updated = UserPreferences.from_dict(current_dict)
-
-        await loop.run_in_executor(None, save_preferences, config_dir, updated)
-        return updated
+        return await loop.run_in_executor(None, update_preferences, config_dir, update_fields)
 
     @api_command("config/get_secrets")
     async def get_secrets(self, **kwargs: Any) -> list[str]:

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -165,11 +165,8 @@ class OnboardingController:
         config_dir = self._db.settings.config_dir
 
         def _bump(prefs: UserPreferences) -> None:
-            # Monotonic via max(): never downgrade a stored higher
-            # version. A user who briefly ran a future build (with
-            # `ONBOARDING_VERSION = 2`) and then rolled back to this
-            # build (`= 1`) shouldn't lose the v2 acknowledgement and
-            # get re-prompted on the next upgrade.
+            # max(), not assign: a rollback from a future build must
+            # not downgrade a higher stored acknowledgement.
             prefs.onboarding_completed_version = max(
                 prefs.onboarding_completed_version, ONBOARDING_VERSION
             )

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -37,7 +37,7 @@ from ..models import (
     UserPreferences,
 )
 from ..models.onboarding import ONBOARDING_VERSION
-from .config import load_preferences, preferences_transaction
+from .config import load_preferences, mutate_preferences
 
 if TYPE_CHECKING:
     from esphome_device_builder.device_builder import DeviceBuilder
@@ -164,21 +164,19 @@ class OnboardingController:
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
 
-        def _bump() -> None:
-            # Read-decide-write under one lock so a concurrent
-            # ``set_preferences`` writing the same blob can't clobber
-            # this acknowledgement (or be clobbered by it).
-            with preferences_transaction(config_dir) as prefs:
-                # Monotonic via max(): never downgrade a stored higher
-                # version. A user who briefly ran a future build (with
-                # `ONBOARDING_VERSION = 2`) and then rolled back to this
-                # build (`= 1`) shouldn't lose the v2 acknowledgement and
-                # get re-prompted on the next upgrade.
-                prefs.onboarding_completed_version = max(
-                    prefs.onboarding_completed_version, ONBOARDING_VERSION
-                )
+        def _bump(prefs: UserPreferences) -> None:
+            # Monotonic via max(): never downgrade a stored higher
+            # version. A user who briefly ran a future build (with
+            # `ONBOARDING_VERSION = 2`) and then rolled back to this
+            # build (`= 1`) shouldn't lose the v2 acknowledgement and
+            # get re-prompted on the next upgrade. mutate_preferences
+            # runs this under one lock so a concurrent set_preferences
+            # write can't clobber the bump (or be clobbered by it).
+            prefs.onboarding_completed_version = max(
+                prefs.onboarding_completed_version, ONBOARDING_VERSION
+            )
 
-        await loop.run_in_executor(None, _bump)
+        await loop.run_in_executor(None, mutate_preferences, config_dir, _bump)
         return await self.get_state()
 
 

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -169,9 +169,7 @@ class OnboardingController:
             # version. A user who briefly ran a future build (with
             # `ONBOARDING_VERSION = 2`) and then rolled back to this
             # build (`= 1`) shouldn't lose the v2 acknowledgement and
-            # get re-prompted on the next upgrade. mutate_preferences
-            # runs this under one lock so a concurrent set_preferences
-            # write can't clobber the bump (or be clobbered by it).
+            # get re-prompted on the next upgrade.
             prefs.onboarding_completed_version = max(
                 prefs.onboarding_completed_version, ONBOARDING_VERSION
             )

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -37,7 +37,7 @@ from ..models import (
     UserPreferences,
 )
 from ..models.onboarding import ONBOARDING_VERSION
-from .config import load_preferences, save_preferences
+from .config import load_preferences, preferences_transaction
 
 if TYPE_CHECKING:
     from esphome_device_builder.device_builder import DeviceBuilder
@@ -164,17 +164,21 @@ class OnboardingController:
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
 
-        current = await loop.run_in_executor(None, load_preferences, config_dir)
-        # Monotonic update only — never downgrade a stored higher
-        # version. A user who briefly ran a future build (with
-        # `ONBOARDING_VERSION = 2`) and then rolled back to this
-        # build (`= 1`) shouldn't lose the v2 acknowledgement and
-        # get re-prompted on the next upgrade. ``<`` not ``!=``.
-        if current.onboarding_completed_version < ONBOARDING_VERSION:
-            current_dict = current.to_dict()
-            current_dict["onboarding_completed_version"] = ONBOARDING_VERSION
-            updated = UserPreferences.from_dict(current_dict)
-            await loop.run_in_executor(None, save_preferences, config_dir, updated)
+        def _bump() -> None:
+            # Read-decide-write under one lock so a concurrent
+            # ``set_preferences`` writing the same blob can't clobber
+            # this acknowledgement (or be clobbered by it).
+            with preferences_transaction(config_dir) as prefs:
+                # Monotonic via max(): never downgrade a stored higher
+                # version. A user who briefly ran a future build (with
+                # `ONBOARDING_VERSION = 2`) and then rolled back to this
+                # build (`= 1`) shouldn't lose the v2 acknowledgement and
+                # get re-prompted on the next upgrade.
+                prefs.onboarding_completed_version = max(
+                    prefs.onboarding_completed_version, ONBOARDING_VERSION
+                )
+
+        await loop.run_in_executor(None, _bump)
         return await self.get_state()
 
 

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -72,6 +72,7 @@ from esphome_device_builder.controllers.config import (
     save_remote_build_settings,
     set_device_labels,
     set_device_metadata,
+    update_preferences,
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import (
@@ -792,6 +793,39 @@ async def test_set_prefs_merges_partial_update(tmp_path: Path) -> None:
     # Persisted blob matches the merged state.
     persisted = await asyncio.to_thread(load_preferences, tmp_path)
     assert persisted == result
+
+
+def test_update_preferences_defaults_on_corrupt(tmp_path: Path) -> None:
+    """A malformed ``_preferences`` blob merges onto defaults, then persists clean."""
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(b'{"_preferences": [1, 2, 3]}')
+
+    updated = update_preferences(tmp_path, {"theme": Theme.DARK})
+
+    assert updated == UserPreferences(theme=Theme.DARK)
+    assert load_preferences(tmp_path) == UserPreferences(theme=Theme.DARK)
+
+
+@pytest.mark.asyncio
+async def test_set_prefs_concurrent_updates_do_not_lose_writes(tmp_path: Path) -> None:
+    """Concurrent partial updates of distinct fields all survive.
+
+    The read-merge-save runs inside one ``metadata_transaction``,
+    so two writers can't both read the same baseline and clobber
+    each other's field. A non-atomic load-then-save loses one.
+    """
+    controller = _make_controller(tmp_path)
+
+    await asyncio.gather(
+        controller.set_prefs(theme=Theme.DARK),
+        controller.set_prefs(dashboard_view=DashboardView.TABLE),
+        controller.set_prefs(navigator_visible=False),
+    )
+
+    persisted = await asyncio.to_thread(load_preferences, tmp_path)
+    assert persisted.theme == Theme.DARK
+    assert persisted.dashboard_view == DashboardView.TABLE
+    assert persisted.navigator_visible is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_controller.py
+++ b/tests/test_onboarding_controller.py
@@ -15,7 +15,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.config import save_preferences
+from esphome_device_builder.controllers.config import (
+    load_preferences,
+    save_preferences,
+    update_preferences,
+)
 from esphome_device_builder.controllers.onboarding import (
     OnboardingController,
     _replace_or_append_secret,
@@ -30,7 +34,7 @@ from esphome_device_builder.models.onboarding import (
     OnboardingStepId,
     OnboardingStepStatus,
 )
-from esphome_device_builder.models.preferences import UserPreferences
+from esphome_device_builder.models.preferences import Theme, UserPreferences
 
 
 def _make_controller(config_dir: Path) -> OnboardingController:
@@ -243,6 +247,28 @@ async def test_mark_acknowledged_is_idempotent(tmp_path: Path) -> None:
     await controller.mark_acknowledged()
     state = await controller.mark_acknowledged()
     assert state.completed_version == ONBOARDING_VERSION
+
+
+@pytest.mark.asyncio
+async def test_mark_acknowledged_does_not_clobber_a_concurrent_pref_write(
+    tmp_path: Path,
+) -> None:
+    """Concurrent acknowledgement and a ``set_preferences`` write keep both fields.
+
+    Both share the ``_preferences`` blob and go through
+    ``metadata_transaction``, so neither can read a stale baseline
+    and overwrite the other's field.
+    """
+    controller = _make_controller(tmp_path)
+
+    await asyncio.gather(
+        controller.mark_acknowledged(),
+        asyncio.to_thread(update_preferences, tmp_path, {"theme": Theme.DARK}),
+    )
+
+    persisted = await asyncio.to_thread(load_preferences, tmp_path)
+    assert persisted.onboarding_completed_version == ONBOARDING_VERSION
+    assert persisted.theme == Theme.DARK
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# What does this implement/fix?

Make user-preference writes atomic so concurrent partial updates can't lose each other's fields.

Two endpoints write the shared `_preferences` blob in `.device-builder.json`, both with a load-then-save pair where the read sat outside the write lock:

- `config/set_preferences` read prefs in one executor hop and saved in a second; two concurrent partial updates (multiple tabs, rapid toggles) both read the same baseline, then the later save overwrote the earlier writer's field.
- `onboarding/mark_acknowledged` did the same load-then-save on the same blob, so an acknowledgement racing a `set_preferences` write could clobber it, or be clobbered.

Both now go through one `metadata_transaction` lock, matching the rest of the module (`remote_build_settings_transaction`, `labels_transaction`). A single `mutate_preferences(config_dir, mutate)` primitive owns the load, merge, and save; the callback either returns the next state or mutates in place. `update_preferences` is a thin validated-dict wrapper over it for `set_prefs`, and `mark_acknowledged` passes a callback for its monotonic version bump so the read-decide happens inside the lock. `load_preferences` shares the same defaults-on-corrupt decoder.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
