### PR TITLE
Widen the Windows atomic-write replace-retry budget

### DIFF
--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -22,11 +22,14 @@ from pathlib import Path
 # Windows raises ``PermissionError`` (WinError 5) from ``os.replace`` when a
 # transient handle holds the destination open (a concurrent reader, an
 # antivirus or the search indexer). POSIX rename is atomic and never hits
-# this, so the retry is Windows-only; a few short waits clear the typical
-# sub-second window.
+# this, so the retry is Windows-only. Backoff grows exponentially (capped)
+# so the common sub-second window still clears on the first short wait,
+# while a slow scanner under loaded CI gets several seconds before we give
+# up — far cheaper than losing a metadata / preferences write.
 _IS_WINDOWS = os.name == "nt"
-_REPLACE_RETRIES = 10
+_REPLACE_RETRIES = 15
 _REPLACE_RETRY_BACKOFF_S = 0.05
+_REPLACE_RETRY_BACKOFF_CAP_S = 0.5
 
 
 def atomic_write(
@@ -85,6 +88,6 @@ def _replace_with_retry(src: Path, dst: Path) -> None:
             # there is real; re-raise. On Windows, back off and retry.
             if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
                 raise
-            time.sleep(_REPLACE_RETRY_BACKOFF_S)
+            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
         else:
             return

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -137,6 +137,42 @@ def test_atomic_write_retries_replace_on_windows_handle_race(
     assert not list(tmp_path.glob("demo.bin.*.tmp"))
 
 
+def test_atomic_write_replace_backoff_grows_and_caps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows replace backoff grows exponentially, capped per-sleep.
+
+    Pins the widened retry budget: a slow scanner under loaded CI
+    must get several seconds across all retries, not the old flat
+    0.5s, while each individual wait stays bounded by the cap.
+    """
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", True)
+    sleeps: list[float] = []
+
+    def _record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.time.sleep", _record_sleep)
+    target = tmp_path / "demo.bin"
+    target.write_bytes(b"old")
+
+    real_replace = os.replace
+    calls = {"n": 0}
+
+    def _flaky(src: object, dst: object) -> None:
+        calls["n"] += 1
+        if calls["n"] < 6:
+            raise PermissionError(5, "Access is denied")
+        real_replace(src, dst)
+
+    monkeypatch.setattr("os.replace", _flaky)
+    atomic_write(target, b"new")
+
+    assert target.read_bytes() == b"new"
+    # Exponential growth (0.05 × 2**attempt) capped at 0.5s per wait.
+    assert sleeps == [0.05, 0.1, 0.2, 0.4, 0.5]
+
+
 def test_atomic_write_does_not_retry_replace_on_posix(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flaky Windows CI failure where the metadata sidecar
(`.device-builder.json`) intermittently failed to persist with
`PermissionError: [Errno 13]` (WinError 5) raised from `os.replace` in
`helpers/atomic_io.py`. It surfaced most visibly as
`tests/test_onboarding_controller.py::test_mark_acknowledged_does_not_clobber_a_concurrent_pref_write`,
but it can hit any metadata / preferences write on Windows.

The two writers in that test are already correctly serialised by
`_METADATA_LOCK`, so this is not a logic race that loses updates — it's
the documented Windows transient-handle race: when the sidecar is read →
rewritten → replaced in quick succession, a transient handle (a
just-closed reader, Windows Defender, or the search indexer scanning the
freshly-created file) holds the destination open and `os.replace` fails
with WinError 5. POSIX rename is atomic and never hits this.

`_replace_with_retry` already retried this on Windows only, but its
budget was `10 × 50ms` flat = 500ms, which is too short under loaded CI
(xdist worker + Defender). This switches to exponential backoff
(`0.05 × 2**attempt`) capped at 0.5s per wait, raising the total budget
to a few seconds. The common case still clears on the first 50ms wait,
each individual wait stays bounded by the cap, and POSIX behaviour is
unchanged (a `PermissionError` there is real and surfaces immediately).
Adds a regression test pinning the exponential-and-capped sleep
sequence.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
