### PR TITLE
Raise firmware history cap so large batches aren't purged

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -104,15 +104,17 @@ _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*Uploading:.*?\b(\d{1,3})\s*%"),
 )
 
-# History retention. Bulk operations can spawn dozens of jobs at once;
-# we want a useful audit trail without letting the metadata file grow
-# without bound.
+# History retention.
 #   - "Primary" = COMPILE / UPLOAD / INSTALL: dedup'd to the most
-#     recent terminal job per device, then capped globally.
+#     recent terminal job per device, then capped globally. The dedup
+#     already bounds the pool to the distinct-device count, and a
+#     terminal job's output lives in a sidecar (RAM/metadata hold only
+#     a small record), so the cap is a high safety ceiling for large
+#     fleets, not the normal limiter — it must clear a full batch.
 #   - "Aux" = CLEAN / RESET_BUILD_ENV: kept in a separate small pool
 #     so they don't crowd out the device history.
 # Active (queued/running) jobs are exempt from both pools.
-_MAX_PRIMARY_TERMINAL_JOBS = 50
+_MAX_PRIMARY_TERMINAL_JOBS = 500
 _MAX_AUX_TERMINAL_JOBS = 5
 _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}


### PR DESCRIPTION
# What does this implement/fix?

Raise the firmware-job history cap so compiling a large batch of devices doesn't purge the batch's results before the user can review them.

Completed-job history caps the primary pool (terminal compile, upload, install jobs) at 50 entries; a batch touching more than 50 distinct devices dropped the oldest devices' results. That hard 50 is now well below what the storage model can afford. Since #1024 a terminal job's output is lazy-loaded from a per-job sidecar log rather than held in memory, so RAM and the metadata blob keep only a small record per job; and the primary pool is already deduped to one entry per device, so it can never exceed the distinct-device count. Raising the cap to 500 makes it a high safety ceiling for large fleets instead of something that truncates a normal batch. Sidecar logs of any job past the cap are still reaped on the next persist, so disk stays bounded by the cap.

Aux history (clean, reset_build_env) keeps its small separate pool unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1060

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable. (Constant bump; the prune mechanism and dedupe are already covered by `tests/controllers/firmware/test_prune_history.py` and `test_branches_coverage.py`.)
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
