### PR TITLE
Support editing list-shaped triggers (time.on_time) in the visual editor

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -233,13 +233,13 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 ```
 {kind: "script",        id: string}
 {kind: "interval",      index: int}
-{kind: "component_on",  component_id: string, trigger: string}
+{kind: "component_on",  component_id: string, trigger: string, index?: int}
 {kind: "device_on",     trigger: string}
 {kind: "light_effect",  component_id: string, index: int}
 {kind: "api_action",    action_name: string}
 ```
 
-`upsert` / `delete` consume the same shape so the writer knows the exact YAML range to splice. `api_action` covers user-defined actions under `api.actions:` — structurally a callable (named, typed `variables:`, `then:` action list, no trigger) so the editor reuses the script pipeline. The deprecated `service:` discriminator is accepted on read; the writer emits `action:`.
+`upsert` / `delete` consume the same shape so the writer knows the exact YAML range to splice. On `component_on`, `index` is omitted for a single-handler mapping (`on_press: {then: [...]}`) and set for one entry of a list-shaped trigger such as `time.on_time` (a YAML list of cron schedules); `index == <entry count>` on `upsert` appends a new entry. `api_action` covers user-defined actions under `api.actions:` — structurally a callable (named, typed `variables:`, `then:` action list, no trigger) so the editor reuses the script pipeline. The deprecated `service:` discriminator is accepted on read; the writer emits `action:`.
 
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|

--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -43,11 +43,7 @@ def render_script_item(tree: AutomationTree, script_id: str) -> str:
 
 def render_interval_item(tree: AutomationTree) -> str:
     """Render a single ``- interval: ...`` interval list item."""
-    item = CommentedMap()
-    for key, value in tree.trigger_params.items():
-        item[key] = encode_value(value)
-    item["then"] = emit_action_seq(tree.actions)
-    return dump([item])
+    return dump([emit_trigger_list_item(tree)])
 
 
 def render_api_action_item(tree: AutomationTree, action_name: str) -> str:
