### PR TITLE
Add _RemoteBuildBase._subscribe helper for bus listener registration

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_shared.py
+++ b/esphome_device_builder/controllers/remote_build/_shared.py
@@ -12,7 +12,7 @@ Exposes:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +21,7 @@ from .._task_controller_base import TaskControllerBase
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
+    from ...helpers.event_bus import Event, EventType
 
 
 async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
@@ -54,3 +55,7 @@ class _RemoteBuildBase(TaskControllerBase):
         self._db = device_builder
         self._listeners = ExitStack()
         self._shutdown_callbacks: list[ShutdownCallback] = []
+
+    def _subscribe(self, event_type: EventType, listener: Callable[[Event[Any]], None]) -> None:
+        """Register *listener* for *event_type*, auto-removed when ``_listeners`` closes."""
+        self._listeners.callback(self._db.bus.add_listener(event_type, listener))

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -119,36 +119,13 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         for pairing in state.pairings.values():
             if pairing.status is PeerStatus.APPROVED:
                 self._spawn_peer_link_client(pairing)
-        self._listeners.callback(
-            self._db.bus.add_listener(
-                EventType.OFFLOADER_QUEUE_STATUS_CHANGED,
-                self._on_offloader_queue_status_changed,
-            )
+        self._subscribe(
+            EventType.OFFLOADER_QUEUE_STATUS_CHANGED, self._on_offloader_queue_status_changed
         )
-        self._listeners.callback(
-            self._db.bus.add_listener(
-                EventType.OFFLOADER_JOB_STATE_CHANGED,
-                self._on_offloader_job_state_changed,
-            )
-        )
-        self._listeners.callback(
-            self._db.bus.add_listener(
-                EventType.OFFLOADER_PAIR_PIN_MISMATCH,
-                self._on_offloader_pair_pin_mismatch,
-            )
-        )
-        self._listeners.callback(
-            self._db.bus.add_listener(
-                EventType.OFFLOADER_PEER_LINK_OPENED,
-                self._on_offloader_peer_link_opened,
-            )
-        )
-        self._listeners.callback(
-            self._db.bus.add_listener(
-                EventType.OFFLOADER_PEER_LINK_CLOSED,
-                self._on_offloader_peer_link_closed,
-            )
-        )
+        self._subscribe(EventType.OFFLOADER_JOB_STATE_CHANGED, self._on_offloader_job_state_changed)
+        self._subscribe(EventType.OFFLOADER_PAIR_PIN_MISMATCH, self._on_offloader_pair_pin_mismatch)
+        self._subscribe(EventType.OFFLOADER_PEER_LINK_OPENED, self._on_offloader_peer_link_opened)
+        self._subscribe(EventType.OFFLOADER_PEER_LINK_CLOSED, self._on_offloader_peer_link_closed)
         self._start_discovery()
 
     async def stop(self) -> None:

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -109,9 +109,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
             EventType.JOB_STARTED,
             *TERMINAL_JOB_EVENTS,
         ):
-            self._listeners.callback(
-                self._db.bus.add_listener(event_type, self._on_firmware_queue_transition)
-            )
+            self._subscribe(event_type, self._on_firmware_queue_transition)
 
     async def stop(self) -> None:
         """Close listeners, terminate sessions, drain tasks, flush store."""


### PR DESCRIPTION
# What does this implement/fix?

Fold the repeated bus-listener registration in the remote-build controllers into a small helper.

The offloader and receiver both register event-bus listeners with the same `self._listeners.callback(self._db.bus.add_listener(event_type, handler))` shape; the offloader's `start()` had five stacked four-line blocks of it. Both extend `_RemoteBuildBase`, which already owns the `_db` and the `_listeners` ExitStack, so this adds a `_subscribe(event_type, listener)` method there and routes the call sites through it. Each registration is now one line and the ExitStack bookkeeping lives in one place.

No behaviour change; the listeners register and tear down exactly as before. `JobFanout` keeps its own form since it isn't a `_RemoteBuildBase` and already reads the bus through a local variable.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable. (Behaviour-preserving refactor; existing remote-build listener/controller tests cover registration and teardown.)
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
