### PR TITLE
Coerce ruamel ScalarFloat to float in automation parser

### DIFF
--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import TaggedScalar
+from ruamel.yaml.scalarfloat import ScalarFloat
 from ruamel.yaml.scalarstring import LiteralScalarString
 
 from ...helpers.api import CommandError
@@ -669,7 +670,10 @@ def _render_value(value: Any) -> Any:
         return {k: _render_value(v) for k, v in value.items()}
     if isinstance(value, list):
         return [_render_value(v) for v in value]
-    return value
+    # ruamel round-trip mode wraps floats in ScalarFloat (a float subclass);
+    # orjson serialises int/bool subclasses but refuses float subclasses, so
+    # coerce to a plain float for the wire.
+    return float(value) if isinstance(value, ScalarFloat) else value
 
 
 def _render_params(value: Any) -> Any:

--- a/tests/fixtures/automation_yamls/sensor_on_value_range_float.yaml
+++ b/tests/fixtures/automation_yamls/sensor_on_value_range_float.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: x
+sensor:
+  - platform: template
+    name: 'Temp'
+    id: temp
+    on_value_range:
+      above: 3.14
+      below: 25.5
+      then:
+        - logger.log: hi

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -111,6 +111,7 @@ def test_parse_inline_on_click_surfaces_trigger_params() -> None:
 
 def test_parse_on_value_range_float_params_are_json_serialisable() -> None:
     """Decimal on_value_range thresholds round-trip as plain floats."""
+    parsed = parse_device_yaml(_load("sensor_on_value_range_float.yaml"))
     tree = parsed[0].automation
     assert tree.trigger_id == "sensor.on_value_range"
     assert tree.trigger_params == {"above": 3.14, "below": 25.5}

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -110,8 +110,7 @@ def test_parse_inline_on_click_surfaces_trigger_params() -> None:
 
 
 def test_parse_on_value_range_float_params_are_json_serialisable() -> None:
-    """Decimal on_value_range thresholds round-trip as plain floats (#1124)."""
-    parsed = parse_device_yaml(_load("sensor_on_value_range_float.yaml"))
+    """Decimal on_value_range thresholds round-trip as plain floats."""
     tree = parsed[0].automation
     assert tree.trigger_id == "sensor.on_value_range"
     assert tree.trigger_params == {"above": 3.14, "below": 25.5}

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -109,6 +109,17 @@ def test_parse_inline_on_click_surfaces_trigger_params() -> None:
     assert [a.action_id for a in tree.actions] == ["switch.toggle"]
 
 
+def test_parse_on_value_range_float_params_are_json_serialisable() -> None:
+    """Decimal on_value_range thresholds round-trip as plain floats (#1124)."""
+    parsed = parse_device_yaml(_load("sensor_on_value_range_float.yaml"))
+    tree = parsed[0].automation
+    assert tree.trigger_id == "sensor.on_value_range"
+    assert tree.trigger_params == {"above": 3.14, "below": 25.5}
+    assert type(tree.trigger_params["above"]) is float  # not ScalarFloat
+    # The real regression: the WS layer must be able to serialise the result.
+    orjson.dumps([p.to_dict() for p in parsed])
+
+
 # ---------------------------------------------------------------------------
 # Top-level blocks
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Parsing a `sensor.on_value_range` automation with a decimal `above` / `below` threshold crashed the `automations/parse` WS command with `TypeError: Type is not JSON serializable: ScalarFloat`. ruamel's round-trip loader wraps decimal YAML values in `ScalarFloat`, a `float` subclass that orjson refuses to serialise (it accepts plain int/bool and ruamel's int subclasses, but not float subclasses). The parser's `_render_value` is the single seam every trigger, action, and condition param flows through; it already coerces lambda and tagged scalars, so this coerces `ScalarFloat` to a plain `float` there, fixing decimals everywhere, not just on_value_range.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1124

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
