### PR TITLE
Support native ESP-IDF builds in the remote-build offload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,11 +357,15 @@ jobs:
       - name: Cache ESP-IDF toolchain
         # Native IDF does NOT use PlatformIO; its toolchain installs under
         # ``ESPHOME_ESP_IDF_PREFIX`` (set on the run step). Without the cache
-        # a cold IDF install + toolchain download runs on every PR.
+        # a cold IDF install + toolchain download runs on every PR. The
+        # installed IDF version is pinned by ``esphome@dev`` (reinstalled
+        # each run), not by the test file -- so use a rolling ``run_id`` key
+        # that saves a fresh cache every run (picking up dev IDF bumps) and
+        # ``restore-keys`` to warm from the most recent prior cache.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cache/esphome-idf
-          key: e2e-espidf-${{ runner.os }}-${{ hashFiles('tests/e2e/test_esp_idf_compile_download.py') }}
+          key: e2e-espidf-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
             e2e-espidf-${{ runner.os }}-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,29 +300,80 @@ jobs:
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
 
-      - name: Cache compile toolchains (PlatformIO + ESP-IDF)
-        # LibreTiny builds under ``~/.platformio``; native-IDF does NOT use
-        # PlatformIO, its toolchain installs under ``ESPHOME_ESP_IDF_PREFIX``
-        # (set on the run step). Cache both, keyed per channel + compile test.
+      - name: Cache PlatformIO core + per-platform toolchains
+        # The LibreTiny e2e (test_libretiny_compile_download.py) runs a real
+        # bk7231n compile, which clones the LibreTiny SDK from source on a
+        # cold runner. Cache ``~/.platformio`` per channel so stable/dev
+        # SDK downloads don't collide. The native-IDF e2e runs in its own
+        # job below (different toolchain tree), so it isn't cached here.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: |
-            ~/.platformio
-            ~/.cache/esphome-idf
-          key: e2e-toolchains-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/test_libretiny_compile_download.py', 'tests/e2e/test_esp_idf_compile_download.py') }}
+          path: ~/.platformio
+          key: pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/test_libretiny_compile_download.py') }}
           restore-keys: |
-            e2e-toolchains-${{ runner.os }}-${{ matrix.channel }}-
+            pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-
 
       - name: Run e2e tests
-        # 20 min cap: a cold SDK/toolchain install plus compile runs minutes.
-        # Fast tests keep ``--timeout=120``; real-compile ones set their own.
-        # Without ``ESPHOME_ESP_IDF_PREFIX`` esphome installs IDF under the
-        # throwaway per-job ``ESPHOME_DATA_DIR`` and reinstalls every run; it
-        # ``expanduser()``s the value, so ``~`` matches the cache path above.
+        # 20 min outer cap: a cold LibreTiny SDK clone plus compile runs
+        # minutes. Fast tests keep ``--timeout=120``; the LibreTiny test
+        # opts out via its own ``@pytest.mark.timeout(600)``. The native-IDF
+        # e2e is excluded here and runs in the dev-only job below.
         timeout-minutes: 20
+        run: >-
+          uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
+          --ignore=tests/e2e/test_esp_idf_compile_download.py
+
+  e2e-native-idf:
+    name: E2E native ESP-IDF (esphome dev)
+    runs-on: ubuntu-latest
+    # The native ESP-IDF toolchain (esphome 2026.5.0+) is new and its cold
+    # compile installs the full IDF toolchain (minutes). It runs on its own
+    # runner, dev channel only and advisory (``continue-on-error``): it must
+    # neither slow the main e2e matrix nor gate a PR on an esphome nightly
+    # break. Fold it into the stable matrix once the toolchain has settled.
+    continue-on-error: true
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up uv and Python 3.14
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.14"
+
+      - name: Create venv + install package + test deps
+        run: |
+          uv venv
+          uv pip install -e '.[esphome,test]'
+
+      - name: Install esphome (dev channel)
+        run: uv pip install --upgrade git+https://github.com/esphome/esphome.git@dev
+
+      - name: Show installed esphome version
+        run: uv pip show esphome | grep -E '^(Name|Version):'
+
+      - name: Cache ESP-IDF toolchain
+        # Native IDF does NOT use PlatformIO; its toolchain installs under
+        # ``ESPHOME_ESP_IDF_PREFIX`` (set on the run step). Without the cache
+        # a cold IDF install + toolchain download runs on every PR.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/esphome-idf
+          key: e2e-espidf-${{ runner.os }}-${{ hashFiles('tests/e2e/test_esp_idf_compile_download.py') }}
+          restore-keys: |
+            e2e-espidf-${{ runner.os }}-
+
+      - name: Run native ESP-IDF e2e
+        # A cold native-IDF compile installs the IDF toolchain then runs
+        # ninja; the test's own ``@pytest.mark.timeout(900)`` caps it.
+        # esphome ``expanduser()``s ESPHOME_ESP_IDF_PREFIX, so ``~`` matches
+        # the cache path above.
+        timeout-minutes: 25
         env:
           ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
-        run: uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
+        run: uv run pytest -q tests/e2e/test_esp_idf_compile_download.py --durations=10 --timeout=900 --no-cov
 
   benchmarks:
     name: Run benchmarks (CodSpeed)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,24 +300,28 @@ jobs:
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
 
-      - name: Cache PlatformIO core + per-platform toolchains
-        # The LibreTiny e2e (test_libretiny_compile_download.py) runs a real
-        # bk7231n compile, which clones the LibreTiny SDK from source on a
-        # cold runner. Cache ``~/.platformio`` per channel so stable/dev
-        # SDK downloads don't collide.
+      - name: Cache compile toolchains (PlatformIO + ESP-IDF)
+        # LibreTiny builds under ``~/.platformio``; native-IDF does NOT use
+        # PlatformIO, its toolchain installs under ``ESPHOME_ESP_IDF_PREFIX``
+        # (set on the run step). Cache both, keyed per channel + compile test.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
-          path: ~/.platformio
-          key: pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/test_libretiny_compile_download.py') }}
+          path: |
+            ~/.platformio
+            ~/.cache/esphome-idf
+          key: e2e-toolchains-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/test_libretiny_compile_download.py', 'tests/e2e/test_esp_idf_compile_download.py') }}
           restore-keys: |
-            pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-
+            e2e-toolchains-${{ runner.os }}-${{ matrix.channel }}-
 
       - name: Run e2e tests
-        # 20 min outer cap (vs the unit job's 5): a cold LibreTiny SDK clone
-        # plus compile runs minutes. The fast e2e tests keep the per-test
-        # ``--timeout=120``; the LibreTiny test opts out via its own
-        # ``@pytest.mark.timeout(600)`` decorator.
+        # 20 min cap: a cold SDK/toolchain install plus compile runs minutes.
+        # Fast tests keep ``--timeout=120``; real-compile ones set their own.
+        # Without ``ESPHOME_ESP_IDF_PREFIX`` esphome installs IDF under the
+        # throwaway per-job ``ESPHOME_DATA_DIR`` and reinstalls every run; it
+        # ``expanduser()``s the value, so ``~`` matches the cache path above.
         timeout-minutes: 20
+        env:
+          ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
         run: uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
 
   benchmarks:

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -69,40 +69,52 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
         storage = StorageJSON.load(resolve_storage_path(configuration))
         if storage is None:
             return []
