### PR TITLE
Ship firmware.json in libretiny artifact tarball; add bk7231n compile+download e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,8 +300,24 @@ jobs:
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
 
+      - name: Cache PlatformIO core + per-platform toolchains
+        # The LibreTiny e2e (test_libretiny_compile_download.py) runs a real
+        # bk7231n compile, which clones the LibreTiny SDK from source on a
+        # cold runner. Cache ``~/.platformio`` per channel so stable/dev
+        # SDK downloads don't collide.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.platformio
+          key: pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/test_libretiny_compile_download.py') }}
+          restore-keys: |
+            pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-
+
       - name: Run e2e tests
-        timeout-minutes: 5
+        # 20 min outer cap (vs the unit job's 5): a cold LibreTiny SDK clone
+        # plus compile runs minutes. The fast e2e tests keep the per-test
+        # ``--timeout=120``; the LibreTiny test opts out via its own
+        # ``@pytest.mark.timeout(600)`` decorator.
+        timeout-minutes: 20
         run: uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
 
   benchmarks:

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/_libretiny.py
@@ -6,4 +6,8 @@ BUILD_FILES: tuple[str, ...] = (
     ".pioenvs/{name}/firmware.uf2",
     ".pioenvs/{name}/firmware.bin",
     ".pioenvs/{name}/firmware.elf",
+    # libretiny's get_download_types reads firmware.json to enumerate the
+    # public chip images (Beken .rbl, cloudcutter .ug.bin); without it the
+    # offloader's Download picker offers only firmware.uf2 (#1102).
+    ".pioenvs/{name}/firmware.json",
 )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -41,6 +41,8 @@ from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
