### PR TITLE
Emit multi_conf components in list form on first add

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -93,7 +93,7 @@ def merge_component_yaml(
     return _append_block(existing, block)
 
 
-def generate_component_yaml(  # noqa: C901
+def generate_component_yaml(  # noqa: C901, PLR0912
     component: ComponentCatalogEntry,
     fields: dict[str, Any],
 ) -> str:
@@ -167,19 +167,26 @@ def generate_component_yaml(  # noqa: C901
         autofill.update(sub)
         fields[entry.key] = autofill
 
-    lines: list[str] = []
     if is_platform:
-        lines.append(f"{category}:")
-        lines.append(f"{ESPHOME_YAML_INDENT}- platform: {unqualified}")
+        lines = [f"{category}:", f"{ESPHOME_YAML_INDENT}- platform: {unqualified}"]
         indent = ESPHOME_YAML_INDENT * 2
-    else:
-        lines.append(f"{comp_id}:")
-        indent = ESPHOME_YAML_INDENT
+        for key, value in fields.items():
+            lines.extend(_emit_field(key, value, indent))
+        return "\n".join(lines)
 
+    body: list[str] = []
     for key, value in fields.items():
-        lines.extend(_emit_field(key, value, indent))
+        body.extend(_emit_field(key, value, ESPHOME_YAML_INDENT))
 
-    return "\n".join(lines)
+    # ``multi_conf`` components are YAML lists (``globals:`` a list of
+    # typed variables, ``i2c:`` a list of buses), so emit the first
+    # entry in ``- `` list form. A bare mapping only survives via
+    # ``cv.ensure_list`` and misleads the user about the block's shape;
+    # the next add normalises it to list form anyway.
+    if component.multi_conf:
+        return "\n".join([f"{comp_id}:", *_mapping_body_to_list_item(body)])
+
+    return "\n".join([f"{comp_id}:", *body])
 
 
 def _coerce_string_map_values(
@@ -283,19 +290,18 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
 
 def _splice_into_multi_conf_block(existing: str, comp_id: str, block: str) -> str | None:
     """
-    Normalise ``<comp_id>:`` to list-form, then splice *block* in.
+    Normalise an existing ``<comp_id>:`` body to list-form, then splice *block* in.
 
-    Returns ``None`` when no such block exists so the caller can
-    fall back to a plain append.
+    *block* already arrives list-form from
+    :func:`generate_component_yaml`; this only has to rewrite a legacy
+    mapping-form body already on disk before appending the new item.
+    Returns ``None`` when no such block exists so the caller can fall
+    back to a plain append.
     """
     normalized = _normalize_multi_conf_block(existing, comp_id)
     if normalized is None:
         return None
-    block_lines = block.splitlines()
-    if len(block_lines) < 2 or block_lines[0].rstrip() != f"{comp_id}:":
-        return None
-    list_block = f"{comp_id}:\n" + "\n".join(_mapping_body_to_list_item(block_lines[1:]))
-    return _splice_into_domain_block(normalized, comp_id, list_block)
+    return _splice_into_domain_block(normalized, comp_id, block)
 
 
 def _normalize_multi_conf_block(existing: str, comp_id: str) -> str | None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -981,8 +981,8 @@ _RTTTL_LIST = "rtttl:\n  - id: rtttl_1\n    output: buzz\n  - id: rtttl_2\n    o
             "esphome:\n  name: kitchen\n",
             "rtttl_1",
             ["rtttl_1"],
-            "rtttl:\n  id: rtttl_1\n  output: buzz\n",
-            id="first_add_emits_mapping",
+            "rtttl:\n  - id: rtttl_1\n    output: buzz\n",
+            id="first_add_emits_list",
         ),
         pytest.param(
             f"esphome:\n  name: kitchen\n\n{_RTTTL_MAPPING}",
@@ -1091,6 +1091,22 @@ def test_mapping_body_to_list_item_preserves_blank_lines() -> None:
         "",
         "    output: buzz",
     ]
+
+
+def test_generate_component_yaml_multi_conf_emits_list_form() -> None:
+    """A ``multi_conf`` component's first entry renders as a ``- `` list item."""
+    component = _component(component_id="globals", category=ComponentCategory.MISC, multi_conf=True)
+    out = generate_component_yaml(component, {"id": "g1", "type": "int", "initial_value": "0"})
+    assert out.startswith("globals:\n  - id: g1\n")
+    assert "    type: int" in out
+    assert "    initial_value:" in out
+
+
+def test_generate_component_yaml_singleton_emits_mapping_form() -> None:
+    """A non-``multi_conf`` singleton stays a bare mapping (no ``- ``)."""
+    component = _component(component_id="wifi", category=ComponentCategory.MISC, multi_conf=False)
+    out = generate_component_yaml(component, {"ssid": "home"})
+    assert out == "wifi:\n  ssid: home"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Adding the first instance of a multi_conf component (globals, i2c, script, and friends) through the Visual Editor emitted a bare mapping under the section key, so globals came out as globals: with type and id on the following lines. In ESPHome those sections are YAML lists, so the bare mapping only survives because cv.ensure_list coerces it, and it reads as though globals were a single mapping; adding a second entry then rewrites the whole block into list form. This emits the first entry in list form from the start, matching what the second add already produces and what the ESPHome docs show. Non multi_conf singletons are unchanged.

**Related issue or feature (if applicable):**

- follow-up to the globals list handling in esphome/device-builder#1097

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
