### PR TITLE
Extract reusable trigger-mapping decompose and list-splice helpers

### DIFF
--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -390,33 +390,34 @@ def _decompose_trigger_body(body: Any, *, trigger_id: str) -> AutomationTree:
     tree: bare action list (``on_press: - action: ...``), single
     bare action (``on_press: action: ...``), explicit ``then:``.
     """
-    trigger_params: dict[str, Any] = {}
-    actions: list[ActionNode] = []
+    if isinstance(body, dict):
+        return _decompose_trigger_mapping(body, trigger_id=trigger_id)
+    actions = _decompose_action_list(body) if isinstance(body, list) else []
+    return AutomationTree(trigger_id=trigger_id, trigger_params={}, actions=actions)
 
-    if body is None:
-        return AutomationTree(
-            trigger_id=trigger_id,
-            trigger_params={},
-            actions=[],
-        )
 
-    if isinstance(body, list):
-        actions = _decompose_action_list(body)
-    elif isinstance(body, dict):
-        trigger_params = _collect_block_params(body, action_list_keys={"then"})
-        if "then" in body:
-            actions = _decompose_action_list(body["then"])
-        else:
-            # Single-action shortcut: the body's keys are a mix of
-            # trigger params and known catalog action ids.
-            # ``_collect_block_params`` naively absorbed both; pull
-            # the action keys back out by catalog lookup and rebuild
-            # ``trigger_params`` without them.
-            action_body = {k: v for k, v in body.items() if catalog.action_by_id(k) is not None}
-            if action_body:
-                actions = _decompose_action_list([action_body])
-                trigger_params = {k: v for k, v in trigger_params.items() if k not in action_body}
+def _decompose_trigger_mapping(body: dict[str, Any], *, trigger_id: str) -> AutomationTree:
+    """
+    Decompose one mapping-form trigger handler (params + ``then:``).
 