@@ -63,6 +65,7 @@ from esphome_device_builder.models import (
     JobLifecycleData,
     JobStatus,
     JobType,
+    QueueStatus,
 )
 
 from ..conftest import (
@@ -70,6 +73,7 @@ from ..conftest import (
     _CapturedEvents,
     capture_events,
     make_remote_build_controller,
+    wire_firmware_remote_peer_api_mocks,
 )
 
 
@@ -376,19 +380,24 @@ def make_remote_peer_job(
     )
 
 
-def make_real_bundle(*, configuration_filename: str = "kitchen.yaml") -> bytes:
+def make_real_bundle(
+    *,
+    configuration_filename: str = "kitchen.yaml",
+    yaml_body: bytes = b"esphome:\n  name: kitchen\n",
+) -> bytes:
     """
     Build a minimal-but-valid esphome bundle the upstream extractor accepts.
 
     Emits a ``manifest.json`` + the referenced YAML member; skips
     :class:`BundleBuilder` so the test doesn't need a real
-    ``CORE.config_dir`` / ``CORE.config_path`` setup.
+    ``CORE.config_dir`` / ``CORE.config_path`` setup. Pass *yaml_body*
+    to drive a real ``esphome compile`` against a platform-specific
+    config (the LibreTiny e2e ships a ``bk72xx`` board here).
     """
     manifest = {
         "manifest_version": 1,
         "config_filename": configuration_filename,
     }
-    yaml_body = b"esphome:\n  name: kitchen\n"
     members: list[tuple[str, bytes]] = [
         ("manifest.json", json.dumps(manifest).encode("utf-8")),
         (configuration_filename, yaml_body),
@@ -434,3 +443,81 @@ async def make_and_seed_remote_peer_job(
     # before the test fires the next event.
     await asyncio.sleep(0)
     return job
+
+
+def wire_receiver_firmware_recorder(instances: PairedInstances) -> list[FirmwareJob]:
+    """Wire receiver's ``db.firmware`` to record submitted jobs.
+
+    The receiver-side ``_create_job`` builds a :class:`FirmwareJob`
+    carrying every field the production controller's dispatch
+    sets (configuration / job_type / remote_peer / remote_job_id);
+    ``_enqueue`` resolves with ``accepted=True`` so the
+    ``submit_job_ack`` lands on the success branch. The recorded
+    list lets the test mutate the job's ``status`` from
+    ``QUEUED`` → ``COMPLETED`` after firing the lifecycle events
+    so the download-side ``_find_remote_job`` accepts it.
+
+    ``firmware.state.jobs`` is a real dict (not a mock) so the
+    receiver-side download path's ``firmware.state.jobs.values()``
+    iteration finds the recorded job.
+    """
+    created_jobs: list[FirmwareJob] = []
+    receiver_jobs: dict[str, FirmwareJob] = {}
+
+    def _create_job(
+        configuration: str,
+        job_type: JobType,
+        *,
+        remote_peer: str = "",
+        remote_job_id: str = "",
+        **_: Any,
+    ) -> FirmwareJob:
+        job = FirmwareJob(
+            job_id=f"rcv-{len(created_jobs)}",
+            configuration=configuration,
+            job_type=job_type,
+            status=JobStatus.QUEUED,
+            remote_peer=remote_peer,
+            remote_job_id=remote_job_id,
+        )
+        created_jobs.append(job)
+        receiver_jobs[job.job_id] = job
+        return job
+
+    firmware = instances.receiver._db.firmware
+    firmware._create_job = MagicMock(side_effect=_create_job)
+    firmware._enqueue = AsyncMock(side_effect=lambda job: job)
+    wire_firmware_remote_peer_api_mocks(firmware, receiver_jobs)
+    # ``_on_firmware_queue_transition`` (registered on every
+    # JOB_QUEUED / JOB_STARTED / terminal event) reads
+    # ``queue_status_snapshot()`` and tuple-unpacks the result.
+    # The harness's ``MagicMock`` firmware controller returns a
+    # MagicMock by default — unpacks as zero values and trips a
+    # ValueError. Pin a sane tuple so the listener runs cleanly
+    # rather than spamming the test log with swallowed
+    # exceptions on every fire().
+    firmware.queue_status_snapshot = MagicMock(
+        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
+    )
+    return created_jobs
+
+
+async def drive_remote_job_to_completed(
+    instances: PairedInstances,
+    job: FirmwareJob,
+    state_changes: _CapturedEvents,
+) -> None:
+    """Drive *job* QUEUED → STARTED → COMPLETED on the receiver bus and flip it COMPLETED.
+
+    Awaits the offloader's ``running`` then ``completed``
+    ``OFFLOADER_JOB_STATE_CHANGED`` via *state_changes* (a
+    :func:`capture_events` handle), then sets ``job.status`` so the
+    download side's ``_find_remote_job`` accepts it for
+    ``download_artifacts``.
+    """
+    instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=job))
+    instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=job))
+    await state_changes.wait_for_status("running")
+    instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=job))
+    await state_changes.wait_for_status("completed")
+    job.status = JobStatus.COMPLETED

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -57,7 +57,7 @@ import tarfile
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from esphome.core import CORE
@@ -93,68 +93,13 @@ from esphome_device_builder.models import (
 from esphome_device_builder.models.api import ErrorCode
 
 from .._storage_fixtures import write_storage_json
-from ..conftest import capture_events, wire_firmware_remote_peer_api_mocks
-from .conftest import PairedInstances, make_real_bundle
-
-
-def _wire_receiver_firmware_recorder(instances: PairedInstances) -> list[FirmwareJob]:
-    """Wire receiver's ``db.firmware`` to record submitted jobs.
-
-    Mirror of ``test_submit_job._wire_receiver_firmware_recorder``.
-    The receiver-side ``_create_job`` builds a :class:`FirmwareJob`
-    carrying every field the production controller's dispatch
-    sets (configuration / job_type / remote_peer / remote_job_id);
-    ``_enqueue`` resolves with ``accepted=True`` so the
-    ``submit_job_ack`` lands on the success branch. The recorded
-    list lets the test mutate the job's ``status`` from
-    ``QUEUED`` → ``COMPLETED`` after firing the lifecycle events
-    so the download-side ``_find_remote_job`` accepts it.
-
-    ``firmware.state.jobs`` is a real dict (not a mock) so the
-    receiver-side download path's ``firmware.state.jobs.values()``
-    iteration finds the recorded job. Production has the real
-    queue populating this dict; here we populate it from
-    ``_create_job``.
-    """
-    created_jobs: list[FirmwareJob] = []
-    receiver_jobs: dict[str, FirmwareJob] = {}
-
-    def _create_job(
-        configuration: str,
-        job_type: JobType,
-        *,
-        remote_peer: str = "",
-        remote_job_id: str = "",
-        **_: Any,
-    ) -> FirmwareJob:
-        job = FirmwareJob(
-            job_id=f"rcv-{len(created_jobs)}",
-            configuration=configuration,
-            job_type=job_type,
-            status=JobStatus.QUEUED,
-            remote_peer=remote_peer,
-            remote_job_id=remote_job_id,
-        )
-        created_jobs.append(job)
-        receiver_jobs[job.job_id] = job
-        return job
-
-    firmware = instances.receiver._db.firmware
-    firmware._create_job = MagicMock(side_effect=_create_job)
-    firmware._enqueue = AsyncMock(side_effect=lambda job: job)
-    wire_firmware_remote_peer_api_mocks(firmware, receiver_jobs)
-    # ``_on_firmware_queue_transition`` (registered on every
-    # JOB_QUEUED / JOB_STARTED / terminal event) reads
-    # ``queue_status_snapshot()`` and tuple-unpacks the result.
-    # The harness's ``MagicMock`` firmware controller returns a
-    # MagicMock by default — unpacks as zero values and trips a
-    # ValueError. Pin a sane tuple so the listener runs cleanly
-    # rather than spamming the test log with swallowed
-    # exceptions on every fire().
-    firmware.queue_status_snapshot = MagicMock(
-        return_value=QueueStatus(idle=True, running=False, queue_depth=0)
-    )
-    return created_jobs
+from ..conftest import capture_events
+from .conftest import (
+    PairedInstances,
+    drive_remote_job_to_completed,
+    make_real_bundle,
+    wire_receiver_firmware_recorder,
+)
 
 
 def _write_build_artifacts_on_disk(tmp_path: Path, *, configuration: str) -> dict[str, bytes]:
@@ -428,7 +373,7 @@ async def test_remote_install_submit_then_lifecycle_then_download_on_one_session
       fan-out frames.
     """
     await paired_instances.wait_until_session_opened()
-    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    created_jobs = wire_receiver_firmware_recorder(paired_instances)
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
@@ -543,7 +488,7 @@ async def test_remote_compile_materialises_for_local_firmware_download(
 ) -> None:
     """#624: compile remote → materialise → firmware/download reads staged bytes."""
     await paired_instances.wait_until_session_opened()
-    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    created_jobs = wire_receiver_firmware_recorder(paired_instances)
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
@@ -574,12 +519,7 @@ async def test_remote_compile_materialises_for_local_firmware_download(
     receiver_job = created_jobs[0]
     images = _write_build_artifacts_on_disk(tmp_path, configuration=receiver_job.configuration)
 
-    paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
-    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=receiver_job))
-    await state_changes.wait_for_status("running")
-    paired_instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=receiver_job))
-    await state_changes.wait_for_status("completed")
-    receiver_job.status = JobStatus.COMPLETED
+    await drive_remote_job_to_completed(paired_instances, receiver_job, state_changes)
 
     packed = await handle.client.download_artifacts(job_id="off-compile-1")
     build_path = await asyncio.to_thread(
@@ -670,7 +610,7 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
 ) -> None:
     """Windows-receiver tarball over a real Noise session lands a readable factory binary."""
     await paired_instances.wait_until_session_opened()
