### PR TITLE
List only existing build artifacts and the ELF from get_binaries

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -144,10 +144,12 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `firmware/get_job` | `{job_id}` | `FirmwareJob` | Get job with full output |
 | `firmware/follow_job` | `{job_id}` | Streaming | Historical output + live stream for one job |
 | `firmware/follow_jobs` | `{snapshot?: true}` | Streaming | All jobs' lifecycle + output + progress |
-| `firmware/get_binaries` | `{configuration}` | `[{title, file}]` | List compiled firmware files |
+| `firmware/get_binaries` | `{configuration}` | `[{title, file, description?}]` | List downloadable build artifacts present on disk |
 | `firmware/download` | `{configuration, file, compressed?}` | `{filename, data, size}` | Download binary (base64) |
 | `firmware/cancel` | `{job_id}` | — | Cancel queued or running job |
 | `firmware/clear` | `{status?}` | — | Remove finished jobs |
+
+**`firmware/get_binaries`**: returns only artifacts that exist in the build directory (an empty list means "compile first"), each `{title, file, description?}` — `description` is optional subtext from the platform's `get_download_types`. A `firmware.elf` entry (debug symbols for the ESP stack trace decoder) is appended when present; `get_download_types` itself never lists it. Any `file` can be fetched via `firmware/download`.
 
 **Job queue**: one job runs at a time, others wait. Jobs persist across server restarts. Output buffered in `FirmwareJob.output` — clients can reconnect via `firmware/follow_job`.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -144,12 +144,12 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `firmware/get_job` | `{job_id}` | `FirmwareJob` | Get job with full output |
 | `firmware/follow_job` | `{job_id}` | Streaming | Historical output + live stream for one job |
 | `firmware/follow_jobs` | `{snapshot?: true}` | Streaming | All jobs' lifecycle + output + progress |
-| `firmware/get_binaries` | `{configuration}` | `[{title, file, description?}]` | List downloadable build artifacts present on disk |
+| `firmware/get_binaries` | `{configuration}` | `[{title, file, type?, description?}]` | List downloadable build artifacts present on disk |
 | `firmware/download` | `{configuration, file, compressed?}` | `{filename, data, size}` | Download binary (base64) |
 | `firmware/cancel` | `{job_id}` | — | Cancel queued or running job |
 | `firmware/clear` | `{status?}` | — | Remove finished jobs |
 
-**`firmware/get_binaries`**: returns only artifacts that exist in the build directory (an empty list means "compile first"), each `{title, file, description?}` — `description` is optional subtext from the platform's `get_download_types`. A `firmware.elf` entry (debug symbols for the ESP stack trace decoder) is appended when present; `get_download_types` itself never lists it. Any `file` can be fetched via `firmware/download`.
+**`firmware/get_binaries`**: returns only artifacts that exist in the build directory (an empty list means "compile first"), each `{title, file, type?, description?}`. `description` is optional subtext from the platform's `get_download_types`. `type` is a stable tag (`factory` / `ota` / `bin` / `uf2` / `elf`) the frontend maps to a localized label, falling back to `title` when absent or unrecognized. A `firmware.elf` entry (debug symbols for the ESP stack trace decoder) is appended when present; `get_download_types` itself never lists it. Any `file` can be fetched via `firmware/download`.
 
 **Job queue**: one job runs at a time, others wait. Jobs persist across server restarts. Output buffered in `FirmwareJob.output` — clients can reconnect via `firmware/follow_job`.
 

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -33,6 +33,17 @@ _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPON
     "libretiny"
 }
 