+    Splits the mapping into trigger params and its action list,
+    accepting the explicit ``then:`` form and the single-action
+    shortcut. Reused per list entry for list-shaped triggers.
+    """
+    trigger_params = _collect_block_params(body, action_list_keys={"then"})
+    if "then" in body:
+        actions = _decompose_action_list(body["then"])
+    else:
+        # Single-action shortcut: the body's keys are a mix of
+        # trigger params and known catalog action ids.
+        # ``_collect_block_params`` naively absorbed both; pull
+        # the action keys back out by catalog lookup and rebuild
+        # ``trigger_params`` without them.
+        action_body = {k: v for k, v in body.items() if catalog.action_by_id(k) is not None}
+        actions = []
+        if action_body:
+            actions = _decompose_action_list([action_body])
+            trigger_params = {k: v for k, v in trigger_params.items() if k not in action_body}
     return AutomationTree(
         trigger_id=trigger_id,
         trigger_params=trigger_params,

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -37,14 +37,13 @@ from ...models.automations import (
 )
 from . import api_actions, catalog
 from .emitter import (
-    dump,
-    emit_effect_item,
     render_api_action_item,
     render_interval_item,
     render_script_item,
     render_trigger_handler,
 )
 from .parsing import make_yaml
+from .writing_lists import delete_light_effect, upsert_light_effect
 
 # ---------------------------------------------------------------------------
 # Public entry points
@@ -73,7 +72,7 @@ def render_upsert(
     if isinstance(location, ComponentOnLocation):
         return _upsert_component_on(yaml_text, tree, location)
     if isinstance(location, LightEffectLocation):
-        return _upsert_light_effect(yaml_text, tree, location)
+        return upsert_light_effect(yaml_text, tree, location)
     if isinstance(location, ApiActionLocation):
         return _upsert_api_action(yaml_text, tree, location)
     msg = f"Unsupported AutomationLocation: {type(location).__name__}"
@@ -91,7 +90,7 @@ def render_delete(
     if isinstance(location, ComponentOnLocation):
         return _delete_component_on(yaml_text, location)
     if isinstance(location, LightEffectLocation):
-        return _delete_light_effect(yaml_text, location)
+        return delete_light_effect(yaml_text, location)
     if isinstance(location, ApiActionLocation):
         return _delete_api_action(yaml_text, location)
     msg = f"Unsupported AutomationLocation: {type(location).__name__}"
@@ -199,43 +198,6 @@ def _upsert_api_action(
         rendered_text = api_actions.indent_for_list(rendered, item_indent)
         return api_actions.render_replacement(lines, item_start, item_end, rendered_text)
     return api_actions.render_append(lines, actions_end, item_indent, rendered)
-
-
-def _upsert_light_effect(
-    yaml_text: str,
-    tree: AutomationTree,
-    location: LightEffectLocation,
-) -> tuple[str, YamlDiff]:
-    """Splice an ``effects:`` list item under a configured light."""
-    # The tree carries the effect id under ``trigger_params`` (one
-    # key mapping to its params dict). Reverse the parser's shape.
-    if not tree.trigger_params or len(tree.trigger_params) != 1:
-        msg = "LightEffect upsert requires exactly one effect-id key in trigger_params"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    effect_id, params = next(iter(tree.trigger_params.items()))
-    catalog_entry = catalog.light_effect_by_id(str(effect_id))
-    if catalog_entry is None:
-        msg = f"Unknown light effect id: {effect_id!r}"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    rendered = _wrap_effects_block(
-        dump([emit_effect_item(catalog_entry, str(effect_id), params or {})]),
-    )
-    res = upsert_inline_handler(
-        yaml_text,
-        component_domain="light",
-        component_id=location.component_id,
-        handler_key="effects",
-        rendered_yaml=rendered,
-    )
-    if res is None:
-        msg = f"Light instance id={location.component_id!r} not found; can't splice effect entry"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    new_text, from_line, to_line, replacement = res
-    return new_text, YamlDiff(
-        fromLine=from_line,
-        toLine=to_line,
-        replacement=replacement,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -546,68 +508,6 @@ def _delete_api_action(
     return api_actions.render_delete_actions_key(lines, actions_start, actions_end)
 
 
-def _delete_light_effect(
-    yaml_text: str,
-    location: LightEffectLocation,
-) -> tuple[str, YamlDiff]:
-    """Drop one entry from a light's ``effects:`` list."""
-    # Easiest path: parse, mutate the list, re-emit. We don't have a
-    # line-precise splice helper for "remove list item at index N
-    # inside an inline handler" — this keeps the writer simple at
-    # the cost of touching the whole ``effects:`` block in the diff.
-    yaml = make_yaml()
-    data = yaml.load(yaml_text) or {}
-    lights = data.get("light") if isinstance(data, dict) else None
-    if not isinstance(lights, list):
-        msg = "No light: block; can't delete effect"
-        raise CommandError(ErrorCode.NOT_FOUND, msg)
-    for instance in lights:
-        if not isinstance(instance, dict):
-            continue
-        if str(instance.get("id", "")) != location.component_id:
-            continue
-        effects = instance.get("effects")
-        if not isinstance(effects, list) or not 0 <= location.index < len(effects):
-            msg = f"effects[{location.index}] not present on light id={location.component_id!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        del effects[location.index]
-        if not effects:
-            del instance["effects"]
-        # Re-render the inline handler block to splice through
-        # ``upsert_inline_handler`` (or remove it when empty).
-        if "effects" in instance:
-            rendered = _wrap_effects_block(dump(effects))
-            res = upsert_inline_handler(
-                yaml_text,
-                component_domain="light",
-                component_id=location.component_id,
-                handler_key="effects",
-                rendered_yaml=rendered,
-            )
-            if res is None:  # pragma: no cover — instance found above
-                msg = f"light id={location.component_id!r} not found in splice"
-                raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
-            new_text, from_line, to_line, replacement = res
-            return new_text, YamlDiff(
-                fromLine=from_line,
-                toLine=to_line,
-                replacement=replacement,
-            )
-        removed = remove_inline_handler(
-            yaml_text,
-            component_domain="light",
-            component_id=location.component_id,
-            handler_key="effects",
-        )
-        if removed is None:  # pragma: no cover — instance found above
-            msg = f"effects: not found on light id={location.component_id!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        new_text, from_line, to_line = removed
-        return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement="")
-    msg = f"Light id={location.component_id!r} not found"
-    raise CommandError(ErrorCode.NOT_FOUND, msg)
-
-
 # ---------------------------------------------------------------------------
 # Low-level utilities
 # ---------------------------------------------------------------------------
