### PR TITLE
Route logs and reachability streams through registered_stream

### DIFF
--- a/esphome_device_builder/controllers/devices/logs.py
+++ b/esphome_device_builder/controllers/devices/logs.py
@@ -8,6 +8,7 @@ import os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from ...helpers.api import registered_stream
 from ...helpers.process import kill_quietly
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...models import StreamEvent
@@ -85,50 +86,49 @@ async def stream_subprocess(
     uses it to scrub resolved secrets that ``esphome config``
     leaks via the ANSI conceal SGR.
     """
-    # Register before the first await so an early ``stop_stream``
-    # (during subprocess spawn) still finds and cancels this task.
-    task = asyncio.current_task()
-    assert task is not None
-    client.register_stream(message_id, task)
+    # ``registered_stream`` enters before the first await so an early
+    # ``stop_stream`` (during subprocess spawn) still finds and cancels
+    # this task.
+    with registered_stream(client, message_id):
+        env = {**os.environ, "PLATFORMIO_FORCE_ANSI": "true"}
+        proc: asyncio.subprocess.Process | None = None
+        try:
+            proc = await create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=env,
+            )
+            assert proc.stdout is not None
+            # Use the shared `\n`/`\r` splitter so esptool / PlatformIO
+            # carriage-return progress lines surface live; strip the
+            # terminator since the frontend's logs view appends every
+            # event as a new line.
+            async for line in iter_lines_with_progress(proc.stdout):
+                payload = line.rstrip("\n\r")
+                if line_transform is not None:
+                    payload = line_transform(payload)
+                await client.send_event(message_id, StreamEvent.OUTPUT, payload)
+            exit_code = await proc.wait()
+        except asyncio.CancelledError:
+            # Synchronous kill only; no awaits in the cancel path.
+            # The finally block reaps the process. ``proc`` may be
+            # None if cancellation arrived before spawn returned.
+            if proc is not None and proc.returncode is None:
+                kill_quietly(proc)
+            # Honour the asyncio cancellation contract: only swallow
+            # if no outstanding cancel requests remain (asyncio.timeout
+            # / TaskGroup may have called Task.uncancel()).
+            if (current := asyncio.current_task()) and current.cancelling():
+                raise
+            return
+        finally:
+            if proc is not None and proc.returncode is None:
+                # Reap so the transport closes cleanly; shielded so an
+                # additional cancellation doesn't strand the subprocess.
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.shield(proc.wait())
 
-    env = {**os.environ, "PLATFORMIO_FORCE_ANSI": "true"}
-    proc: asyncio.subprocess.Process | None = None
-    try:
-        proc = await create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=env,
+        await client.send_event(
+            message_id, "result", {"success": exit_code == 0, "code": exit_code}
         )
-        assert proc.stdout is not None
-        # Use the shared `\n`/`\r` splitter so esptool / PlatformIO
-        # carriage-return progress lines surface live; strip the
-        # terminator since the frontend's logs view appends every
-        # event as a new line.
-        async for line in iter_lines_with_progress(proc.stdout):
-            payload = line.rstrip("\n\r")
-            if line_transform is not None:
-                payload = line_transform(payload)
-            await client.send_event(message_id, StreamEvent.OUTPUT, payload)
-        exit_code = await proc.wait()
-    except asyncio.CancelledError:
-        # Synchronous kill only; no awaits in the cancel path.
-        # The finally block reaps the process. ``proc`` may be
-        # None if cancellation arrived before spawn returned.
-        if proc is not None and proc.returncode is None:
-            kill_quietly(proc)
-        # Honour the asyncio cancellation contract: only swallow
-        # if no outstanding cancel requests remain (asyncio.timeout
-        # / TaskGroup may have called Task.uncancel()).
-        if (current := asyncio.current_task()) and current.cancelling():
-            raise
-        return
-    finally:
-        client.unregister_stream(message_id)
-        if proc is not None and proc.returncode is None:
-            # Reap so the transport closes cleanly; shielded so an
-            # additional cancellation doesn't strand the subprocess.
-            with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.shield(proc.wait())
-
-    await client.send_event(message_id, "result", {"success": exit_code == 0, "code": exit_code})

--- a/esphome_device_builder/controllers/devices/reachability.py
+++ b/esphome_device_builder/controllers/devices/reachability.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ...helpers.api import CommandError
+from ...helpers.api import CommandError, registered_stream
 from ...helpers.event_bus import Event, StreamControls, stream_events
 from ...models import (
     DeviceReachabilityData,
@@ -50,44 +50,40 @@ async def subscribe(
 
     # Register so a peer ``devices/stop_stream`` (or this client's
     # cleanup on disconnect) cancels the running task.
-    task = asyncio.current_task()
-    assert task is not None
-    client.register_stream(message_id, task)
+    with registered_stream(client, message_id):
+        refresh_task: asyncio.Task | None = None
 
-    refresh_task: asyncio.Task | None = None
+        async def _send_initial(controls: StreamControls) -> None:
+            snapshot = controller.get_reachability_snapshot(device_name)
+            if snapshot is not None:
+                await client.send_event(message_id, "reachability_state", snapshot)
+            await client.send_result(message_id, {"subscribed": True})
 
-    async def _send_initial(controls: StreamControls) -> None:
-        snapshot = controller.get_reachability_snapshot(device_name)
-        if snapshot is not None:
-            await client.send_event(message_id, "reachability_state", snapshot)
-        await client.send_result(message_id, {"subscribed": True})
+        def _handle_event(event: Event[DeviceReachabilityData], controls: StreamControls) -> None:
+            data = event.data
+            if data["device"] != device_name:
+                # Bus event is broadcast to all subscribers; filter
+                # so each only forwards its own device's events.
+                return
+            controls.push("reachability_state", data)
 
-    def _handle_event(event: Event[DeviceReachabilityData], controls: StreamControls) -> None:
-        data = event.data
-        if data["device"] != device_name:
-            # Bus event is broadcast to all subscribers; filter
-            # so each only forwards its own device's events.
-            return
-        controls.push("reachability_state", data)
-
-    try:
-        # Routed through the controller's bound delegate so tests
-        # patching the loop on the instance still intercept.
-        refresh_task = asyncio.create_task(controller._reachability_refresh_loop(device_name))
-        await stream_events(
-            client=client,
-            message_id=message_id,
-            bus=controller._db.bus,
-            event_types=[EventType.DEVICE_REACHABILITY],
-            handle_event=_handle_event,
-            send_initial=_send_initial,
-        )
-    finally:
-        if refresh_task is not None:
-            refresh_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await refresh_task
-        client.unregister_stream(message_id)
+        try:
+            # Routed through the controller's bound delegate so tests
+            # patching the loop on the instance still intercept.
+            refresh_task = asyncio.create_task(controller._reachability_refresh_loop(device_name))
+            await stream_events(
+                client=client,
+                message_id=message_id,
+                bus=controller._db.bus,
+                event_types=[EventType.DEVICE_REACHABILITY],
+                handle_event=_handle_event,
+                send_initial=_send_initial,
+            )
+        finally:
+            if refresh_task is not None:
+                refresh_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await refresh_task
 
 
 async def refresh_loop(controller: DevicesController, device_name: str) -> None:

--- a/tests/controllers/devices/test_stream_cancel.py
+++ b/tests/controllers/devices/test_stream_cancel.py
@@ -125,6 +125,40 @@ async def test_stream_subprocess_normal_completion_emits_success(tmp_path: Any) 
     assert result_events == [{"code": 0, "success": True}]
 
 
+async def test_stream_subprocess_swallows_non_task_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``CancelledError`` that isn't a task cancellation returns quietly, no result.
+
+    Spawn / ``proc.wait`` can surface ``CancelledError`` while the
+    task's ``cancelling()`` count is 0 (asyncio.timeout / TaskGroup
+    uncancel). The handler swallows it and unregisters rather than
+    propagating or emitting a ``result``.
+    """
+    ctrl = _make_controller()
+    client = _make_client()
+    sent_events: list[tuple[str, Any]] = []
+
+    async def capture(_mid: str, event: str, data: Any = None) -> None:
+        sent_events.append((event, data))
+
+    client.send_event = capture  # type: ignore[method-assign]
+
+    async def boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.logs.create_subprocess_exec", boom
+    )
+
+    # Awaited directly, not via ``task.cancel()`` — so the running
+    # task's ``cancelling()`` is 0 when the except branch checks it.
+    await ctrl._stream_subprocess([sys.executable, "-c", "pass"], client, "stream-x")
+
+    assert sent_events == []
+    assert "stream-x" not in client._stream_tasks
+
+
 async def test_stream_subprocess_emits_carriage_return_progress_lines() -> None:
     r"""`\r` progress lines reach the client as separate events.
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1059, which added the `registered_stream` context manager and used it in `firmware/follow_job`. The two other streams that register for `devices/stop_stream` cancellation, `devices/logs` (and `devices/validate`, which shares `stream_subprocess`) and `devices/subscribe_reachability`, still hand wrote the same `current_task` / `register_stream` / `unregister_stream` pairing.

This routes both through `registered_stream` so all stream handlers share one pattern. The subprocess reap and the reachability refresh task keep their own `finally`; only the stream registration moves into the context manager. Reachability keeps its exact prior ordering. For logs there is one benign ordering refinement, the unregister now runs on context exit, after the final result send and the proc reap, rather than first in the `finally`, so the stream stays registered until the handler truly finishes; the only observable effect is a tiny window where a concurrent `devices/stop_stream` returns cancelled rather than not found. The existing stop_stream tests cover both paths, plus a new test for the non task cancellation swallow branch.

**Related issue or feature (if applicable):**

- Follow up to #1059

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
