### PR TITLE
Edit inline automations on flat singleton components (sun:, mqtt:)

### DIFF
--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -312,11 +312,12 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
         scripts = _scope_scripts(data["script"])
     for domain in set(data.keys()):
         section = data.get(domain)
-        if not isinstance(section, list):
-            continue
-        domains.update(_qualified_domains(domain, section))
-        if domain in component_domains:
-            devices.extend(_scope_component_instances(domain, section))
+        if isinstance(section, list):
+            domains.update(_qualified_domains(domain, section))
+            if domain in component_domains:
+                devices.extend(_scope_component_instances(domain, section))
+        elif isinstance(section, dict) and domain in component_domains:
+            devices.extend(_scope_singleton_instance(domain, section))
     return _ScopedYaml(domains=domains, scripts=scripts, devices=devices)
 
 
@@ -373,14 +374,29 @@ def _scope_component_instances(
             continue
         platform = item.get("platform")
         catalog_id = f"{domain}.{platform}" if platform else domain
-        out.append(
-            AvailableComponentInstance(
-                component_id=catalog_id,
-                id=str(comp_id),
-                name=str(item["name"]) if "name" in item else None,
-            ),
-        )
+        out.append(_component_instance(catalog_id, str(comp_id), item))
     return out
+
+
+def _scope_singleton_instance(
+    domain: str,
+    section: dict,
+) -> list[AvailableComponentInstance]:
+    """Surface a flat singleton component (``sun:`` / ``mqtt:``) as a targetable instance."""
+    return [_component_instance(domain, parsing.singleton_component_id(section, domain), section)]
+
+
+def _component_instance(
+    component_id: str,
+    id_: str,
+    section: dict,
+) -> AvailableComponentInstance:
+    """Build one ``AvailableComponentInstance``, carrying ``name:`` only when declared."""
+    return AvailableComponentInstance(
+        component_id=component_id,
+        id=id_,
+        name=str(section["name"]) if "name" in section else None,
+    )
 
 
 def _decode_location(raw: dict) -> AutomationLocation:

--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -298,43 +298,67 @@ def _parse_api_actions(root: Any) -> list[ParsedAutomation]:
     return out
 
 
+def singleton_component_id(section: dict, domain: str) -> str:
+    """Identity of a flat singleton component — its ``id:`` or the domain when id-less."""
+    return str(section.get("id") or domain)
+
+
 def _parse_inline_component_triggers(root: Any) -> list[ParsedAutomation]:
-    """Walk configured component instances for inline ``on_*:`` handlers."""
+    """
+    Walk component instances for inline ``on_*:`` handlers.
+
+    Handles list-domain instances (``switch:`` is a list) and flat
+    singleton components (``sun:`` / ``mqtt:`` are a single mapping).
+    """
     if not isinstance(root, dict):
         return []
     out: list[ParsedAutomation] = []
     for domain, section in root.items():
         if domain not in _component_trigger_domains():
             continue
-        if not isinstance(section, list):
+        if isinstance(section, list):
+            for idx, instance in enumerate(section):
+                if not isinstance(instance, dict):
+                    continue
+                comp_id = str(instance.get("id") or f"{domain}_{idx}")
+                out.extend(_parse_instance_triggers(domain, instance, comp_id))
+        elif isinstance(section, dict):
+            # Flat singleton: the whole block is the single instance.
+            out.extend(
+                _parse_instance_triggers(domain, section, singleton_component_id(section, domain))
+            )
+    return out
+
+
+def _parse_instance_triggers(
+    domain: str,
+    instance: dict,
+    comp_id: str,
+) -> list[ParsedAutomation]:
+    """Emit every recognised inline ``on_*:`` handler on one component instance."""
+    comp_name = str(instance.get("name") or comp_id)
+    out: list[ParsedAutomation] = []
+    for key, body in list(instance.items()):
+        if not key.startswith("on_"):
             continue
-        for idx, instance in enumerate(section):
-            if not isinstance(instance, dict):
-                continue
-            comp_id = instance.get("id") or f"{domain}_{idx}"
-            comp_name = instance.get("name") or comp_id
-            for key, body in list(instance.items()):
-                if not key.startswith("on_"):
-                    continue
-                trigger = catalog.trigger_by_id(f"{domain}.{key}")
-                if trigger is None:
-                    # Not a known component trigger — skip rather
-                    # than surface as a parse error. Component
-                    # schemas occasionally carry ``on_*`` keys that
-                    # are config values rather than automations
-                    # (e.g. legacy aliases). The catalog is the
-                    # source of truth.
-                    continue
-                out.extend(
-                    _parse_one_inline_trigger(
-                        instance,
-                        comp_id=str(comp_id),
-                        comp_name=str(comp_name),
-                        key=key,
-                        body=body,
-                        trigger=trigger,
-                    )
-                )
+        trigger = catalog.trigger_by_id(f"{domain}.{key}")
+        if trigger is None:
+            # Not a known component trigger — skip rather than surface
+            # as a parse error. Component schemas occasionally carry
+            # ``on_*`` keys that are config values rather than
+            # automations (e.g. legacy aliases). The catalog is the
+            # source of truth.
+            continue
+        out.extend(
+            _parse_one_inline_trigger(
+                instance,
+                comp_id=comp_id,
+                comp_name=comp_name,
+                key=key,
+                body=body,
+                trigger=trigger,
+            )
+        )
     return out
 
 

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -612,6 +612,12 @@ def _component_domain_from_yaml(
     for domain in top_level_domains:
         if synthetic_instance_index(domain, target_id) is not None:
             return domain
+    # An id-less flat singleton (``sun:`` / ``mqtt:``) is keyed by the
+    # domain name itself; recover it before the catalog guess, which
+    # mis-attributes a shared trigger key (``mqtt.on_connect`` vs
+    # ``wifi.on_connect``).
+    if target_id in top_level_domains:
+        return target_id
     return _component_domain(location)
 
 

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from ...models.common import ConfigEntryType
-from .scalar import _PLAIN_SCALAR_INDICATOR_LEAD, ESPHOME_YAML_INDENT, _quote
+from .scalar import _PLAIN_SCALAR_INDICATOR_LEAD, ESPHOME_YAML_INDENT, _quote, block_body_is_list
 
 if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry
@@ -319,13 +319,8 @@ def _normalize_multi_conf_block(existing: str, comp_id: str) -> str | None:
         return None
     block_start, last_content = bounds
 
-    for idx in range(block_start + 1, last_content):
-        stripped = file_lines[idx].strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if stripped.startswith("- ") or stripped == "-":
-            return existing
-        break
+    if block_body_is_list(file_lines, block_start, last_content):
+        return existing
 
     body_lines = [line.rstrip("\n\r") for line in file_lines[block_start + 1 : last_content]]
     rewritten = "\n".join(_mapping_body_to_list_item(body_lines)) + "\n"

--- a/esphome_device_builder/helpers/yaml/inline.py
+++ b/esphome_device_builder/helpers/yaml/inline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from .scalar import ESPHOME_YAML_INDENT
+from .scalar import ESPHOME_YAML_INDENT, block_body_is_list
 
 
 def synthetic_instance_index(domain: str, component_id: str) -> int | None:
@@ -170,6 +170,11 @@ def _locate_component_instance(  # noqa: C901
             domain_end = idx
             break
 
+    if not block_body_is_list(lines, domain_start, domain_end):
+        # Flat singleton mapping (``sun:`` / ``mqtt:``) — its only ``- ``
+        # lines (if any) are inner action lists, never instance items.
+        return _locate_singleton_instance(lines, domain, component_id, domain_start, domain_end)
+
     # Walk the domain body looking for a list item whose first child
     # line carries ``id: <component_id>``. Only column-2 dashes count
     # as instance starts — deeper dashes are inner action lists.
@@ -234,6 +239,27 @@ def _locate_idless_instance(
     if _instance_declared_id(lines, start, end, child_indent) is not None:
         return None
     return start, end, child_indent
+
+
+def _locate_singleton_instance(
+    lines: list[str],
+    domain: str,
+    component_id: str,
+    domain_start: int,
+    domain_end: int,
+) -> tuple[int, int, str] | None:
+    """
+    Locate a flat singleton component block (``sun:`` / ``mqtt:``) as one span.
+
+    The ``<domain>:`` header is the instance start, the next top-level
+    key is the end, and child fields sit one indent in. Matches when
+    *component_id* is the block's declared ``id:`` or — when id-less —
+    the domain name itself.
+    """
+    declared = _instance_declared_id(lines, domain_start, domain_end, ESPHOME_YAML_INDENT)
+    if component_id == declared or (declared is None and component_id == domain):
+        return domain_start, domain_end, ESPHOME_YAML_INDENT
+    return None
 
 
 def _instance_declared_id(

--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -18,6 +18,16 @@ if TYPE_CHECKING:
 ESPHOME_YAML_INDENT = "  "
 
 
+def block_body_is_list(lines: list[str], header_idx: int, end_idx: int) -> bool:
+    """Return True when a block body — lines ``(header_idx, end_idx)`` — is a YAML list."""
+    for idx in range(header_idx + 1, end_idx):
+        stripped = lines[idx].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return stripped.startswith("- ") or stripped == "-"
+    return False
+
+
 class YamlUpsertNotSupportedError(ValueError):
     """The YAML's existing shape can't be safely upserted line-by-line.
 

--- a/tests/fixtures/automation_yamls/inline_mqtt_singleton.yaml
+++ b/tests/fixtures/automation_yamls/inline_mqtt_singleton.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: x
+mqtt:
+  broker: 192.168.1.10
+  on_message:
+    topic: my/topic
+    then:
+      - logger.log: got message
+  on_connect:
+    then:
+      - logger.log: connected

--- a/tests/fixtures/automation_yamls/inline_sun_empty.yaml
+++ b/tests/fixtures/automation_yamls/inline_sun_empty.yaml
@@ -1,0 +1,6 @@
+esphome:
+  name: x
+sun:
+  id: home_sun
+  latitude: 51.0
+  longitude: -0.1

--- a/tests/fixtures/automation_yamls/inline_sun_idd.yaml
+++ b/tests/fixtures/automation_yamls/inline_sun_idd.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: x
+sun:
+  id: home_sun  # the declared id keys the location
+  latitude: 51.0
+  longitude: -0.1
+  on_sunrise:
+    then:
+      - logger.log: sunrise
+  on_sunset:
+    then:
+      - logger.log: sunset

--- a/tests/fixtures/automation_yamls/inline_sun_on_sunrise.yaml
+++ b/tests/fixtures/automation_yamls/inline_sun_on_sunrise.yaml
@@ -1,0 +1,8 @@
+esphome:
+  name: x
+sun:
+  latitude: 51.0
+  longitude: -0.1
+  on_sunrise:
+    then:
+      - logger.log: sunrise

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -225,6 +225,23 @@ async def test_get_available_lists_configured_component_instances(tmp_path: Path
     assert ("switch.gpio", "relay_two") in devices
 
 
+async def test_get_available_surfaces_flat_singleton_instances(tmp_path: Path) -> None:
+    """Flat singletons (``sun:`` / ``mqtt:``) are surfaced as targetable instances."""
+    config = tmp_path / "singleton.yaml"
+    config.write_text(
+        "esphome:\n  name: d\n"
+        "sun:\n  id: home_sun\n  latitude: 51.0\n  longitude: -0.1\n"
+        "mqtt:\n  broker: 192.168.1.10\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.get_available(configuration="singleton.yaml")
+    devices = {(d["component_id"], d["id"]) for d in result["devices"]}
+    # id'd singleton keys on its declared id; id-less keys on the domain.
+    assert ("sun", "home_sun") in devices
+    assert ("mqtt", "mqtt") in devices
+
+
 async def test_get_available_scopes_actions_and_conditions_to_present_domains(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -109,6 +109,46 @@ def test_parse_inline_on_click_surfaces_trigger_params() -> None:
     assert [a.action_id for a in tree.actions] == ["switch.toggle"]
 
 
+# ---------------------------------------------------------------------------
+# Inline triggers on flat singleton components (sun:, mqtt:)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_flat_singleton_idless_keys_on_domain() -> None:
+    """An id-less ``sun:`` block keys its handler on the domain name."""
+    parsed = parse_device_yaml(_load("inline_sun_on_sunrise.yaml"))
+    assert len(parsed) == 1
+    item = parsed[0]
+    assert item.location.kind == "component_on"
+    assert item.location.component_id == "sun"
+    assert item.location.trigger == "on_sunrise"
+    assert item.location.index is None
+    assert [a.action_id for a in item.automation.actions] == ["logger.log"]
+
+
+def test_parse_flat_singleton_uses_declared_id() -> None:
+    """An id'd ``sun:`` block keys both handlers on its declared id."""
+    parsed = parse_device_yaml(_load("inline_sun_idd.yaml"))
+    assert {p.location.component_id for p in parsed} == {"home_sun"}
+    assert {p.location.trigger for p in parsed} == {"on_sunrise", "on_sunset"}
+
+
+def test_parse_flat_singleton_mqtt_surfaces_trigger_params() -> None:
+    """``mqtt:`` is a singleton; ``on_message.topic`` is a trigger param, not an action."""
+    parsed = parse_device_yaml(_load("inline_mqtt_singleton.yaml"))
+    by_trigger = {p.location.trigger: p for p in parsed}
+    assert set(by_trigger) == {"on_message", "on_connect"}
+    assert by_trigger["on_message"].location.component_id == "mqtt"
+    assert by_trigger["on_message"].automation.trigger_params == {"topic": "my/topic"}
+
+
+def test_parse_flat_singleton_ignores_config_keys() -> None:
+    """Plain config keys (``latitude:`` / ``broker:``) aren't surfaced as automations."""
+    sun = parse_device_yaml(_load("inline_sun_on_sunrise.yaml"))
+    assert all(p.location.trigger.startswith("on_") for p in sun)
+    assert parse_device_yaml(_load("inline_sun_empty.yaml")) == []
+
+
 def test_parse_on_value_range_float_params_are_json_serialisable() -> None:
     """Decimal on_value_range thresholds round-trip as plain floats."""
     parsed = parse_device_yaml(_load("sensor_on_value_range_float.yaml"))

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -200,6 +200,145 @@ def test_idless_multidomain_trigger_resolves_configured_domain() -> None:
     assert reparsed[0].location == location
 
 
+# ---------------------------------------------------------------------------
+# Flat singleton components (sun:, mqtt:)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_inline_sun_preserves_actions_and_siblings() -> None:
+    """An id-less ``sun:`` handler round-trips; sibling config keys survive."""
+    text = _load("inline_sun_on_sunrise.yaml")
+    parsed_first = parse_device_yaml(text)[0]
+    new_text, _diff = render_upsert(
+        text, tree=parsed_first.automation, location=parsed_first.location
+    )
+    assert "latitude: 51.0" in new_text
+    assert "longitude: -0.1" in new_text
+    reparsed = parse_device_yaml(new_text)
+    assert len(reparsed) == 1
+    assert reparsed[0].location == parsed_first.location
+
+
+def test_upsert_adds_second_handler_to_sun_block() -> None:
+    """A new ``on_sunset`` splices in beside the existing ``on_sunrise``."""
+    text = _load("inline_sun_on_sunrise.yaml")
+    new_text, diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="sun.on_sunset",
+            actions=[ActionNode(action_id="logger.log", params={"format": "sunset"})],
+        ),
+        location=ComponentOnLocation(component_id="sun", trigger="on_sunset"),
+    )
+    assert "on_sunrise:" in new_text
+    assert "on_sunset:" in new_text
+    assert "latitude: 51.0" in new_text
+    # Pure-insert flags the empty replaced range.
+    assert diff.toLine == diff.fromLine - 1
+    assert {p.location.trigger for p in parse_device_yaml(new_text)} == {"on_sunrise", "on_sunset"}
+
+
+def test_upsert_replaces_existing_handler_on_sun_block() -> None:
+    """Re-upserting ``on_sunrise`` replaces it rather than duplicating."""
+    text = _load("inline_sun_on_sunrise.yaml")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="sun.on_sunrise",
+            actions=[ActionNode(action_id="logger.log", params={"format": "dawn"})],
+        ),
+        location=ComponentOnLocation(component_id="sun", trigger="on_sunrise"),
+    )
+    assert new_text.count("on_sunrise:") == 1
+    assert "dawn" in new_text
+
+
+def test_delete_inline_handler_on_sun_block() -> None:
+    """Deleting ``on_sunrise`` drops it but keeps the block's config keys."""
+    text = _load("inline_sun_on_sunrise.yaml")
+    location = parse_device_yaml(text)[0].location
+    new_text, diff = render_delete(text, location=location)
+    assert "on_sunrise:" not in new_text
+    assert "latitude: 51.0" in new_text
+    assert parse_device_yaml(new_text) == []
+    assert diff.replacement == ""
+
+
+def test_delete_one_handler_keeps_sibling_on_singleton() -> None:
+    """Deleting one handler on a multi-handler singleton leaves the sibling intact."""
+    text = _load("inline_sun_idd.yaml")
+    location = ComponentOnLocation(component_id="home_sun", trigger="on_sunrise")
+    new_text, diff = render_delete(text, location=location)
+    assert "on_sunrise:" not in new_text
+    assert "on_sunset:" in new_text
+    assert "id: home_sun" in new_text
+    assert "latitude: 51.0" in new_text
+    assert diff.replacement == ""
+    remaining = parse_device_yaml(new_text)
+    assert [(p.location.component_id, p.location.trigger) for p in remaining] == [
+        ("home_sun", "on_sunset"),
+    ]
+
+
+def test_round_trip_mqtt_singleton_resolves_mqtt_domain() -> None:
+    """``mqtt.on_message``/``on_connect`` are ambiguous keys but resolve to ``mqtt:``."""
+    text = _load("inline_mqtt_singleton.yaml")
+    on_connect = next(p for p in parse_device_yaml(text) if p.location.trigger == "on_connect")
+    new_text, _diff = render_upsert(text, tree=on_connect.automation, location=on_connect.location)
+    # Reattached under mqtt:, not mis-routed to ble_client/wifi/logger.
+    assert "broker: 192.168.1.10" in new_text
+    reparsed = {p.location.trigger: p.location.component_id for p in parse_device_yaml(new_text)}
+    assert reparsed == {"on_message": "mqtt", "on_connect": "mqtt"}
+
+
+def test_upsert_inline_handler_on_block_without_handlers() -> None:
+    """An ``on_*`` inserts under a singleton block that has only config keys."""
+    text = _load("inline_sun_empty.yaml")
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="sun.on_sunrise",
+            actions=[ActionNode(action_id="logger.log", params={"format": "sunrise"})],
+        ),
+        location=ComponentOnLocation(component_id="home_sun", trigger="on_sunrise"),
+    )
+    assert "on_sunrise:" in new_text
+    assert "id: home_sun" in new_text
+    reparsed = parse_device_yaml(new_text)
+    assert len(reparsed) == 1
+    assert reparsed[0].location.component_id == "home_sun"
+
+
+def test_upsert_inline_handler_on_bodyless_singleton_block() -> None:
+    """An ``on_*`` inserts under an id-less singleton with an empty body."""
+    text = "esphome:\n  name: x\nsun:\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="sun.on_sunrise",
+            actions=[ActionNode(action_id="logger.log", params={"format": "sunrise"})],
+        ),
+        location=ComponentOnLocation(component_id="sun", trigger="on_sunrise"),
+    )
+    assert "on_sunrise:" in new_text
+    assert parse_device_yaml(new_text)[0].location.component_id == "sun"
+
+
+def test_upsert_flat_singleton_unknown_id_raises() -> None:
+    """A location whose id matches no singleton raises a clean error."""
+    text = _load("inline_sun_on_sunrise.yaml")
+    with pytest.raises(CommandError) as err:
+        render_upsert(
+            text,
+            tree=AutomationTree(
+                trigger_id="sun.on_sunrise",
+                actions=[ActionNode(action_id="logger.log", params={"format": "x"})],
+            ),
+            location=ComponentOnLocation(component_id="nonexistent", trigger="on_sunrise"),
+        )
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
 def test_stale_positional_id_on_idd_instance_is_refused() -> None:
     """A ``<domain>_<idx>`` id pointing at an instance with a real id is refused."""
     text = "esphome:\n  name: x\nbinary_sensor:\n  - platform: gpio\n    id: real\n    pin: GPIO0\n"