@@ -683,16 +583,6 @@ def _component_domain_from_yaml(
         if m and m.group(1) == target_id:
             return current_domain
     return _component_domain(location)
-
-
-def _wrap_effects_block(rendered_list: str) -> str:
-    """Prefix a rendered ``- effect: ...`` list with the ``effects:`` key."""
-    # ``upsert_inline_handler`` writes ``rendered_yaml`` verbatim under the
-    # component instance — for trigger handlers the renderer already
-    # emits ``on_press:\n  ...``; for effects the list dump is bare, so
-    # add the ``effects:`` header here.
-    body = rendered_list.rstrip()
-    return "effects:\n" + body + "\n"
 
 
 def _indent_block(block_text: str, indent: str) -> list[str]:

--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -1,0 +1,131 @@
+"""
+Splice helpers for list-shaped handlers under a component instance.
+
+These handlers are a YAML *list* nested under a configured component
+instance — light ``effects:`` today, list-form triggers (``time.on_time``)
+next. They share one shape: parse-mutate-reemit the whole list block, then
+splice it back through :func:`helpers.yaml.upsert_inline_handler` (or remove
+it when emptied). Kept out of ``writing.py`` so that file stays focused on
+the single-handler / top-level splice paths.
+"""
+
+from __future__ import annotations
+
+from ...helpers.api import CommandError
+from ...helpers.yaml import remove_inline_handler, upsert_inline_handler
+from ...models.api import ErrorCode
+from ...models.automations import (
+    AutomationTree,
+    LightEffectLocation,
+    YamlDiff,
+)
+from . import catalog
+from .emitter import dump, emit_effect_item
+from .parsing import make_yaml
+
+
+def wrap_handler_list_block(handler_key: str, rendered_list: str) -> str:
+    """Prefix a rendered dashed list with its ``<handler_key>:`` header."""
+    # ``upsert_inline_handler`` writes ``rendered_yaml`` verbatim under the
+    # component instance; the list dump is bare, so add the header here.
+    return f"{handler_key}:\n" + rendered_list.rstrip() + "\n"
+
+
+def upsert_light_effect(
+    yaml_text: str,
+    tree: AutomationTree,
+    location: LightEffectLocation,
+) -> tuple[str, YamlDiff]:
+    """Splice an ``effects:`` list item under a configured light."""
+    # The tree carries the effect id under ``trigger_params`` (one
+    # key mapping to its params dict). Reverse the parser's shape.
+    if not tree.trigger_params or len(tree.trigger_params) != 1:
+        msg = "LightEffect upsert requires exactly one effect-id key in trigger_params"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    effect_id, params = next(iter(tree.trigger_params.items()))
+    catalog_entry = catalog.light_effect_by_id(str(effect_id))
+    if catalog_entry is None:
+        msg = f"Unknown light effect id: {effect_id!r}"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    rendered = wrap_handler_list_block(
+        "effects",
+        dump([emit_effect_item(catalog_entry, str(effect_id), params or {})]),
+    )
+    res = upsert_inline_handler(
+        yaml_text,
+        component_domain="light",
+        component_id=location.component_id,
+        handler_key="effects",
+        rendered_yaml=rendered,
+    )
+    if res is None:
+        msg = f"Light instance id={location.component_id!r} not found; can't splice effect entry"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    new_text, from_line, to_line, replacement = res
+    return new_text, YamlDiff(
+        fromLine=from_line,
+        toLine=to_line,
+        replacement=replacement,
+    )
+
+
+def delete_light_effect(
+    yaml_text: str,
+    location: LightEffectLocation,
+) -> tuple[str, YamlDiff]:
+    """Drop one entry from a light's ``effects:`` list."""
+    # Easiest path: parse, mutate the list, re-emit. We don't have a
+    # line-precise splice helper for "remove list item at index N
+    # inside an inline handler" — this keeps the writer simple at
+    # the cost of touching the whole ``effects:`` block in the diff.
+    yaml = make_yaml()
+    data = yaml.load(yaml_text) or {}
+    lights = data.get("light") if isinstance(data, dict) else None
+    if not isinstance(lights, list):
+        msg = "No light: block; can't delete effect"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    for instance in lights:
+        if not isinstance(instance, dict):
+            continue
+        if str(instance.get("id", "")) != location.component_id:
+            continue
+        effects = instance.get("effects")
+        if not isinstance(effects, list) or not 0 <= location.index < len(effects):
+            msg = f"effects[{location.index}] not present on light id={location.component_id!r}"
+            raise CommandError(ErrorCode.NOT_FOUND, msg)
+        del effects[location.index]
+        if not effects:
+            del instance["effects"]
+        # Re-render the inline handler block to splice through
+        # ``upsert_inline_handler`` (or remove it when empty).
+        if "effects" in instance:
+            rendered = wrap_handler_list_block("effects", dump(effects))
+            res = upsert_inline_handler(
+                yaml_text,
+                component_domain="light",
+                component_id=location.component_id,
+                handler_key="effects",
+                rendered_yaml=rendered,
+            )
+            if res is None:  # pragma: no cover — instance found above
+                msg = f"light id={location.component_id!r} not found in splice"
+                raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
+            new_text, from_line, to_line, replacement = res
+            return new_text, YamlDiff(
+                fromLine=from_line,
+                toLine=to_line,
+                replacement=replacement,
+            )
+        removed = remove_inline_handler(
+            yaml_text,
+            component_domain="light",
+            component_id=location.component_id,
+            handler_key="effects",
+        )
+        if removed is None:  # pragma: no cover — instance found above
+            msg = f"effects: not found on light id={location.component_id!r}"
+            raise CommandError(ErrorCode.NOT_FOUND, msg)
+        new_text, from_line, to_line = removed
+        return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement="")
+    msg = f"Light id={location.component_id!r} not found"
+    raise CommandError(ErrorCode.NOT_FOUND, msg)

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -34,6 +34,7 @@ from esphome_device_builder.controllers.automations.parsing import (
     _decompose_action_list,
     _decompose_condition,
     _decompose_condition_list,
+    _decompose_trigger_mapping,
     _dump_slice,
     _estimate_end_line,
     _item_range,
@@ -235,6 +236,25 @@ def test_parse_light_skips_non_dict_instances() -> None:
     )
     effects = [p for p in parsed if p.location.kind == "light_effect"]
     assert len(effects) == 1
