### PR TITLE
Add ha_ingress to ServerInfoMessage for HA-embedded frontend

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -12,8 +12,10 @@ The primary API. A single multiplexed WebSocket handles all 44 commands.
 
 On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/models/api.py):
 ```json
-{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "requires_auth": false}
+{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false}
 ```
+
+`ha_ingress` is `true` only when the connection is proxied through the HA Supervisor ingress (the `X-Ingress-Path` header is present); the frontend slims its header in that case so HA's own panel bar isn't doubled up. An add-on reached directly on its exposed port reports `ha_addon: true` but `ha_ingress: false`.
 
 **Send a [`CommandMessage`](../esphome_device_builder/models/api.py):**
 ```json

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -335,6 +335,9 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
         esphome_version=esphome_version,
         port=settings.port,
         ha_addon=settings.on_ha_addon,
+        # Supervisor sets X-Ingress-Path only on ingress-proxied requests
+        # (this WS upgrade included).
+        ha_ingress=bool(request.headers.get("X-Ingress-Path")),
         requires_auth=(not pre_authenticated),
     )
     await client.send(info.to_dict())

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -108,4 +108,7 @@ class ServerInfoMessage(DataClassORJSONMixin):
     esphome_version: str
     port: int
     ha_addon: bool = False
+    # True only when the connection is proxied through HA ingress; an
+    # add-on reached directly on its exposed port is False, unlike ha_addon.
+    ha_ingress: bool = False
     requires_auth: bool = False

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -238,3 +238,35 @@ async def test_invalid_json_message_returns_invalid_message_error(
         assert result_payload["result"] == {"pong": "yes"}
     finally:
         await ws.close()
+
+
+async def test_server_info_ha_ingress_reflects_x_ingress_path_header(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """``ha_ingress`` mirrors whether Supervisor's ``X-Ingress-Path`` header is present."""
+    device_builder = MagicMock()
+    device_builder.settings = _make_settings(using_password=False)
+    device_builder.auth = MagicMock()
+    device_builder.command_handlers = {}
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True
+    ws_module.init_ws_app(app)
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+
+    ws, info = await _connect_and_drain_server_info(
+        client, headers={"X-Ingress-Path": "/api/hassio_ingress/token"}
+    )
+    try:
+        assert info["ha_ingress"] is True
+    finally:
+        await ws.close()
+
+    ws, info = await _connect_and_drain_server_info(client)
+    try:
+        assert info["ha_ingress"] is False
+    finally:
+        await ws.close()


### PR DESCRIPTION
# What does this implement/fix?

Adds an ha_ingress boolean to the ServerInfoMessage the backend sends on WebSocket connect. It is true only when the request is proxied through the Home Assistant Supervisor ingress, detected from the X-Ingress-Path header that Supervisor sets (present on the WS upgrade too). This is distinct from ha_addon; an add-on reached directly on its exposed port reports ha_addon true but ha_ingress false.

The frontend uses this to slim its own header when embedded in the HA panel, so HA's panel bar and ours aren't doubled up. The field defaults to false, so an older frontend simply ignores it.

**Related issue or feature (if applicable):**

- part of esphome/device-builder-frontend#41

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#510

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
