### PR TITLE
Stop list-handler writes from duplicating the comment after the block

### DIFF
--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -11,6 +11,8 @@ the single-handler / top-level splice paths.
 
 from __future__ import annotations
 
+from typing import Any
+
 from ...helpers.api import CommandError
 from ...helpers.yaml import (
     remove_inline_handler,
@@ -33,6 +35,37 @@ def wrap_handler_list_block(handler_key: str, rendered_list: str) -> str:
     # ``upsert_inline_handler`` writes ``rendered_yaml`` verbatim under the
     # component instance; the list dump is bare, so add the header here.
     return f"{handler_key}:\n" + rendered_list.rstrip() + "\n"
+
+
+def _drop_after_block_comment(entries: list) -> None:
+    """
+    Strip the comments ruamel bound to the last list entry.
+
+    That trailing slot also holds whatever followed the block in the
+    source (the next sibling's leading comment); re-emitting it would
+    duplicate that comment on splice. The sequence's own comments and
+    earlier entries are untouched, so inner comments survive. A comment
+    authored at the tail of the last entry is indistinguishable from the
+    after-block one, so it's dropped; an accepted cost versus the
+    duplication it would otherwise cause.
+    """
+    if entries:
+        _strip_comments(entries[-1])
+
+
+def _strip_comments(node: Any) -> None:
+    """Recursively clear ruamel comment associations on *node*."""
+    ca = getattr(node, "ca", None)
+    if ca is not None:
+        ca.items.clear()
+        ca.comment = None
+        ca.end.clear()
+    if isinstance(node, dict):
+        for child in node.values():
+            _strip_comments(child)
+    elif isinstance(node, list):
+        for child in node:
+            _strip_comments(child)
 
 
 def _resplice_list_block(
@@ -101,6 +134,7 @@ def upsert_component_on_entry(
         msg = f"{trigger_key}: is a single mapping, not a list; convert it to a list first"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     entries = existing if isinstance(existing, list) else []
+    _drop_after_block_comment(entries)
     new_item = emit_trigger_list_item(tree)
     if index == len(entries):
         entries.append(new_item)
@@ -155,6 +189,7 @@ def delete_list_entry(
     if not isinstance(entries, list) or not 0 <= index < len(entries):
         msg = f"{handler_key}[{index}] not present on component id={component_id!r}"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
+    _drop_after_block_comment(entries)
     del entries[index]
     return _resplice_list_block(
         yaml_text,

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -1119,6 +1119,72 @@ def test_upsert_appends_entry_for_non_on_time_repeatable_trigger() -> None:
     assert reparsed[1].automation.trigger_params == {"below": 5}
 
 
+_ON_TIME_COMMENTED = (
+    "time:\n  - platform: sntp\n    id: my_time\n    on_time:\n"
+    "      # morning schedule\n"
+    "      - seconds: 0\n        then:\n          - logger.log: morning\n"
+    "\n# unrelated trailing comment\nsensor:\n  - platform: template\n    id: s1\n    name: s\n"
+)
+
+
+def test_upsert_preserves_inner_comments_and_does_not_duplicate_the_trailing_one() -> None:
+    """Append keeps an entry's own comment and leaves the after-block comment in place, once."""
+    tree = AutomationTree(
+        trigger_id="time.on_time",
+        trigger_params={"hours": 23},
+        actions=[ActionNode(action_id="logger.log", params={"format": "night"})],
+    )
+    new_text, _diff = render_upsert(
+        _ON_TIME_COMMENTED,
+        tree=tree,
+        location=ComponentOnLocation(component_id="my_time", trigger="on_time", index=1),
+    )
+    # Inner comment survives; the after-block comment isn't duplicated and stays
+    # attached to the following block.
+    assert new_text.count("# morning schedule") == 1
+    assert new_text.count("# unrelated trailing comment") == 1
+    assert "\n# unrelated trailing comment\nsensor:" in new_text
+    assert [p.location.index for p in parse_device_yaml(new_text)] == [0, 1]
+
+
+def test_upsert_drops_a_comment_trailing_the_last_entry() -> None:
+    """A comment ruamel binds to the last entry is dropped, never duplicated (accepted trade)."""
+    yaml_text = (
+        "time:\n  - platform: sntp\n    id: my_time\n    on_time:\n"
+        "      - seconds: 0\n        then:\n          - logger.log: hi\n"
+        "      # tail of the last entry\n"
+        "sensor:\n  - platform: template\n    id: s1\n    name: s\n"
+    )
+    tree = AutomationTree(
+        trigger_id="time.on_time",
+        trigger_params={"hours": 23},
+        actions=[ActionNode(action_id="logger.log", params={"format": "night"})],
+    )
+    new_text, _diff = render_upsert(
+        yaml_text,
+        tree=tree,
+        location=ComponentOnLocation(component_id="my_time", trigger="on_time", index=1),
+    )
+    # Indistinguishable from the after-block comment, so intentionally dropped, not duplicated.
+    assert new_text.count("# tail of the last entry") == 0
+    assert [p.location.index for p in parse_device_yaml(new_text)] == [0, 1]
+
+
+def test_delete_entry_does_not_duplicate_the_trailing_comment() -> None:
+    """Deleting an entry leaves the after-block comment intact and un-duplicated."""
+    yaml_text = (
+        "time:\n  - platform: sntp\n    id: my_time\n    on_time:\n"
+        "      - seconds: 0\n        then:\n          - logger.log: a\n"
+        "      - seconds: 30\n        then:\n          - logger.log: b\n"
+        "\n# unrelated trailing comment\nsensor:\n  - platform: template\n    id: s1\n    name: s\n"
+    )
+    new_text, _diff = render_delete(
+        yaml_text, location=ComponentOnLocation(component_id="my_time", trigger="on_time", index=0)
+    )
+    assert new_text.count("# unrelated trailing comment") == 1
+    assert [p.location.index for p in parse_device_yaml(new_text)] == [0]
+
+
 def test_upsert_on_time_appends_entry_at_end() -> None:
     """An index equal to the entry count appends a new schedule."""
     yaml_text = _load("time_on_time_list.yaml")


### PR DESCRIPTION
# What does this implement/fix?

Appending or deleting an entry of a list-shaped handler under a component (the repeatable `on_*` triggers like `time.on_time`, and light `effects:`) re-emits the parsed list block through ruamel. ruamel parks the comment that textually follows the block on the block's last entry, so the re-emit pulled that comment into the rebuilt block while the original stayed in the surrounding text. The result was a duplicated, mis-indented comment and a mangled block.

Repro: a `time.on_time` with one entry and a comment before the next top-level key; adding a second schedule from the visual editor produced two copies of the comment, one of them pulled inside the `on_time:` list.

Clear that one trailing slot on the parse-time-last entry before mutating, so the after-block comment stays where it belongs and isn't re-emitted into the block. Inner comments live on earlier entries and on the sequence itself, so they survive. The fresh-item effects-upsert path builds its entry from scratch and never had the leak.

Found while testing the add-automation wizard for the `repeatable` triggers; this is an independent, pre-existing writer bug (the list-append path predates that change).

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
