### PR TITLE
Fix duplicated trailing blocks when appending an automation mid-file

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -707,25 +707,32 @@ def _next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
 
 
 def _build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:
-    """Build a diff describing the lines added by an append-style write.
+    """Build a diff describing the lines changed by an append-style write.
 
-    Walks both texts to find the first divergent line, then takes
-    everything after that on the new side as the inserted range.
-    Good enough for the append case where we always grow the file
-    at the end (or just after the matched top-level block).
+    Bounds the change to the region between the common leading and
+    trailing lines, so a splice into a block that isn't the last in
+    the file replaces only the changed span — without the suffix
+    match the unchanged tail would be re-emitted and duplicated.
     """
     old_lines = old_yaml.splitlines()
     new_lines = new_yaml.splitlines()
-    common = 0
+    prefix = 0
     while (
-        common < len(old_lines)
-        and common < len(new_lines)
-        and old_lines[common] == new_lines[common]
+        prefix < len(old_lines)
+        and prefix < len(new_lines)
+        and old_lines[prefix] == new_lines[prefix]
     ):
-        common += 1
-    from_line = common + 1
-    to_line = common  # exclusive; equal start ⇒ pure insert
-    replacement = "\n".join(new_lines[common:])
+        prefix += 1
+    suffix = 0
+    while (
+        suffix < len(old_lines) - prefix
+        and suffix < len(new_lines) - prefix
+        and old_lines[len(old_lines) - 1 - suffix] == new_lines[len(new_lines) - 1 - suffix]
+    ):
+        suffix += 1
+    from_line = prefix + 1
+    to_line = len(old_lines) - suffix  # == from_line - 1 ⇒ pure insert
+    replacement = "\n".join(new_lines[prefix : len(new_lines) - suffix])
     if replacement and not replacement.endswith("\n"):
         replacement += "\n"
     return YamlDiff(fromLine=from_line, toLine=to_line, replacement=replacement)

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -707,7 +707,8 @@ def _next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
 
 
 def _build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:
-    """Build a diff describing the lines changed by an append-style write.
+    """
+    Build a diff describing the lines changed by an append-style write.
 
     Bounds the change to the region between the common leading and
     trailing lines, so a splice into a block that isn't the last in

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -438,12 +438,7 @@ def test_round_trip_script_with_parameters() -> None:
 
 
 def test_append_diff_into_block_followed_by_others_does_not_duplicate_tail() -> None:
-    """Appending a second script returns a diff that applies cleanly.
-
-    The ``script:`` block is followed by ``ota:`` / ``web_server:``,
-    so the splice lands mid-document; the returned diff must replace
-    only the changed span, not re-emit the unchanged trailing blocks.
-    """
+    """A mid-file append's diff reproduces new_text without duplicating trailing blocks."""
     text = (
         "esphome:\n  name: x\n"
         "script:\n  - id: first\n    mode: single\n    then: []\n"

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -33,6 +33,7 @@ from esphome_device_builder.models.automations import (
     IntervalLocation,
     LightEffectLocation,
     ScriptLocation,
+    YamlDiff,
 )
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "automation_yamls"
@@ -40,6 +41,17 @@ _FIXTURES = Path(__file__).parent / "fixtures" / "automation_yamls"
 
 def _load(name: str) -> str:
     return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _apply_diff(text: str, diff: YamlDiff) -> str:
+    """Apply a :class:`YamlDiff` exactly as the frontend ``applyYamlDiff`` does."""
+    lines = text.split("\n")
+    start = diff.fromLine - 1
+    delete = max(0, diff.toLine - diff.fromLine + 1)
+    replacement = diff.replacement
+    replacement = replacement.removesuffix("\n")
+    rep_lines = [] if replacement == "" else replacement.split("\n")
+    return "\n".join([*lines[:start], *rep_lines, *lines[start + delete :]])
 
 
 # ---------------------------------------------------------------------------
@@ -423,6 +435,32 @@ def test_round_trip_script_with_parameters() -> None:
         "message": "string",
     }
     assert parsed_second.automation.trigger_params.get("mode") == "single"
+
+
+def test_append_diff_into_block_followed_by_others_does_not_duplicate_tail() -> None:
+    """Appending a second script returns a diff that applies cleanly.
+
+    The ``script:`` block is followed by ``ota:`` / ``web_server:``,
+    so the splice lands mid-document; the returned diff must replace
+    only the changed span, not re-emit the unchanged trailing blocks.
+    """
+    text = (
+        "esphome:\n  name: x\n"
+        "script:\n  - id: first\n    mode: single\n    then: []\n"
+        "ota:\n  - platform: esphome\n"
+        "web_server:\n  port: 80\n"
+    )
+    new_text, diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id=None, trigger_params={"mode": "single"}, actions=[]),
+        location=ScriptLocation(id="second"),
+    )
+    # The diff the frontend applies must reproduce the backend's own
+    # post-splice text — the contract the editor relies on.
+    assert _apply_diff(text, diff) == new_text
+    assert new_text.count("ota:") == 1
+    assert new_text.count("web_server:") == 1
+    assert {s.location.id for s in parse_device_yaml(new_text)} == {"first", "second"}
 
 
 def test_round_trip_interval_lambda() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes a YAML corruption when adding an automation (script, interval, api action, or a new device-level handler) into a config where the target block is not the last thing in the file.

Adding a second `script:` entry to a config whose `script:` block is followed by other top-level blocks (`ota:`, `web_server:`, ...) duplicated the entire trailing section of the file. The same shape hit every append path that routes through `_build_diff_for_append` (`script:`, `interval:`, `api.actions:` block creation, and device-level `on_*:` block creation).

Root cause: `_build_diff_for_append` matched only the common *leading* lines, then treated everything after the first divergent line as inserted content with a pure-insert range (`toLine = fromLine - 1`, deletes nothing). That assumption only holds when the file grows at EOF. When the splice lands mid-document, the `replacement` scooped up the unchanged trailing blocks while the range deleted nothing, so applying the diff re-emitted that tail on top of the original; hence the duplication.

The writer's own post-splice text (`new_text`) was always correct; only the `YamlDiff` it returned to the frontend was wrong, and the frontend applies that diff to its draft buffer.

**Related issue or feature (if applicable):**

- fixes the duplicate-blocks regression reported when adding a script via the Visual Editor

## How

- `_build_diff_for_append` now also matches the common *trailing* lines and deletes the bounded old span between the common prefix and suffix, so the returned `YamlDiff` reproduces the writer's own post-splice text regardless of where in the file the splice lands.
- Added `tests/test_automations_writer.py::test_append_diff_into_block_followed_by_others_does_not_duplicate_tail`, which appends a second `script:` entry above `ota:`/`web_server:` and asserts the returned diff, applied exactly as the frontend `applyYamlDiff` does, equals the writer's `new_text` with no duplicated blocks. Added an `_apply_diff` helper mirroring the frontend applier so the diff/text contract is pinned, not just `new_text`.

## Testing

- `tests/test_automations_writer.py`: 81 passed (new regression test fails on `main`, passes with the fix).
- Full automation suite (`-k automation`): 307 passed.
- `ruff check` / `ruff format` clean; pre-commit hooks pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
