### PR TITLE
Omit null index from component_on automation locations on the wire

### DIFF
--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal
 
+from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import Discriminator
 
@@ -266,6 +267,15 @@ class ComponentOnLocation(DataClassORJSONMixin):
     trigger: str
     index: int | None = None
     kind: Literal["component_on"] = "component_on"
+
+    class Config(BaseConfig):
+        """Drop ``index`` from the wire for the single-handler form."""
+
+        # The frontend keys a single handler with no ``index``; a trailing
+        # ``null`` would never match its un-indexed location key. omit_none
+        # only — omit_default would also drop the ``kind`` discriminator and
+        # break union decode.
+        omit_none = True
 
 
 @dataclass

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -185,6 +185,19 @@ def test_decode_location_component_on_carries_index() -> None:
     assert loc.index == 2
 
 
+def test_component_on_single_form_omits_index_on_the_wire() -> None:
+    """The single-handler form serializes without an ``index`` key."""
+    wire = ComponentOnLocation(component_id="b", trigger="on_state").to_dict()
+    assert "index" not in wire
+    assert wire == {"kind": "component_on", "component_id": "b", "trigger": "on_state"}
+
+
+def test_component_on_list_form_keeps_index_on_the_wire() -> None:
+    """A list-shaped handler keeps its integer ``index`` on the wire."""
+    wire = ComponentOnLocation(component_id="my_time", trigger="on_time", index=0).to_dict()
+    assert wire["index"] == 0
+
+
 def test_is_list_form_trigger_discriminates_cron_vs_bare_actions() -> None:
     """A cron entry list is list-form; a bare action list is not."""
     on_time = catalog.trigger_by_id("time.on_time")


### PR DESCRIPTION
# What does this implement/fix?

A single (non-list) inline `on_*:` handler decomposed to a `ComponentOnLocation` with `index` None, which serialized to the wire as `index: null`. The Visual Editor keys a single handler with no index, so the trailing `null` broke the key match when you re-selected the automation; the actions rendered empty even though the YAML was saved correctly.

This omits `index` from the wire for the single-handler form so it matches the frontend's index-absent location key; the list-shaped form (`time.on_time`) still carries its integer index.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1094

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
