### PR TITLE
Let add_component merge into an unsaved editor draft (fixes #1146)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -117,7 +117,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/delete_archived` | `{configuration}` | — | Permanently delete an archived YAML and its sidecars. The companion to `unarchive` for "I really don't want this back". |
 | `devices/get_config` | `{configuration}` | `string` | Read device YAML config |
 | `devices/update_config` | `{configuration, content}` | — | Write device YAML config |
-| `devices/add_component` | `{configuration, component_id, fields?, sub_entities?}` | `AddComponentResponse` | Add component to device config |
+| `devices/add_component` | `{configuration, component_id, fields?, sub_entities?, yaml?}` | `AddComponentResponse` | Add component to device config. Optional `yaml` is the editor's unsaved draft — merge into it and return the result **without** persisting (the editor saves it, like `automations/upsert`); omit to merge the on-disk YAML and persist. |
 | `devices/import` | `{name, project_name?, package_import_url?, ...}` | `dict` | Import/adopt discovered device |
 | `devices/ignore` | `{name, ignore?}` | — | Toggle device visibility |
 | `devices/validate` | `{configuration}` | Streaming | Validate YAML config |

--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -18,9 +18,10 @@ async def add_component(
     configuration: str,
     component_id: str,
     fields: dict[str, Any] | None,
+    yaml: str | None = None,
 ) -> AddComponentResponse:
     """
-    Add a component block to an existing device YAML.
+    Add a component block to a device YAML.
 
     ``fields`` is a flat mapping of config-entry key → value;
     nested entries map to nested dicts. Featured ids
@@ -29,6 +30,12 @@ async def add_component(
     ``locked`` / ``suggestions`` constraints, and merge the
     manifest's preset values into ``fields`` before the regular
     merge.
+
+    When ``yaml`` is given it is the caller's unsaved editor draft:
+    the merge runs against it and the result is returned without
+    touching disk, so the user's unsaved edits survive (the editor
+    saves later). Without it the merge runs against the on-disk YAML
+    and is persisted immediately.
     """
     assert controller._db.components is not None  # type narrowing
 
@@ -64,8 +71,11 @@ async def add_component(
             msg = f"Missing required field: {entry.key}"
             raise ValueError(msg)
 
-    config_path = controller._db.settings.rel_path(configuration)
-    existing = await controller._read_yaml_async(config_path)
+    if yaml is None:
+        config_path = controller._db.settings.rel_path(configuration)
+        existing = await controller._read_yaml_async(config_path)
+    else:
+        existing = yaml
     # Honour each field's ``depends_on_component`` gate against
     # what's actually in the device YAML; drops MQTT-only options
     # (``availability:``, ``state_topic:``, ...) when the device
@@ -73,8 +83,9 @@ async def add_component(
     # does field-by-field on the input form.
     fields = _drop_unconfigured_dependent_fields(fields, component, existing)
     new_yaml = merge_component_yaml(existing, component, fields)
-    # Atomic write; wizard-driven add-component should not be able
-    # to corrupt the source YAML on a mid-write crash.
-    await controller._persist_yaml_mutation(configuration, new_yaml)
+    if yaml is None:
+        # Atomic write; wizard-driven add-component should not be able
+        # to corrupt the source YAML on a mid-write crash.
+        await controller._persist_yaml_mutation(configuration, new_yaml)
 
     return AddComponentResponse(yaml=new_yaml)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -648,14 +648,21 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         configuration: str,
         component_id: str,
         fields: dict[str, Any] | None = None,
+        yaml: str | None = None,
         **kwargs: Any,
     ) -> AddComponentResponse:
-        """Add a component block to an existing device YAML."""
+        """Add a component block to a device YAML.
+
+        Pass ``yaml`` to merge into the caller's unsaved editor draft and
+        return the result without writing disk; the editor saves it later.
+        Omit it to merge into the on-disk YAML and persist.
+        """
         return await add_component.add_component(
             self,
             configuration=configuration,
             component_id=component_id,
             fields=fields,
+            yaml=yaml,
         )
 
     @api_command("devices/import")

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -535,6 +535,78 @@ async def test_add_component_missing_required_field_raises(
 
 
 # ---------------------------------------------------------------------------
+# add_component draft vs disk
+# ---------------------------------------------------------------------------
+
+
+def _stub_components(controller: object) -> None:
+    """Wire ``_db.components`` to a no-required-fields component."""
+    component = MagicMock()
+    component.config_entries = []
+    controller._db.components = MagicMock()
+    controller._db.components.get_component = AsyncMock(return_value=component)
+
+
+async def test_add_component_with_draft_merges_draft_and_skips_persist(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A passed ``yaml`` draft is the merge base and disk is untouched.
+
+    The wizard hands the editor's unsaved draft so the merge lands on
+    top of it; persisting here would discard the user's other unsaved
+    edits and write a possibly mid-edit config.
+    """
+    controller = make_controller(tmp_path)
+    _stub_components(controller)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.add_component.merge_component_yaml",
+        lambda existing, component, fields: f"{existing}# added\n",
+    )
+    persist = AsyncMock()
+    monkeypatch.setattr(controller, "_persist_yaml_mutation", persist)
+    (tmp_path / "kitchen.yaml").write_text("DISK\n", encoding="utf-8")
+
+    resp = await controller.add_component(
+        configuration="kitchen.yaml",
+        component_id="i2c",
+        fields={},
+        yaml="DRAFT\n",
+    )
+
+    assert resp.yaml == "DRAFT\n# added\n"
+    persist.assert_not_awaited()
+    assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8") == "DISK\n"
+
+
+async def test_add_component_without_draft_reads_disk_and_persists(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``yaml`` keeps the legacy disk-read + persist behaviour."""
+    controller = make_controller(tmp_path)
+    _stub_components(controller)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.add_component.merge_component_yaml",
+        lambda existing, component, fields: f"{existing}# added\n",
+    )
+    persist = AsyncMock()
+    monkeypatch.setattr(controller, "_persist_yaml_mutation", persist)
+    (tmp_path / "kitchen.yaml").write_text("DISK\n", encoding="utf-8")
+
+    resp = await controller.add_component(
+        configuration="kitchen.yaml",
+        component_id="i2c",
+        fields={},
+    )
+
+    assert resp.yaml == "DISK\n# added\n"
+    persist.assert_awaited_once_with("kitchen.yaml", "DISK\n# added\n")
+
+
+# ---------------------------------------------------------------------------
 # _on_ip_change short-circuit
 # ---------------------------------------------------------------------------
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -38,6 +38,8 @@ from esphome_device_builder.helpers.build_size import BuildDirSignal, BuildSizeR
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import (
     AdoptableDevice,
+    ComponentCatalogEntry,
+    ComponentCategory,
     ConfigEntry,
     ConfigEntryType,
     Device,
@@ -552,12 +554,7 @@ async def test_add_component_with_draft_merges_draft_and_skips_persist(
     make_controller: MakeControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A passed ``yaml`` draft is the merge base and disk is untouched.
-
-    The wizard hands the editor's unsaved draft so the merge lands on
-    top of it; persisting here would discard the user's other unsaved
-    edits and write a possibly mid-edit config.
-    """
+    """A passed ``yaml`` draft is the merge base and disk is left untouched."""
     controller = make_controller(tmp_path)
     _stub_components(controller)
     monkeypatch.setattr(
@@ -604,6 +601,34 @@ async def test_add_component_without_draft_reads_disk_and_persists(
 
     assert resp.yaml == "DISK\n# added\n"
     persist.assert_awaited_once_with("kitchen.yaml", "DISK\n# added\n")
+
+
+async def test_add_component_into_broken_draft_appends_through_real_merge(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken draft survives the real (un-stubbed) command merge, no persist."""
+    controller = make_controller(tmp_path)
+    component = ComponentCatalogEntry(
+        id="i2c", name="i2c", description="", category=ComponentCategory.BUS
+    )
+    controller._db.components = MagicMock()
+    controller._db.components.get_component = AsyncMock(return_value=component)
+    persist = AsyncMock()
+    monkeypatch.setattr(controller, "_persist_yaml_mutation", persist)
+
+    broken = 'esphome:\n  name: "kitch\nsensor:\n  - platform:\n'
+    resp = await controller.add_component(
+        configuration="kitchen.yaml",
+        component_id="i2c",
+        fields={"sda": "GPIO21", "scl": "GPIO22"},
+        yaml=broken,
+    )
+
+    assert broken in resp.yaml
+    assert "i2c:\n  sda: GPIO21\n  scl: GPIO22\n" in resp.yaml
+    persist.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -946,6 +946,25 @@ def test_merge_component_yaml_splice_handles_trailing_blank_lines() -> None:
     assert "- platform: dht" in sensor_block
 
 
+def test_merge_component_yaml_accepts_incomplete_draft() -> None:
+    """A mid-edit / syntactically broken draft is merged, not rejected.
+
+    The wizard now merges into the editor's unsaved draft, which may
+    be incomplete while the user is typing. The merge is a line-based
+    text splice, so it appends the new block and leaves the user's
+    in-progress (even invalid) content untouched for them to repair.
+    """
+    component = _component(component_id="i2c", category=ComponentCategory.BUS)
+    fields: dict[str, Any] = {"sda": "GPIO21", "scl": "GPIO22"}
+
+    # Unterminated quote + dangling key — invalid YAML mid-edit.
+    broken = 'esphome:\n  name: "kitch\nsensor:\n  - platform:\n'
+    result = merge_component_yaml(broken, component, fields)
+
+    assert broken in result
+    assert "i2c:\n  sda: GPIO21\n  scl: GPIO22\n" in result
+
+
 @pytest.mark.parametrize("category", [ComponentCategory.OUTPUT, ComponentCategory.SWITCH])
 def test_merge_component_yaml_splices_other_platform_categories(
     category: ComponentCategory,

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -947,13 +947,7 @@ def test_merge_component_yaml_splice_handles_trailing_blank_lines() -> None:
 
 
 def test_merge_component_yaml_accepts_incomplete_draft() -> None:
-    """A mid-edit / syntactically broken draft is merged, not rejected.
-
-    The wizard now merges into the editor's unsaved draft, which may
-    be incomplete while the user is typing. The merge is a line-based
-    text splice, so it appends the new block and leaves the user's
-    in-progress (even invalid) content untouched for them to repair.
-    """
+    """A syntactically broken draft is appended-merged, not rejected."""
     component = _component(component_id="i2c", category=ComponentCategory.BUS)
     fields: dict[str, Any] = {"sda": "GPIO21", "scl": "GPIO22"}
 


### PR DESCRIPTION
# What does this implement/fix?

Backend half of the fix for the add-component wizard discarding unsaved YAML-editor changes.

`devices/add_component` always read the device YAML from disk, merged the new component into it, and persisted the result. The frontend wizard therefore had no way to add a component on top of the editor's *unsaved* draft: the merge ignored the draft, and the persisted/returned YAML overwrote it. It also meant a wizard add could auto-write a mid-edit (possibly invalid) config to disk.

This adds an optional `yaml` parameter to `devices/add_component`, mirroring the `automations/upsert` draft-override design:

- When `yaml` is provided, it is the caller's unsaved editor draft; the merge runs against it and the result is returned **without touching disk** (the editor saves it later via the normal Save flow).
- When `yaml` is omitted, behaviour is unchanged: read the on-disk YAML, merge, and persist.

`merge_component_yaml` is a line-based text splice that does not parse/validate its input, so merging into an incomplete/broken draft appends the new block and leaves the user's in-progress content intact for them to repair — which is the desired behaviour when the editor is mid-edit.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1146 (with the companion frontend PR)

## Companion frontend PR

esphome/device-builder-frontend#566 — passes the editor draft to `addComponent` and applies the result as an unsaved draft (`yaml-draft`). Lockstep; both land together.

## Testing

- `tests/controllers/devices/test_branches_coverage.py`: draft `yaml` merges into the draft and does **not** persist (disk unchanged); omitting `yaml` reads disk and persists (unchanged behaviour pinned).
- `tests/test_yaml_helpers.py`: `merge_component_yaml` accepts an incomplete/broken draft (block appended, no raise).
- Full `tests/test_yaml_helpers.py` + `tests/controllers/devices/`: 561 passed. `ruff` + pre-commit clean.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#566

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
