### PR TITLE
Retry the atomic-write rename on a transient Windows handle race

### DIFF
--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -16,7 +16,17 @@ from __future__ import annotations
 import contextlib
 import os
 import tempfile
+import time
 from pathlib import Path
+
+# Windows raises ``PermissionError`` (WinError 5) from ``os.replace`` when a
+# transient handle holds the destination open (a concurrent reader, an
+# antivirus or the search indexer). POSIX rename is atomic and never hits
+# this, so the retry is Windows-only; a few short waits clear the typical
+# sub-second window.
+_IS_WINDOWS = os.name == "nt"
+_REPLACE_RETRIES = 10
+_REPLACE_RETRY_BACKOFF_S = 0.05
 
 
 def atomic_write(
@@ -55,7 +65,7 @@ def atomic_write(
             if mode is not None:
                 tmp_path.chmod(mode)
             fh.write(data)
-        tmp_path.replace(path)
+        _replace_with_retry(tmp_path, path)
     except Exception:
         # Suppress all OSError on cleanup so the original write
         # failure isn't masked by a secondary unlink permission
@@ -63,3 +73,18 @@ def atomic_write(
         with contextlib.suppress(OSError):
             tmp_path.unlink()
         raise
+
+
+def _replace_with_retry(src: Path, dst: Path) -> None:
+    """``Path.replace`` *src* onto *dst*, retried on a Windows handle race."""
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            src.replace(dst)
+        except PermissionError:
+            # POSIX rename can't hit this transiently, so a PermissionError
+            # there is real; re-raise. On Windows, back off and retry.
+            if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(_REPLACE_RETRY_BACKOFF_S)
+        else:
+            return

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -109,3 +109,47 @@ def test_atomic_write_closes_fd_when_fdopen_fails(
     assert len(closed) == 1, f"expected one explicit os.close, got {closed}"
     assert not target.exists()
     assert not list(tmp_path.glob("demo.bin.*.tmp"))
+
+
+def test_atomic_write_retries_replace_on_windows_handle_race(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient Windows ``PermissionError`` on rename is retried, not surfaced."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", True)
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.time.sleep", lambda _s: None)
+    target = tmp_path / "demo.bin"
+    target.write_bytes(b"old")
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def _flaky(src: object, dst: object) -> None:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError(5, "Access is denied")
+        real_replace(src, dst)
+
+    monkeypatch.setattr("os.replace", _flaky)
+    atomic_write(target, b"new")
+
+    assert calls["n"] == 3  # failed twice, succeeded on the third
+    assert target.read_bytes() == b"new"
+    assert not list(tmp_path.glob("demo.bin.*.tmp"))
+
+
+def test_atomic_write_does_not_retry_replace_on_posix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``PermissionError`` on POSIX is a real error and surfaces immediately."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", False)
+    calls = {"n": 0}
+
+    def _fail(src: object, dst: object) -> None:
+        calls["n"] += 1
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("os.replace", _fail)
+    with pytest.raises(PermissionError):
+        atomic_write(tmp_path / "demo.bin", b"x")
+
+    assert calls["n"] == 1  # no retry on POSIX


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flaky Windows CI failure. `test_mark_acknowledged_does_not_clobber_a_concurrent_pref_write` (and any concurrent metadata write) intermittently fails on `windows-latest` with:

```
PermissionError: [WinError 5] Access is denied: '...\.device-builder.json.<rand>.tmp' -> '...\.device-builder.json'
```

`atomic_write` stages bytes in a sibling tempfile then `os.replace`s it into place. On Windows `os.replace` raises `PermissionError` (WinError 5) when a transient handle briefly holds the destination open, a concurrent reader, an antivirus, or the search indexer. POSIX rename is atomic and never hits this, so the test is green everywhere else.

The fix retries the rename a handful of times with a short backoff, gated to Windows; a `PermissionError` on POSIX is a real error (bad dir perms, etc.) and surfaces immediately. This also hardens production metadata / cert / token writes on Windows, not just the test. Added tests for the retry-then-succeed path and the POSIX-surfaces-immediately path; `atomic_io` is at 100% coverage.

**Related issue or feature (if applicable):**

- N/A (CI flake)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