### PR DESCRIPTION
# What does this implement/fix?

The automation editor's parse / upsert / delete only handled **list-domain**
component instances (`switch:`, `time:` — YAML lists). **Flat singleton**
components that host inline `on_*:` triggers — `sun:` (`on_sunrise`/`on_sunset`),
`mqtt:` (`on_message`/`on_connect`/…) — are single mappings, and were silently
skipped: their inline automations couldn't be shown, edited, or deleted in the
Visual Editor, even though the wizard already offered `sun.on_sunrise` as
addable (the available surface and the parse/write surface disagreed).

Changes:
- **Parser** walks both list instances and flat singleton mappings; a singleton
  keys on its declared `id:` or the domain name when id-less.
- **Locator** routes a flat-mapping body to a singleton span (the whole block)
  instead of hunting for `- ` list items, so upsert and delete both work.
- **Domain recovery** resolves an id-less singleton's domain before the ambiguous
  catalog guess, so a shared trigger key (`mqtt.on_connect` vs `wifi.on_connect`)
  attaches under the configured domain.
- **get_available** surfaces singletons as targetable `AvailableComponentInstance`
  entries so the available surface agrees with parse/write.

No new location kind is needed — `ComponentOnLocation(..., index=None)` already
models the single-handler form. `writing_lists.py` is untouched: flat singletons
are always single-handler (`index=None`) and route through the inline path, never
the list-index path.

DRY: the shared "is this block body a list?" check is hoisted into
`block_body_is_list`, replacing a duplicated inline scan in the multi-conf
normaliser.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1138

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#<number>

This backend PR makes flat singletons parse/edit/delete and surfaces them in
`get_available`. A coordinated frontend PR will add the affordance for *adding*
a new automation to a flat singleton (frontend #552 deliberately left flat
singletons out of scope pending this backend support).

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