+# Stable ``type`` tag per artifact filename so the frontend can map it to a
+# localized label (falling back to the platform-supplied ``title`` for any
+# file not listed here).
+_ARTIFACT_TYPES: dict[str, str] = {
+    "firmware.factory.bin": "factory",
+    "firmware.ota.bin": "ota",
+    "firmware.bin": "bin",
+    "firmware.uf2": "uf2",
+    "firmware.elf": "elf",
+}
+
 
 async def get_binaries(controller: FirmwareController, *, configuration: str) -> list[dict]:
     """List on-disk downloadable artifacts as ``[{title, file}]``.
@@ -67,7 +78,7 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
         build_dir = storage.firmware_bin_path.parent
         # Filter to files that exist so a cleaned build reads as "compile
         # first" rather than offering a name ``firmware/download`` would 404 on.
-        downloads = [t for t in types if (build_dir / t["file"]).is_file()]
+        downloads = [dict(t) for t in types if (build_dir / t["file"]).is_file()]
         # firmware.elf sits beside firmware.bin on every platform
         # (remote_build/artifact_platforms/*.py). The `not any` guards against a
         # future get_download_types that lists it, so it can't appear twice.
@@ -81,6 +92,10 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
                     "file": "firmware.elf",
                 }
             )
+        for entry in downloads:
+            artifact_type = _ARTIFACT_TYPES.get(entry["file"])
+            if artifact_type:
+                entry["type"] = artifact_type
         return downloads
 
     return await loop.run_in_executor(None, _get_types)

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -35,15 +35,12 @@ _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPON
 
 
 async def get_binaries(controller: FirmwareController, *, configuration: str) -> list[dict]:
-    """List downloadable artifacts for a built device as ``[{title, file}]``.
+    """List on-disk downloadable artifacts as ``[{title, file}]``.
 
-    Returns the platform's ``get_download_types`` entries whose file is
-    actually present in the build directory, plus an ``firmware.elf``
-    entry when that file exists (debug symbols for the ESP stack trace
-    decoder, which ``get_download_types`` never lists). An empty list
-    means nothing is built yet, which the dashboard reads as "compile
-    first". The ``file`` names can be passed to ``firmware/download``
-    to retrieve the content.
+    The platform's ``get_download_types`` entries that exist, plus a
+    ``firmware.elf`` entry when present (``get_download_types`` never
+    lists it). Empty means nothing is built yet. ``file`` feeds
+    ``firmware/download``.
     """
     # ``resolve_storage_path`` collapses to
     # ``<data_dir>/storage/<Path(configuration).name>.json``; a
@@ -64,19 +61,15 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
         except Exception:  # noqa: BLE001 — third-party regression: upstream ``get_download_types`` could raise anything
             _LOGGER.warning("Could not determine download types for %s", configuration)
             return []
-        # Without a known build directory we can't confirm any artifact
-        # is on disk, so the device reads as not-yet-built.
+        # No build dir → can't confirm anything on disk → treat as not built.
         if storage.firmware_bin_path is None:
             return []
         build_dir = storage.firmware_bin_path.parent
-        # Only offer artifacts that actually exist. A cleaned or partial
-        # build then reads as "compile first" instead of handing back a
-        # name ``firmware/download`` would 404 on, and the ELF entry only
-        # appears once its symbols are on disk.
+        # Filter to files that exist so a cleaned build reads as "compile
+        # first" rather than offering a name ``firmware/download`` would 404 on.
         downloads = [t for t in types if (build_dir / t["file"]).is_file()]