-    created_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    created_jobs = wire_receiver_firmware_recorder(paired_instances)
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )
@@ -698,12 +638,7 @@ async def test_windows_receiver_tarball_materialises_for_local_firmware_download
     receiver_build = await asyncio.to_thread(_seed_factory_binary)
     images["firmware.factory.bin"] = b"FACTORY-BIN-BYTES"
 
-    paired_instances.receiver_bus.fire(EventType.JOB_QUEUED, JobLifecycleData(job=receiver_job))
-    paired_instances.receiver_bus.fire(EventType.JOB_STARTED, JobLifecycleData(job=receiver_job))
-    await state_changes.wait_for_status("running")
-    paired_instances.receiver_bus.fire(EventType.JOB_COMPLETED, JobLifecycleData(job=receiver_job))
-    await state_changes.wait_for_status("completed")
-    receiver_job.status = JobStatus.COMPLETED
+    await drive_remote_job_to_completed(paired_instances, receiver_job, state_changes)
 
     packed = await handle.client.download_artifacts(job_id="off-windows-1")
     munged = await asyncio.to_thread(
@@ -852,7 +787,7 @@ async def test_back_to_back_successful_jobs_keep_scheduler_routing_remote(
         paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
     )
     await paired_instances.wait_until_session_opened()
-    receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    receiver_jobs = wire_receiver_firmware_recorder(paired_instances)
     # Initial cold-connect push lands; cache should already be
     # idle before we drive any traffic.
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
@@ -913,7 +848,7 @@ async def test_failed_first_job_still_routes_remote_on_second_install(
         paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
     )
     await paired_instances.wait_until_session_opened()
-    receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    receiver_jobs = wire_receiver_firmware_recorder(paired_instances)
     await _wait_for_offloader_idle(paired_instances, queue_status_events)
 
     handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
@@ -972,7 +907,7 @@ async def test_remote_clean_round_trip_lands_clean_job_and_fans_state_back(
     ``JOB_COMPLETED`` is the whole terminal.
     """
     await paired_instances.wait_until_session_opened()
-    receiver_jobs = _wire_receiver_firmware_recorder(paired_instances)
+    receiver_jobs = wire_receiver_firmware_recorder(paired_instances)
     state_changes = capture_events(
         paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
     )

--- a/tests/e2e/test_libretiny_compile_download.py
+++ b/tests/e2e/test_libretiny_compile_download.py
@@ -1,0 +1,142 @@
+"""
+End-to-end: a real LibreTiny (bk7231n) compile round-trips through the offload session (#1102).
+
+The synthetic install round-trip (``test_install_round_trip.py``)
+writes fake esp32-shaped binaries; nothing exercised the LibreTiny
+artifact set. A bk7231n build's ``firmware_bin_path`` is
+``firmware.uf2`` (not ``firmware.bin``), it emits no esp-style flash
+images, and the downloadable Beken / cloudcutter images are listed in
+a ``firmware.json`` the offloader must re-read. #1102 was the
+offloader's Download picker offering only ``firmware.uf2`` after a
+remote build because ``firmware.json`` never shipped in the artifact
+tarball.
+
+This test runs a real ``esphome compile`` of a bk7231n config through
+the full paired session (submit_job → receiver compile →
+download_artifacts → materialise) and asserts the offloader can
+enumerate every public chip image, matching what a local build offers.
+It is slow (cold runs clone the LibreTiny SDK), hence
+``@pytest.mark.timeout(600)``; it runs in the dedicated e2e CI jobs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from esphome.core import CORE
+
+from esphome_device_builder.controllers.firmware.download import get_binaries
+from esphome_device_builder.helpers.remote_artifacts_materialise import (
+    materialise_remote_artifacts,
+)
+from esphome_device_builder.helpers.remote_build_layout import (
+    parse_from_configuration as parse_remote_build_path,
+)
+from esphome_device_builder.models import EventType
+
+from ..conftest import capture_events
+from .conftest import (
+    PairedInstances,
+    drive_remote_job_to_completed,
+    make_real_bundle,
+    wire_receiver_firmware_recorder,
+)
+
+_DEVICE = "bk7231n-e2e"
+_CONFIGURATION_FILENAME = f"{_DEVICE}.yaml"
+_BK7231N_YAML = f"""\
+esphome:
+  name: {_DEVICE}
+bk72xx:
+  board: generic-bk7231n-qfn32-tuya
+logger:
+""".encode()
+
+
+def _run_esphome_compile(
+    yaml_path: Path, *, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run ``esphome compile`` on *yaml_path* with *env*'s ESPHOME_DATA_DIR override."""
+    return subprocess.run(  # noqa: S603 — fixed argv list, no shell, test-only invocation
+        [sys.executable, "-m", "esphome", "compile", str(yaml_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        close_fds=False,
+        env=env,
+    )
+
+
+@pytest.mark.timeout(600)
+async def test_libretiny_bk7231n_compile_download_round_trip(
+    paired_instances: PairedInstances,
+) -> None:
+    """A real bk7231n compile lands every public Beken/cloudcutter image offloader-side (#1102)."""
+    await paired_instances.wait_until_session_opened()
+    created_jobs = wire_receiver_firmware_recorder(paired_instances)
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    # 1. submit the bk7231n bundle; the receiver extracts the YAML to its
+    #    remote-build subtree and dispatches a queued job.
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-bk-1",
+        configuration_filename=_CONFIGURATION_FILENAME,
+        target="compile",
+        bundle_bytes=make_real_bundle(
+            configuration_filename=_CONFIGURATION_FILENAME, yaml_body=_BK7231N_YAML
+        ),
+    )
+    assert ack["accepted"] is True
+    receiver_job = created_jobs[0]
+
+    # 2. real compile into the receiver's remote-build data dir — the exact
+    #    ESPHOME_DATA_DIR ``compose_subprocess_env`` pins for a remote job, so
+    #    ``pack_build_artifacts`` reads the produced storage/build/idedata back.
+    remote_build_path = parse_remote_build_path(receiver_job.configuration)
+    assert remote_build_path is not None
+    data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
+    config_dir = Path(paired_instances.receiver._db.settings.config_dir)
+    yaml_path = config_dir / receiver_job.configuration
+    result = await asyncio.to_thread(
+        _run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
+    )
+    assert result.returncode == 0, (
+        f"bk7231n compile failed:\nstdout:\n{result.stdout[-4000:]}\n"
+        f"stderr:\n{result.stderr[-2000:]}"
+    )
+    receiver_pioenvs = data_dir / "build" / _DEVICE / ".pioenvs" / _DEVICE
+    assert (receiver_pioenvs / "firmware.uf2").is_file()
+    assert (receiver_pioenvs / "firmware.json").is_file()
+
+    # 3. drive the receiver queue lifecycle so the download side accepts the job.
+    await drive_remote_job_to_completed(paired_instances, receiver_job, state_changes)
+
+    # 4. pull the artifacts back over the same session and materialise locally.
+    packed = await handle.client.download_artifacts(job_id="off-bk-1")
+    build_path = await asyncio.to_thread(
+        materialise_remote_artifacts, packed.tarball, _CONFIGURATION_FILENAME
+    )
+    pioenvs = build_path / ".pioenvs" / _DEVICE
+    assert (pioenvs / "firmware.uf2").is_file()
+    # The #1102 fix: firmware.json rides back so get_download_types can
+    # re-enumerate the chip images on the offloader.
+    assert (pioenvs / "firmware.json").is_file()
+
+    # 5. the offloader's Download picker offers firmware.uf2 plus the public
+    #    Beken (.rbl) and cloudcutter (.ug.bin) images — not uf2 alone (#1102).
+    firmware = paired_instances.offloader._db.firmware
+    firmware._validate_configuration_boundary = AsyncMock()
+    binaries = await get_binaries(firmware, configuration=_CONFIGURATION_FILENAME)
+    offered = {entry["file"] for entry in binaries}
+    assert "firmware.uf2" in offered
+    assert any(name.endswith(".rbl") for name in offered), offered
+    assert any(name.endswith(".ug.bin") for name in offered), offered

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -497,7 +497,7 @@ def test_pack_build_artifacts_skips_missing_build_files(tmp_path: Path) -> None:
 
 
 def test_pack_build_artifacts_libretiny_ships_uf2(tmp_path: Path) -> None:
-    """Libretiny BUILD_FILES is resolved from the registry (.uf2 + .bin + .elf)."""
+    """Libretiny BUILD_FILES is resolved from the registry (.uf2 + .bin + .elf + .json)."""
     _write_receiver_state(
         tmp_path,
         device_name="bw15",
@@ -505,6 +505,9 @@ def test_pack_build_artifacts_libretiny_ships_uf2(tmp_path: Path) -> None:
         extra_build_files={
             ".pioenvs/bw15/firmware.uf2": b"UF2",
             ".pioenvs/bw15/firmware.elf": b"ELF",
+            # firmware.json lets the offloader re-enumerate the public chip
+            # images via get_download_types (#1102).
+            ".pioenvs/bw15/firmware.json": b"[]",
         },
     )
 
@@ -516,6 +519,7 @@ def test_pack_build_artifacts_libretiny_ships_uf2(tmp_path: Path) -> None:
     assert ".pioenvs/bw15/firmware.uf2" in names
     assert ".pioenvs/bw15/firmware.bin" in names
     assert ".pioenvs/bw15/firmware.elf" in names
+    assert ".pioenvs/bw15/firmware.json" in names
 
 
 def test_pack_build_artifacts_rejects_unknown_target_platform(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes the remote-build firmware download for LibreTiny chips (reported on bk7231n). After a remote compile, the offloader's Download picker offered only `firmware.uf2`; every Beken `.rbl` and cloudcutter `.ug.bin` image was missing, even though those files had already been transferred. The cause is that the artifact tarball did not ship `firmware.json`, which LibreTiny's `get_download_types` reads to enumerate the public chip images; without it the offloader could not re-derive the list and silently dropped them. The fix adds `firmware.json` to the LibreTiny `BUILD_FILES`, so the offloader offers the same images a local build does.

It also adds a real `esphome compile` of a bk7231n config that runs end to end through the paired offload session (submit_job, receiver compile, download_artifacts, materialise, then list the binaries on the offloader); this is the first e2e that exercises the LibreTiny artifact set rather than fake esp32 binaries. A fast packer unit test pins that `firmware.json` ships. The LibreTiny compile is slow, so the e2e job gains a `~/.platformio` cache and a 20 minute cap.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1102

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