@@ -70,13 +66,18 @@ def render_trigger_handler(tree: AutomationTree, *, key: str) -> str:
     round-trips stay deterministic (the parser accepts both
     shortcut shapes too).
     """
-    body = CommentedMap()
-    for param_key, value in tree.trigger_params.items():
-        body[param_key] = encode_value(value)
-    body["then"] = emit_action_seq(tree.actions)
     wrapper = CommentedMap()
-    wrapper[key] = body
+    wrapper[key] = emit_trigger_list_item(tree)
     return dump(wrapper)
+
+
+def emit_trigger_list_item(tree: AutomationTree) -> CommentedMap:
+    """Build one entry mapping (trigger params plus ``then:``) for a list-shaped trigger."""
+    item = CommentedMap()
+    for key, value in tree.trigger_params.items():
+        item[key] = encode_value(value)
+    item["then"] = emit_action_seq(tree.actions)
+    return item
 
 
 def emit_action_seq(actions: list[ActionNode]) -> CommentedSeq:

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -36,6 +36,7 @@ from ...models.automations import (
     ActionNode,
     ApiActionLocation,
     AutomationTree,
+    AutomationTrigger,
     ComponentOnLocation,
     ConditionNode,
     DeviceOnLocation,
@@ -307,8 +308,8 @@ def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
             for key, body in list(instance.items()):
                 if not key.startswith("on_"):
                     continue
-                trigger_id = f"{domain}.{key}"
-                if catalog.trigger_by_id(trigger_id) is None:
+                trigger = catalog.trigger_by_id(f"{domain}.{key}")
+                if trigger is None:
                     # Not a known component trigger — skip rather
                     # than surface as a parse error. Component
                     # schemas occasionally carry ``on_*`` keys that
@@ -316,25 +317,116 @@ def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
                     # (e.g. legacy aliases). The catalog is the
                     # source of truth.
                     continue
-                from_line, to_line = _key_range(instance, key)
-                tree, error = _safe_tree(
-                    partial(_decompose_trigger_body, body, trigger_id=trigger_id),
-                    trigger_id=trigger_id,
-                )
-                out.append(
-                    ParsedAutomation(
-                        location=ComponentOnLocation(
-                            component_id=str(comp_id),
-                            trigger=key,
-                        ),
-                        label=f"{comp_name} → {_pretty_name(key)}",
-                        automation=tree,
-                        from_line=from_line,
-                        to_line=to_line,
-                        raw_yaml=_dump_slice({key: body}),
-                        error=error,
+                out.extend(
+                    _parse_one_inline_trigger(
+                        instance,
+                        comp_id=str(comp_id),
+                        comp_name=str(comp_name),
+                        key=key,
+                        body=body,
+                        trigger=trigger,
                     )
                 )
+    return out
+
+
+def _parse_one_inline_trigger(
+    instance: dict,
+    *,
+    comp_id: str,
+    comp_name: str,
+    key: str,
+    body: Any,
+    trigger: AutomationTrigger,
+) -> list[ParsedAutomation]:
+    """Parse one inline ``on_*:`` handler — single mapping or list-shaped."""
+    trigger_id = trigger.id
+    if _is_list_form_trigger(body, trigger):
+        return _parse_list_form_trigger(
+            body, comp_id=comp_id, comp_name=comp_name, key=key, trigger_id=trigger_id
+        )
+    from_line, to_line = _key_range(instance, key)
+    tree, error = _safe_tree(
+        partial(_decompose_trigger_body, body, trigger_id=trigger_id),
+        trigger_id=trigger_id,
+    )
+    return [
+        ParsedAutomation(
+            location=ComponentOnLocation(component_id=comp_id, trigger=key),
+            label=f"{comp_name} → {_pretty_name(key)}",
+            automation=tree,
+            from_line=from_line,
+            to_line=to_line,
+            raw_yaml=_dump_slice({key: body}),
+            error=error,
+        )
+    ]
+
+
+def _is_list_form_trigger(body: Any, trigger: AutomationTrigger) -> bool:
+    """
+    Report whether *body* is a YAML list of trigger entries (``time.on_time``).
+
+    A bare action list (``on_press: [{light.turn_on: id}, ...]``) is *not*
+    list-form: every item there is a known action id. List-form requires a
+    non-empty list whose every item is trigger-shaped (see
+    :func:`_is_trigger_entry`), so the conservative default keeps the
+    existing bare-action-list behaviour intact.
+    """
+    return (
+        isinstance(body, list)
+        and bool(body)
+        and all(_is_trigger_entry(item, trigger) for item in body)
+    )
+
+
+def _is_trigger_entry(item: Any, trigger: AutomationTrigger) -> bool:
+    """
+    Report whether *item* looks like one entry of a list-shaped trigger.
+
+    Requires a ``then:`` or one of the trigger's own config keys — a bare
+    action item (including an unknown action id) is *not* an entry, so it
+    stays a bare action list and its parse error still surfaces.
+    """
+    if not isinstance(item, dict) or not item:
+        return False
+    if "then" in item:
+        return True
+    cron_keys = {entry.key for entry in trigger.config_entries}
+    return any(key in cron_keys for key in item)
+
+
+def _parse_list_form_trigger(
+    body: list,
+    *,
+    comp_id: str,
+    comp_name: str,
+    key: str,
+    trigger_id: str,
+) -> list[ParsedAutomation]:
+    """Emit one :class:`ParsedAutomation` per entry of a list-shaped trigger."""
+    out: list[ParsedAutomation] = []
+    for index, entry in enumerate(body):
+        from_line, to_line = _item_range(body, index)
+        tree, error = _safe_tree(
+            partial(_decompose_trigger_mapping, entry, trigger_id=trigger_id),
+            trigger_id=trigger_id,
+        )
+        out.append(
+            ParsedAutomation(
+                location=ComponentOnLocation(
+                    component_id=comp_id,
+                    trigger=key,
+                    index=index,
+                ),
+                label=f"{comp_name} → {_pretty_name(key)} #{index + 1}",
+                automation=tree,
+                from_line=from_line,
+                to_line=to_line,
+                raw_yaml=_dump_slice([entry]),
+                error=error,
+            )
+        )
     return out
 
 

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -43,7 +43,12 @@ from .emitter import (
     render_trigger_handler,
 )
 from .parsing import make_yaml
-from .writing_lists import delete_light_effect, upsert_light_effect
+from .writing_lists import (
+    delete_light_effect,
+    delete_list_entry,
+    upsert_component_on_entry,
+    upsert_light_effect,
+)
 
 # ---------------------------------------------------------------------------
 # Public entry points
@@ -138,12 +143,20 @@ def _upsert_component_on(
     location: ComponentOnLocation,
 ) -> tuple[str, YamlDiff]:
     """Splice an inline ``on_*:`` handler under a configured component."""
-    trigger = catalog.trigger_by_id(
-        f"{_component_domain_from_yaml(yaml_text, location)}.{location.trigger}",
-    )
+    instance_domain = _component_domain_from_yaml(yaml_text, location)
+    trigger = catalog.trigger_by_id(f"{instance_domain}.{location.trigger}")
     if trigger is None:
         msg = f"Unknown trigger id {location.trigger!r} on component {location.component_id!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    if location.index is not None:
+        return upsert_component_on_entry(
+            yaml_text,
+            tree=tree,
+            domain=instance_domain,
+            component_id=location.component_id,
+            trigger_key=location.trigger,
+            index=location.index,
+        )
     domain = trigger.applies_to[0] if trigger.applies_to else ""
     rendered = render_trigger_handler(tree, key=location.trigger)
     res = upsert_inline_handler(
@@ -445,9 +458,16 @@ def _delete_component_on(
     location: ComponentOnLocation,
 ) -> tuple[str, YamlDiff]:
     """Drop an inline ``on_*:`` handler from a configured component."""
-    trigger = catalog.trigger_by_id(
-        f"{_component_domain_from_yaml(yaml_text, location)}.{location.trigger}",
-    )
+    instance_domain = _component_domain_from_yaml(yaml_text, location)
+    if location.index is not None:
+        return delete_list_entry(
+            yaml_text,
+            domain=instance_domain,
+            component_id=location.component_id,
+            handler_key=location.trigger,
+            index=location.index,
+        )
+    trigger = catalog.trigger_by_id(f"{instance_domain}.{location.trigger}")
     domain = trigger.applies_to[0] if trigger and trigger.applies_to else ""
     res = remove_inline_handler(
         yaml_text,

--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -20,7 +20,7 @@ from ...models.automations import (
     YamlDiff,
 )
 from . import catalog
-from .emitter import dump, emit_effect_item
+from .emitter import dump, emit_effect_item, emit_trigger_list_item
 from .parsing import make_yaml
 
 
@@ -29,6 +29,129 @@ def wrap_handler_list_block(handler_key: str, rendered_list: str) -> str:
     # ``upsert_inline_handler`` writes ``rendered_yaml`` verbatim under the
     # component instance; the list dump is bare, so add the header here.
     return f"{handler_key}:\n" + rendered_list.rstrip() + "\n"
+
+
+def _resplice_list_block(
+    yaml_text: str,
+    *,
+    domain: str,
+    component_id: str,
+    handler_key: str,
+    entries: list,
+) -> tuple[str, YamlDiff]:
+    """
+    Re-emit a component's list handler from *entries* and return the diff.
+
+    Non-empty *entries* replace the whole block; an empty list removes the
+    handler key. Callers locate the instance first, so a ``None`` splice
+    result is unreachable.
+    """
+    if entries:
+        rendered = wrap_handler_list_block(handler_key, dump(entries))
+        res = upsert_inline_handler(
+            yaml_text,
+            component_domain=domain,
+            component_id=component_id,
+            handler_key=handler_key,
+            rendered_yaml=rendered,
+        )
+        if res is None:  # pragma: no cover — instance located by the caller
+            msg = f"Component instance id={component_id!r} not found under {domain!r}"
+            raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
+        new_text, from_line, to_line, replacement = res
+        return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement=replacement)
+    removed = remove_inline_handler(
+        yaml_text,
+        component_domain=domain,
+        component_id=component_id,
+        handler_key=handler_key,
+    )
+    if removed is None:  # pragma: no cover — instance located by the caller
+        msg = f"{handler_key}: not found on component id={component_id!r}"
+        raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
+    new_text, from_line, to_line = removed
+    return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement="")
+
+
+def upsert_component_on_entry(
+    yaml_text: str,
+    *,
+    tree: AutomationTree,
+    domain: str,
+    component_id: str,
+    trigger_key: str,
+    index: int,
+) -> tuple[str, YamlDiff]:
+    """
+    Insert or replace one entry of a list-shaped trigger (``time.on_time``).
+
+    ``index == len(entries)`` appends; an in-range index replaces. Refuses
+    when the existing handler is a single mapping rather than a list — the
+    user picked that shape, so don't silently rewrite it.
+    """
+    instance = _require_instance(
+        yaml_text, domain=domain, component_id=component_id, error_code=ErrorCode.INVALID_ARGS
+    )
+    existing = instance.get(trigger_key)
+    if existing is not None and not isinstance(existing, list):
+        msg = f"{trigger_key}: is a single mapping, not a list; convert it to a list first"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    entries = existing if isinstance(existing, list) else []
+    new_item = emit_trigger_list_item(tree)
+    if index == len(entries):
+        entries.append(new_item)
+    elif 0 <= index < len(entries):
+        entries[index] = new_item
+    else:
+        msg = f"{trigger_key}[{index}] out of range (have {len(entries)})"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return _resplice_list_block(
+        yaml_text,
+        domain=domain,
+        component_id=component_id,
+        handler_key=trigger_key,
+        entries=entries,
+    )
+
+
+def _require_instance(
+    yaml_text: str, *, domain: str, component_id: str, error_code: ErrorCode
+) -> dict:
+    """
+    Return the ``<domain>:`` list item whose ``id`` matches *component_id*.
+
+    ``error_code`` selects the ``CommandError`` code so callers keep their
+    INVALID_ARGS (upsert) / NOT_FOUND (delete) contracts.
+    """
+    data = make_yaml().load(yaml_text) or {}
+    section = data.get(domain) if isinstance(data, dict) else None
+    if isinstance(section, list):
+        for instance in section:
+            if isinstance(instance, dict) and str(instance.get("id", "")) == component_id:
+                return instance
+    msg = f"Component instance id={component_id!r} not found under {domain!r}"
+    raise CommandError(error_code, msg)
+
+
+def delete_list_entry(
+    yaml_text: str, *, domain: str, component_id: str, handler_key: str, index: int
+) -> tuple[str, YamlDiff]:
+    """Drop entry *index* from a component's ``<handler_key>:`` list; re-splice."""
+    instance = _require_instance(
+        yaml_text, domain=domain, component_id=component_id, error_code=ErrorCode.NOT_FOUND
+    )
+    entries = instance.get(handler_key)
+    if not isinstance(entries, list) or not 0 <= index < len(entries):
+        msg = f"{handler_key}[{index}] not present on component id={component_id!r}"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    del entries[index]
+    return _resplice_list_block(
+        yaml_text,
+        domain=domain,
+        component_id=component_id,
+        handler_key=handler_key,
+        entries=entries,
+    )
 
 
 def upsert_light_effect(
@@ -47,25 +170,20 @@ def upsert_light_effect(
     if catalog_entry is None:
         msg = f"Unknown light effect id: {effect_id!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    rendered = wrap_handler_list_block(
-        "effects",
-        dump([emit_effect_item(catalog_entry, str(effect_id), params or {})]),
-    )
-    res = upsert_inline_handler(
+    _require_instance(
         yaml_text,
-        component_domain="light",
+        domain="light",
+        component_id=location.component_id,
+        error_code=ErrorCode.INVALID_ARGS,
+    )
+    item = emit_effect_item(catalog_entry, str(effect_id), params or {})
+    # Effects upsert replaces the whole block with the one rendered entry.
+    return _resplice_list_block(
+        yaml_text,
+        domain="light",
         component_id=location.component_id,
         handler_key="effects",
-        rendered_yaml=rendered,
-    )
-    if res is None:
-        msg = f"Light instance id={location.component_id!r} not found; can't splice effect entry"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    new_text, from_line, to_line, replacement = res
-    return new_text, YamlDiff(
-        fromLine=from_line,
-        toLine=to_line,
-        replacement=replacement,
+        entries=[item],
     )
 
 
@@ -74,58 +192,10 @@ def delete_light_effect(
     location: LightEffectLocation,
 ) -> tuple[str, YamlDiff]:
     """Drop one entry from a light's ``effects:`` list."""
-    # Easiest path: parse, mutate the list, re-emit. We don't have a
-    # line-precise splice helper for "remove list item at index N
-    # inside an inline handler" — this keeps the writer simple at
-    # the cost of touching the whole ``effects:`` block in the diff.
-    yaml = make_yaml()
-    data = yaml.load(yaml_text) or {}
-    lights = data.get("light") if isinstance(data, dict) else None
-    if not isinstance(lights, list):
-        msg = "No light: block; can't delete effect"
-        raise CommandError(ErrorCode.NOT_FOUND, msg)
-    for instance in lights:
-        if not isinstance(instance, dict):
-            continue
-        if str(instance.get("id", "")) != location.component_id:
-            continue
-        effects = instance.get("effects")
-        if not isinstance(effects, list) or not 0 <= location.index < len(effects):
-            msg = f"effects[{location.index}] not present on light id={location.component_id!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        del effects[location.index]
-        if not effects:
-            del instance["effects"]
-        # Re-render the inline handler block to splice through
-        # ``upsert_inline_handler`` (or remove it when empty).
-        if "effects" in instance:
-            rendered = wrap_handler_list_block("effects", dump(effects))
-            res = upsert_inline_handler(
-                yaml_text,
-                component_domain="light",
-                component_id=location.component_id,
-                handler_key="effects",
-                rendered_yaml=rendered,
-            )
-            if res is None:  # pragma: no cover — instance found above
-                msg = f"light id={location.component_id!r} not found in splice"
-                raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
-            new_text, from_line, to_line, replacement = res
-            return new_text, YamlDiff(
-                fromLine=from_line,
-                toLine=to_line,
-                replacement=replacement,
-            )
-        removed = remove_inline_handler(
-            yaml_text,
-            component_domain="light",
-            component_id=location.component_id,
-            handler_key="effects",
-        )
-        if removed is None:  # pragma: no cover — instance found above
-            msg = f"effects: not found on light id={location.component_id!r}"
-            raise CommandError(ErrorCode.NOT_FOUND, msg)
-        new_text, from_line, to_line = removed
-        return new_text, YamlDiff(fromLine=from_line, toLine=to_line, replacement="")
-    msg = f"Light id={location.component_id!r} not found"
-    raise CommandError(ErrorCode.NOT_FOUND, msg)
+    return delete_list_entry(
+        yaml_text,
+        domain="light",
+        component_id=location.component_id,
+        handler_key="effects",
+        index=location.index,
+    )

--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -241,10 +241,18 @@ class IntervalLocation(DataClassORJSONMixin):
 
 @dataclass
 class ComponentOnLocation(DataClassORJSONMixin):
-    """An inline ``on_*:`` handler under a configured component instance."""
+    """
+    An inline ``on_*:`` handler under a configured component instance.
+
+    ``index`` is ``None`` for the single-handler mapping form
+    (``on_press: {then: [...]}``); for a list-shaped trigger
+    (``time.on_time`` is a YAML list of cron entries) it selects one
+    entry of that list.
+    """
 
     component_id: str
     trigger: str
+    index: int | None = None
     kind: Literal["component_on"] = "component_on"
 
 

--- a/tests/fixtures/automation_yamls/time_on_time_list.yaml
+++ b/tests/fixtures/automation_yamls/time_on_time_list.yaml
@@ -1,0 +1,12 @@
+time:
+  - platform: sntp
+    id: my_time
+    on_time:
+      - seconds: 0
+        minutes: 30
+        hours: 8
+        then:
+          - logger.log: morning
+      - cron: "0 0 12 * * *"
+        then:
+          - logger.log: noon

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -37,6 +37,7 @@ from esphome_device_builder.controllers.automations.parsing import (
     _decompose_trigger_mapping,
     _dump_slice,
     _estimate_end_line,
+    _is_list_form_trigger,
     _item_range,
     _key_range,
     _render_params,
@@ -165,6 +166,38 @@ def test_scope_skips_component_instance_without_id() -> None:
 def test_decode_location_per_kind(payload: dict, expected: type) -> None:
     """Each ``kind`` discriminator routes to the matching dataclass."""
     assert isinstance(_decode_location(payload), expected)
+
+
+def test_decode_location_component_on_legacy_payload_defaults_index_none() -> None:
+    """A pre-index component_on payload decodes with ``index`` None."""
+    loc = _decode_location({"kind": "component_on", "component_id": "b", "trigger": "on_press"})
+    assert isinstance(loc, ComponentOnLocation)
+    assert loc.index is None
+
+
+def test_decode_location_component_on_carries_index() -> None:
+    """A component_on payload with ``index`` round-trips it."""
+    loc = _decode_location(
+        {"kind": "component_on", "component_id": "my_time", "trigger": "on_time", "index": 2}
+    )
+    assert isinstance(loc, ComponentOnLocation)
+    assert loc.index == 2
+
+
+def test_is_list_form_trigger_discriminates_cron_vs_bare_actions() -> None:
+    """A cron entry list is list-form; a bare action list is not."""
+    on_time = catalog.trigger_by_id("time.on_time")
+    on_press = catalog.trigger_by_id("binary_sensor.on_press")
+    assert _is_list_form_trigger([{"seconds": 0, "then": []}], on_time) is True
+    assert _is_list_form_trigger([{"then": []}], on_press) is True
+    assert _is_list_form_trigger([{"seconds": 0}], on_time) is True
+    assert _is_list_form_trigger([{"switch.toggle": "relay"}], on_press) is False
+    # An unknown action id is a bare action, not a trigger entry — so its
+    # parse error still surfaces instead of being read as trigger params.
+    assert _is_list_form_trigger([{"not_a_real_action": 5}], on_press) is False
+    assert _is_list_form_trigger(["bare-scalar"], on_time) is False
+    assert _is_list_form_trigger([], on_time) is False
+    assert _is_list_form_trigger({"seconds": 0}, on_time) is False
 
 
 def test_decode_location_missing_kind_raises_invalid_args() -> None:

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -384,6 +384,76 @@ def test_parse_raises_on_unloadable_yaml() -> None:
         parse_device_yaml("switch:\n  - name: [unterminated\n")
 
 
+# ---------------------------------------------------------------------------
+# List-shaped triggers (time.on_time)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_on_time_list_emits_one_entry_per_item() -> None:
+    """Each entry of a list-form on_time is its own indexed automation."""
+    parsed = parse_device_yaml(_load("time_on_time_list.yaml"))
+    assert len(parsed) == 2
+    first, second = parsed
+    assert first.location.kind == "component_on"
+    assert first.location.component_id == "my_time"
+    assert first.location.trigger == "on_time"
+    assert first.location.index == 0
+    assert second.location.index == 1
+    assert first.automation.trigger_params == {"seconds": 0, "minutes": 30, "hours": 8}
+    assert second.automation.trigger_params == {"cron": "0 0 12 * * *"}
+    assert [a.action_id for a in first.automation.actions] == ["logger.log"]
+    assert first.error is None and second.error is None
+
+
+def test_parse_on_time_single_mapping_uses_index_none() -> None:
+    """The single-mapping on_time form stays one automation with index None."""
+    yaml = (
+        "time:\n  - platform: sntp\n    id: my_time\n"
+        "    on_time:\n      seconds: 0\n      hours: 8\n"
+        "      then:\n        - logger.log: hi\n"
+    )
+    parsed = parse_device_yaml(yaml)
+    assert len(parsed) == 1
+    assert parsed[0].location.index is None
+    assert parsed[0].automation.trigger_params == {"seconds": 0, "hours": 8}
+
+
+def test_parse_on_time_list_isolates_one_bad_entry() -> None:
+    """An unknown action in one on_time entry flags only that entry."""
+    yaml = (
+        "time:\n  - platform: sntp\n    id: my_time\n"
+        "    on_time:\n"
+        "      - seconds: 0\n        then:\n          - logger.log: ok\n"
+        "      - hours: 8\n        then:\n          - not_a_real_action: 5\n"
+    )
+    parsed = parse_device_yaml(yaml)
+    assert len(parsed) == 2
+    assert parsed[0].error is None
+    assert parsed[1].error is not None
+    assert "not_a_real_action" in parsed[1].error
+    assert parsed[1].automation.actions == []
+
+
+def test_parse_bare_action_list_is_not_list_form() -> None:
+    """A bare action list (on_press) is one automation, not per-item entries."""
+    parsed = parse_device_yaml(_load("inline_on_press_bare_actionlist.yaml"))
+    component_on = [p for p in parsed if p.location.kind == "component_on"]
+    assert all(p.location.index is None for p in component_on)
+
+
+def test_parse_unknown_action_in_list_surfaces_as_error() -> None:
+    """A bare action list with an unknown id stays one entry with its error set."""
+    yaml = (
+        "binary_sensor:\n  - platform: gpio\n    id: btn\n"
+        "    on_press:\n      - not_a_real_action: 5\n"
+    )
+    parsed = parse_device_yaml(yaml)
+    assert len(parsed) == 1
+    assert parsed[0].location.index is None
+    assert parsed[0].error is not None
+    assert "not_a_real_action" in parsed[0].error
+
+
 def test_parse_returns_empty_for_minimal_yaml() -> None:
     """A YAML without any recognised automation shape parses to empty list."""
     assert parse_device_yaml("esphome:\n  name: x\n") == []

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -1003,3 +1003,116 @@ def test_round_trip_preserves_comments_above_top_level_blocks() -> None:
     assert "# This is a wake-up script\n" in new_text
     # Original script body is untouched.
     assert "- id: alarm" in new_text
+
+
+# ---------------------------------------------------------------------------
+# List-shaped triggers (time.on_time)
+# ---------------------------------------------------------------------------
+
+
+def _on_time_loc(index: int) -> ComponentOnLocation:
+    return ComponentOnLocation(component_id="my_time", trigger="on_time", index=index)
+
+
+def test_round_trip_on_time_list_entry_is_stable() -> None:
+    """Parse → upsert an entry with its own tree → re-parse keeps both entries."""
+    yaml_text = _load("time_on_time_list.yaml")
+    first = parse_device_yaml(yaml_text)[0]
+    new_text, _diff = render_upsert(yaml_text, tree=first.automation, location=_on_time_loc(0))
+    reparsed = parse_device_yaml(new_text)
+    assert [p.location.index for p in reparsed] == [0, 1]
+    assert reparsed[0].automation.trigger_params == {"seconds": 0, "minutes": 30, "hours": 8}
+
+
+def test_upsert_on_time_appends_entry_at_end() -> None:
+    """An index equal to the entry count appends a new schedule."""
+    yaml_text = _load("time_on_time_list.yaml")
+    tree = AutomationTree(
+        trigger_id="time.on_time",
+        trigger_params={"hours": 23},
+        actions=[ActionNode(action_id="logger.log", params={"id": "night"})],
+    )
+    new_text, _diff = render_upsert(yaml_text, tree=tree, location=_on_time_loc(2))
+    reparsed = parse_device_yaml(new_text)
+    assert [p.location.index for p in reparsed] == [0, 1, 2]
+    assert reparsed[2].automation.trigger_params == {"hours": 23}
+
+
+def test_upsert_on_time_replaces_entry_and_leaves_siblings() -> None:
+    """Replacing one entry leaves the other untouched."""
+    yaml_text = _load("time_on_time_list.yaml")
+    tree = AutomationTree(
+        trigger_id="time.on_time",
+        trigger_params={"seconds": 5},
+        actions=[ActionNode(action_id="logger.log", params={"id": "tick"})],
+    )
+    new_text, _diff = render_upsert(yaml_text, tree=tree, location=_on_time_loc(0))
+    reparsed = parse_device_yaml(new_text)
+    assert reparsed[0].automation.trigger_params == {"seconds": 5}
+    assert reparsed[1].automation.trigger_params == {"cron": "0 0 12 * * *"}
+
+
+def test_upsert_on_time_index_out_of_range_raises() -> None:
+    """An index past the append slot is rejected."""
+    yaml_text = _load("time_on_time_list.yaml")
+    tree = AutomationTree(trigger_id="time.on_time", trigger_params={"hours": 1})
+    with pytest.raises(CommandError) as exc:
+        render_upsert(yaml_text, tree=tree, location=_on_time_loc(9))
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+
+
+def test_upsert_on_time_with_index_refuses_existing_mapping() -> None:
+    """Indexing into a single-mapping on_time is refused, not silently rewritten."""
+    yaml_text = (
+        "time:\n  - platform: sntp\n    id: my_time\n"
+        "    on_time:\n      seconds: 0\n      then:\n        - logger.log: hi\n"
+    )
+    tree = AutomationTree(trigger_id="time.on_time", trigger_params={"hours": 1})
+    with pytest.raises(CommandError) as exc:
+        render_upsert(yaml_text, tree=tree, location=_on_time_loc(0))
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+
+
+def test_delete_on_time_entry_keeps_siblings() -> None:
+    """Deleting one entry leaves the rest of the list in place."""
+    yaml_text = _load("time_on_time_list.yaml")
+    new_text, _diff = render_delete(yaml_text, location=_on_time_loc(0))
+    reparsed = parse_device_yaml(new_text)
+    assert len(reparsed) == 1
+    assert reparsed[0].automation.trigger_params == {"cron": "0 0 12 * * *"}
+
+
+def test_delete_last_on_time_entry_removes_the_key() -> None:
+    """Deleting the final entry drops the whole on_time: key."""
+    yaml_text = (
+        "time:\n  - platform: sntp\n    id: my_time\n"
+        "    on_time:\n      - seconds: 0\n        then:\n          - logger.log: hi\n"
+    )
+    new_text, _diff = render_delete(yaml_text, location=_on_time_loc(0))
+    assert "on_time:" not in new_text
+    assert parse_device_yaml(new_text) == []
+
+
+def test_delete_on_time_missing_index_raises_not_found() -> None:
+    """Deleting an index that isn't there is a NOT_FOUND."""
+    yaml_text = _load("time_on_time_list.yaml")
+    with pytest.raises(CommandError) as exc:
+        render_delete(yaml_text, location=_on_time_loc(9))
+    assert exc.value.code is ErrorCode.NOT_FOUND
+
+
+def test_upsert_on_time_no_component_block_raises_invalid_args() -> None:
+    """Upserting an entry when no time component exists is INVALID_ARGS."""
+    tree = AutomationTree(trigger_id="time.on_time", trigger_params={"hours": 1})
+    with pytest.raises(CommandError) as exc:
+        render_upsert("esphome:\n  name: x\n", tree=tree, location=_on_time_loc(0))
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+
+
+def test_delete_on_time_unknown_component_raises_not_found() -> None:
+    """Deleting an entry on an id that isn't configured is NOT_FOUND."""
+    yaml_text = _load("time_on_time_list.yaml")
+    loc = ComponentOnLocation(component_id="ghost", trigger="on_time", index=0)
+    with pytest.raises(CommandError) as exc:
+        render_delete(yaml_text, location=loc)
+    assert exc.value.code is ErrorCode.NOT_FOUND


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes. -->

`time.on_time` is a YAML list of cron schedule entries, each with its own params (seconds, minutes, hours, days_of_week, cron) plus a `then:`; the parser treated any list body as a bare action list, so it raised `invalid_args` on the first cron key, and the whole automation could not be edited in the visual editor. This parses each entry as its own indexed automation via a new optional `index` on `ComponentOnLocation`, and adds the emitter and writer paths to upsert (replace, or append when `index` equals the entry count) and delete one entry while leaving its siblings in place. Single mapping `on_time` keeps working with `index` unset; the cron fields render from the existing trigger `config_entries`.

Stacked on #1075 (the behaviour free refactor); review that one first. The companion frontend PR is esphome/device-builder-frontend#463.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1049

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#463

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
