### PR TITLE
Require a native ESP-IDF tarball to carry its firmware binary

### DIFF
--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -184,6 +184,12 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             )
         if idedata_bytes is None:
             raise MaterialiseError(f"tarball missing required {IDEDATA_MEMBER_NAME!r} member")
+    elif new_storage.firmware_bin_path is None or not new_storage.firmware_bin_path.is_file():
+        # Native ESP-IDF has no platformio.ini / idedata to validate against,
+        # so confirm its firmware binary actually landed -- a truncated
+        # tarball that kept storage.json but lost the build/ tree would
+        # otherwise materialise empty and surface only as a 404 download later.
+        raise MaterialiseError("native ESP-IDF tarball missing its firmware binary")
     return _ExtractedTarball(
         storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -659,6 +659,22 @@ def test_materialise_rejects_pio_tarball_missing_platformio_ini(tmp_path: Path) 
         _materialise_in_tmp(tarball, tmp_path)
 
 
+def test_materialise_rejects_native_idf_tarball_missing_firmware(tmp_path: Path) -> None:
+    """A native-IDF tarball missing its firmware binary raises rather than materialising empty."""
+    # Ungated: materialise reads the raw shipped ``toolchain`` field, so it
+    # holds on any esphome version (unlike the pack-side native-IDF tests).
+    storage = {
+        "storage_version": 1,
+        "name": "kitchen",
+        "build_path": _FAKE_BUILD_PATH,
+        "firmware_bin_path": f"{_FAKE_BUILD_PATH}/build/kitchen.bin",
+        "toolchain": "esp-idf",
+    }
+    tarball = _synthetic_tarball(storage=storage, idedata=None, platformio_ini=None)
+    with pytest.raises(MaterialiseError, match="missing its firmware binary"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
 @pytest.mark.skipif(
     not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
 )


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1128. The native ESP-IDF offload path made platformio.ini and idedata.json optional, so a native-IDF tarball only requires storage.json. A structurally valid but truncated tarball that kept storage.json yet lost its build/ tree would materialise "successfully" and surface only later as a missing download or a 404. This raises a MaterialiseError at extraction time when the firmware binary is absent, matching the pack side, which already guarantees firmware_bin_path always ships. The PlatformIO path is unchanged (platformio.ini plus idedata are still required there).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
