### PR TITLE
Clean the wizard and clone name/friendly_name to ESPHome's schema rules

### DIFF
--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -16,6 +16,11 @@ try:
 except ImportError:  # pragma: no cover; covered by the import below
     from esphome.dashboard.util.text import friendly_name_slugify
 
+try:
+    from esphome.core.config import FRIENDLY_NAME_MAX_LEN
+except ImportError:  # pragma: no cover; older esphome without the constant
+    FRIENDLY_NAME_MAX_LEN = 120
+
 from esphome.helpers import rmtree, sort_ip_addresses
 from esphome.storage_json import StorageJSON
 
@@ -48,11 +53,60 @@ __all__ = [
     "_unlink_storage_sidecar",
     "_validate_archive_configuration",
     "_wipe_device_build_dir",
+    "clean_friendly_name",
     "friendly_name_slugify",
+    "slugify_hostname",
 ]
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# C0 controls, DEL, and C1 controls. ESPHome's friendly_name validator
+# doesn't reject these, and ``_safe_yaml_scalar`` only escapes a few
+# (``\n`` / ``\t`` / ``\r``) while emitting the rest (NUL, bell, …)
+# literally — a literal NUL alone makes the YAML unparsable.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+# ESPHome's ``validate_hostname`` caps the device name at 31 chars (24
+# with name_add_mac_suffix, which the create wizard never sets). Keep
+# in sync with ESPHOME_DEVICE_NAME_MAX_LEN in esphome/core/entity_base.h.
+_HOSTNAME_MAX_LEN = 31
+
+
+def slugify_hostname(value: str) -> str:
+    """
+    Slugify *value* into a valid ``esphome.name`` (the mDNS hostname).
+
+    Wraps ESPHome's ``friendly_name_slugify`` (lowercase-dashed ASCII)
+    and clamps to the hostname length cap ``validate_hostname``
+    enforces — ``friendly_name_slugify`` itself doesn't, so a long
+    display name would otherwise generate a config ESPHome rejects.
+    A dash left dangling at the cut is dropped so the slug stays valid.
+    """
+    slug: str = friendly_name_slugify(value)
+    return slug[:_HOSTNAME_MAX_LEN].rstrip("-")
+
+
+def clean_friendly_name(value: str) -> str:
+    """
+    Clean a raw display name into a valid ``esphome.friendly_name``.
+
+    ESPHome validates friendly_name only with ``string_no_slash`` plus a
+    ``FRIENDLY_NAME_MAX_LEN``-byte cap — it accepts control characters,
+    so a pasted newline / tab / NUL would otherwise land in the YAML
+    scalar. This swaps the reserved ``/`` for ``⁄`` (U+2044, ESPHome's
+    own substitution), turns control characters (EOL / tab / …) into
+    spaces and collapses whitespace runs, then clamps to the byte cap on
+    a character boundary. YAML-metacharacter quoting (``:``, ``#``) is
+    the separate job of ``_safe_yaml_scalar`` at emit time.
+    """
+    cleaned = _CONTROL_CHARS_RE.sub(" ", value.replace("/", "⁄"))
+    cleaned = " ".join(cleaned.split())
+    encoded = cleaned.encode("utf-8")
+    if len(encoded) > FRIENDLY_NAME_MAX_LEN:
+        cleaned = encoded[:FRIENDLY_NAME_MAX_LEN].decode("utf-8", "ignore").rstrip()
+    return cleaned
 
 
 def _rewrite_required_yaml_leaf(

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -13,7 +13,11 @@ from ...helpers.yaml import (
     rewrite_name_or_substitution,
 )
 from ...models import ErrorCode
-from .helpers import _rewrite_required_yaml_leaf, friendly_name_slugify
+from .helpers import (
+    _rewrite_required_yaml_leaf,
+    clean_friendly_name,
+    friendly_name_slugify,
+)
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -107,10 +111,16 @@ async def clone_device(  # noqa: C901
     new_content = _rewrite_required_yaml_leaf(source_content, ("esphome", "name"), new_name)
     # ``friendly_name`` is optional on the clone path; the
     # underlying helper is already a no-op when the leaf is
-    # missing, so skip the required-leaf wrapper here.
+    # missing, so skip the required-leaf wrapper here. The clone
+    # dialog supplies a raw display name, so clean it to ESPHome's
+    # friendly_name rules (slash swap / control strip / byte cap) —
+    # the same generator-hardening as the create wizard, so a clone
+    # can't reintroduce the #1070 symptom.
     if new_friendly_name:
         new_content = rewrite_name_or_substitution(
-            new_content, ("esphome", "friendly_name"), new_friendly_name
+            new_content,
+            ("esphome", "friendly_name"),
+            clean_friendly_name(new_friendly_name),
         )
     # No-op when the source uses ``!secret`` / ``${...}`` for
     # the key; those indirections stay shared with the source.

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -11,7 +11,7 @@ from ...helpers.api import CommandError
 from ...helpers.device_yaml import parse_platform_from_yaml
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, WizardResponse
-from .helpers import friendly_name_slugify
+from .helpers import clean_friendly_name, slugify_hostname
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -43,20 +43,18 @@ async def create_device(  # noqa: PLR0912, PLR0915, C901
     (its hard-coded ``board: esp32dev`` would mis-bind).
     """
     # The wizard passes the user's raw input here — capitalisation,
-    # inter-word spaces, and unicode all stay intact (only the
-    # surrounding whitespace is trimmed, since accidental leading
-    # / trailing spaces on a display label are almost certainly
-    # noise). Slugify the cleaned value for the hostname (mDNS /
-    # filename / esphome.name: schema all require the canonical
-    # lowercase-dashed form) and keep the cleaned original as the
-    # display label written into esphome.friendly_name:.
-    # Centralising the slug here keeps the frontend out of the
-    # sanitisation business and avoids two slug implementations
-    # drifting apart.
-    friendly = name.strip()
+    # inter-word spaces, and unicode all stay intact. ``clean_friendly_name``
+    # makes it a valid ``esphome.friendly_name:`` (trims, swaps the
+    # reserved ``/`` for ``⁄`` as ESPHome itself does, drops control
+    # chars, clamps to the byte cap), and ``slugify_hostname`` derives
+    # the canonical lowercase-dashed hostname clamped to ESPHome's name
+    # length cap (mDNS / filename / esphome.name: schema). Centralising
+    # both here keeps the frontend out of the sanitisation business and
+    # avoids two implementations drifting.
+    friendly = clean_friendly_name(name)
     if not friendly:
         raise CommandError(ErrorCode.INVALID_ARGS, "name is required")
-    name = friendly_name_slugify(friendly)
+    name = slugify_hostname(friendly)
     if not name:
         raise CommandError(
             ErrorCode.INVALID_ARGS,

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -108,6 +108,29 @@ async def test_clone_device_uses_explicit_friendly_name_when_provided(
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_clone_device_cleans_friendly_name_to_schema_rules(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A clone's raw friendly name is cleaned like the create wizard's (#1070)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    await ctrl.clone_device(
+        configuration="kitchen.yaml",
+        new_name="bedroom-bulb",
+        new_friendly_name="Bath / Lamp\twith\x00ctl",
+    )
+
+    new_yaml = (tmp_path / "bedroom-bulb.yaml").read_text("utf-8")
+    # ``/`` -> ``⁄`` (ESPHome's own swap), tab -> space, NUL dropped,
+    # whitespace collapsed. ``⁄`` is not a YAML metachar, so it stays a
+    # plain scalar.
+    assert "friendly_name: Bath ⁄ Lamp with ctl\n" in new_yaml
+    assert "/" not in new_yaml.split("friendly_name:", 1)[1].splitlines()[0]
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_clone_device_skips_friendly_rewrite_when_blank(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -11,24 +11,37 @@ exception.
 from __future__ import annotations
 
 import asyncio
+import io
+import warnings
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import esphome.config_validation as cv
 import pytest
+from esphome.core.config import FRIENDLY_NAME_MAX_LEN
 from esphome.storage_json import StorageJSON
+from ruamel.yaml import YAML
 
 from esphome_device_builder.controllers.config import (
     get_device_metadata,
     set_device_metadata,
 )
+from esphome_device_builder.controllers.devices.helpers import (
+    clean_friendly_name,
+    slugify_hostname,
+)
 from esphome_device_builder.controllers.devices.mutations_yaml import (
     yaml_content_for_create,
 )
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.yaml import _safe_yaml_scalar
 from esphome_device_builder.models import ErrorCode
 
 from .conftest import MakeControllerFactory, StubBoardLookups
+
+# ESPHome's friendly_name field validator (no slash + byte cap).
+_FRIENDLY_NAME_VALIDATOR = cv.All(cv.string_no_slash, cv.ByteLength(max=FRIENDLY_NAME_MAX_LEN))
 
 VALID_FILE_CONTENT = (
     "esphome:\n  name: kitchen\n  friendly_name: Kitchen\n"
@@ -186,6 +199,135 @@ async def test_create_device_rejects_name_with_no_hostname_safe_characters(
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "hostname-safe" in excinfo.value.message
     assert ctrl._scanner.calls == []
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_swaps_reserved_slash_in_friendly_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A ``/`` in the name becomes ``⁄`` in friendly_name, ESPHome's own swap (#1070)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
+
+    result = await ctrl.create_device(name="Living Room / Bath #2")
+
+    assert result.configuration == "living-room--bath-2.yaml"
+    storage = StorageJSON.load(tmp_path / "storage.json")
+    assert storage is not None
+    # ESPHome reserves ``/`` (deprecated, hard error in 2026.7.0); the
+    # backend swaps it for ``⁄`` so the generated YAML validates.
+    assert storage.friendly_name == "Living Room ⁄ Bath #2"
+    assert "/" not in storage.friendly_name
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_strips_control_chars_from_friendly_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Control / EOL chars become spaces (collapsed) so the YAML scalar stays clean (#1070)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
+
+    # Newline + tab become spaces; bell + NUL are dropped; a literal NUL
+    # would otherwise make the generated YAML unparsable.
+    result = await ctrl.create_device(name="Bed\nroom\trm\x07\x00")
+
+    assert result.configuration == "bed-room-rm.yaml"
+    storage = StorageJSON.load(tmp_path / "storage.json")
+    assert storage is not None
+    assert storage.friendly_name == "Bed room rm"
+    assert not any(ord(c) < 0x20 or 0x7F <= ord(c) <= 0x9F for c in storage.friendly_name)
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_clamps_friendly_name_to_byte_limit(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An over-long name is clamped to the friendly_name byte cap on a char boundary (#1070)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    boards = StubBoardLookups(ctrl)
+    boards.find_by_pio_board_returns(None)
+    boards.find_by_platform_variant_returns(None)
+
+    # 70 × ``ü`` = 140 UTF-8 bytes (2 each); friendly_name clamps to 60
+    # (120 bytes) on a char boundary, while the hostname is independently
+    # clamped to ESPHome's 31-char name cap. Both caps must hold or the
+    # create fails ESPHome validation.
+    result = await ctrl.create_device(name="ü" * 70)
+
+    storage = StorageJSON.load(tmp_path / "storage.json")
+    assert storage is not None
+    assert storage.friendly_name == "ü" * 60
+    assert len(storage.friendly_name.encode("utf-8")) == 120
+    assert storage.name == "u" * 31
+    assert result.configuration == f"{'u' * 31}.yaml"
+
+
+def test_slugify_hostname_clamps_after_trimming_the_cut_dash() -> None:
+    """The clamp is applied before the dash-strip so the cut can't leave a trailing dash (#1070)."""
+    # 30 'a' + " b" slugs to 'aaaa…(30)-b' (32 chars); the cut at 31
+    # lands on the dash. Stripping must happen AFTER the truncation,
+    # or the hostname would end in '-'.
+    assert slugify_hostname("a" * 30 + " b") == "a" * 30
+    # General length clamp + validity.
+    long_name = "A Very Long Living Room Climate Sensor Name Here"
+    out = slugify_hostname(long_name)
+    assert len(out) <= 31
+    assert not out.startswith("-") and not out.endswith("-")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param("Bedroom #2: lamp", id="hash-and-colon"),
+        pytest.param('Lamp "quoted"', id="double-quote"),
+        pytest.param("back\\slash", id="backslash"),
+        pytest.param("it's a 'test'", id="single-quote"),
+        pytest.param(": leading colon", id="leading-colon"),
+        pytest.param("- leading dash", id="leading-dash"),
+        pytest.param("! & * ? | > % @ ` ~ [ ] { } ,", id="all-indicators"),
+        pytest.param("trailing colon:", id="trailing-colon"),
+        pytest.param("null", id="reserved-word"),
+        pytest.param("Kitchen/Bath", id="slash"),
+        pytest.param("emoji 🚀 home", id="emoji"),
+        pytest.param("tab\tnl\ncr\r", id="eol-and-tab"),
+        pytest.param("\x00\x07\x1b bell", id="c0-control"),
+        pytest.param("C1\x85\x9f here", id="c1-control"),
+        pytest.param("x" * 200, id="over-byte-cap"),
+    ],
+)
+def test_clean_friendly_name_round_trips_and_validates(raw: str) -> None:
+    """Both derived fields stay valid for any raw input (#1070).
+
+    Pins that ``clean_friendly_name`` + ``_safe_yaml_scalar`` leave no
+    character class that lands invalid YAML or a schema-invalid
+    friendly_name, and that ``slugify_hostname`` always yields a valid,
+    length-capped ``esphome.name``.
+    """
+    cleaned = clean_friendly_name(raw)
+    if not cleaned:
+        return  # slugs/cleans to empty -> create rejects via "name is required"
+
+    # ESPHome accepts it, with no friendly_name deprecation warning
+    # (the slash was already swapped for ``⁄``).
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _FRIENDLY_NAME_VALIDATOR(cleaned) == cleaned
+
+    # And the emitted scalar re-parses to exactly the cleaned value.
+    doc = f"esphome:\n  name: x\n  friendly_name: {_safe_yaml_scalar(cleaned)}\n"
+    parsed = YAML(typ="safe").load(io.StringIO(doc))
+    assert parsed["esphome"]["friendly_name"] == cleaned
+
+    # The hostname from the same input is a valid, length-capped name.
+    hostname = slugify_hostname(raw)
+    if hostname:
+        assert len(hostname) <= 31
+        assert cv.valid_name(hostname) == hostname
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")


### PR DESCRIPTION
# What does this implement/fix?

The new-device wizard kept the user's raw name as `friendly_name` and derived the hostname with an unbounded slugify, but ESPHome validates `friendly_name` with `string_no_slash` plus a 120 byte cap (and accepts control chars), and caps the hostname (`esphome.name`) at 31 chars; so a slash, an over-cap name, a pasted control character, or a long name produces YAML ESPHome rejects or that is unparsable (a literal NUL). This adds `clean_friendly_name` (swap the reserved `/` for `⁄` exactly as ESPHome's validator does, drop control / EOL chars, clamp to the byte cap on a character boundary) and `slugify_hostname` (clamp to the 31 char name cap, trimming a dash the cut may leave), and routes the wizard name through both before write. `_safe_yaml_scalar` still handles YAML quoting; a parametrized round-trip test pins that no character class lands invalid YAML or a schema-invalid name. A companion frontend PR stops the wizard from slugifying the name, so the backend receives the descriptive value to preserve. Clone's caller-supplied friendly_name is routed through `clean_friendly_name` too, so the clone path can't reintroduce the same symptom.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1070

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#461

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.



