### PR TITLE
Register follow_job stream so stop_stream can cancel it

### DIFF
--- a/esphome_device_builder/controllers/firmware/follow.py
+++ b/esphome_device_builder/controllers/firmware/follow.py
@@ -44,64 +44,17 @@ async def follow_job(
         msg = f"Job not found: {job_id}"
         raise ValueError(msg)
 
-    # Capture snapshot before ``stream_events`` attaches listeners.
-    is_terminal = job.status in TERMINAL_JOB_STATUSES
-    snapshot = await _initial_snapshot(job, job_id)
-    terminal_status = job.status.value if is_terminal else ""
-    terminal_exit_code = job.exit_code
-    terminal_error = job.error if is_terminal else None
-
-    async def _send_initial(controls: StreamControls) -> None:
-        for line in snapshot:
-            await client.send_event(message_id, StreamEvent.OUTPUT, line)
-        if is_terminal:
-            await client.send_event(
-                message_id,
-                StreamEvent.RESULT,
-                {
-                    "status": terminal_status,
-                    "exit_code": terminal_exit_code,
-                    # ``error`` carries the human-readable failure
-                    # reason the frontend install dialog renders in
-                    # its red banner. Without it the banner falls
-                    # back to a generic "Install failed." that
-                    # misattributes a receiver-restart to a broken
-                    # build env. ``None`` for successful jobs.
-                    "error": terminal_error,
-                },
-            )
-            # End the stream so the helper returns instead of
-            # parking on ``queue.get`` — already-terminal job has
-            # nothing more to deliver.
-            controls.end()
-
-    def _handle_event(event: Event, controls: StreamControls) -> None:
-        if event.event_type == EventType.JOB_OUTPUT:
-            if event.data.get("job_id") == job_id:
-                controls.push(StreamEvent.OUTPUT, event.data["line"])
-        elif event.event_type in TERMINAL_JOB_EVENTS:
-            ev_job = event.data.get("job")
-            if ev_job and getattr(ev_job, "job_id", None) == job_id:
-                status = getattr(ev_job, "status", "unknown")
-                status_val = status.value if hasattr(status, "value") else str(status)
-                controls.push_priority(
-                    StreamEvent.RESULT,
-                    {
-                        "status": status_val,
-                        "exit_code": getattr(ev_job, "exit_code", None),
-                        "error": getattr(ev_job, "error", None),
-                    },
-                )
-                controls.end()
-
-    await stream_events(
-        client=client,
-        message_id=message_id,
-        bus=controller._db.bus,
-        event_types=(EventType.JOB_OUTPUT, *TERMINAL_JOB_EVENTS),
-        handle_event=_handle_event,
-        send_initial=_send_initial,
-    )
+    # Register before the first await so a ``devices/stop_stream`` for
+    # this id (the frontend fires it when the log dialog closes or
+    # switches jobs) actually cancels the follow instead of leaving a
+    # live job's tail streaming until it completes or the WS drops.
+    task = asyncio.current_task()
+    assert task is not None
+    client.register_stream(message_id, task)
+    try:
+        await _stream_job(controller, job, job_id=job_id, client=client, message_id=message_id)
+    finally:
+        client.unregister_stream(message_id)
 
 
 async def follow_jobs(
@@ -179,6 +132,75 @@ async def follow_jobs(
             EventType.JOB_OUTPUT,
             EventType.JOB_PROGRESS,
         ),
+        handle_event=_handle_event,
+        send_initial=_send_initial,
+    )
+
+
+async def _stream_job(
+    controller: FirmwareController,
+    job: Any,
+    *,
+    job_id: str,
+    client: Any,
+    message_id: str,
+) -> None:
+    """Replay history then tail live output for one job until it ends or is cancelled."""
+    # Capture snapshot before ``stream_events`` attaches listeners.
+    is_terminal = job.status in TERMINAL_JOB_STATUSES
+    snapshot = await _initial_snapshot(job, job_id)
+    terminal_status = job.status.value if is_terminal else ""
+    terminal_exit_code = job.exit_code
+    terminal_error = job.error if is_terminal else None
+
+    async def _send_initial(controls: StreamControls) -> None:
+        for line in snapshot:
+            await client.send_event(message_id, StreamEvent.OUTPUT, line)
+        if is_terminal:
+            await client.send_event(
+                message_id,
+                StreamEvent.RESULT,
+                {
+                    "status": terminal_status,
+                    "exit_code": terminal_exit_code,
+                    # ``error`` carries the human-readable failure
+                    # reason the frontend install dialog renders in
+                    # its red banner. Without it the banner falls
+                    # back to a generic "Install failed." that
+                    # misattributes a receiver-restart to a broken
+                    # build env. ``None`` for successful jobs.
+                    "error": terminal_error,
+                },
+            )
+            # End the stream so the helper returns instead of
+            # parking on ``queue.get`` — already-terminal job has
+            # nothing more to deliver.
+            controls.end()
+
+    def _handle_event(event: Event, controls: StreamControls) -> None:
+        if event.event_type == EventType.JOB_OUTPUT:
+            if event.data.get("job_id") == job_id:
+                controls.push(StreamEvent.OUTPUT, event.data["line"])
+        elif event.event_type in TERMINAL_JOB_EVENTS:
+            ev_job = event.data.get("job")
+            if ev_job and getattr(ev_job, "job_id", None) == job_id:
+                status = getattr(ev_job, "status", "unknown")
+                status_val = status.value if hasattr(status, "value") else str(status)
+                controls.push_priority(
+                    StreamEvent.RESULT,
+                    {
+                        "status": status_val,
+                        "exit_code": getattr(ev_job, "exit_code", None),
+                        "error": getattr(ev_job, "error", None),
+                    },
+                )
+                controls.end()
+
+    await stream_events(
+        client=client,
+        message_id=message_id,
+        bus=controller._db.bus,
+        event_types=(EventType.JOB_OUTPUT, *TERMINAL_JOB_EVENTS),
         handle_event=_handle_event,
         send_initial=_send_initial,
     )

--- a/esphome_device_builder/controllers/firmware/follow.py
+++ b/esphome_device_builder/controllers/firmware/follow.py
@@ -6,6 +6,7 @@ import asyncio
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
+from ...helpers.api import registered_stream
 from ...helpers.event_bus import StreamControls, stream_events
 from ...models import (
     TERMINAL_JOB_EVENTS,
@@ -48,13 +49,8 @@ async def follow_job(
     # this id (the frontend fires it when the log dialog closes or
     # switches jobs) actually cancels the follow instead of leaving a
     # live job's tail streaming until it completes or the WS drops.
-    task = asyncio.current_task()
-    assert task is not None
-    client.register_stream(message_id, task)
-    try:
+    with registered_stream(client, message_id):
         await _stream_job(controller, job, job_id=job_id, client=client, message_id=message_id)
-    finally:
-        client.unregister_stream(message_id)
 
 
 async def follow_jobs(

--- a/esphome_device_builder/helpers/api.py
+++ b/esphome_device_builder/helpers/api.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Coroutine
+import asyncio
+from collections.abc import Callable, Coroutine, Iterator
+from contextlib import contextmanager
 from typing import Any, TypeVar
 
 from ..models import ErrorCode
@@ -30,6 +32,24 @@ class CommandError(Exception):
         super().__init__(message)
         self.code = code
         self.message = message
+
+
+@contextmanager
+def registered_stream(client: Any, message_id: str) -> Iterator[None]:
+    """
+    Register the running task as a cancellable stream for the block's lifetime.
+
+    Captures ``asyncio.current_task()`` so a ``devices/stop_stream`` for
+    ``message_id`` can cancel it, and unregisters on exit. Enter before the
+    first ``await`` so an early stop_stream still finds the task.
+    """
+    task = asyncio.current_task()
+    assert task is not None
+    client.register_stream(message_id, task)
+    try:
+        yield
+    finally:
+        client.unregister_stream(message_id)
 
 
 def api_command(command: str) -> Callable[[_F], _F]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -521,6 +521,20 @@ class FakeWebSocketClient:
         self.events: list[tuple[str, str, Any]] = []
         self.results: list[tuple[str, Any]] = []
         self._yield_per_event = yield_per_event
+        self._stream_tasks: dict[str, asyncio.Task] = {}
+
+    def register_stream(self, message_id: str, task: asyncio.Task) -> None:
+        self._stream_tasks[message_id] = task
+
+    def unregister_stream(self, message_id: str) -> None:
+        self._stream_tasks.pop(message_id, None)
+
+    def cancel_stream(self, message_id: str) -> bool:
+        task = self._stream_tasks.pop(message_id, None)
+        if task is None or task.done():
+            return False
+        task.cancel()
+        return True
 
     async def send_event(self, message_id: str, event: str, data: Any) -> None:
         if self._yield_per_event:

--- a/tests/controllers/firmware/test_follow_job_cancel.py
+++ b/tests/controllers/firmware/test_follow_job_cancel.py
@@ -1,0 +1,84 @@
+"""``firmware.follow_job`` registers its task so ``devices/stop_stream`` cancels it.
+
+The frontend fires ``devices/stop_stream`` with the follow's
+message_id when the log dialog closes or switches jobs. That command
+calls ``client.cancel_stream(message_id)``, which only finds tasks a
+handler registered via ``register_stream``. Without registration a
+live job's tail kept streaming server-side until the job finished or
+the WS dropped, and orphaned follows piled up across job switches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
+
+from ...conftest import FakeWebSocketClient
+from .conftest import FirmwareControllerFactory, make_follow_race_controller
+
+
+async def test_live_follow_registers_and_stop_stream_cancels(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A live follow is registered, cancellable by id, and detaches on cancel."""
+    job = FirmwareJob(
+        job_id="abc",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.RUNNING,
+        output=["history\n"],
+    )
+    controller = make_follow_race_controller(firmware_controller_factory, job)
+    bus = controller._db.bus
+    client = FakeWebSocketClient()
+
+    follow_task = asyncio.create_task(
+        controller.follow_job(job_id="abc", client=client, message_id="m1")
+    )
+    # Let follow_job run through registration + snapshot and park on
+    # the drain loop with its listener attached.
+    for _ in range(50):
+        await asyncio.sleep(0)
+        if "m1" in client._stream_tasks:
+            break
+
+    assert "m1" in client._stream_tasks
+    assert len(bus._listeners.get(EventType.JOB_OUTPUT, set())) == 1
+
+    # This is exactly what ``devices/stop_stream`` invokes.
+    assert client.cancel_stream("m1") is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await follow_task
+
+    # Drain pending callbacks so the handler's ``finally`` (unregister)
+    # and ``stream_events``'s listener teardown both run.
+    for _ in range(20):
+        await asyncio.sleep(0)
+
+    assert "m1" not in client._stream_tasks
+    assert bus._listeners.get(EventType.JOB_OUTPUT, set()) == set()
+
+
+async def test_terminal_follow_unregisters_without_leak(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A terminal job replays + ends and leaves no registry entry behind."""
+    job = FirmwareJob(
+        job_id="abc",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        status=JobStatus.COMPLETED,
+        output=["line a\n"],
+        exit_code=0,
+    )
+    controller = make_follow_race_controller(firmware_controller_factory, job)
+    client = FakeWebSocketClient()
+
+    await controller.follow_job(job_id="abc", client=client, message_id="m1")
+
+    assert "m1" not in client._stream_tasks
+    assert client.cancel_stream("m1") is False

--- a/tests/controllers/firmware/test_follow_job_cancel.py
+++ b/tests/controllers/firmware/test_follow_job_cancel.py
@@ -1,12 +1,4 @@
-"""``firmware.follow_job`` registers its task so ``devices/stop_stream`` cancels it.
-
-The frontend fires ``devices/stop_stream`` with the follow's
-message_id when the log dialog closes or switches jobs. That command
-calls ``client.cancel_stream(message_id)``, which only finds tasks a
-handler registered via ``register_stream``. Without registration a
-live job's tail kept streaming server-side until the job finished or
-the WS dropped, and orphaned follows piled up across job switches.
-"""
+"""``follow_job`` registers its stream so ``devices/stop_stream`` can cancel it."""
 
 from __future__ import annotations
 

--- a/tests/controllers/firmware/test_follow_job_race.py
+++ b/tests/controllers/firmware/test_follow_job_race.py
@@ -230,6 +230,9 @@ async def test_slow_follower_drops_lines_above_queue_cap(
     received: list[tuple[str, Any]] = []
 
     class BlockingClient:
+        def register_stream(self, _mid: str, _task: Any) -> None: ...
+        def unregister_stream(self, _mid: str) -> None: ...
+
         async def send_event(self, _mid: str, event: str, data: Any) -> None:
             received.append((event, data))
             await block.wait()
@@ -296,6 +299,9 @@ async def test_terminal_sentinel_evicts_to_unblock_drain_when_queue_full(
     received: list[tuple[str, Any]] = []
 
     class BlockingClient:
+        def register_stream(self, _mid: str, _task: Any) -> None: ...
+        def unregister_stream(self, _mid: str) -> None: ...
+
         async def send_event(self, _mid: str, event: str, data: Any) -> None:
             received.append((event, data))
             # Only block on output; let result/sentinel through so


### PR DESCRIPTION
# What does this implement/fix?

`firmware/follow_job` never registered its streaming task, so `devices/stop_stream` could not cancel it. The frontend sends that command when the job log dialog closes or switches to another job; with no registration the cancel was a no op, so a running job's output kept streaming over the websocket after the client stopped reading it, and orphaned follows accumulated for the life of the connection.

This registers the follow task before the first await, the same way the `devices/logs`, `devices/validate`, and `devices/subscribe_reachability` streams already do, and unregisters it in a `finally`, so the cancel lands. `follow_jobs` and `subscribe_events` are left alone since they are connection lifetime singletons the frontend never stops individually.

**Related issue or feature (if applicable):**

- No tracked issue; surfaced while reviewing #1046

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
