### PR TITLE
Split e2e tests into dedicated stable + dev esphome CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
         #   at ~1-2 minutes; without the cap a single hung worker
         #   burns the runner's full 6h budget.
         timeout-minutes: 5
-        run: uv run pytest -q -n auto --maxfail=5 --durations=10 --timeout=120 --ignore=tests/benchmarks --ignore=tests/real_compile --cov=esphome_device_builder --cov-report=xml --cov-report=term
+        run: uv run pytest -q -n auto --maxfail=5 --durations=10 --timeout=120 --ignore=tests/benchmarks --ignore=tests/real_compile --ignore=tests/e2e --cov=esphome_device_builder --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
@@ -252,7 +252,57 @@ jobs:
         # upstream beta/dev are exactly the case this protects
         # against.
         timeout-minutes: 5
-        run: uv run pytest -q -n auto --maxfail=5 --durations=10 --timeout=120 --ignore=tests/benchmarks --ignore=tests/real_compile
+        run: uv run pytest -q -n auto --maxfail=5 --durations=10 --timeout=120 --ignore=tests/benchmarks --ignore=tests/real_compile --ignore=tests/e2e
+
+  e2e:
+    name: E2E (esphome ${{ matrix.channel }})
+    runs-on: ubuntu-latest
+    # The remote-build offload e2e suite (``tests/e2e/``) stands up
+    # two real controllers over a live peer-link wire. It's split off
+    # the unit matrix so it can't slow the unit run or conflate signal
+    # (an e2e flake reading as a unit failure) as the suite grows.
+    # ``stable`` is a strict gate; ``dev`` is advisory because
+    # ESPHome's nightly can break mid-day — we want the signal without
+    # a permanent red on every device-builder PR.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - channel: stable
+            # No extra install — the ``[esphome]`` extra resolves the
+            # stable release the dashboard ships with.
+            install: ""
+            allow_failure: false
+          - channel: dev
+            install: uv pip install --upgrade git+https://github.com/esphome/esphome.git@dev
+            allow_failure: true
+    continue-on-error: ${{ matrix.allow_failure }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up uv and Python 3.14
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.14"
+
+      - name: Create venv + install package + test deps
+        run: |
+          uv venv
+          uv pip install -e '.[esphome,test]'
+
+      - name: Install esphome (${{ matrix.channel }} channel)
+        if: matrix.install != ''
+        run: ${{ matrix.install }}
+
+      - name: Show installed esphome version
+        run: uv pip show esphome | grep -E '^(Name|Version):'
+
+      - name: Run e2e tests
+        timeout-minutes: 5
+        run: uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
 
   benchmarks:
     name: Run benchmarks (CodSpeed)


### PR DESCRIPTION
# What does this implement/fix?

Moves the `tests/e2e/` suite out of the unit-test runners and into its own CI jobs. We are about to add a lot more e2e tests, and leaving them inline with the unit matrix would slow the unit run and conflate signal; an e2e flake would read as a unit failure.

The unit `test` matrix and the `test-esphome-channels` job now pass `--ignore=tests/e2e`, so e2e no longer runs there. A new `e2e` job runs the suite twice: against stable esphome (strict) and against dev esphome (advisory, `continue-on-error`), matching how `test-esphome-channels` treats the dev channel. Local `pytest` still runs e2e since `addopts` is unchanged.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