+
+
+def test_decompose_trigger_mapping_explicit_then() -> None:
+    """A mapping with ``then:`` splits into trigger params and its action list."""
+    tree = _decompose_trigger_mapping(
+        {"seconds": 0, "then": [{"delay": "1s"}]}, trigger_id="time.on_time"
+    )
+    assert tree.trigger_id == "time.on_time"
+    assert tree.trigger_params == {"seconds": 0}
+    assert [a.action_id for a in tree.actions] == ["delay"]
+
+
+def test_decompose_trigger_mapping_single_action_shortcut() -> None:
+    """The single-action shortcut pulls the action key out of trigger params."""
+    tree = _decompose_trigger_mapping(
+        {"min_length": "50ms", "logger.log": "hi"}, trigger_id="binary_sensor.on_click"
+    )
+    assert tree.trigger_params == {"min_length": "50ms"}
+    assert [a.action_id for a in tree.actions] == ["logger.log"]
 
 
 def test_decompose_action_list_returns_empty_for_none() -> None:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

Behaviour free refactor that prepares for visual editing of list shaped triggers like `time.on_time`; it extracts the dict branch of `_decompose_trigger_body` into a standalone `_decompose_trigger_mapping` so one entry of a list can be decomposed on its own, and moves the light effects splice helpers into a new `writing_lists.py`, which also brings `writing.py` back under the 800 line cap. No behaviour change, the existing automation tests cover it.

**Related issue or feature (if applicable):**

- Preparation for #1049 (on_time list trigger support); the feature lands in a follow up PR

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