-        # ``firmware.elf`` sits beside ``firmware.bin`` in ``.pioenvs/<name>/``
-        # on every platform (see remote_build/artifact_platforms/*.py), so the
-        # build dir is the right place to look regardless of target.
+        # firmware.elf sits beside firmware.bin on every platform
+        # (remote_build/artifact_platforms/*.py).
         if (build_dir / "firmware.elf").is_file():
             downloads.append(
                 {

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -69,8 +69,11 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
         # first" rather than offering a name ``firmware/download`` would 404 on.
         downloads = [t for t in types if (build_dir / t["file"]).is_file()]
         # firmware.elf sits beside firmware.bin on every platform
-        # (remote_build/artifact_platforms/*.py).
-        if (build_dir / "firmware.elf").is_file():
+        # (remote_build/artifact_platforms/*.py). The `not any` guards against a
+        # future get_download_types that lists it, so it can't appear twice.
+        if (build_dir / "firmware.elf").is_file() and not any(
+            t["file"] == "firmware.elf" for t in downloads
+        ):
             downloads.append(
                 {
                     "title": "ELF (for debugging)",

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -35,10 +35,15 @@ _LIBRETINY_TARGET_PLATFORMS: frozenset[str] = frozenset(_LIBRETINY_FAMILY_COMPON
 
 
 async def get_binaries(controller: FirmwareController, *, configuration: str) -> list[dict]:
-    """List firmware binaries for a compiled device as ``[{title, file}]``.
+    """List downloadable artifacts for a built device as ``[{title, file}]``.
 
-    The ``file`` names can be passed to ``firmware/download`` to
-    retrieve the binary content.
+    Returns the platform's ``get_download_types`` entries whose file is
+    actually present in the build directory, plus an ``firmware.elf``
+    entry when that file exists (debug symbols for the ESP stack trace
+    decoder, which ``get_download_types`` never lists). An empty list
+    means nothing is built yet, which the dashboard reads as "compile
+    first". The ``file`` names can be passed to ``firmware/download``
+    to retrieve the content.
     """
     # ``resolve_storage_path`` collapses to
     # ``<data_dir>/storage/<Path(configuration).name>.json``; a
@@ -55,10 +60,32 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
         try:
             component = _resolve_download_component(storage.target_platform)
             module = importlib.import_module(f"esphome.components.{component}")
-            return list(module.get_download_types(storage))
+            types = list(module.get_download_types(storage))
         except Exception:  # noqa: BLE001 — third-party regression: upstream ``get_download_types`` could raise anything
             _LOGGER.warning("Could not determine download types for %s", configuration)
             return []
+        # Without a known build directory we can't confirm any artifact
+        # is on disk, so the device reads as not-yet-built.
+        if storage.firmware_bin_path is None:
+            return []
+        build_dir = storage.firmware_bin_path.parent
+        # Only offer artifacts that actually exist. A cleaned or partial
+        # build then reads as "compile first" instead of handing back a
+        # name ``firmware/download`` would 404 on, and the ELF entry only
+        # appears once its symbols are on disk.
+        downloads = [t for t in types if (build_dir / t["file"]).is_file()]
+        # ``firmware.elf`` sits beside ``firmware.bin`` in ``.pioenvs/<name>/``
+        # on every platform (see remote_build/artifact_platforms/*.py), so the
+        # build dir is the right place to look regardless of target.
+        if (build_dir / "firmware.elf").is_file():
+            downloads.append(
+                {
+                    "title": "ELF (for debugging)",
+                    "description": "Debug symbols for the ESP stack trace decoder.",
+                    "file": "firmware.elf",
+                }
+            )
+        return downloads
 
     return await loop.run_in_executor(None, _get_types)
 

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -382,6 +382,33 @@ async def test_get_binaries_appends_elf_entry_when_present(
     assert result == [factory, _ELF_ENTRY]
 
 
+async def test_get_binaries_does_not_duplicate_elf_listed_upstream(
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """If a platform's get_download_types ever lists firmware.elf, it appears once.
+
+    ``get_download_types`` doesn't list the ELF today, but guard the
+    append so a future upstream that does can't produce a duplicate
+    entry in the picker.
+    """
+    elf = {"title": "Upstream ELF", "file": "firmware.elf"}
+    _install_fake_component(monkeypatch, "esp32", [elf])
+
+    build_dir = _make_build(tmp_path, "firmware.elf")
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        firmware_bin_path=build_dir / "firmware.bin",
+        overrides={"esp_platform": "esp32"},
+    )
+    controller = firmware_controller_factory()
+
+    result = await controller.get_binaries(configuration="kitchen.yaml")
+
+    assert result == [elf]
+    assert sum(entry["file"] == "firmware.elf" for entry in result) == 1
+
+
 async def test_get_binaries_omits_elf_entry_when_absent(
     tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -88,6 +88,30 @@ def _install_fake_component(
     return captured
 
 
+# The ELF entry ``get_binaries`` appends when ``firmware.elf`` is on disk.
+# Kept in sync with ``download.get_binaries`` by assertion below.
+_ELF_ENTRY = {
+    "title": "ELF (for debugging)",
+    "description": "Debug symbols for the ESP stack trace decoder.",
+    "file": "firmware.elf",
+}
+
+
+def _make_build(tmp_path: Path, *files: str) -> Path:
+    """Create a fake ``.pioenvs/kitchen`` build dir holding *files*.
+
+    Returns the directory so the test can point ``firmware_bin_path``
+    at a sibling — ``get_binaries`` only stats the entry files and
+    ``firmware.elf`` under this parent, so ``firmware.bin`` itself need
+    not exist.
+    """
+    build_dir = tmp_path / ".esphome" / "build" / "kitchen" / ".pioenvs" / "kitchen"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    for name in files:
+        (build_dir / name).write_bytes(b"x")
+    return build_dir
+
+
 # ---------------------------------------------------------------------------
 # _resolve_download_component
 # ---------------------------------------------------------------------------
@@ -253,9 +277,11 @@ async def test_get_binaries_routes_esp32_variants_through_umbrella_module(
         [{"title": "Modern (Web Serial)", "file": "firmware-factory.bin"}],
     )
 
+    build_dir = _make_build(tmp_path, "firmware-factory.bin")
     write_storage_json(
         tmp_path,
         "kitchen.yaml",
+        firmware_bin_path=build_dir / "firmware.bin",
         overrides={"esp_platform": "esp32c3"},
     )
     controller = firmware_controller_factory()
@@ -286,9 +312,11 @@ async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
         [{"title": "LibreTiny RBL", "file": "firmware.rbl"}],
     )
 
+    build_dir = _make_build(tmp_path, "firmware.rbl")
     write_storage_json(
         tmp_path,
         "kitchen.yaml",
+        firmware_bin_path=build_dir / "firmware.bin",
         overrides={"esp_platform": "bk72xx"},
     )
     controller = firmware_controller_factory()
@@ -299,32 +327,98 @@ async def test_get_binaries_routes_libretiny_families_through_umbrella_module(
     assert len(captured) == 1
 
 
-async def test_get_binaries_returns_module_list_verbatim(
+async def test_get_binaries_filters_to_files_present_on_disk(
     tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
-    """The upstream module's list is returned verbatim — no filtering, no re-shaping.
+    """Only ``get_download_types`` entries whose file exists are returned.
 
-    Pin the pass-through so a refactor that adds a "drop entries
-    without an OTA bin" filter (or any other transform) shows up
-    as a contract change in the test diff. The frontend's flash
-    picker maps over each entry's ``title``/``file`` directly;
-    silently dropping entries would hide install options from the
-    user.
+    A cleaned or partial build then reads as "compile first" instead
+    of offering a name ``firmware/download`` would 404 on. Here the
+    upstream module lists three formats but only two are on disk, so
+    the missing ``boot_app0.bin`` is dropped.
     """
-    expected = [
-        {"title": "Modern (Web Serial)", "file": "firmware-factory.bin"},
-        {"title": "OTA Update", "file": "firmware.ota.bin"},
-        {"title": "Boot App 0", "file": "boot_app0.bin"},
-    ]
-    _install_fake_component(monkeypatch, "esp32", expected)
+    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}
+    ota = {"title": "OTA Update", "file": "firmware.ota.bin"}
+    boot = {"title": "Boot App 0", "file": "boot_app0.bin"}
+    _install_fake_component(monkeypatch, "esp32", [factory, ota, boot])
 
+    build_dir = _make_build(tmp_path, "firmware.factory.bin", "firmware.ota.bin")
     write_storage_json(
         tmp_path,
         "kitchen.yaml",
+        firmware_bin_path=build_dir / "firmware.bin",
         overrides={"esp_platform": "esp32"},
     )
     controller = firmware_controller_factory()
 
     result = await controller.get_binaries(configuration="kitchen.yaml")
 
-    assert result == expected
+    assert result == [factory, ota]
+
+
+async def test_get_binaries_appends_elf_entry_when_present(
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """``firmware.elf`` is offered as an extra entry for the stack trace decoder.
+
+    ``get_download_types`` never lists the ELF; ``get_binaries`` adds
+    it when the symbols are on disk so the unified Download picker can
+    offer it alongside the firmware images.
+    """
+    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}
+    _install_fake_component(monkeypatch, "esp32", [factory])
+
+    build_dir = _make_build(tmp_path, "firmware.factory.bin", "firmware.elf")
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        firmware_bin_path=build_dir / "firmware.bin",
+        overrides={"esp_platform": "esp32"},
+    )
+    controller = firmware_controller_factory()
+
+    result = await controller.get_binaries(configuration="kitchen.yaml")
+
+    assert result == [factory, _ELF_ENTRY]
+
+
+async def test_get_binaries_omits_elf_entry_when_absent(
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """No ``firmware.elf`` on disk → no ELF entry."""
+    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}
+    _install_fake_component(monkeypatch, "esp32", [factory])
+
+    build_dir = _make_build(tmp_path, "firmware.factory.bin")
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        firmware_bin_path=build_dir / "firmware.bin",
+        overrides={"esp_platform": "esp32"},
+    )
+    controller = firmware_controller_factory()
+
+    result = await controller.get_binaries(configuration="kitchen.yaml")
+
+    assert result == [factory]
+    assert _ELF_ENTRY not in result
+
+
+async def test_get_binaries_returns_empty_when_no_build_path(
+    tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """Storage exists but ``firmware_bin_path`` is unset → empty list.
+
+    Without a build directory we can't confirm any artifact is on
+    disk, so the device reads as not-yet-built ("compile first").
+    """
+    _install_fake_component(
+        monkeypatch, "esp32", [{"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}]
+    )
+
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"esp_platform": "esp32"})
+    controller = firmware_controller_factory()
+
+    result = await controller.get_binaries(configuration="kitchen.yaml")
+
+    assert result == []

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -16,8 +16,9 @@ configuration-traversal branch is already covered in
   upstream's ``FAMILY_COMPONENT.values()``), so a new ESP32
   variant or LibreTiny family in upstream auto-shows up as a
   parametrised case here without an inline list edit.
-- The result-list pass-through is honest — whatever the upstream
-  module returns is what the WS client sees.
+- The transforms layered on the upstream list: filtering to files
+  present on disk, appending the ``firmware.elf`` entry, and tagging
+  each entry with a stable artifact ``type``.
 """
 
 from __future__ import annotations
@@ -94,6 +95,7 @@ _ELF_ENTRY = {
     "title": "ELF (for debugging)",
     "description": "Debug symbols for the ESP stack trace decoder.",
     "file": "firmware.elf",
+    "type": "elf",
 }
 
 
@@ -337,8 +339,8 @@ async def test_get_binaries_filters_to_files_present_on_disk(
     upstream module lists three formats but only two are on disk, so
     the missing ``boot_app0.bin`` is dropped.
     """
-    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}
-    ota = {"title": "OTA Update", "file": "firmware.ota.bin"}
+    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin", "type": "factory"}
+    ota = {"title": "OTA Update", "file": "firmware.ota.bin", "type": "ota"}
     boot = {"title": "Boot App 0", "file": "boot_app0.bin"}
     _install_fake_component(monkeypatch, "esp32", [factory, ota, boot])
 
@@ -365,7 +367,7 @@ async def test_get_binaries_appends_elf_entry_when_present(
     it when the symbols are on disk so the unified Download picker can
     offer it alongside the firmware images.
     """
-    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}
+    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin", "type": "factory"}
     _install_fake_component(monkeypatch, "esp32", [factory])
 
     build_dir = _make_build(tmp_path, "firmware.factory.bin", "firmware.elf")
@@ -391,7 +393,7 @@ async def test_get_binaries_does_not_duplicate_elf_listed_upstream(
     append so a future upstream that does can't produce a duplicate
     entry in the picker.
     """
-    elf = {"title": "Upstream ELF", "file": "firmware.elf"}
+    elf = {"title": "Upstream ELF", "file": "firmware.elf", "type": "elf"}
     _install_fake_component(monkeypatch, "esp32", [elf])
 
     build_dir = _make_build(tmp_path, "firmware.elf")
@@ -413,7 +415,7 @@ async def test_get_binaries_omits_elf_entry_when_absent(
     tmp_path: Path, monkeypatch: Any, firmware_controller_factory: FirmwareControllerFactory
 ) -> None:
     """No ``firmware.elf`` on disk → no ELF entry."""
-    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}
+    factory = {"title": "Modern (Web Serial)", "file": "firmware.factory.bin", "type": "factory"}
     _install_fake_component(monkeypatch, "esp32", [factory])
 
     build_dir = _make_build(tmp_path, "firmware.factory.bin")
@@ -440,7 +442,9 @@ async def test_get_binaries_returns_empty_when_no_build_path(
     disk, so the device reads as not-yet-built ("compile first").
     """
     _install_fake_component(
-        monkeypatch, "esp32", [{"title": "Modern (Web Serial)", "file": "firmware.factory.bin"}]
+        monkeypatch,
+        "esp32",
+        [{"title": "Modern (Web Serial)", "file": "firmware.factory.bin", "type": "factory"}],
     )
 
     write_storage_json(tmp_path, "kitchen.yaml", overrides={"esp_platform": "esp32"})

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -194,6 +194,13 @@ def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dic
         "firmware.bin": b"firmware-bin-bytes",
         "bootloader.bin": b"bootloader-bytes",
         "partitions.bin": b"partitions-bytes",
+        # Download artefacts a real esp32 compile also emits: the two
+        # downloadable images plus the ELF the stack trace decoder needs.
+        # They ride back through the BUILD_FILES tarball but are not flash
+        # images, so they don't appear in the ``result["images"]`` set.
+        "firmware.factory.bin": b"factory-bin-bytes",
+        "firmware.ota.bin": b"ota-bin-bytes",
+        "firmware.elf": b"elf-debug-symbols",
     }
     image_paths: dict[str, Path] = {}
     for name, payload in images.items():
@@ -590,6 +597,13 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     assert (download_dir / "firmware.bin").read_bytes() == images["firmware.bin"]
     assert (download_dir / "bootloader.bin").read_bytes() == images["bootloader.bin"]
     assert (download_dir / "partitions.bin").read_bytes() == images["partitions.bin"]
+    # The download artefacts (factory/OTA + ELF) ride back from the remote
+    # builder into the same dir ``get_binaries`` reads, so the Download picker
+    # offers them with no local recompile. (get_binaries' filter + ELF-append
+    # is covered against this layout in test_get_binaries.py.)
+    assert (download_dir / "firmware.elf").read_bytes() == images["firmware.elf"]
+    assert (download_dir / "firmware.factory.bin").read_bytes() == images["firmware.factory.bin"]
+    assert (download_dir / "firmware.ota.bin").read_bytes() == images["firmware.ota.bin"]
 
     # #654: read_build_info_hash resolves post-materialise.
     assert (build_path / BUILD_INFO_MEMBER_NAME).is_file()


### PR DESCRIPTION
# What does this implement/fix?

`firmware/get_binaries` now returns only the artifacts that are actually present in the build directory, and it adds a `firmware.elf` entry when those debug symbols are on disk.

Previously it returned ESPHome's `get_download_types` list verbatim (Factory, OTA), with no existence check and no ELF. Two consequences: a cleaned or partial build still advertised binaries that `firmware/download` would 404 on, and the `.elf` (needed for the ESP stack trace decoder) was never offered even though it lives right beside `firmware.bin`. Filtering to on-disk files makes an empty list a reliable "nothing built yet" signal, and the ELF entry lets the dashboard offer it from the unified Download picker. `firmware/download` already serves any file in the build dir traversal-safely, so it is unchanged.

`firmware.elf` sits in `.pioenvs/<name>/` next to `firmware.bin` on every platform (esp32, esp8266, rp2040, the libretiny family, nrf52), per `remote_build/artifact_platforms/*.py`, so resolving it from `firmware_bin_path.parent` is correct across targets.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Frontend coordination

- [x] Companion frontend PR: esphome/device-builder-frontend#470

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