-        try:
-            component = _resolve_download_component(storage.target_platform)
-            module = importlib.import_module(f"esphome.components.{component}")
-            types = list(module.get_download_types(storage))
-        except Exception:  # noqa: BLE001 — third-party regression: upstream ``get_download_types`` could raise anything
-            _LOGGER.warning("Could not determine download types for %s", configuration)
-            return []
-        # No build dir → can't confirm anything on disk → treat as not built.
-        if storage.firmware_bin_path is None:
-            return []
-        build_dir = storage.firmware_bin_path.parent
-        # Filter to files that exist so a cleaned build reads as "compile
-        # first" rather than offering a name ``firmware/download`` would 404 on.
-        downloads = [dict(t) for t in types if (build_dir / t["file"]).is_file()]
-        # firmware.elf sits beside firmware.bin on every platform
-        # (remote_build/artifact_platforms/*.py). The `not any` guards against a
-        # future get_download_types that lists it, so it can't appear twice.
-        if (build_dir / "firmware.elf").is_file() and not any(
-            t["file"] == "firmware.elf" for t in downloads
-        ):
-            downloads.append(
-                {
-                    "title": "ELF (for debugging)",
-                    "description": "Debug symbols for the ESP stack trace decoder.",
-                    "file": "firmware.elf",
-                }
-            )
-        for entry in downloads:
-            artifact_type = _ARTIFACT_TYPES.get(entry["file"])
-            if artifact_type:
-                entry["type"] = artifact_type
-        return downloads
+        return collect_download_entries(storage)
 
     return await loop.run_in_executor(None, _get_types)
+
+
+def collect_download_entries(storage: StorageJSON) -> list[dict]:
+    """Return the downloadable artifacts on disk for *storage* as ``[{title, file, ...}]``.
+
+    The platform's ``get_download_types`` entries that exist under
+    ``firmware_bin_path.parent`` (the build dir, ``.pioenvs/<name>/`` or
+    native-IDF ``build/``), plus ``firmware.elf`` when present. Empty
+    when nothing is built. The single source of truth for what a build
+    offers; ``get_binaries`` is its async wrapper.
+    """
+    try:
+        component = _resolve_download_component(storage.target_platform)
+        module = importlib.import_module(f"esphome.components.{component}")
+        types = list(module.get_download_types(storage))
+    except Exception:  # noqa: BLE001 — third-party regression: upstream ``get_download_types`` could raise anything
+        _LOGGER.warning("Could not determine download types for %s", storage.name)
+        return []
+    # No build dir → can't confirm anything on disk → treat as not built.
+    if storage.firmware_bin_path is None:
+        return []
+    build_dir = storage.firmware_bin_path.parent
+    # Filter to files that exist so a cleaned build reads as "compile
+    # first" rather than offering a name ``firmware/download`` would 404 on.
+    downloads = [dict(t) for t in types if (build_dir / t["file"]).is_file()]
+    # firmware.elf sits beside firmware.bin on every platform
+    # (remote_build/artifact_platforms/*.py). The `not any` guards against a
+    # future get_download_types that lists it, so it can't appear twice.
+    if (build_dir / "firmware.elf").is_file() and not any(
+        t["file"] == "firmware.elf" for t in downloads
+    ):
+        downloads.append(
+            {
+                "title": "ELF (for debugging)",
+                "description": "Debug symbols for the ESP stack trace decoder.",
+                "file": "firmware.elf",
+            }
+        )
+    for entry in downloads:
+        artifact_type = _ARTIFACT_TYPES.get(entry["file"])
+        if artifact_type:
+            entry["type"] = artifact_type
+    return downloads
 
 
 def _resolve_artifact_path(configuration: str, file: str) -> tuple[Path, str]:

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -69,26 +69,31 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
         storage = StorageJSON.load(resolve_storage_path(configuration))
         if storage is None:
             return []
-        return collect_download_entries(storage)
+        return collect_download_entries(storage, label=configuration)
 
     return await loop.run_in_executor(None, _get_types)
 
 
-def collect_download_entries(storage: StorageJSON) -> list[dict]:
+def collect_download_entries(storage: StorageJSON, *, label: str | None = None) -> list[dict]:
     """Return the downloadable artifacts on disk for *storage* as ``[{title, file, ...}]``.
 
     The platform's ``get_download_types`` entries that exist under
     ``firmware_bin_path.parent`` (the build dir, ``.pioenvs/<name>/`` or
     native-IDF ``build/``), plus ``firmware.elf`` when present. Empty
     when nothing is built. The single source of truth for what a build
-    offers; ``get_binaries`` is its async wrapper.
+    offers; ``get_binaries`` is its async wrapper. *label* identifies the
+    build in the failure log -- the caller's configuration filename when it
+    has one (more specific than ``storage.name`` across colliding device
+    names); defaults to ``storage.name``.
     """
     try:
         component = _resolve_download_component(storage.target_platform)
         module = importlib.import_module(f"esphome.components.{component}")
         types = list(module.get_download_types(storage))
