### PR TITLE
Reuse resolved config in the scan platform-detection fallback

### DIFF
--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -99,10 +99,6 @@ if TYPE_CHECKING:
 
 _PLATFORM_KEYS = frozenset({"esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "ln882x", "nrf52"})
 
-# Distinguishes "caller passed no resolved_config" from a legitimate
-# None (parse failure), so the detector only loads when not pre-fed.
-_UNSET: Any = object()
-
 # Wi-Fi-first families for the fallback dispatcher's allowlist —
 # mirrors upstream's ``_WIFI_FIRST_PLATFORMS`` so the wizard's
 # behaviour stays identical whether the upstream helper is
@@ -505,39 +501,16 @@ def parse_platform_from_yaml(yaml_content: str) -> tuple[str, str, str]:
     return platform, pio_board, variant
 
 
-def detect_platform_from_yaml(
-    path: Path,
-    *,
-    yaml_content: str | None = None,
-    resolved_config: Any = _UNSET,
-) -> str:
+def detect_platform_from_yaml(yaml_content: str, resolved_config: dict | None) -> str:
     """
-    Find a YAML file's platform key.
+    Find a config's platform key from its raw text and merged config.
 
-    First tries the cheap line-scan against the raw file (no parser
-    involved, survives mid-edit drafts). Falls back to the
-    package-merged load ONLY when the raw scan misses AND the file
-    actually contains a ``packages:`` block — configs that place
-    ``esp32:`` / ``esp8266:`` / etc. inside a package only register
-    that key after merge runs. Without the gate every YAML that
-    happens to omit a top-level platform key (mid-edit drafts,
-    package-less configs that get their platform from
-    ``StorageJSON``) would pay a full parser load on every
-    dashboard scan, even though there's nothing in the file the
-    merge could surface. The cheap-regex-only fast path stays the
-    winner for the typical no-packages config.
-
-    Hot-path callers may pass the already-read *yaml_content* and
-    merged *resolved_config* to skip a second ``read_text`` +
-    ``load_device_yaml`` (which can re-clone remote packages).
-
-    Returns the empty string when neither path turns up a platform.
+    Cheap line-scan of *yaml_content* first (survives mid-edit
+    drafts); falls back to *resolved_config* only on a raw-scan
+    miss when the text has a ``packages:`` block, since a packaged
+    ``esp32:`` key only appears post-merge. Empty string when
+    neither turns one up.
     """
-    if yaml_content is None:
-        try:
-            yaml_content = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            return ""
     try:
         platform, _, _ = parse_platform_from_yaml(yaml_content)
     except Exception:  # noqa: BLE001 — future-proof against parse_platform_from_yaml gaining a throw shape
@@ -546,12 +519,10 @@ def detect_platform_from_yaml(
         return platform
     if not yaml_has_top_level_block(yaml_content, CONF_PACKAGES):
         # No ``packages:`` block in the raw text → the merge can't
-        # surface a platform key that wasn't already there. Skip
-        # the load to keep the scan cheap.
+        # surface a platform key that wasn't already there.
         return ""
-    config = resolved_config if resolved_config is not _UNSET else load_device_yaml(path)
-    if isinstance(config, dict):
-        for key in config:
+    if isinstance(resolved_config, dict):
+        for key in resolved_config:
             # ``key`` is ``Any`` (dict came from ``yaml_util.load_yaml``
             # which is untyped); the runtime contract is "platform keys
             # are always strings", so narrow with ``isinstance`` before
@@ -924,7 +895,7 @@ def load_device_from_storage(
     #    ``StorageJSON`` doesn't carry the attribute at all —
     #    pyproject's floor is ``esphome>=2024.1.0`` so the
     #    pre-#9028 path is reachable.
-    # 2. ``detect_platform_from_yaml(path)`` — the YAML's top-level
+    # 2. ``detect_platform_from_yaml`` — the YAML's top-level
     #    platform key, also lowercase. Picks up never-compiled
     #    devices and pre-2025.6 ``StorageJSON`` files that don't
     #    carry ``core_platform`` yet.
@@ -944,9 +915,7 @@ def load_device_from_storage(
         if core_platform:
             target_platform = core_platform.lower()
     if not target_platform:
-        target_platform = detect_platform_from_yaml(
-            path, yaml_content=yaml_content, resolved_config=resolved_config
-        )
+        target_platform = detect_platform_from_yaml(yaml_content, resolved_config)
 
     loaded_integrations = sorted(storage.loaded_integrations) if storage else []
     # Subset of loaded_integrations the user directly wrote — top-

--- a/esphome_device_builder/helpers/device_yaml.py
+++ b/esphome_device_builder/helpers/device_yaml.py
@@ -99,6 +99,10 @@ if TYPE_CHECKING:
 
 _PLATFORM_KEYS = frozenset({"esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "ln882x", "nrf52"})
 
+# Distinguishes "caller passed no resolved_config" from a legitimate
+# None (parse failure), so the detector only loads when not pre-fed.
+_UNSET: Any = object()
+
 # Wi-Fi-first families for the fallback dispatcher's allowlist —
 # mirrors upstream's ``_WIFI_FIRST_PLATFORMS`` so the wizard's
 # behaviour stays identical whether the upstream helper is
@@ -501,7 +505,12 @@ def parse_platform_from_yaml(yaml_content: str) -> tuple[str, str, str]:
     return platform, pio_board, variant
 
 
-def detect_platform_from_yaml(path: Path) -> str:
+def detect_platform_from_yaml(
+    path: Path,
+    *,
+    yaml_content: str | None = None,
+    resolved_config: Any = _UNSET,
+) -> str:
     """
     Find a YAML file's platform key.
 
@@ -518,24 +527,29 @@ def detect_platform_from_yaml(path: Path) -> str:
     merge could surface. The cheap-regex-only fast path stays the
     winner for the typical no-packages config.
 
+    Hot-path callers may pass the already-read *yaml_content* and
+    merged *resolved_config* to skip a second ``read_text`` +
+    ``load_device_yaml`` (which can re-clone remote packages).
+
     Returns the empty string when neither path turns up a platform.
     """
+    if yaml_content is None:
+        try:
+            yaml_content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return ""
     try:
-        raw = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return ""
-    try:
-        platform, _, _ = parse_platform_from_yaml(raw)
+        platform, _, _ = parse_platform_from_yaml(yaml_content)
     except Exception:  # noqa: BLE001 — future-proof against parse_platform_from_yaml gaining a throw shape
         platform = ""
     if platform:
         return platform
-    if not yaml_has_top_level_block(raw, CONF_PACKAGES):
+    if not yaml_has_top_level_block(yaml_content, CONF_PACKAGES):
         # No ``packages:`` block in the raw text → the merge can't
         # surface a platform key that wasn't already there. Skip
         # the load to keep the scan cheap.
         return ""
-    config = load_device_yaml(path)
+    config = resolved_config if resolved_config is not _UNSET else load_device_yaml(path)
     if isinstance(config, dict):
         for key in config:
             # ``key`` is ``Any`` (dict came from ``yaml_util.load_yaml``
@@ -930,7 +944,9 @@ def load_device_from_storage(
         if core_platform:
             target_platform = core_platform.lower()
     if not target_platform:
-        target_platform = detect_platform_from_yaml(path)
+        target_platform = detect_platform_from_yaml(
+            path, yaml_content=yaml_content, resolved_config=resolved_config
+        )
 
     loaded_integrations = sorted(storage.loaded_integrations) if storage else []
     # Subset of loaded_integrations the user directly wrote — top-

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -150,105 +150,42 @@ def test_load_device_yaml_merges_packages(tmp_path: Path) -> None:
     assert get_api_encryption_key(config) == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 
-def test_detect_platform_from_yaml_falls_back_to_resolved_config(
-    tmp_path: Path,
-) -> None:
-    """Platform detection falls through to the resolved config on raw-scan miss.
-
-    The fast path (raw-text scan) survives mid-edit drafts but
-    can't see ``esp32:`` blocks pulled in via ``packages:``. The
-    slow path (full ``load_device_yaml`` with package merge) is
-    only invoked when the raw scan returned empty, so the typical
-    no-packages config still pays only the cheap regex.
-    """
-    (tmp_path / "board.yaml").write_text(
-        "esp32:\n  board: esp32dev\n  framework:\n    type: esp-idf\n"
-    )
-    yaml_file = tmp_path / "ble.yaml"
-    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n")
-    # Raw scan: no top-level ``esp32:`` line, so it returns "".
-    # Fallback: load + package-merge → ``esp32`` becomes top-level.
-    assert detect_platform_from_yaml(yaml_file) == "esp32"
+def test_detect_platform_from_yaml_falls_back_to_resolved_config() -> None:
+    """Raw-scan miss on a ``packages:`` config falls through to the merged config."""
+    yaml_content = "esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n"
+    resolved = {"esphome": {"name": "ble"}, "esp32": {"board": "esp32dev"}}
+    assert detect_platform_from_yaml(yaml_content, resolved) == "esp32"
 
 
-def test_detect_platform_from_yaml_keeps_raw_scan_for_inline_platform(
-    tmp_path: Path,
-) -> None:
-    """Top-level inline platform key resolves via the raw-scan fast path.
-
-    Pinning this avoids regressing the fast path: a future
-    refactor that always loaded the resolved config would parse
-    every YAML on every dashboard scan, which is what the cheap
-    regex was put in place to avoid.
-    """
-    yaml_file = tmp_path / "kitchen.yaml"
-    yaml_file.write_text("esphome:\n  name: kitchen\nesp8266:\n  board: nodemcuv2\n")
-    assert detect_platform_from_yaml(yaml_file) == "esp8266"
+def test_detect_platform_from_yaml_keeps_raw_scan_for_inline_platform() -> None:
+    """A top-level inline platform key resolves via the raw-scan fast path."""
+    yaml_content = "esphome:\n  name: kitchen\nesp8266:\n  board: nodemcuv2\n"
+    assert detect_platform_from_yaml(yaml_content, None) == "esp8266"
 
 
-def test_detect_platform_from_yaml_skips_load_when_no_packages_block(
-    tmp_path: Path,
-) -> None:
-    """Config without ``packages:`` doesn't pay the load+merge cost.
-
-    Mid-edit drafts and post-compile-only configs frequently omit
-    a top-level platform key (the user gets it from
-    ``StorageJSON``). Without the ``packages:`` gate, every such
-    YAML would trigger a full ESPHome YAML parse on every
-    dashboard scan — pure waste because the merge has nothing to
-    surface. Spy on ``load_device_yaml`` to confirm we don't call
-    it when the raw text has no ``packages:`` block.
-    """
-    yaml_file = tmp_path / "kitchen.yaml"
-    yaml_file.write_text("esphome:\n  name: kitchen\n# platform comes from storage\n")
-    with mock.patch(
-        "esphome_device_builder.helpers.device_yaml.load_device_yaml",
-        wraps=device_yaml.load_device_yaml,
-    ) as spy:
-        assert detect_platform_from_yaml(yaml_file) == ""
-    spy.assert_not_called()
+def test_detect_platform_from_yaml_ignores_resolved_config_without_packages_block() -> None:
+    """No ``packages:`` block returns '' without consulting the merged config."""
+    yaml_content = "esphome:\n  name: kitchen\n# platform comes from storage\n"
+    assert detect_platform_from_yaml(yaml_content, {"esp32": {}}) == ""
 
 
 def test_detect_platform_from_yaml_swallows_parser_exceptions(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Mid-edit drafts can't crash the platform detector.
-
-    ``parse_platform_from_yaml`` is regex-based and fairly
-    forgiving, but a future tightening that started raising on
-    weird input shouldn't blank the dashboard's platform flag.
-    Stub the parser to raise and confirm the caller catches and
-    falls through to the empty-string return rather than
-    propagating.
-    """
-    yaml_file = tmp_path / "broken.yaml"
-    yaml_file.write_text("esphome:\n  name: x\n")
+    """A raising ``parse_platform_from_yaml`` falls through to '' rather than propagating."""
     monkeypatch.setattr(
         device_yaml,
         "parse_platform_from_yaml",
         mock.MagicMock(side_effect=ValueError("simulated parser failure")),
     )
-    assert detect_platform_from_yaml(yaml_file) == ""
+    assert detect_platform_from_yaml("esphome:\n  name: x\n", None) == ""
 
 
-def test_detect_platform_from_yaml_returns_empty_when_resolved_config_has_no_platform(
-    tmp_path: Path,
-) -> None:
-    """``packages:`` present but the merged config has no platform key.
-
-    Pins the final ``return ""`` after the resolved-config walk —
-    the load fired (raw scan missed AND ``packages:`` was in the
-    raw text), the merge succeeded, but no platform key landed at
-    the top level. Realistic shape: a `packages:` reference that
-    contributes only api / wifi / sensor blocks, with the
-    platform expected to come from ``StorageJSON`` post-compile.
-    """
-    (tmp_path / "common.yaml").write_text(
-        "wifi:\n  ssid: x\n  password: y\n"  # no platform key here
-    )
-    yaml_file = tmp_path / "ble.yaml"
-    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  common: !include common.yaml\n")
-    assert detect_platform_from_yaml(yaml_file) == ""
+def test_detect_platform_from_yaml_returns_empty_when_resolved_config_has_no_platform() -> None:
+    """``packages:`` present but the merged config carries no platform key → ''."""
+    yaml_content = "esphome:\n  name: ble\npackages:\n  common: !include common.yaml\n"
+    resolved = {"esphome": {"name": "ble"}, "wifi": {"ssid": "x"}}
+    assert detect_platform_from_yaml(yaml_content, resolved) == ""
 
 
 def test_load_device_yaml_uses_two_step_when_resolve_packages_missing(

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -21,7 +21,6 @@ from esphome_device_builder.helpers.device_yaml import (
     _select_wifi_helper,
     compute_has_pending_changes,
     configuration_stem,
-    detect_platform_from_yaml,
     generate_device_yaml,
     generate_minimal_stub_yaml,
     load_device_from_storage,
@@ -774,50 +773,8 @@ esp8266:
 
 
 # ----------------------------------------------------------------------
-# detect_platform_from_yaml — file I/O wrapper
+# detect_platform_from_yaml — scan platform-detection
 # ----------------------------------------------------------------------
-
-
-def test_detect_platform_returns_empty_on_missing_file(tmp_path: Path) -> None:
-    """Unreadable file (``OSError``) falls into the ``except`` branch.
-
-    Pin the silent-fallback contract — callers (the device-loader
-    address fallback) rely on the empty-string sentinel rather
-    than having to wrap every call in their own try/except.
-    """
-    missing = tmp_path / "no-such-file.yaml"
-    assert detect_platform_from_yaml(missing) == ""
-
-
-def test_detect_platform_reads_real_file(tmp_path: Path) -> None:
-    """Round-trip through the file reader picks up the platform key."""
-    path = tmp_path / "device.yaml"
-    path.write_text("esp32:\n  variant: ESP32S3\n", encoding="utf-8")
-    assert detect_platform_from_yaml(path) == "esp32"
-
-
-def test_detect_platform_uses_prefed_yaml_content_without_reading(tmp_path: Path) -> None:
-    """Pre-fed ``yaml_content`` detects without touching disk (file doesn't exist)."""
-    missing = tmp_path / "no-such-file.yaml"
-    assert (
-        detect_platform_from_yaml(missing, yaml_content="esp8266:\n  board: nodemcuv2\n")
-        == "esp8266"
-    )
-
-
-def test_detect_platform_uses_prefed_resolved_config_skips_reparse(tmp_path: Path) -> None:
-    """Pre-fed ``resolved_config`` for a packages config never re-loads the YAML."""
-    yaml_content = "esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n"
-    resolved = {"esphome": {"name": "ble"}, "esp32": {"board": "esp32dev"}}
-    with mock.patch(
-        "esphome_device_builder.helpers.device_yaml.load_device_yaml",
-        wraps=device_yaml.load_device_yaml,
-    ) as spy:
-        result = detect_platform_from_yaml(
-            tmp_path / "ble.yaml", yaml_content=yaml_content, resolved_config=resolved
-        )
-    assert result == "esp32"
-    spy.assert_not_called()
 
 
 def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Path) -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -10,6 +10,7 @@ import logging
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, ClassVar
+from unittest import mock
 
 import pytest
 
@@ -793,6 +794,47 @@ def test_detect_platform_reads_real_file(tmp_path: Path) -> None:
     path = tmp_path / "device.yaml"
     path.write_text("esp32:\n  variant: ESP32S3\n", encoding="utf-8")
     assert detect_platform_from_yaml(path) == "esp32"
+
+
+def test_detect_platform_uses_prefed_yaml_content_without_reading(tmp_path: Path) -> None:
+    """Pre-fed ``yaml_content`` detects without touching disk (file doesn't exist)."""
+    missing = tmp_path / "no-such-file.yaml"
+    assert (
+        detect_platform_from_yaml(missing, yaml_content="esp8266:\n  board: nodemcuv2\n")
+        == "esp8266"
+    )
+
+
+def test_detect_platform_uses_prefed_resolved_config_skips_reparse(tmp_path: Path) -> None:
+    """Pre-fed ``resolved_config`` for a packages config never re-loads the YAML."""
+    yaml_content = "esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n"
+    resolved = {"esphome": {"name": "ble"}, "esp32": {"board": "esp32dev"}}
+    with mock.patch(
+        "esphome_device_builder.helpers.device_yaml.load_device_yaml",
+        wraps=device_yaml.load_device_yaml,
+    ) as spy:
+        result = detect_platform_from_yaml(
+            tmp_path / "ble.yaml", yaml_content=yaml_content, resolved_config=resolved
+        )
+    assert result == "esp32"
+    spy.assert_not_called()
+
+
+def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Path) -> None:
+    """The scan path reuses the merged config: ``load_device_yaml`` runs once, not twice."""
+    (tmp_path / "board.yaml").write_text("esp32:\n  board: esp32dev\n", encoding="utf-8")
+    yaml_file = tmp_path / "ble.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: ble\npackages:\n  board: !include board.yaml\n",
+        encoding="utf-8",
+    )
+    with mock.patch(
+        "esphome_device_builder.helpers.device_yaml.load_device_yaml",
+        wraps=device_yaml.load_device_yaml,
+    ) as spy:
+        device = load_device_from_storage(yaml_file)
+    assert device.target_platform == "esp32"
+    assert spy.call_count == 1
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

On the dashboard scan path, resolve each device's merged config once instead of twice.

`load_device_from_storage` already reads the YAML text and computes the full merged `resolved_config = load_device_yaml(path)`. When `storage.core_platform` is absent (the common case: never-compiled devices and pre-2025.6 ESPHome) it falls back to `detect_platform_from_yaml(path)` to find the top-level platform key. That fallback re-read the same file and, for any config with a `packages:` block, called `load_device_yaml` a second time. `load_device_yaml` can synchronously `git clone` remote packages, so the duplicate parse re-triggered network work once per packages device on every scan.

`detect_platform_from_yaml` now takes the raw text and merged config as required arguments and returns the platform key; the one caller passes what it already has. It no longer reads the file or loads the config itself, since there are no external users that needed the lazy path. The raw-text fast path and the `packages:` gate are unchanged, so behaviour is identical; the second read and merge are simply gone.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
