### PR TITLE
Quote component field values with leading YAML indicators

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from ...models.common import ConfigEntryType
-from .scalar import ESPHOME_YAML_INDENT
+from .scalar import _PLAIN_SCALAR_INDICATOR_LEAD, ESPHOME_YAML_INDENT, _quote
 
 if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry
@@ -359,7 +359,7 @@ def _format_yaml_value(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        return f'"{value}"' if _string_needs_quoting(value) else value
+        return _quote(value) if _string_needs_quoting(value) else value
     return str(value)
 
 
@@ -370,15 +370,19 @@ def _string_needs_quoting(value: str) -> bool:
     """Return True when *value* needs YAML quoting to round-trip as a string."""
     # YAML 1.1 recognises every case variant of the reserved words
     # (``true``/``True``/``TRUE`` etc.) as bool/null, so ``str(True)``
-    # from a JSON bool would otherwise re-parse as ``True``. ``%`` is
-    # a YAML directive indicator; ``~`` and empty string are YAML null
-    # shorthands; ``!`` opens a tag; ``:`` opens a mapping value;
-    # ``#`` opens a comment. Anything that survives those checks then
-    # gets the (cheap pre-filtered) ``yaml.safe_load`` round-trip test
-    # for numeric-looking strings — the original #901 case.
-    if value.lower() in _YAML_RESERVED_KEYWORDS or value in ("%", "~", ""):
+    # from a JSON bool would otherwise re-parse as ``True``. ``~`` and
+    # empty string are YAML null shorthands. A leading YAML indicator
+    # character (the ``_PLAIN_SCALAR_INDICATOR_LEAD`` set: ``! & * ? |
+    # > % @ ` # - , [ ] { } " '``) changes the scalar's shape — e.g. a
+    # globals ``initial_value`` C++ literal ``"Hello"`` emitted bare
+    # round-trips as the plain string ``Hello``, dropping the quotes
+    # ESPHome compiles against (#1095). ``:`` opens a mapping value and
+    # ``#`` opens a comment anywhere in the value. Survivors then take
+    # the (cheap pre-filtered) ``yaml.safe_load`` round-trip test for
+    # numeric-looking strings — the original #901 case.
+    if value.lower() in _YAML_RESERVED_KEYWORDS or value in ("~", ""):
         return True
-    if value.startswith("!") or ":" in value or "#" in value:
+    if value[0] in _PLAIN_SCALAR_INDICATOR_LEAD or ":" in value or "#" in value:
         return True
     return _yaml_reparses_as_non_string(value)
 
@@ -422,7 +426,7 @@ def _format_flow_yaml_value(value: Any) -> str:
         and not formatted.startswith('"')
         and any(c in value for c in ",[]{}")
     ):
-        return f'"{value}"'
+        return _quote(value)
     return formatted
 
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+import yaml
 
 from esphome_device_builder.helpers.yaml import (
     YamlUpsertNotSupportedError,
@@ -1211,6 +1212,30 @@ def test_generate_component_yaml_quotes_strings_that_reparse_as_non_string(
     assert f'  v: "{value}"' in out
 
 
+@pytest.mark.parametrize(
+    "value",
+    ['"Hello"', "'single'", "with:colon", "has#hash", '"quote\\and\\slash"'],
+    ids=[
+        "cpp-literal",
+        "leading-squote",
+        "embedded-colon",
+        "embedded-hash",
+        "leading-quote-backslash",
+    ],
+)
+def test_generate_component_yaml_quote_bearing_string_round_trips(value: str) -> None:
+    r"""Quote/indicator-bearing scalar values survive a full re-parse (#1095).
+
+    A globals ``initial_value`` for a ``std::string`` is a C++ literal
+    (``'"Hello"'``); emitting it bare round-trips as plain ``Hello`` so
+    ESPHome compiles an undeclared symbol. Embedded ``"`` / ``\`` are
+    escaped via ``_quote`` rather than wrapped in invalid ``""..."``.
+    """
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"v": value})
+    assert yaml.safe_load(out)["myc"]["v"] == value
+
+
 # ---------------------------------------------------------------------------
 # generate_component_yaml — nested fields (_emit_field branches)
 # ---------------------------------------------------------------------------
@@ -1331,6 +1356,18 @@ def test_generate_component_yaml_quotes_flow_string_with_flow_indicator() -> Non
     component = _component(component_id="myc", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"items": ["a,b", "c"]})
     assert '  items: ["a,b", c]' in out
+
+
+@pytest.mark.parametrize(
+    "value",
+    ['a,"b', "x,\\y", '{a},"q"'],
+    ids=["embedded-quote", "backslash", "brace-quote"],
+)
+def test_generate_component_yaml_flow_list_escapes_quote_bearing_element(value: str) -> None:
+    """A flow-list element carrying both a flow indicator and a quote/backslash escapes cleanly."""
+    component = _component(component_id="myc", category=ComponentCategory.MISC)
+    out = generate_component_yaml(component, {"items": [value, "c"]})
+    assert yaml.safe_load(out)["myc"]["items"] == [value, "c"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Adding a component through the Visual Editor could emit a string value that does not round trip through YAML. A globals initial_value holding a C++ string literal like "Hello" was written unquoted, so YAML read it back as the bare word Hello and the compile failed on an undeclared symbol; a value containing a quote got wrapped by a naive f string into invalid double quoting. The value emitter now treats any leading YAML indicator character as needing quotes and reuses the shared _quote helper, so embedded quotes and backslashes are escaped properly.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1095

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
