### PR TITLE
Wipe orphaned idedata + validated-config caches on delete/archive

### DIFF
--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -14,6 +14,7 @@ from ...helpers.device_yaml import parse_esphome_meta
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode
 from .helpers import (
+    _unlink_compiled_config,
     _unlink_storage_sidecar,
     _wipe_device_build_dir,
 )
@@ -57,6 +58,7 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
         _wipe_device_build_dir(configuration)
         shutil.move(str(config_path), str(target))
         _unlink_storage_sidecar(configuration)
+        _unlink_compiled_config(configuration)
 
     try:
         await loop.run_in_executor(None, _archive_sync)
@@ -148,6 +150,7 @@ async def delete_archived_single(controller: DevicesController, configuration: s
             # sidecars now; leave them alone.
             return False
         _unlink_storage_sidecar(configuration)
+        _unlink_compiled_config(configuration)
         return True
 
     sidecars_purged = await loop.run_in_executor(None, _delete_all)
@@ -179,6 +182,7 @@ async def delete_single(controller: DevicesController, configuration: str) -> No
         (config_dir / ".trash" / configuration).unlink(missing_ok=True)
         (config_dir / ".archive" / f"{configuration}.json").unlink(missing_ok=True)
         _unlink_storage_sidecar(configuration)
+        _unlink_compiled_config(configuration)
 
     await loop.run_in_executor(None, _delete_all)
     await controller._delete_device_metadata(configuration)

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -174,8 +174,11 @@ def _unlink_compiled_config(configuration: str) -> None:
     compiled_path = resolve_compiled_config_path(configuration)
     try:
         compiled_path.unlink(missing_ok=True)
-    except OSError:
-        _LOGGER.warning("Could not remove validated-config cache for %s", configuration)
+    except OSError as exc:
+        # Same best-effort level + detail as the idedata wipe above:
+        # both are regenerable caches, debug-logged with the exception
+        # so a permissions vs FS failure is distinguishable.
+        _LOGGER.debug("_unlink_compiled_config: unlink(%s) failed: %s", compiled_path, exc)
 
 
 def _unlink_storage_sidecar(configuration: str) -> None:

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -26,7 +26,11 @@ from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
 from ...helpers.hostname import is_local_hostname, normalize_hostname
-from ...helpers.storage_path import resolve_storage_path
+from ...helpers.storage_path import (
+    resolve_compiled_config_path,
+    resolve_idedata_path,
+    resolve_storage_path,
+)
 from ...helpers.yaml import read_yaml_scalar, rewrite_name_or_substitution
 from ...models import ConfigEntryType, Device, ErrorCode
 from .constants import _CONCEALED_SECRET_RE
@@ -50,6 +54,7 @@ __all__ = [
     "_normalize_pin_value",
     "_redact_concealed_secrets",
     "_rewrite_required_yaml_leaf",
+    "_unlink_compiled_config",
     "_unlink_storage_sidecar",
     "_validate_archive_configuration",
     "_wipe_device_build_dir",
@@ -139,20 +144,38 @@ def _rewrite_required_yaml_leaf(
 
 def _wipe_device_build_dir(configuration: str) -> None:
     """
-    Remove the per-device build dir if one exists.
+    Remove the per-device build dir + idedata cache if they exist.
 
     No-op when the StorageJSON sidecar is gone or the device
     has never been built; rmtree failures debug-log + fall
     through so a partial failure doesn't block the delete flow.
+    The idedata cache is keyed on ``StorageJSON.name`` (not the
+    YAML filename), so it's purged here where that name is in hand.
     """
-    storage_path = resolve_storage_path(configuration)
-    storage = StorageJSON.load(storage_path)
-    if storage is None or not storage.build_path:
+    storage = StorageJSON.load(resolve_storage_path(configuration))
+    if storage is None:
+        return
+    if storage.name:
+        idedata_path = resolve_idedata_path(configuration, name=storage.name)
+        try:
+            idedata_path.unlink(missing_ok=True)
+        except OSError as exc:
+            _LOGGER.debug("_wipe_device_build_dir: unlink(%s) failed: %s", idedata_path, exc)
+    if not storage.build_path:
         return
     try:
         rmtree(storage.build_path)
     except OSError as exc:
         _LOGGER.debug("_wipe_device_build_dir: rmtree(%s) failed: %s", storage.build_path, exc)
+
+
+def _unlink_compiled_config(configuration: str) -> None:
+    """Remove the validated-config cache (``<file>.validated.yaml``); no-op if absent."""
+    compiled_path = resolve_compiled_config_path(configuration)
+    try:
+        compiled_path.unlink(missing_ok=True)
+    except OSError:
+        _LOGGER.warning("Could not remove validated-config cache for %s", configuration)
 
 
 def _unlink_storage_sidecar(configuration: str) -> None:

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -129,6 +129,31 @@ async def test_archive_wipes_storage_sidecar(
     assert not storage_path.exists()
 
 
+async def test_archive_wipes_build_caches(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    seed_device: SeedDeviceFactory,
+) -> None:
+    """Regenerable build caches (idedata, validated YAML) go with the build dir.
+
+    Same rationale as wiping the build tree: a future device that
+    recycles the filename mustn't inherit the archived device's
+    stale idedata / validated-config cache.
+    """
+    controller = make_controller(tmp_path)
+    await seed_device(tmp_path, "kitchen.yaml", with_build_dir=True)
+    idedata = tmp_path / ".esphome" / "idedata" / "kitchen.json"
+    idedata.parent.mkdir(parents=True, exist_ok=True)
+    idedata.write_text("{}", encoding="utf-8")
+    validated = tmp_path / ".esphome" / "storage" / "kitchen.yaml.validated.yaml"
+    validated.write_text("esphome: {}\n", encoding="utf-8")
+
+    await controller._archive_single("kitchen.yaml")
+
+    assert not idedata.exists()
+    assert not validated.exists()
+
+
 async def test_archive_clears_volatile_metadata_keeps_identity(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
@@ -566,12 +591,15 @@ async def test_delete_archived_removes_yaml_and_sidecars(
     storage_dir.mkdir(parents=True, exist_ok=True)
     storage_path = storage_dir / "kitchen.yaml.json"
     storage_path.write_text("{}", encoding="utf-8")
+    validated_path = storage_dir / "kitchen.yaml.validated.yaml"
+    validated_path.write_text("esphome: {}\n", encoding="utf-8")
 
     controller = make_controller(tmp_path)
     await controller._delete_archived_single("kitchen.yaml")
 
     assert not (archive_dir / "kitchen.yaml").exists()
     assert not storage_path.exists()
+    assert not validated_path.exists()
 
 
 async def test_delete_archived_preserves_active_sidecars(

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -22,13 +22,27 @@ from tests._storage_fixtures import write_storage_json
 from .conftest import MakeControllerFactory
 
 
+def _cache_paths(config_dir: Path, configuration: str) -> tuple[Path, Path]:
+    """Return ``(idedata_cache, validated_config_cache)`` for *configuration*.
+
+    The idedata cache is keyed on the device ``name`` (the YAML
+    stem here); the validated-config cache is keyed on the YAML
+    filename — matching esphome's own layout under ``.esphome``.
+    """
+    stem = Path(configuration).stem
+    idedata = config_dir / ".esphome" / "idedata" / f"{stem}.json"
+    validated = config_dir / ".esphome" / "storage" / f"{configuration}.validated.yaml"
+    return idedata, validated
+
+
 def _seed_device(
     config_dir: Path, configuration: str, *, with_build_dir: bool = True
 ) -> tuple[Path, Path]:
-    """Lay out a YAML, StorageJSON sidecar, and (optionally) the build tree.
+    """Lay out a YAML, StorageJSON sidecar, build tree, and build caches.
 
     Returns ``(yaml_path, build_path)`` so the test can assert the
-    rmtree happened on the right directory.
+    rmtree happened on the right directory. The idedata + validated-
+    config caches are seeded too (see :func:`_cache_paths`).
     """
     yaml_path = config_dir / configuration
     yaml_path.write_text(f"esphome:\n  name: {Path(configuration).stem}\n", encoding="utf-8")
@@ -42,6 +56,12 @@ def _seed_device(
         (build_path / "firmware.bin").write_bytes(b"\x00" * 16)
         (build_path / "src").mkdir()
         (build_path / "src" / "main.cpp").write_text("// fake\n", encoding="utf-8")
+
+    idedata, validated = _cache_paths(config_dir, configuration)
+    idedata.parent.mkdir(parents=True, exist_ok=True)
+    idedata.write_text("{}", encoding="utf-8")
+    validated.parent.mkdir(parents=True, exist_ok=True)
+    validated.write_text("esphome: {}\n", encoding="utf-8")
 
     write_storage_json(
         config_dir,
@@ -63,12 +83,17 @@ async def test_delete_wipes_build_directory(
     """
     controller = make_controller(tmp_path)
     yaml_path, build_path = _seed_device(tmp_path, "kitchen.yaml")
+    idedata, validated = _cache_paths(tmp_path, "kitchen.yaml")
 
     await controller._delete_single("kitchen.yaml")
 
     assert not yaml_path.exists()
     assert not build_path.exists()
     assert not (tmp_path / ".esphome" / "storage" / "kitchen.yaml.json").exists()
+    # Regenerable build caches keyed off the device go too, so a
+    # recycled name doesn't pick up stale idedata / validated YAML.
+    assert not idedata.exists()
+    assert not validated.exists()
 
 
 @pytest.mark.usefixtures("redirect_storage_path")

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -13,6 +13,7 @@ retry.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -94,6 +95,60 @@ async def test_delete_wipes_build_directory(
     # recycled name doesn't pick up stale idedata / validated YAML.
     assert not idedata.exists()
     assert not validated.exists()
+
+
+@pytest.mark.usefixtures("redirect_storage_path")
+async def test_delete_wipes_idedata_when_no_build_path(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A never-built device (build_path None) still has its idedata cache wiped."""
+    controller = make_controller(tmp_path)
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    idedata, _ = _cache_paths(tmp_path, "kitchen.yaml")
+    idedata.parent.mkdir(parents=True, exist_ok=True)
+    idedata.write_text("{}", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"build_path": None})
+
+    await controller._delete_single("kitchen.yaml")
+
+    assert not yaml_path.exists()
+    assert not idedata.exists()
+
+
+@pytest.mark.usefixtures("redirect_storage_path")
+async def test_delete_tolerates_idedata_unlink_failure(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An OSError unlinking the idedata cache doesn't unwind the delete."""
+    controller = make_controller(tmp_path)
+    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
+    idedata, _ = _cache_paths(tmp_path, "kitchen.yaml")
+    # Swap the cache file for a directory so unlink() raises OSError.
+    idedata.unlink()
+    idedata.mkdir()
+
+    await controller._delete_single("kitchen.yaml")
+
+    assert not yaml_path.exists()
+
+
+@pytest.mark.usefixtures("redirect_storage_path")
+async def test_delete_tolerates_compiled_config_unlink_failure(
+    tmp_path: Path, make_controller: MakeControllerFactory, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An OSError unlinking the validated-config cache is logged, not raised."""
+    controller = make_controller(tmp_path)
+    yaml_path, _ = _seed_device(tmp_path, "kitchen.yaml")
+    _, validated = _cache_paths(tmp_path, "kitchen.yaml")
+    validated.unlink()
+    validated.mkdir()
+
+    with caplog.at_level(logging.WARNING):
+        await controller._delete_single("kitchen.yaml")
+
+    assert not yaml_path.exists()
+    assert any("validated-config cache" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.usefixtures("redirect_storage_path")

--- a/tests/controllers/devices/test_delete.py
+++ b/tests/controllers/devices/test_delete.py
@@ -144,11 +144,11 @@ async def test_delete_tolerates_compiled_config_unlink_failure(
     validated.unlink()
     validated.mkdir()
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         await controller._delete_single("kitchen.yaml")
 
     assert not yaml_path.exists()
-    assert any("validated-config cache" in rec.message for rec in caplog.records)
+    assert any("_unlink_compiled_config" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.usefixtures("redirect_storage_path")


### PR DESCRIPTION
# What does this implement/fix?

Delete and archive already wipe the per-device build tree and the
StorageJSON sidecar, but they left two regenerable per-device caches
behind:

- `idedata/<name>.json` — keyed on the device `name:` (not the YAML
  filename), written by esphome's platformio idedata extraction.
- `storage/<file>.validated.yaml` — the validated-config cache, keyed
  on the YAML filename (same key as the StorageJSON sidecar).

On a recycled filename the next compile could pick up stale cached
state, and these files accumulate on long-running fleets.

`_wipe_device_build_dir` now also unlinks the idedata cache (it already
loads `StorageJSON`, which carries the name), and a new
`_unlink_compiled_config` sibling removes the validated-config cache
alongside the storage sidecar in `delete_single`, `archive_single`, and
`delete_archived_single`. Both use the existing
`resolve_idedata_path` / `resolve_compiled_config_path` helpers, so the
remote-build per-build subtree is handled correctly. Cleanup stays
best-effort — an `OSError` is logged, never raised, so it can't unwind
a delete.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