-    except Exception:  # noqa: BLE001 — third-party regression: upstream ``get_download_types`` could raise anything
-        _LOGGER.warning("Could not determine download types for %s", storage.name)
+    except Exception:  # a third-party get_download_types regression could raise anything
+        _LOGGER.warning(
+            "Could not determine download types for %s", label or storage.name, exc_info=True
+        )
         return []
     # No build dir → can't confirm anything on disk → treat as not built.
     if storage.firmware_bin_path is None:

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -22,7 +22,9 @@ BUILD_FILES: tuple[str, ...] = (
     ".pioenvs/{name}/ota_data_initial.bin",
     # Native ESP-IDF (non-PIO) layout — only present when the
     # build went through ``KEY_NATIVE_IDF``; harmlessly skipped
-    # otherwise.
+    # otherwise. ``build/firmware.elf`` is the native-IDF ELF; the
+    # ``.pioenvs`` copy above wins the basename dedupe when both exist.
     "build/firmware.factory.bin",
     "build/{name}.bin",
+    "build/firmware.elf",
 )

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -201,21 +201,21 @@ def _collect_pack_members(  # noqa: C901
         raise RuntimeError(msg)
 
     idedata_cache_path = resolve_idedata_path(configuration, name=storage.name)
-    platformio_ini = build_path / "platformio.ini"
-    if not idedata_cache_path.is_file():
+    platformio_ini = build_path / PLATFORMIO_INI_MEMBER_NAME
+    # A PlatformIO build always emits platformio.ini + an idedata cache;
+    # the cache missing alongside it is a real failure. A native ESP-IDF
+    # build (CMake/ninja) emits neither, so both ride only when present.
+    if platformio_ini.is_file() and not idedata_cache_path.is_file():
         msg = f"idedata cache missing for {configuration}: {idedata_cache_path}"
-        raise FileNotFoundError(msg)
-    if not platformio_ini.is_file():
-        msg = f"platformio.ini missing for {configuration}: {platformio_ini}"
         raise FileNotFoundError(msg)
 
     build_info_path = build_path / BUILD_INFO_MEMBER_NAME
     validated_yaml_path = resolve_compiled_config_path(configuration)
-    members: list[tuple[str, Path]] = [
-        (STORAGE_MEMBER_NAME, storage_path),
-        (IDEDATA_MEMBER_NAME, idedata_cache_path),
-        (PLATFORMIO_INI_MEMBER_NAME, platformio_ini),
-    ]
+    members: list[tuple[str, Path]] = [(STORAGE_MEMBER_NAME, storage_path)]
+    if idedata_cache_path.is_file():
+        members.append((IDEDATA_MEMBER_NAME, idedata_cache_path))
+    if platformio_ini.is_file():
+        members.append((PLATFORMIO_INI_MEMBER_NAME, platformio_ini))
     if build_info_path.is_file():
         members.append((BUILD_INFO_MEMBER_NAME, build_info_path))
     if _validated_yaml_is_fresh(validated_yaml_path, storage_path):

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -202,12 +202,18 @@ def _collect_pack_members(  # noqa: C901
 
     idedata_cache_path = resolve_idedata_path(configuration, name=storage.name)
     platformio_ini = build_path / PLATFORMIO_INI_MEMBER_NAME
-    # A PlatformIO build always emits platformio.ini + an idedata cache;
-    # the cache missing alongside it is a real failure. A native ESP-IDF
-    # build (CMake/ninja) emits neither, so both ride only when present.
-    if platformio_ini.is_file() and not idedata_cache_path.is_file():
-        msg = f"idedata cache missing for {configuration}: {idedata_cache_path}"
-        raise FileNotFoundError(msg)
+    # A native ESP-IDF build (CMake/ninja) emits neither platformio.ini nor
+    # an idedata cache; a PlatformIO build always emits both, so their
+    # absence on a PIO build is a real failure that must surface here rather
+    # than ship a silently-incomplete tarball. Detect native-IDF positively
+    # off the build toolchain, never off file absence.
+    if getattr(storage, "toolchain", None) != "esp-idf":
+        if not platformio_ini.is_file():
+            msg = f"platformio.ini missing for {configuration}: {platformio_ini}"
+            raise FileNotFoundError(msg)
+        if not idedata_cache_path.is_file():
+            msg = f"idedata cache missing for {configuration}: {idedata_cache_path}"
+            raise FileNotFoundError(msg)
 
     build_info_path = build_path / BUILD_INFO_MEMBER_NAME
     validated_yaml_path = resolve_compiled_config_path(configuration)

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -172,10 +172,18 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
                 )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
-    # PlatformIO ships platformio.ini + idedata.json together; a PIO
-    # tarball missing idedata is wire drift. Native ESP-IDF ships neither.
-    if (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file() and idedata_bytes is None:
-        raise MaterialiseError(f"tarball missing required {IDEDATA_MEMBER_NAME!r} member")
+    # A native ESP-IDF tarball (toolchain "esp-idf") ships neither
+    # platformio.ini nor idedata.json; a PlatformIO tarball ships both, so
+    # their absence there is wire drift. Detect native-IDF positively off
+    # the toolchain, never off file absence, so a corrupt PIO tarball that
+    # lost its metadata still raises rather than passing as native-IDF.
+    if receiver_storage.get("toolchain") != "esp-idf":
+        if not (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file():
+            raise MaterialiseError(
+                f"tarball missing required {PLATFORMIO_INI_MEMBER_NAME!r} member"
+            )
+        if idedata_bytes is None:
+            raise MaterialiseError(f"tarball missing required {IDEDATA_MEMBER_NAME!r} member")
     return _ExtractedTarball(
         storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -64,7 +64,8 @@ class MaterialiseError(RuntimeError):
 
 class _ExtractedTarball(NamedTuple):
     storage_bytes: bytes
-    idedata_bytes: bytes
+    # None for a native ESP-IDF build, which emits no idedata cache.
+    idedata_bytes: bytes | None
     # ``PurePath``-flavoured per the receiver's OS so the path
     # remap works when receiver and offloader differ.
     receiver_build_path: PurePath
@@ -85,17 +86,20 @@ def materialise_remote_artifacts(tarball: bytes, configuration: str) -> Path:
     side-effects (the runner) can discard it.
     """
     extracted = _open_and_extract_build_tree(tarball, configuration)
-    cached_idedata_path = _stage_offloader_idedata(
-        configuration=configuration,
-        idedata_bytes=extracted.idedata_bytes,
-        device_name=extracted.build_path.name,
-        receiver_build_path=extracted.receiver_build_path,
-        offloader_build_path=extracted.build_path,
-    )
-    _force_idedata_cache_hit(
-        platformio_ini=extracted.build_path / PLATFORMIO_INI_MEMBER_NAME,
-        cached_idedata=cached_idedata_path,
-    )
+    # Native ESP-IDF ships no idedata cache; the offloader's esphome
+    # re-derives it from the CMake build at upload/logs time.
+    if extracted.idedata_bytes is not None:
+        cached_idedata_path = _stage_offloader_idedata(
+            configuration=configuration,
+            idedata_bytes=extracted.idedata_bytes,
+            device_name=extracted.build_path.name,
+            receiver_build_path=extracted.receiver_build_path,
+            offloader_build_path=extracted.build_path,
+        )
+        _force_idedata_cache_hit(
+            platformio_ini=extracted.build_path / PLATFORMIO_INI_MEMBER_NAME,
+            cached_idedata=cached_idedata_path,
+        )
     if extracted.validated_yaml_bytes is not None:
         _stage_offloader_validated_yaml(
             configuration=configuration,
@@ -120,7 +124,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             storage_bytes, total_bytes = _read_member_required(
                 tar, STORAGE_MEMBER_NAME, total_so_far=total_bytes
             )
-            idedata_bytes, total_bytes = _read_member_required(
+            idedata_bytes, total_bytes = _read_member_optional(
                 tar, IDEDATA_MEMBER_NAME, total_so_far=total_bytes
             )
             validated_yaml_bytes, total_bytes = _read_member_optional(
@@ -168,8 +172,10 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
                 )
     except tarfile.TarError as err:
         raise MaterialiseError(f"tarball is malformed: {err}") from err
-    if not (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file():
-        raise MaterialiseError(f"tarball missing required {PLATFORMIO_INI_MEMBER_NAME!r} member")
+    # PlatformIO ships platformio.ini + idedata.json together; a PIO
+    # tarball missing idedata is wire drift. Native ESP-IDF ships neither.
+    if (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file() and idedata_bytes is None:
+        raise MaterialiseError(f"tarball missing required {IDEDATA_MEMBER_NAME!r} member")
     return _ExtractedTarball(
         storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,18 @@ from esphome_device_builder.models import (
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
 
+# True when the installed esphome carries the native ESP-IDF toolchain
+# (>= 2026.5.0). StorageJSON only grows its ``toolchain`` field there, so
+# tests that synthesize a native-IDF build (which the offload path detects
+# via ``toolchain == "esp-idf"``) skip on older esphome where the field is
+# dropped on load. Mirrors the gate on the native-IDF compile e2e.
+try:
+    from esphome.const import CONF_TOOLCHAIN as _CONF_TOOLCHAIN  # noqa: F401
+
+    HAS_NATIVE_IDF_TOOLCHAIN = True
+except ImportError:
+    HAS_NATIVE_IDF_TOOLCHAIN = False
+
 # Call sites known to do bounded blocking I/O during one-time server
 # startup, where the cost is paid once and not on the request path.
 # Listed here as ``(filename, function_name)`` pairs so blockbuster

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ regressions, not async hygiene.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import sys
 import tempfile as _tempfile
 from collections.abc import Callable, Iterator
@@ -28,6 +29,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from blockbuster import blockbuster_ctx
 from esphome.core import CORE
+from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.controllers._device_mqtt_coordinator import (
     DeviceMqttCoordinator,
@@ -59,17 +61,14 @@ from esphome_device_builder.models import (
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
 
-# True when the installed esphome carries the native ESP-IDF toolchain
-# (>= 2026.5.0). StorageJSON only grows its ``toolchain`` field there, so
-# tests that synthesize a native-IDF build (which the offload path detects
-# via ``toolchain == "esp-idf"``) skip on older esphome where the field is
-# dropped on load. Mirrors the gate on the native-IDF compile e2e.
-try:
-    from esphome.const import CONF_TOOLCHAIN as _CONF_TOOLCHAIN  # noqa: F401
-
-    HAS_NATIVE_IDF_TOOLCHAIN = True
-except ImportError:
-    HAS_NATIVE_IDF_TOOLCHAIN = False
+# True when the installed esphome's StorageJSON carries a ``toolchain``
+# field (>= 2026.5.0). That field is the exact dependency the offload path
+# keys native-IDF detection on (``toolchain == "esp-idf"``); older esphome
+# drops it on load, so tests that synthesize a native-IDF build skip there.
+# Probed off the StorageJSON signature directly rather than a correlated
+# const so the gate tracks the real runtime dependency. Mirrors the
+# native-IDF compile e2e gate.
+HAS_NATIVE_IDF_TOOLCHAIN = "toolchain" in inspect.signature(StorageJSON.__init__).parameters
 
 # Call sites known to do bounded blocking I/O during one-time server
 # startup, where the cost is paid once and not on the request path.

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -250,7 +250,8 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
 
     assert result == []
     assert any(
-        "Could not determine download types for kitchen" in rec.message for rec in caplog.records
+        "Could not determine download types for kitchen.yaml" in rec.message
+        for rec in caplog.records
     )
 
 

--- a/tests/controllers/firmware/test_get_binaries.py
+++ b/tests/controllers/firmware/test_get_binaries.py
@@ -250,8 +250,7 @@ async def test_get_binaries_logs_and_returns_empty_on_module_failure(
 
     assert result == []
     assert any(
-        "Could not determine download types for kitchen.yaml" in rec.message
-        for rec in caplog.records
+        "Could not determine download types for kitchen" in rec.message for rec in caplog.records
     )
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,6 +36,8 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import subprocess
+import sys
 import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
@@ -409,6 +411,20 @@ def make_real_bundle(
             info.size = len(data)
             tar.addfile(info, io.BytesIO(data))
     return buf.getvalue()
+
+
+def run_esphome_compile(
+    yaml_path: Path, *, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run ``esphome compile`` on *yaml_path* with *env*'s ESPHOME_DATA_DIR override."""
+    return subprocess.run(  # noqa: S603 — fixed argv list, no shell, test-only invocation
+        [sys.executable, "-m", "esphome", "compile", str(yaml_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        close_fds=False,
+        env=env,
+    )
 
 
 async def make_and_seed_remote_peer_job(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import os
 import subprocess
 import sys
 import tarfile
@@ -49,6 +50,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
+from esphome.core import CORE
 
 from esphome_device_builder.api.ws import init_ws_app
 from esphome_device_builder.controllers.remote_build import (
@@ -61,6 +63,10 @@ from esphome_device_builder.controllers.remote_build.peer_link import (
 )
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.helpers.peer_link_identity import PeerLinkIdentityStore
+from esphome_device_builder.helpers.remote_artifacts_materialise import (
+    materialise_remote_artifacts,
+)
+from esphome_device_builder.helpers.remote_build_layout import parse_from_configuration
 from esphome_device_builder.models import (
     EventType,
     FirmwareJob,
@@ -425,6 +431,56 @@ def run_esphome_compile(
         close_fds=False,
         env=env,
     )
+
+
+async def run_offload_compile_round_trip(
+    instances: PairedInstances,
+    *,
+    job_id: str,
+    configuration_filename: str,
+    yaml_body: bytes,
+) -> tuple[Path, Path]:
+    """Submit + real-compile *yaml_body* on the receiver, download + materialise on the offloader.
+
+    Returns ``(receiver_data_dir, offloader_build_path)``. Owns the
+    submit -> compile -> lifecycle -> download -> materialise
+    orchestration the platform-specific compile e2es share; callers
+    assert on the produced artifacts. The compile + materialise run via
+    ``asyncio.to_thread`` so their blocking I/O stays off the loop.
+    """
+    await instances.wait_until_session_opened()
+    created_jobs = wire_receiver_firmware_recorder(instances)
+    state_changes = capture_events(instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED)
+
+    handle = instances.offloader.state.peer_link_clients[instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id=job_id,
+        configuration_filename=configuration_filename,
+        target="compile",
+        bundle_bytes=make_real_bundle(
+            configuration_filename=configuration_filename, yaml_body=yaml_body
+        ),
+    )
+    assert ack["accepted"] is True
+    receiver_job = created_jobs[0]
+
+    remote_build_path = parse_from_configuration(receiver_job.configuration)
+    assert remote_build_path is not None
+    data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
+    yaml_path = Path(instances.receiver._db.settings.config_dir) / receiver_job.configuration
+    result = await asyncio.to_thread(
+        run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
+    )
+    assert result.returncode == 0, (
+        f"compile failed:\nstdout:\n{result.stdout[-4000:]}\nstderr:\n{result.stderr[-2000:]}"
+    )
+
+    await drive_remote_job_to_completed(instances, receiver_job, state_changes)
+    packed = await handle.client.download_artifacts(job_id=job_id)
+    build_path = await asyncio.to_thread(
+        materialise_remote_artifacts, packed.tarball, configuration_filename
+    )
+    return data_dir, build_path
 
 
 async def make_and_seed_remote_peer_job(

--- a/tests/e2e/test_esp_idf_compile_download.py
+++ b/tests/e2e/test_esp_idf_compile_download.py
@@ -11,34 +11,18 @@ CI job's ``dev`` channel. ``timeout(900)`` covers a cold IDF install.
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
-from esphome.core import CORE
 from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.controllers.firmware.download import (
     collect_download_entries,
     get_binaries,
 )
-from esphome_device_builder.helpers.remote_artifacts_materialise import (
-    materialise_remote_artifacts,
-)
-from esphome_device_builder.helpers.remote_build_layout import (
-    parse_from_configuration as parse_remote_build_path,
-)
-from esphome_device_builder.models import EventType
 
-from ..conftest import capture_events
-from .conftest import (
-    PairedInstances,
-    drive_remote_job_to_completed,
-    make_real_bundle,
-    run_esphome_compile,
-    wire_receiver_firmware_recorder,
-)
+from .conftest import PairedInstances, run_offload_compile_round_trip
 
 try:
     from esphome.const import CONF_TOOLCHAIN  # noqa: F401
@@ -83,56 +67,23 @@ async def test_esp_idf_compile_download_round_trip(
     paired_instances: PairedInstances,
 ) -> None:
     """A native-IDF compile lands the same downloads offloader-side as a local build (#1102)."""
-    await paired_instances.wait_until_session_opened()
-    created_jobs = wire_receiver_firmware_recorder(paired_instances)
-    state_changes = capture_events(
-        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
-    )
-
-    # 1. submit the native-IDF bundle; the receiver extracts the YAML to
-    #    its remote-build subtree and dispatches a queued job.
-    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
-    ack = await handle.client.submit_job(
+    data_dir, _build_path = await run_offload_compile_round_trip(
+        paired_instances,
         job_id="off-idf-1",
         configuration_filename=_CONFIGURATION_FILENAME,
-        target="compile",
-        bundle_bytes=make_real_bundle(
-            configuration_filename=_CONFIGURATION_FILENAME, yaml_body=_ESP_IDF_YAML
-        ),
-    )
-    assert ack["accepted"] is True
-    receiver_job = created_jobs[0]
-
-    # 2. real compile into the receiver's remote-build data dir — the exact
-    #    ESPHOME_DATA_DIR ``compose_subprocess_env`` pins for a remote job.
-    remote_build_path = parse_remote_build_path(receiver_job.configuration)
-    assert remote_build_path is not None
-    data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
-    config_dir = Path(paired_instances.receiver._db.settings.config_dir)
-    yaml_path = config_dir / receiver_job.configuration
-    result = await asyncio.to_thread(
-        run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
-    )
-    assert result.returncode == 0, (
-        f"native-IDF compile failed:\nstdout:\n{result.stdout[-4000:]}\n"
-        f"stderr:\n{result.stderr[-2000:]}"
+        yaml_body=_ESP_IDF_YAML,
     )
 
-    # The set a local build of this device would offer for download.
-    expected = _local_download_set(data_dir)
+    # The set a local build of this device would offer for download. Off the
+    # loop: ``collect_download_entries`` stats the build dir (blockbuster).
+    expected = await asyncio.to_thread(_local_download_set, data_dir)
     assert expected, "compile produced no downloadable artifacts"
     assert "firmware.factory.bin" in expected, expected
 
-    # 3. drive the receiver queue lifecycle so the download side accepts the job.
-    await drive_remote_job_to_completed(paired_instances, receiver_job, state_changes)
-
-    # 4. pull the artifacts back over the same session and materialise locally.
-    packed = await handle.client.download_artifacts(job_id="off-idf-1")
-    await asyncio.to_thread(materialise_remote_artifacts, packed.tarball, _CONFIGURATION_FILENAME)
-
-    # 5. the offloader's Download picker offers exactly what a local build
-    #    offers — including build/firmware.elf, which only rides back once
-    #    BUILD_FILES lists the native-IDF ELF path (#1102).
+    # The offloader's Download picker offers exactly what a local build
+    # offers — including build/firmware.elf, which only rides back once
+    # BUILD_FILES lists the native-IDF ELF path, and only after the tarball
+    # stops requiring platformio.ini / idedata.json (#1102).
     firmware = paired_instances.offloader._db.firmware
     firmware._validate_configuration_boundary = AsyncMock()
     binaries = await get_binaries(firmware, configuration=_CONFIGURATION_FILENAME)

--- a/tests/e2e/test_esp_idf_compile_download.py
+++ b/tests/e2e/test_esp_idf_compile_download.py
@@ -22,17 +22,11 @@ from esphome_device_builder.controllers.firmware.download import (
     get_binaries,
 )
 
+from ..conftest import HAS_NATIVE_IDF_TOOLCHAIN
 from .conftest import PairedInstances, run_offload_compile_round_trip
 
-try:
-    from esphome.const import CONF_TOOLCHAIN  # noqa: F401
-
-    _HAS_NATIVE_IDF = True
-except ImportError:
-    _HAS_NATIVE_IDF = False
-
 pytestmark = pytest.mark.skipif(
-    not _HAS_NATIVE_IDF, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
+    not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
 )
 
 _DEVICE = "esp-idf-e2e"

--- a/tests/e2e/test_esp_idf_compile_download.py
+++ b/tests/e2e/test_esp_idf_compile_download.py
@@ -1,0 +1,145 @@
+"""
+A real native ESP-IDF compile round-trips through the offload session (#1102).
+
+The native-IDF toolchain (``esp32: toolchain: esp-idf``) builds into
+``build/`` not ``.pioenvs/<name>/``, so it stresses the offloader's
+artifact enumeration differently than the LibreTiny e2e. Skipped on
+esphome without the toolchain (< 2026.5.0); runs for real on the e2e
+CI job's ``dev`` channel. ``timeout(900)`` covers a cold IDF install.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from esphome.components.esp32 import get_download_types
+from esphome.core import CORE
+from esphome.storage_json import StorageJSON
+
+from esphome_device_builder.controllers.firmware.download import get_binaries
+from esphome_device_builder.helpers.remote_artifacts_materialise import (
+    materialise_remote_artifacts,
+)
+from esphome_device_builder.helpers.remote_build_layout import (
+    parse_from_configuration as parse_remote_build_path,
+)
+from esphome_device_builder.models import EventType
+
+from ..conftest import capture_events
+from .conftest import (
+    PairedInstances,
+    drive_remote_job_to_completed,
+    make_real_bundle,
+    run_esphome_compile,
+    wire_receiver_firmware_recorder,
+)
+
+try:
+    from esphome.const import CONF_TOOLCHAIN  # noqa: F401
+
+    _HAS_NATIVE_IDF = True
+except ImportError:
+    _HAS_NATIVE_IDF = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_NATIVE_IDF, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
+)
+
+_DEVICE = "esp-idf-e2e"
+_CONFIGURATION_FILENAME = f"{_DEVICE}.yaml"
+_ESP_IDF_YAML = f"""\
+esphome:
+  name: {_DEVICE}
+esp32:
+  board: esp32-c3-devkitm-1
+  toolchain: esp-idf
+  framework:
+    type: esp-idf
+logger:
+""".encode()
+
+
+def _local_download_set(data_dir: Path) -> set[str]:
+    """Return the download filenames a *local* build of this device offers.
+
+    Mirrors :func:`get_binaries`' selection against the receiver's own
+    storage + build dir: ``get_download_types`` entries that exist on
+    disk, plus ``firmware.elf`` when present. Derived from the receiver
+    rather than hard-coded so it tracks the esphome build layout.
+    """
+    [storage_path] = list((data_dir / "storage").glob("*.json"))
+    storage = StorageJSON.load(storage_path)
+    assert storage is not None and storage.firmware_bin_path is not None
+    build_dir = Path(storage.firmware_bin_path).parent
+    offered = {
+        dl["file"] for dl in get_download_types(storage) if (build_dir / dl["file"]).is_file()
+    }
+    if (build_dir / "firmware.elf").is_file():
+        offered.add("firmware.elf")
+    return offered
+
+
+@pytest.mark.timeout(900)
+async def test_esp_idf_compile_download_round_trip(
+    paired_instances: PairedInstances,
+) -> None:
+    """A native-IDF compile lands the same downloads offloader-side as a local build (#1102)."""
+    await paired_instances.wait_until_session_opened()
+    created_jobs = wire_receiver_firmware_recorder(paired_instances)
+    state_changes = capture_events(
+        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
+    )
+
+    # 1. submit the native-IDF bundle; the receiver extracts the YAML to
+    #    its remote-build subtree and dispatches a queued job.
+    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
+    ack = await handle.client.submit_job(
+        job_id="off-idf-1",
+        configuration_filename=_CONFIGURATION_FILENAME,
+        target="compile",
+        bundle_bytes=make_real_bundle(
+            configuration_filename=_CONFIGURATION_FILENAME, yaml_body=_ESP_IDF_YAML
+        ),
+    )
+    assert ack["accepted"] is True
+    receiver_job = created_jobs[0]
+
+    # 2. real compile into the receiver's remote-build data dir — the exact
+    #    ESPHOME_DATA_DIR ``compose_subprocess_env`` pins for a remote job.
+    remote_build_path = parse_remote_build_path(receiver_job.configuration)
+    assert remote_build_path is not None
+    data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
+    config_dir = Path(paired_instances.receiver._db.settings.config_dir)
+    yaml_path = config_dir / receiver_job.configuration
+    result = await asyncio.to_thread(
+        run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
+    )
+    assert result.returncode == 0, (
+        f"native-IDF compile failed:\nstdout:\n{result.stdout[-4000:]}\n"
+        f"stderr:\n{result.stderr[-2000:]}"
+    )
+
+    # The set a local build of this device would offer for download.
+    expected = _local_download_set(data_dir)
+    assert expected, "compile produced no downloadable artifacts"
+    assert "firmware.factory.bin" in expected, expected
+
+    # 3. drive the receiver queue lifecycle so the download side accepts the job.
+    await drive_remote_job_to_completed(paired_instances, receiver_job, state_changes)
+
+    # 4. pull the artifacts back over the same session and materialise locally.
+    packed = await handle.client.download_artifacts(job_id="off-idf-1")
+    await asyncio.to_thread(materialise_remote_artifacts, packed.tarball, _CONFIGURATION_FILENAME)
+
+    # 5. the offloader's Download picker offers exactly what a local build
+    #    offers — including build/firmware.elf, which only rides back once
+    #    BUILD_FILES lists the native-IDF ELF path (#1102).
+    firmware = paired_instances.offloader._db.firmware
+    firmware._validate_configuration_boundary = AsyncMock()
+    binaries = await get_binaries(firmware, configuration=_CONFIGURATION_FILENAME)
+    offered = {entry["file"] for entry in binaries}
+    assert offered == expected

--- a/tests/e2e/test_esp_idf_compile_download.py
+++ b/tests/e2e/test_esp_idf_compile_download.py
@@ -16,11 +16,13 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
-from esphome.components.esp32 import get_download_types
 from esphome.core import CORE
 from esphome.storage_json import StorageJSON
 
-from esphome_device_builder.controllers.firmware.download import get_binaries
+from esphome_device_builder.controllers.firmware.download import (
+    collect_download_entries,
+    get_binaries,
+)
 from esphome_device_builder.helpers.remote_artifacts_materialise import (
     materialise_remote_artifacts,
 )
@@ -66,21 +68,14 @@ logger:
 def _local_download_set(data_dir: Path) -> set[str]:
     """Return the download filenames a *local* build of this device offers.
 
-    Mirrors :func:`get_binaries`' selection against the receiver's own
-    storage + build dir: ``get_download_types`` entries that exist on
-    disk, plus ``firmware.elf`` when present. Derived from the receiver
-    rather than hard-coded so it tracks the esphome build layout.
+    Runs the production selection (:func:`collect_download_entries`)
+    against the receiver's own storage + build dir, so the parity check
+    shares one source of truth with the offloader side.
     """
     [storage_path] = list((data_dir / "storage").glob("*.json"))
     storage = StorageJSON.load(storage_path)
-    assert storage is not None and storage.firmware_bin_path is not None
-    build_dir = Path(storage.firmware_bin_path).parent
-    offered = {
-        dl["file"] for dl in get_download_types(storage) if (build_dir / dl["file"]).is_file()
-    }
-    if (build_dir / "firmware.elf").is_file():
-        offered.add("firmware.elf")
-    return offered
+    assert storage is not None
+    return {entry["file"] for entry in collect_download_entries(storage)}
 
 
 @pytest.mark.timeout(900)

--- a/tests/e2e/test_libretiny_compile_download.py
+++ b/tests/e2e/test_libretiny_compile_download.py
@@ -21,31 +21,13 @@ It is slow (cold runs clone the LibreTiny SDK), hence
 
 from __future__ import annotations
 
-import asyncio
-import os
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
-from esphome.core import CORE
 
 from esphome_device_builder.controllers.firmware.download import get_binaries
-from esphome_device_builder.helpers.remote_artifacts_materialise import (
-    materialise_remote_artifacts,
-)
-from esphome_device_builder.helpers.remote_build_layout import (
-    parse_from_configuration as parse_remote_build_path,
-)
-from esphome_device_builder.models import EventType
 
-from ..conftest import capture_events
-from .conftest import (
-    PairedInstances,
-    drive_remote_job_to_completed,
-    make_real_bundle,
-    run_esphome_compile,
-    wire_receiver_firmware_recorder,
-)
+from .conftest import PairedInstances, run_offload_compile_round_trip
 
 _DEVICE = "bk7231n-e2e"
 _CONFIGURATION_FILENAME = f"{_DEVICE}.yaml"
@@ -63,61 +45,21 @@ async def test_libretiny_bk7231n_compile_download_round_trip(
     paired_instances: PairedInstances,
 ) -> None:
     """A real bk7231n compile lands every public Beken/cloudcutter image offloader-side (#1102)."""
-    await paired_instances.wait_until_session_opened()
-    created_jobs = wire_receiver_firmware_recorder(paired_instances)
-    state_changes = capture_events(
-        paired_instances.offloader_bus, EventType.OFFLOADER_JOB_STATE_CHANGED
-    )
-
-    # 1. submit the bk7231n bundle; the receiver extracts the YAML to its
-    #    remote-build subtree and dispatches a queued job.
-    handle = paired_instances.offloader.state.peer_link_clients[paired_instances.pin_sha256]
-    ack = await handle.client.submit_job(
+    _data_dir, build_path = await run_offload_compile_round_trip(
+        paired_instances,
         job_id="off-bk-1",
         configuration_filename=_CONFIGURATION_FILENAME,
-        target="compile",
-        bundle_bytes=make_real_bundle(
-            configuration_filename=_CONFIGURATION_FILENAME, yaml_body=_BK7231N_YAML
-        ),
+        yaml_body=_BK7231N_YAML,
     )
-    assert ack["accepted"] is True
-    receiver_job = created_jobs[0]
 
-    # 2. real compile into the receiver's remote-build data dir — the exact
-    #    ESPHOME_DATA_DIR ``compose_subprocess_env`` pins for a remote job, so
-    #    ``pack_build_artifacts`` reads the produced storage/build/idedata back.
-    remote_build_path = parse_remote_build_path(receiver_job.configuration)
-    assert remote_build_path is not None
-    data_dir = remote_build_path.data_dir(Path(CORE.data_dir))
-    config_dir = Path(paired_instances.receiver._db.settings.config_dir)
-    yaml_path = config_dir / receiver_job.configuration
-    result = await asyncio.to_thread(
-        run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
-    )
-    assert result.returncode == 0, (
-        f"bk7231n compile failed:\nstdout:\n{result.stdout[-4000:]}\n"
-        f"stderr:\n{result.stderr[-2000:]}"
-    )
-    receiver_pioenvs = data_dir / "build" / _DEVICE / ".pioenvs" / _DEVICE
-    assert (receiver_pioenvs / "firmware.uf2").is_file()
-    assert (receiver_pioenvs / "firmware.json").is_file()
-
-    # 3. drive the receiver queue lifecycle so the download side accepts the job.
-    await drive_remote_job_to_completed(paired_instances, receiver_job, state_changes)
-
-    # 4. pull the artifacts back over the same session and materialise locally.
-    packed = await handle.client.download_artifacts(job_id="off-bk-1")
-    build_path = await asyncio.to_thread(
-        materialise_remote_artifacts, packed.tarball, _CONFIGURATION_FILENAME
-    )
+    # The #1102 fix: firmware.json rides back beside firmware.uf2 so
+    # get_download_types can re-enumerate the chip images on the offloader.
     pioenvs = build_path / ".pioenvs" / _DEVICE
     assert (pioenvs / "firmware.uf2").is_file()
-    # The #1102 fix: firmware.json rides back so get_download_types can
-    # re-enumerate the chip images on the offloader.
     assert (pioenvs / "firmware.json").is_file()
 
-    # 5. the offloader's Download picker offers firmware.uf2 plus the public
-    #    Beken (.rbl) and cloudcutter (.ug.bin) images — not uf2 alone (#1102).
+    # The offloader's Download picker offers firmware.uf2 plus the public
+    # Beken (.rbl) and cloudcutter (.ug.bin) images — not uf2 alone (#1102).
     firmware = paired_instances.offloader._db.firmware
     firmware._validate_configuration_boundary = AsyncMock()
     binaries = await get_binaries(firmware, configuration=_CONFIGURATION_FILENAME)

--- a/tests/e2e/test_libretiny_compile_download.py
+++ b/tests/e2e/test_libretiny_compile_download.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -45,6 +43,7 @@ from .conftest import (
     PairedInstances,
     drive_remote_job_to_completed,
     make_real_bundle,
+    run_esphome_compile,
     wire_receiver_firmware_recorder,
 )
 
@@ -57,20 +56,6 @@ bk72xx:
   board: generic-bk7231n-qfn32-tuya
 logger:
 """.encode()
-
-
-def _run_esphome_compile(
-    yaml_path: Path, *, env: dict[str, str]
-) -> subprocess.CompletedProcess[str]:
-    """Run ``esphome compile`` on *yaml_path* with *env*'s ESPHOME_DATA_DIR override."""
-    return subprocess.run(  # noqa: S603 — fixed argv list, no shell, test-only invocation
-        [sys.executable, "-m", "esphome", "compile", str(yaml_path)],
-        capture_output=True,
-        text=True,
-        check=False,
-        close_fds=False,
-        env=env,
-    )
 
 
 @pytest.mark.timeout(600)
@@ -107,7 +92,7 @@ async def test_libretiny_bk7231n_compile_download_round_trip(
     config_dir = Path(paired_instances.receiver._db.settings.config_dir)
     yaml_path = config_dir / receiver_job.configuration
     result = await asyncio.to_thread(
-        _run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
+        run_esphome_compile, yaml_path, env={**os.environ, "ESPHOME_DATA_DIR": str(data_dir)}
     )
     assert result.returncode == 0, (
         f"bk7231n compile failed:\nstdout:\n{result.stdout[-4000:]}\n"

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -124,6 +124,13 @@ def test_esp32_includes_factory_firmware_for_idf() -> None:
     assert "build/firmware.factory.bin" in rendered
 
 
+def test_esp32_includes_native_idf_elf() -> None:
+    """Native-IDF emits build/firmware.elf; BUILD_FILES ships it for the ELF download."""
+    rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
+    assert ".pioenvs/kitchen/firmware.elf" in rendered
+    assert "build/firmware.elf" in rendered
+
+
 def test_libretiny_includes_uf2_and_bin() -> None:
     """Libretiny ships both .uf2 (UART/ltchiptool) and .bin (OTA)."""
     rendered = [f.format(name="bw15") for f in build_files_for_platform("bk72xx")]

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -599,10 +599,10 @@ def test_materialise_rejects_missing_storage_member(tmp_path: Path) -> None:
         _materialise_in_tmp(tarball, tmp_path)
 
 
-def test_materialise_rejects_missing_idedata_member(tmp_path: Path) -> None:
-    """A tarball without idedata.json raises MaterialiseError."""
+def test_materialise_rejects_pio_tarball_missing_idedata(tmp_path: Path) -> None:
+    """A PlatformIO tarball (platformio.ini present) without idedata.json is wire drift."""
     tarball = _synthetic_tarball(idedata=None)
-    with pytest.raises(MaterialiseError, match=r"missing required member: 'idedata\.json'"):
+    with pytest.raises(MaterialiseError, match=r"missing required 'idedata\.json' member"):
         _materialise_in_tmp(tarball, tmp_path)
 
 
@@ -651,11 +651,30 @@ def test_materialise_rejects_non_json_storage(tmp_path: Path) -> None:
         _materialise_in_tmp(tarball, tmp_path)
 
 
-def test_materialise_rejects_missing_platformio_ini(tmp_path: Path) -> None:
-    """A tarball without platformio.ini raises MaterialiseError post-extract."""
-    tarball = _synthetic_tarball(platformio_ini=None)
-    with pytest.raises(MaterialiseError, match=r"missing required 'platformio\.ini'"):
-        _materialise_in_tmp(tarball, tmp_path)
+def test_materialise_native_idf_round_trip_without_pio_metadata(
+    paired_roots: tuple[Path, Path],
+) -> None:
+    """Native ESP-IDF (no platformio.ini / idedata) round-trips; no idedata cache staged."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(
+        receiver_root,
+        native_idf=True,
+        extra_build_files={
+            "build/firmware.factory.bin": b"FACTORY",
+            "build/firmware.ota.bin": b"OTA",
+            "build/firmware.elf": b"ELF",
+        },
+    )
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+
+    assert build_path == offloader_root / ".esphome" / "build" / "kitchen"
+    assert (build_path / "build" / "kitchen.bin").is_file()
+    assert (build_path / "build" / "firmware.factory.bin").is_file()
+    assert not (build_path / "platformio.ini").exists()
+    # Native IDF ships no idedata cache, so the offloader stages none.
+    sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"
+    with patch.object(CORE, "config_path", sentinel):
+        assert not resolve_idedata_path("kitchen.yaml", name="kitchen").exists()
 
 
 def test_materialise_rejects_oversized_member(

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -47,6 +47,7 @@ from esphome_device_builder.helpers.storage_path import (
     resolve_idedata_path,
     resolve_storage_path,
 )
+from tests.conftest import HAS_NATIVE_IDF_TOOLCHAIN
 from tests.test_remote_build_artifacts_download import _write_receiver_state
 
 _SENTINEL = object()
@@ -651,6 +652,16 @@ def test_materialise_rejects_non_json_storage(tmp_path: Path) -> None:
         _materialise_in_tmp(tarball, tmp_path)
 
 
+def test_materialise_rejects_pio_tarball_missing_platformio_ini(tmp_path: Path) -> None:
+    """A PlatformIO tarball without platformio.ini raises, not silently passed as native-IDF."""
+    tarball = _synthetic_tarball(platformio_ini=None)
+    with pytest.raises(MaterialiseError, match=r"missing required 'platformio\.ini'"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
+@pytest.mark.skipif(
+    not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
+)
 def test_materialise_native_idf_round_trip_without_pio_metadata(
     paired_roots: tuple[Path, Path],
 ) -> None:

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -337,23 +337,28 @@ def _write_receiver_state(
     extras: list[tuple[str, str]] | None = None,
     extra_build_files: dict[str, bytes] | None = None,
     validated_yaml: bytes | None = None,
+    native_idf: bool = False,
 ) -> dict[str, Path]:
     """Lay down a minimal receiver-side build state on disk.
 
-    Writes:
+    PlatformIO shape (default) writes:
 
     * ``<data_dir>/build/<device_name>/platformio.ini``
     * ``<data_dir>/build/<device_name>/.pioenvs/<device_name>/firmware.bin``
-    * Any additional build-tree files in *extra_build_files*
-      (keys are paths relative to ``<build_path>/``).
-    * ``<data_dir>/storage/<basename>.json`` with the JSON
-      fields the new packer reads via ``StorageJSON.load``.
     * ``<data_dir>/idedata/<device_name>.json`` with an
       ``extra.flash_images`` entry per *extras*
       (``(basename, offset_hex)``); receiver-absolute paths
       under ``.pioenvs/<device_name>/<basename>`` so the
       WS-adapter rewrite to basenames is observable.
 
+    ``native_idf=True`` instead writes the CMake/ninja shape:
+    ``firmware_bin`` at ``build/<device_name>.bin`` and neither
+    platformio.ini nor an idedata cache (both PlatformIO-only),
+    so the packer's non-PIO branch is exercised. *extras* /
+    idedata are skipped in that mode.
+
+    Always writes ``<data_dir>/storage/<basename>.json`` and any
+    *extra_build_files* (keys relative to ``<build_path>/``).
     Returns the key paths so individual tests can mutate them
     (e.g. drop ``platformio.ini`` to drive the missing-file
     branch).
@@ -366,17 +371,23 @@ def _write_receiver_state(
     """
     data_dir = tmp_path / ".esphome"
     build_path = data_dir / "build" / device_name
-    pioenvs = build_path / ".pioenvs" / device_name
-    pioenvs.mkdir(parents=True, exist_ok=True)
-    (build_path / "platformio.ini").write_bytes(b"[env:kitchen]\nplatform = espressif32\n")
-    firmware_bin = pioenvs / "firmware.bin"
+    if native_idf:
+        idf_build = build_path / "build"
+        idf_build.mkdir(parents=True, exist_ok=True)
+        firmware_bin = idf_build / f"{device_name}.bin"
+    else:
+        pioenvs = build_path / ".pioenvs" / device_name
+        pioenvs.mkdir(parents=True, exist_ok=True)
+        (build_path / "platformio.ini").write_bytes(b"[env:kitchen]\nplatform = espressif32\n")
+        firmware_bin = pioenvs / "firmware.bin"
     firmware_bin.write_bytes(b"FIRMWARE")
 
     extra_paths: list[dict[str, str]] = []
-    for basename, offset in extras or []:
-        path = pioenvs / basename
-        path.write_bytes(basename.encode("ascii"))
-        extra_paths.append({"path": str(path), "offset": offset})
+    if not native_idf:
+        for basename, offset in extras or []:
+            path = pioenvs / basename
+            path.write_bytes(basename.encode("ascii"))
+            extra_paths.append({"path": str(path), "offset": offset})
 
     for rel_path, payload in (extra_build_files or {}).items():
         abs_path = build_path / rel_path
@@ -396,25 +407,8 @@ def _write_receiver_state(
                 "loaded_integrations": loaded_integrations or [],
                 "loaded_platforms": [],
                 "no_mdns": False,
-                "framework": "arduino",
+                "framework": "esp-idf" if native_idf else "arduino",
                 "core_platform": target_platform.lower(),
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    idedata_path = resolve_idedata_path(configuration, name=device_name)
-    idedata_path.parent.mkdir(parents=True, exist_ok=True)
-    idedata_path.write_text(
-        json.dumps(
-            {
-                "prog_path": str(pioenvs / "firmware.elf"),
-                "cc_path": (
-                    "/home/receiver/.platformio/packages/toolchain-xtensa32"
-                    "/bin/xtensa-esp32-elf-gcc"
-                ),
-                "extra": {"flash_images": extra_paths},
             }
         )
         + "\n",
@@ -425,9 +419,26 @@ def _write_receiver_state(
         "build_path": build_path,
         "firmware_bin": firmware_bin,
         "storage_path": storage_path,
-        "idedata_path": idedata_path,
         "platformio_ini": build_path / "platformio.ini",
     }
+    if not native_idf:
+        idedata_path = resolve_idedata_path(configuration, name=device_name)
+        idedata_path.parent.mkdir(parents=True, exist_ok=True)
+        idedata_path.write_text(
+            json.dumps(
+                {
+                    "prog_path": str(pioenvs / "firmware.elf"),
+                    "cc_path": (
+                        "/home/receiver/.platformio/packages/toolchain-xtensa32"
+                        "/bin/xtensa-esp32-elf-gcc"
+                    ),
+                    "extra": {"flash_images": extra_paths},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        paths["idedata_path"] = idedata_path
     if validated_yaml is not None:
         validated_yaml_path = resolve_compiled_config_path(configuration)
         validated_yaml_path.parent.mkdir(parents=True, exist_ok=True)
@@ -571,8 +582,8 @@ def test_pack_build_artifacts_raises_when_storage_missing(tmp_path: Path) -> Non
         pack_build_artifacts("kitchen.yaml")
 
 
-def test_pack_build_artifacts_raises_when_idedata_missing(tmp_path: Path) -> None:
-    """No cached idedata.json → FileNotFoundError."""
+def test_pack_build_artifacts_raises_when_pio_idedata_missing(tmp_path: Path) -> None:
+    """A PlatformIO build (platformio.ini present) without idedata.json → FileNotFoundError."""
     state = _write_receiver_state(tmp_path)
     state["idedata_path"].unlink()
 
@@ -580,13 +591,30 @@ def test_pack_build_artifacts_raises_when_idedata_missing(tmp_path: Path) -> Non
         pack_build_artifacts("kitchen.yaml")
 
 
-def test_pack_build_artifacts_raises_when_platformio_ini_missing(tmp_path: Path) -> None:
-    """No platformio.ini → FileNotFoundError."""
-    state = _write_receiver_state(tmp_path)
-    state["platformio_ini"].unlink()
+def test_pack_build_artifacts_native_idf_omits_pio_metadata(tmp_path: Path) -> None:
+    """Native ESP-IDF (no platformio.ini / idedata) packs storage + build/ files, no PIO members."""
+    _write_receiver_state(
+        tmp_path,
+        native_idf=True,
+        extra_build_files={
+            "build/firmware.factory.bin": b"FACTORY",
+            "build/firmware.ota.bin": b"OTA",
+            "build/firmware.elf": b"ELF",
+        },
+    )
 
-    with pytest.raises(FileNotFoundError, match=r"platformio\.ini missing"):
-        pack_build_artifacts("kitchen.yaml")
+    packed = pack_build_artifacts("kitchen.yaml")
+
+    names = _tar_member_names(packed.tarball)
+    assert IDEDATA_MEMBER_NAME not in names
+    assert PLATFORMIO_INI_MEMBER_NAME not in names
+    assert names[0] == STORAGE_MEMBER_NAME
+    # firmware_bin + the get_download_types factory/ota images + the ELF all
+    # ride from the native-IDF ``build/`` tree.
+    assert "build/kitchen.bin" in names
+    assert "build/firmware.factory.bin" in names
+    assert "build/firmware.ota.bin" in names
+    assert "build/firmware.elf" in names
 
 
 def test_pack_build_artifacts_includes_get_download_types_files(tmp_path: Path) -> None:

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -58,6 +58,7 @@ from esphome_device_builder.models import (
     JobStatus,
 )
 
+from .conftest import HAS_NATIVE_IDF_TOOLCHAIN
 from .conftest import make_peer_link_session as _make_session
 
 # ---------------------------------------------------------------------------
@@ -408,6 +409,7 @@ def _write_receiver_state(
                 "loaded_platforms": [],
                 "no_mdns": False,
                 "framework": "esp-idf" if native_idf else "arduino",
+                "toolchain": "esp-idf" if native_idf else "platformio",
                 "core_platform": target_platform.lower(),
             }
         )
@@ -591,6 +593,18 @@ def test_pack_build_artifacts_raises_when_pio_idedata_missing(tmp_path: Path) ->
         pack_build_artifacts("kitchen.yaml")
 
 
+def test_pack_build_artifacts_raises_when_pio_platformio_ini_missing(tmp_path: Path) -> None:
+    """A PlatformIO build whose platformio.ini is gone raises, not silent native-IDF."""
+    state = _write_receiver_state(tmp_path)
+    state["platformio_ini"].unlink()
+
+    with pytest.raises(FileNotFoundError, match=r"platformio\.ini missing"):
+        pack_build_artifacts("kitchen.yaml")
+
+
+@pytest.mark.skipif(
+    not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
+)
 def test_pack_build_artifacts_native_idf_omits_pio_metadata(tmp_path: Path) -> None:
     """Native ESP-IDF (no platformio.ini / idedata) packs storage + build/ files, no PIO members."""
     _write_receiver_state(


### PR DESCRIPTION
# What does this implement/fix?

We had a real compile e2e for LibreTiny but none for the new native ESP-IDF toolchain (`esp32: toolchain: esp-idf`), which a commenter on #1102 reported has the same shortfall. Adding the e2e surfaced a real bug: native ESP-IDF remote builds couldn't be downloaded at all.

A native ESP-IDF build is CMake/ninja, so it emits neither platformio.ini nor an idedata cache; the offload tarball required both on pack and on materialise, so the receiver rejected every native-IDF download with build_dir_missing. This makes both members optional, present only for PlatformIO builds (keyed on platformio.ini presence so the PIO wire drift guarantee still holds). The download picker already works off get_download_types plus firmware_bin_path.parent, so native-IDF builds now enumerate the factory, ota, and elf images; BUILD_FILES also gains build/firmware.elf so the native ELF rides back, and the picker's selection is factored into one helper shared by get_binaries and the test.

The e2e is skipped unless the native ESP-IDF toolchain is present, and asserts the offloader offers exactly what a local build offers. The Web Serial flasher and the esphome upload fast path for native IDF still need idedata; those are tracked as follow ups.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
