### PR TITLE
Add git-backed YAML version history

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -306,6 +306,24 @@ User-defined chips (name + optional `#rrggbb` color) that can be assigned to dev
 
 Renaming or recoloring a label leaves device assignments untouched — devices reference labels by id, not by name. The frontend is expected to subscribe to `subscribe_events`, fetch the catalog once via `labels/list`, then resolve ids → name + color at render time.
 
+### Version History
+
+> Controller: [`VersionHistoryController`](../esphome_device_builder/controllers/version_history/controller.py)
+
+Git-backed history of the config directory. On startup the backend adopts an existing git work tree (covering `/config/esphome` already being a repo, or sitting inside one such as `/config`) or initializes a fresh one. Every dashboard YAML mutation is committed with a descriptive message; edits made outside the dashboard (VS Code, the HA File Editor) are picked up by a debounced, scanner-driven catch-all. Deleting or archiving a config commits the removal so its pre-deletion content stays restorable. The whole feature self-disables when the `git` binary is absent — these commands then return empty lists, and the mutators raise `not_found`.
+
+Commits are pathspec-scoped and never touch the user's git config (commit identity is passed per-invocation), so an automatic commit can't sweep a user's unrelated staged edits into history.
+
+| Command | Args | Response | Description |
+|---------|------|----------|-------------|
+| `version_history/list_versions` | `{configuration}` | `[{sha, short_sha, author, timestamp, message}]` | Commit history for a config, newest first. `[]` when disabled. |
+| `version_history/get_version` | `{configuration, sha}` | `{configuration, sha, content}` | The config's YAML content at a commit. `not_found` if the file didn't exist there. |
+| `version_history/get_diff` | `{configuration, sha}` | `{configuration, sha, diff}` | Unified diff of the config between `sha` and the working copy. |
+| `version_history/list_deleted` | — | `[{configuration}]` | Configs present in history but absent from the working tree (restorable deletions). |
+| `version_history/restore` | `{configuration, sha?}` | `{configuration, restored_from, content}` | Restore a config to `sha` (or its latest surviving version when omitted). Recreates a deleted file; the write goes through the normal persist path, so the device row updates via `device_added` / `device_updated` and the restore is itself committed. |
+
+`sha` is validated as plain hex before reaching git. Reads are transient git queries — like `remote_build/list_hosts`, they're `list_*`-style commands rather than `subscribe_events` state.
+
 ### Remote Build
 
 > Controller: [`RemoteBuildController`](../esphome_device_builder/controllers/remote_build.py)

--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -75,6 +75,8 @@ async def add_component(
     new_yaml = merge_component_yaml(existing, component, fields)
     # Atomic write; wizard-driven add-component should not be able
     # to corrupt the source YAML on a mid-write crash.
-    await controller._persist_yaml_mutation(configuration, new_yaml)
+    await controller._persist_yaml_mutation(
+        configuration, new_yaml, message=f"Add {component.id} to {configuration}"
+    )
 
     return AddComponentResponse(yaml=new_yaml)

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -60,20 +60,24 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
         _unlink_storage_sidecar(configuration)
         _unlink_compiled_config(configuration)
 
-    try:
-        await loop.run_in_executor(None, _archive_sync)
-    except FileExistsError as exc:
-        raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
-    # Drop volatile fields across both stores: live mDNS state and
-    # build-dir caches in the data_dir store, plus ``mac_address``
-    # in the shared sidecar (intrinsic to the physical board, but
-    # volatile across YAML → board re-bindings on unarchive).
-    # Identity fields (board_id / friendly_name / comment / labels)
-    # survive so unarchive restores user-visible state.
-    await controller._clear_volatile_device_metadata(configuration)
-    # The active YAML left the config dir; record it as a removal so
-    # the pre-archive content is restorable from history.
-    await controller._commit_history(configuration, f"Archive {configuration}")
+    # Hold the per-file write lock across the move + history commit so a
+    # concurrent editor save to the same config can't interleave with the
+    # archive's removal commit (same serialisation as ``_persist_yaml_mutation``).
+    async with controller._yaml_write_lock(configuration):
+        try:
+            await loop.run_in_executor(None, _archive_sync)
+        except FileExistsError as exc:
+            raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
+        # Drop volatile fields across both stores: live mDNS state and
+        # build-dir caches in the data_dir store, plus ``mac_address``
+        # in the shared sidecar (intrinsic to the physical board, but
+        # volatile across YAML → board re-bindings on unarchive).
+        # Identity fields (board_id / friendly_name / comment / labels)
+        # survive so unarchive restores user-visible state.
+        await controller._clear_volatile_device_metadata(configuration)
+        # The active YAML left the config dir; record it as a removal so
+        # the pre-archive content is restorable from history.
+        await controller._commit_history(configuration, f"Archive {configuration}")
 
 
 async def unarchive_single(controller: DevicesController, configuration: str) -> None:
@@ -187,11 +191,15 @@ async def delete_single(controller: DevicesController, configuration: str) -> No
         _unlink_storage_sidecar(configuration)
         _unlink_compiled_config(configuration)
 
-    await loop.run_in_executor(None, _delete_all)
-    await controller._delete_device_metadata(configuration)
-    # Record the removal in git so the YAML stays restorable from
-    # history even though its (regenerable) build artifacts are gone.
-    await controller._commit_history(configuration, f"Delete {configuration}")
+    # Per-file write lock so the removal commit can't interleave with a
+    # concurrent editor save's commit on the same config (uniform with
+    # ``_persist_yaml_mutation``).
+    async with controller._yaml_write_lock(configuration):
+        await loop.run_in_executor(None, _delete_all)
+        await controller._delete_device_metadata(configuration)
+        # Record the removal in git so the YAML stays restorable from
+        # history even though its (regenerable) build artifacts are gone.
+        await controller._commit_history(configuration, f"Delete {configuration}")
 
 
 async def run_bulk_per_device(

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -69,6 +69,9 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
     # Identity fields (board_id / friendly_name / comment / labels)
     # survive so unarchive restores user-visible state.
     await controller._clear_volatile_device_metadata(configuration)
+    # The active YAML left the config dir; record it as a removal so
+    # the pre-archive content is restorable from history.
+    await controller._commit_history(configuration, f"Archive {configuration}")
 
 
 async def unarchive_single(controller: DevicesController, configuration: str) -> None:
@@ -182,6 +185,9 @@ async def delete_single(controller: DevicesController, configuration: str) -> No
 
     await loop.run_in_executor(None, _delete_all)
     await controller._delete_device_metadata(configuration)
+    # Record the removal in git so the YAML stays restorable from
+    # history even though its (regenerable) build artifacts are gone.
+    await controller._commit_history(configuration, f"Delete {configuration}")
 
 
 async def run_bulk_per_device(

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -811,12 +811,19 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _persist_yaml_mutation(
         self, configuration: str, content: str, *, message: str | None = None
     ) -> None:
-        """Atomic write + fire-and-forget background reload + StorageJSON regen.
+        """Atomic write + inline version-history commit + background reload.
 
-        Returns once the bytes are on disk; the scanner reload
-        runs on its worker, so callers don't see the post-reload
-        device row before the next event tick. *message* labels the
-        version-history commit; defaults to a generic "Update".
+        Returns once the bytes are on disk *and* committed to version
+        history; the scanner reload runs on its worker, so callers don't
+        see the post-reload device row before the next event tick.
+
+        The git commit is awaited inline (not fire-and-forget) so the
+        pre-clobber content is captured before the next save can
+        overwrite it — the load-bearing recovery guarantee. It's a
+        lock-serialised ``git add``/``commit`` on the executor, so this
+        adds that latency to the save round-trip and is a no-op when
+        version history is disabled. *message* labels the commit;
+        defaults to a generic "Update".
         """
         await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
         await self._commit_history(configuration, message or f"Update {configuration}")

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -847,17 +847,23 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         A git/subprocess failure keeps a hiccup from breaking the user's
         save (recoverable history gap for this one save); a programming
         bug propagates rather than being mislabelled as a git failure.
+        Does **not** itself take the per-file ``_yaml_write_lock`` — the
+        editor-save path in ``_persist_yaml_mutation`` holds it across the
+        write + this call; other callers (delete / archive) run unserialised.
         """
         version_history = self._db.version_history
         if version_history is None:
             return
-        # A dashboard commit supersedes any queued catch-all entry, so its
-        # rich message wins over the generic "external edit" one.
-        version_history.discard_pending(configuration)
         try:
             await version_history.record_configuration(configuration, message)
         except (OSError, subprocess.CalledProcessError):
+            # Leave any queued catch-all entry in place so the debounced
+            # flush still records this save's content (generic message).
             _LOGGER.exception("Version-history commit failed for %s", configuration)
+            return
+        # Committed with the rich message; drop a now-redundant queued
+        # catch-all entry so its generic message can't supersede it.
+        version_history.discard_pending(configuration)
 
     @staticmethod
     async def _read_yaml_async(path: Path) -> str:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -834,10 +834,20 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         self._schedule_storage_regenerate(configuration)
 
     async def _commit_history(self, configuration: str, message: str) -> None:
-        """Record *configuration* in version history; no-op when disabled."""
+        """Record *configuration* in version history; best-effort, never raises.
+
+        This is the boundary that keeps a git failure from breaking a
+        user's save: ``record_configuration`` raises on a genuine git
+        error, and we swallow + log it here. The cost is a recoverable
+        history gap for this one save, never a lost save.
+        """
         version_history = self._db.version_history
-        if version_history is not None:
+        if version_history is None:
+            return
+        try:
             await version_history.record_configuration(configuration, message)
+        except Exception:
+            _LOGGER.exception("Version-history commit failed for %s", configuration)
 
     @staticmethod
     async def _read_yaml_async(path: Path) -> str:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -618,6 +618,18 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             )
         await self._persist_yaml_mutation(configuration, content, message=f"Edit {configuration}")
 
+    async def apply_restored_yaml(
+        self, configuration: str, content: str, *, restored_from: str
+    ) -> None:
+        """Write a version-history-restored YAML back to disk and re-scan.
+
+        Recreates the file if it had been deleted; the scanner reload
+        then re-adds the device row through the normal event path.
+        """
+        await self._persist_yaml_mutation(
+            configuration, content, message=f"Restore {configuration} to {restored_from}"
+        )
+
     def _schedule_storage_regenerate(self, configuration: str) -> None:
         storage_regen.schedule(self, configuration)
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import subprocess
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -112,6 +113,12 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             shutdown_register=self._shutdown_callbacks.append,
         )
         self._shared_sidecar = SharedSidecarClient(self._db.settings.config_dir)
+
+        # Per-file locks serialising a YAML write with its version-history
+        # commit (see ``_persist_yaml_mutation``). One ``asyncio.Lock`` is
+        # retained per configuration ever written — bounded by device count
+        # (tens), so the lack of eviction is deliberate, not a leak.
+        self._yaml_write_locks: dict[str, asyncio.Lock] = {}
 
         # Background ``--only-generate`` bookkeeping. ``--only-generate``
         # validates a YAML and writes its ``StorageJSON`` without doing
@@ -828,26 +835,28 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     def _yaml_write_lock(self, configuration: str) -> asyncio.Lock:
         """Return the per-file lock guarding a YAML write + its history commit."""
-        locks: dict[str, asyncio.Lock] = self.__dict__.setdefault("_yaml_write_locks", {})
-        lock = locks.get(configuration)
+        lock = self._yaml_write_locks.get(configuration)
         if lock is None:
-            lock = locks[configuration] = asyncio.Lock()
+            lock = self._yaml_write_locks[configuration] = asyncio.Lock()
         return lock
 
     async def _commit_history(self, configuration: str, message: str) -> None:
         """
-        Record *configuration* in version history; best-effort, never raises.
+        Record *configuration* in version history; swallow genuine git errors.
 
-        ``record_configuration`` raises on a genuine git error; swallowing
-        it here keeps a git hiccup from breaking the user's save, at the
-        cost of a recoverable history gap for this one save.
+        A git/subprocess failure keeps a hiccup from breaking the user's
+        save (recoverable history gap for this one save); a programming
+        bug propagates rather than being mislabelled as a git failure.
         """
         version_history = self._db.version_history
         if version_history is None:
             return
+        # A dashboard commit supersedes any queued catch-all entry, so its
+        # rich message wins over the generic "external edit" one.
+        version_history.discard_pending(configuration)
         try:
             await version_history.record_configuration(configuration, message)
-        except Exception:
+        except (OSError, subprocess.CalledProcessError):
             _LOGGER.exception("Version-history commit failed for %s", configuration)
 
     @staticmethod

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -616,7 +616,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
                 f"refusing to write empty content to {configuration!r} to prevent "
                 "accidental data loss; use the delete action to remove a file",
             )
-        await self._persist_yaml_mutation(configuration, content)
+        await self._persist_yaml_mutation(configuration, content, message=f"Edit {configuration}")
 
     def _schedule_storage_regenerate(self, configuration: str) -> None:
         storage_regen.schedule(self, configuration)
@@ -789,19 +789,29 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, atomic_write_file, path, content)
 
-    async def _persist_yaml_mutation(self, configuration: str, content: str) -> None:
+    async def _persist_yaml_mutation(
+        self, configuration: str, content: str, *, message: str | None = None
+    ) -> None:
         """Atomic write + fire-and-forget background reload + StorageJSON regen.
 
         Returns once the bytes are on disk; the scanner reload
         runs on its worker, so callers don't see the post-reload
-        device row before the next event tick.
+        device row before the next event tick. *message* labels the
+        version-history commit; defaults to a generic "Update".
         """
         await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
+        await self._commit_history(configuration, message or f"Update {configuration}")
         self._scanner.request(configuration)
         # Mirrors the upstream dashboard's
         # ``async_schedule_storage_json_update``; without it
         # ``loaded_integrations`` stays at its pre-write state.
         self._schedule_storage_regenerate(configuration)
+
+    async def _commit_history(self, configuration: str, message: str) -> None:
+        """Record *configuration* in version history; no-op when disabled."""
+        version_history = self._db.version_history
+        if version_history is not None:
+            await version_history.record_configuration(configuration, message)
 
     @staticmethod
     async def _read_yaml_async(path: Path) -> str:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import subprocess
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -45,6 +44,7 @@ from .._device_scanner import DeviceScanner, ScanChange
 from .._device_state_monitor import DeviceStateMonitor
 from .._reachability_tracker import ReachabilityTracker
 from ..firmware.helpers import _find_esphome_cmd
+from ..version_history import GIT_COMMIT_ERRORS
 from . import (
     add_component,
     api_key,
@@ -856,7 +856,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             return
         try:
             await version_history.record_configuration(configuration, message)
-        except (OSError, subprocess.CalledProcessError):
+        except GIT_COMMIT_ERRORS:
             # Leave any queued catch-all entry in place so the debounced
             # flush still records this save's content (generic message).
             _LOGGER.exception("Version-history commit failed for %s", configuration)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -847,9 +847,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         A git/subprocess failure keeps a hiccup from breaking the user's
         save (recoverable history gap for this one save); a programming
         bug propagates rather than being mislabelled as a git failure.
-        Does **not** itself take the per-file ``_yaml_write_lock`` — the
-        editor-save path in ``_persist_yaml_mutation`` holds it across the
-        write + this call; other callers (delete / archive) run unserialised.
+        Does **not** itself take the per-file ``_yaml_write_lock``; callers
+        needing write+commit atomicity (editor save, delete, archive) hold
+        it across this call so same-config commits can't interleave.
         """
         version_history = self._db.version_history
         if version_history is None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -621,11 +621,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def apply_restored_yaml(
         self, configuration: str, content: str, *, restored_from: str
     ) -> None:
-        """Write a version-history-restored YAML back to disk and re-scan.
-
-        Recreates the file if it had been deleted; the scanner reload
-        then re-adds the device row through the normal event path.
-        """
+        """Write a version-history-restored YAML back to disk; recreates a deleted file."""
         await self._persist_yaml_mutation(
             configuration, content, message=f"Restore {configuration} to {restored_from}"
         )
@@ -811,35 +807,40 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _persist_yaml_mutation(
         self, configuration: str, content: str, *, message: str | None = None
     ) -> None:
-        """Atomic write + inline version-history commit + background reload.
-
-        Returns once the bytes are on disk *and* committed to version
-        history; the scanner reload runs on its worker, so callers don't
-        see the post-reload device row before the next event tick.
-
-        The git commit is awaited inline (not fire-and-forget) so the
-        pre-clobber content is captured before the next save can
-        overwrite it — the load-bearing recovery guarantee. It's a
-        lock-serialised ``git add``/``commit`` on the executor, so this
-        adds that latency to the save round-trip and is a no-op when
-        version history is disabled. *message* labels the commit;
-        defaults to a generic "Update".
         """
-        await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
-        await self._commit_history(configuration, message or f"Update {configuration}")
+        Atomically write *content*, commit it to history, then reload.
+
+        The write and the inline version-history commit are serialised
+        per file: ``commit_paths`` stages whatever is on disk, so a
+        concurrent writer to the same *configuration* must not slip
+        between this write and its commit and win the history slot. The
+        commit is awaited (not fire-and-forget) so the content is
+        captured before the next save can overwrite it.
+        """
+        async with self._yaml_write_lock(configuration):
+            await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
+            await self._commit_history(configuration, message or f"Update {configuration}")
         self._scanner.request(configuration)
         # Mirrors the upstream dashboard's
         # ``async_schedule_storage_json_update``; without it
         # ``loaded_integrations`` stays at its pre-write state.
         self._schedule_storage_regenerate(configuration)
 
-    async def _commit_history(self, configuration: str, message: str) -> None:
-        """Record *configuration* in version history; best-effort, never raises.
+    def _yaml_write_lock(self, configuration: str) -> asyncio.Lock:
+        """Return the per-file lock guarding a YAML write + its history commit."""
+        locks: dict[str, asyncio.Lock] = self.__dict__.setdefault("_yaml_write_locks", {})
+        lock = locks.get(configuration)
+        if lock is None:
+            lock = locks[configuration] = asyncio.Lock()
+        return lock
 
-        This is the boundary that keeps a git failure from breaking a
-        user's save: ``record_configuration`` raises on a genuine git
-        error, and we swallow + log it here. The cost is a recoverable
-        history gap for this one save, never a lost save.
+    async def _commit_history(self, configuration: str, message: str) -> None:
+        """
+        Record *configuration* in version history; best-effort, never raises.
+
+        ``record_configuration`` raises on a genuine git error; swallowing
+        it here keeps a git hiccup from breaking the user's save, at the
+        cost of a recoverable history gap for this one save.
         """
         version_history = self._db.version_history
         if version_history is None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -115,9 +115,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         self._shared_sidecar = SharedSidecarClient(self._db.settings.config_dir)
 
         # Per-file locks serialising a YAML write with its version-history
-        # commit (see ``_persist_yaml_mutation``). One ``asyncio.Lock`` is
-        # retained per configuration ever written — bounded by device count
-        # (tens), so the lack of eviction is deliberate, not a leak.
+        # commit (see ``_persist_yaml_mutation``). One ``asyncio.Lock`` per
+        # distinct filename written this process lifetime; never evicted —
+        # popping on delete could desync a lock a concurrent save is
+        # awaiting. Negligible in practice (a real fleet reuses filenames);
+        # only churn through many unique names grows it.
         self._yaml_write_locks: dict[str, asyncio.Lock] = {}
 
         # Background ``--only-generate`` bookkeeping. ``--only-generate``

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -100,6 +100,8 @@ async def import_device(
         configuration, content, action="import", on_error_cleanup=_cleanup
     )
 
+    await controller._commit_history(configuration, f"Import {configuration}")
+
     # Post-write scan is best-effort; the next periodic scan
     # will catch the new YAML and failing here would mislead the
     # user into a retry that trips ``FileExistsError``.

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -153,6 +153,7 @@ async def clone_device(  # noqa: C901
         raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
     if carry_board_id:
         await controller._persist_device_metadata_async(new_filename, board_id=carry_board_id)
+    await controller._commit_history(new_filename, f"Clone {configuration} to {new_filename}")
     # Rescan so the scanner indexes the new YAML and fires the
     # ADDED event WS subscribers expect; ``probe_device`` runs
     # from the scan-change handler so no double-probe here.

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -167,6 +167,7 @@ async def create_device(  # noqa: PLR0912, PLR0915, C901
     await controller._delete_device_metadata(filename)
     if board_id:
         await controller._persist_device_metadata_async(filename, board_id=board_id)
+    await controller._commit_history(filename, f"Create {filename}")
     # _scanner.scan fires _on_scan_change(ADDED) for the new
     # YAML and that already runs probe_device; don't double-probe.
     # file_content may carry an esphome.name that differs from

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -300,5 +300,7 @@ async def edit_friendly_name(
     await controller._validate_rewritten_yaml_or_raise(
         configuration, new_content, action="update friendly name"
     )
-    await controller._persist_yaml_mutation(configuration, new_content)
+    await controller._persist_yaml_mutation(
+        configuration, new_content, message=f"Update friendly name in {configuration}"
+    )
     return {"configuration": configuration, "rewritten": True}

--- a/esphome_device_builder/controllers/version_history/__init__.py
+++ b/esphome_device_builder/controllers/version_history/__init__.py
@@ -1,0 +1,7 @@
+"""Git-backed version history for the dashboard config directory."""
+
+from __future__ import annotations
+
+from .controller import VersionHistoryController
+
+__all__ = ["VersionHistoryController"]

--- a/esphome_device_builder/controllers/version_history/__init__.py
+++ b/esphome_device_builder/controllers/version_history/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from .controller import VersionHistoryController
+from .git_repo import GIT_COMMIT_ERRORS
 
-__all__ = ["VersionHistoryController"]
+__all__ = ["GIT_COMMIT_ERRORS", "VersionHistoryController"]

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -16,12 +16,30 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ...models import EventType
 from .git_repo import GitRepo
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ...device_builder import DeviceBuilder
+    from ...helpers.event_bus import Event
+    from ...models import DeviceEventData
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long to coalesce scanner-detected disk changes before committing.
+# Dashboard mutations commit immediately with a rich message, so this
+# window only ends up committing genuinely-external edits (VS Code, the
+# HA File Editor) — a dashboard save makes the debounced commit a no-op.
+_DEBOUNCE_SECONDS = 2.0
+
+# Catch-all commit message per scanner change kind (external edits).
+_EXTERNAL_MESSAGE: dict[EventType, str] = {
+    EventType.DEVICE_ADDED: "Add {configuration}",
+    EventType.DEVICE_UPDATED: "Edit {configuration}",
+    EventType.DEVICE_REMOVED: "Delete {configuration}",
+}
 
 
 class VersionHistoryController:
@@ -31,6 +49,10 @@ class VersionHistoryController:
         self._db = device_builder
         self._repo = GitRepo(config_dir=device_builder.settings.config_dir)
         self._lock = asyncio.Lock()
+        self._unsubs: list[Callable[[], None]] = []
+        # configuration → pending commit message; last write wins.
+        self._pending: dict[str, str] = {}
+        self._flush_task: asyncio.Task[None] | None = None
 
     @property
     def enabled(self) -> bool:
@@ -38,14 +60,28 @@ class VersionHistoryController:
         return self._repo.enabled
 
     async def start(self) -> None:
-        """Probe for git and adopt / initialise the config-dir repo."""
+        """Probe for git, adopt / init the repo, and watch for disk changes."""
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._repo.discover_or_init)
-        if self._repo.enabled:
-            _LOGGER.info("Version history active (git work tree: %s)", self._repo.toplevel)
+        if not self._repo.enabled:
+            return
+        _LOGGER.info("Version history active (git work tree: %s)", self._repo.toplevel)
+        # Catch-all for edits made outside the dashboard: the scanner
+        # fires these only on an actual disk cache-key change (mtime /
+        # size / inode), so runtime mDNS / ping state ticks don't reach
+        # us. Dashboard mutations have already committed by the time the
+        # debounced flush runs, so those become no-ops here.
+        for event_type in _EXTERNAL_MESSAGE:
+            self._unsubs.append(self._db.bus.add_listener(event_type, self._on_disk_change))
 
     async def stop(self) -> None:
-        """No persistent resources to release (commits are synchronous)."""
+        """Detach listeners and cancel any pending debounced flush."""
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+        if self._flush_task is not None and not self._flush_task.done():
+            self._flush_task.cancel()
+            self._flush_task = None
 
     async def commit(self, paths: list[Path], message: str) -> str | None:
         """Commit *paths* under *message*; best-effort, never raises.
@@ -68,3 +104,27 @@ class VersionHistoryController:
         """Commit a single config YAML by its dashboard *configuration* name."""
         path = self._db.settings.rel_path(configuration)
         return await self.commit([path], message)
+
+    # ------------------------------------------------------------------
+    # scanner-driven catch-all for external edits
+    # ------------------------------------------------------------------
+
+    def _on_disk_change(self, event: Event[DeviceEventData]) -> None:
+        """Queue a debounced commit for a scanner-detected disk change."""
+        configuration = event.data["device"].configuration
+        self._pending[configuration] = _EXTERNAL_MESSAGE[event.event_type].format(
+            configuration=configuration
+        )
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = asyncio.create_task(self._flush_after_delay())
+
+    async def _flush_after_delay(self) -> None:
+        """Wait out the debounce window, then commit each pending config once."""
+        await asyncio.sleep(_DEBOUNCE_SECONDS)
+        pending = self._pending
+        self._pending = {}
+        for configuration, message in pending.items():
+            try:
+                await self.record_configuration(configuration, message)
+            except Exception:  # noqa: BLE001 — one bad path can't kill the watcher
+                _LOGGER.debug("Version-history catch-all failed for %s", configuration)

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -106,23 +106,25 @@ class VersionHistoryController:
         await self._flush_pending()
 
     async def commit(self, paths: list[Path], message: str) -> str | None:
-        """Commit *paths* under *message*; best-effort, never raises.
+        """Commit *paths* under *message*; return the sha, or ``None`` for a no-op.
 
-        Returns the new commit sha, or ``None`` when nothing changed
-        for those paths or the feature is disabled. Safe to ``await``
-        from any mutation site — a git failure is swallowed and logged.
+        ``None`` means nothing changed for those paths (or the feature
+        is disabled). A genuine git failure **raises** — the distinction
+        between "nothing to commit" and "the commit failed" is what lets
+        the scanner catch-all warn on a persistently broken recorder.
+        Callers that must not break a user's save (the mutation path)
+        wrap this; see :meth:`DevicesController._commit_history`.
         """
         if not self._repo.enabled or not paths:
             return None
         async with self._lock:
-            try:
-                return await self._in_executor(self._repo.commit_paths, paths, message)
-            except Exception:
-                _LOGGER.exception("Version-history commit failed for %s", message)
-                return None
+            return await self._in_executor(self._repo.commit_paths, paths, message)
 
     async def record_configuration(self, configuration: str, message: str) -> str | None:
-        """Commit a single config YAML by its dashboard *configuration* name."""
+        """Commit a single config YAML by its dashboard *configuration* name.
+
+        Returns the sha (or ``None`` for a no-op); raises on a git failure.
+        """
         path = self._db.settings.rel_path(configuration)
         return await self.commit([path], message)
 
@@ -275,10 +277,10 @@ class VersionHistoryController:
                 try:
                     await self.record_configuration(configuration, message)
                 except Exception:
-                    # A git failure inside commit() is already logged there
-                    # and returns None; this guard isolates the rarer case of
-                    # a bad configuration (rel_path raising) so one bad entry
-                    # can't strand the rest of the batch.
+                    # Reachable on a genuine git failure (record_configuration
+                    # now raises) — this is the only recorder for external
+                    # edits, so warn rather than let it pass silently, and
+                    # keep going so one bad entry can't strand the batch.
                     _LOGGER.warning(
                         "Version-history catch-all failed for %s", configuration, exc_info=True
                     )

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -28,9 +29,13 @@ if TYPE_CHECKING:
     from ...helpers.event_bus import Event
     from ...models import DeviceEventData
 
-# A commit id from list_versions — full or abbreviated hex. Validated
-# before reaching git so a crafted ``configuration``/``sha`` can't smuggle
-# extra argv into the read commands.
+# A commit id from list_versions — full or abbreviated hex. ``sha`` is
+# validated against this before reaching git so it can't smuggle extra
+# argv into the read commands. The other untrusted input,
+# ``configuration``, is guarded separately by ``settings.rel_path`` (it
+# raises ``INVALID_ARGS`` for ``..`` / absolute paths that escape the
+# config dir, so a client can't read tracked files elsewhere in an
+# adopted work tree) and only ever reaches git as a pathspec after ``--``.
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{4,40}$")
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,13 +87,23 @@ class VersionHistoryController:
             self._unsubs.append(self._db.bus.add_listener(event_type, self._on_disk_change))
 
     async def stop(self) -> None:
-        """Detach listeners and cancel any pending debounced flush."""
+        """Detach listeners, cancel the debounce timer, and flush what's queued.
+
+        Draining ``_pending`` on the way out means an external edit that
+        landed inside the debounce window isn't silently dropped on
+        shutdown (there's no startup re-snapshot for an already-tracked
+        file, so it would otherwise be a permanent history gap).
+        """
         for unsub in self._unsubs:
             unsub()
         self._unsubs.clear()
-        if self._flush_task is not None and not self._flush_task.done():
-            self._flush_task.cancel()
-            self._flush_task = None
+        task = self._flush_task
+        self._flush_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        await self._flush_pending()
 
     async def commit(self, paths: list[Path], message: str) -> str | None:
         """Commit *paths* under *message*; best-effort, never raises.
@@ -222,22 +237,29 @@ class VersionHistoryController:
             self._flush_task = asyncio.create_task(self._flush_after_delay())
 
     async def _flush_after_delay(self) -> None:
-        """Wait out the debounce window, then commit every pending config.
-
-        Drains in a loop: an external edit that lands while we're
-        committing (the per-config commit awaits) is picked up on the
-        next pass instead of waiting for the next scanner event. The
-        final empty-check and the coroutine return happen without an
-        await between them, so no event can slip in and be stranded —
-        ``_on_disk_change`` then sees the task done and schedules a
-        fresh flush.
-        """
+        """Wait out the debounce window, then flush the queued configs."""
         await asyncio.sleep(_DEBOUNCE_SECONDS)
+        await self._flush_pending()
+
+    async def _flush_pending(self) -> None:
+        """Commit every queued config; drain in a loop so nothing is stranded.
+
+        An external edit that lands while we're committing (the per-config
+        commit awaits) is picked up on the next pass instead of waiting for
+        the next scanner event. The final empty-check and the coroutine
+        return happen without an await between them, so no event can slip
+        in and be stranded — ``_on_disk_change`` then sees the task done
+        and schedules a fresh flush.
+        """
         while self._pending:
             pending = self._pending
             self._pending = {}
             for configuration, message in pending.items():
                 try:
                     await self.record_configuration(configuration, message)
-                except Exception:  # noqa: BLE001 — one bad path can't kill the watcher
-                    _LOGGER.debug("Version-history catch-all failed for %s", configuration)
+                except Exception:
+                    # Warning, not debug: a persistently failing catch-all
+                    # means external edits silently stop being recorded.
+                    _LOGGER.warning(
+                        "Version-history catch-all failed for %s", configuration, exc_info=True
+                    )

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -121,6 +121,14 @@ class VersionHistoryController:
         path = self._db.settings.rel_path(configuration)
         return await self.commit([path], message)
 
+    def discard_pending(self, configuration: str) -> None:
+        """Drop a queued catch-all entry; a specific commit supersedes it.
+
+        Lets a dashboard commit's rich message win over the generic
+        external-edit message a debounced flush would otherwise apply.
+        """
+        self._pending.pop(configuration, None)
+
     # ------------------------------------------------------------------
     # WS commands
     # ------------------------------------------------------------------

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -99,10 +99,9 @@ class VersionHistoryController:
         """
         if not self._repo.enabled or not paths:
             return None
-        loop = asyncio.get_running_loop()
         async with self._lock:
             try:
-                return await loop.run_in_executor(None, self._repo.commit_paths, paths, message)
+                return await self._in_executor(self._repo.commit_paths, paths, message)
             except Exception:
                 _LOGGER.exception("Version-history commit failed for %s", message)
                 return None
@@ -122,8 +121,7 @@ class VersionHistoryController:
         if not self._repo.enabled:
             return []
         path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        commits = await loop.run_in_executor(None, self._repo.log_file, path)
+        commits = await self._in_executor(self._repo.log_file, path)
         return [
             {
                 "sha": c.sha,
@@ -141,8 +139,7 @@ class VersionHistoryController:
         self._require_enabled()
         self._validate_sha(sha)
         path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        content = await loop.run_in_executor(None, self._repo.file_at, path, sha)
+        content = await self._in_executor(self._repo.file_at, path, sha)
         if content is None:
             raise CommandError(ErrorCode.NOT_FOUND, f"{configuration} not found at {sha}")
         return {"configuration": configuration, "sha": sha, "content": content}
@@ -153,8 +150,7 @@ class VersionHistoryController:
         self._require_enabled()
         self._validate_sha(sha)
         path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        diff = await loop.run_in_executor(None, self._repo.diff_file, path, sha)
+        diff = await self._in_executor(self._repo.diff_file, path, sha)
         return {"configuration": configuration, "sha": sha, "diff": diff}
 
     @api_command("version_history/list_deleted")
@@ -162,8 +158,7 @@ class VersionHistoryController:
         """Return configs that have history but no working-tree copy (restorable)."""
         if not self._repo.enabled:
             return []
-        loop = asyncio.get_running_loop()
-        deleted = await loop.run_in_executor(None, self._repo.deleted_files)
+        deleted = await self._in_executor(self._repo.deleted_files)
         return [{"configuration": name} for name in deleted]
 
     @api_command("version_history/restore")
@@ -178,15 +173,14 @@ class VersionHistoryController:
         """
         self._require_enabled()
         path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
         if sha is not None:
             self._validate_sha(sha)
-            content = await loop.run_in_executor(None, self._repo.file_at, path, sha)
+            content = await self._in_executor(self._repo.file_at, path, sha)
             if content is None:
                 raise CommandError(ErrorCode.NOT_FOUND, f"{configuration} not found at {sha}")
             restored_from = sha
         else:
-            result = await loop.run_in_executor(None, self._repo.latest_content, path)
+            result = await self._in_executor(self._repo.latest_content, path)
             if result is None:
                 raise CommandError(ErrorCode.NOT_FOUND, f"no history for {configuration}")
             restored_from, content = result
@@ -195,6 +189,11 @@ class VersionHistoryController:
             raise CommandError(ErrorCode.INTERNAL_ERROR, "devices controller unavailable")
         await devices.apply_restored_yaml(configuration, content, restored_from=restored_from[:7])
         return {"configuration": configuration, "restored_from": restored_from, "content": content}
+
+    async def _in_executor[T](self, fn: Callable[..., T], *args: Any) -> T:
+        """Run a synchronous GitRepo call off the event loop."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, fn, *args)
 
     def _require_enabled(self) -> None:
         """Raise if version history isn't available for this config dir."""
@@ -223,12 +222,22 @@ class VersionHistoryController:
             self._flush_task = asyncio.create_task(self._flush_after_delay())
 
     async def _flush_after_delay(self) -> None:
-        """Wait out the debounce window, then commit each pending config once."""
+        """Wait out the debounce window, then commit every pending config.
+
+        Drains in a loop: an external edit that lands while we're
+        committing (the per-config commit awaits) is picked up on the
+        next pass instead of waiting for the next scanner event. The
+        final empty-check and the coroutine return happen without an
+        await between them, so no event can slip in and be stranded —
+        ``_on_disk_change`` then sees the task done and schedules a
+        fresh flush.
+        """
         await asyncio.sleep(_DEBOUNCE_SECONDS)
-        pending = self._pending
-        self._pending = {}
-        for configuration, message in pending.items():
-            try:
-                await self.record_configuration(configuration, message)
-            except Exception:  # noqa: BLE001 — one bad path can't kill the watcher
-                _LOGGER.debug("Version-history catch-all failed for %s", configuration)
+        while self._pending:
+            pending = self._pending
+            self._pending = {}
+            for configuration, message in pending.items():
+                try:
+                    await self.record_configuration(configuration, message)
+                except Exception:  # noqa: BLE001 — one bad path can't kill the watcher
+                    _LOGGER.debug("Version-history catch-all failed for %s", configuration)

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -1,0 +1,70 @@
+"""
+Version-history controller — git-backed history of the config dir.
+
+Owns a :class:`GitRepo` over ``settings.config_dir`` and exposes an
+async, lock-serialised commit API plus the read/restore WS commands.
+The git index is not concurrency-safe, so every mutating op runs in an
+executor behind :attr:`_lock`; the whole feature is best-effort and
+self-disabling (no git binary, or repo setup failed → every method a
+quiet no-op), so a git hiccup never breaks a user's save.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .git_repo import GitRepo
+
+if TYPE_CHECKING:
+    from ...device_builder import DeviceBuilder
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VersionHistoryController:
+    """Auto-commit YAML edits and serve their history to the dashboard."""
+
+    def __init__(self, device_builder: DeviceBuilder) -> None:
+        self._db = device_builder
+        self._repo = GitRepo(config_dir=device_builder.settings.config_dir)
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        """Whether git-backed history is active for this config dir."""
+        return self._repo.enabled
+
+    async def start(self) -> None:
+        """Probe for git and adopt / initialise the config-dir repo."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._repo.discover_or_init)
+        if self._repo.enabled:
+            _LOGGER.info("Version history active (git work tree: %s)", self._repo.toplevel)
+
+    async def stop(self) -> None:
+        """No persistent resources to release (commits are synchronous)."""
+
+    async def commit(self, paths: list[Path], message: str) -> str | None:
+        """Commit *paths* under *message*; best-effort, never raises.
+
+        Returns the new commit sha, or ``None`` when nothing changed
+        for those paths or the feature is disabled. Safe to ``await``
+        from any mutation site — a git failure is swallowed and logged.
+        """
+        if not self._repo.enabled or not paths:
+            return None
+        loop = asyncio.get_running_loop()
+        async with self._lock:
+            try:
+                return await loop.run_in_executor(None, self._repo.commit_paths, paths, message)
+            except Exception:
+                _LOGGER.exception("Version-history commit failed for %s", message)
+                return None
+
+    async def record_configuration(self, configuration: str, message: str) -> str | None:
+        """Commit a single config YAML by its dashboard *configuration* name."""
+        path = self._db.settings.rel_path(configuration)
+        return await self.commit([path], message)

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError, api_command
 from ...models import ErrorCode, EventType
-from .git_repo import GitRepo
+from .git_repo import GIT_COMMIT_ERRORS, GitRepo
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -275,11 +275,11 @@ class VersionHistoryController:
             for configuration, message in pending.items():
                 try:
                     await self.record_configuration(configuration, message)
-                except Exception:
-                    # Reachable on a genuine git failure (record_configuration
-                    # now raises) — this is the only recorder for external
-                    # edits, so warn rather than let it pass silently, and
-                    # keep going so one bad entry can't strand the batch.
+                except GIT_COMMIT_ERRORS:
+                    # A genuine git failure for one entry: warn and keep
+                    # going so it can't strand the batch. A programming bug
+                    # is *not* caught — it propagates to the task's
+                    # done-callback rather than being masked here.
                     _LOGGER.warning(
                         "Version-history catch-all failed for %s", configuration, exc_info=True
                     )

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -188,6 +188,9 @@ class VersionHistoryController:
         """
         self._require_enabled()
         path = self._db.settings.rel_path(configuration)
+        # Commit any queued external edit first, so restoring over it
+        # still leaves that just-overwritten version recoverable.
+        await self._flush_pending()
         if sha is not None:
             self._validate_sha(sha)
             content = await self._in_executor(self._repo.file_at, path, sha)
@@ -234,7 +237,21 @@ class VersionHistoryController:
             configuration=configuration
         )
         if self._flush_task is None or self._flush_task.done():
-            self._flush_task = asyncio.create_task(self._flush_after_delay())
+            task = asyncio.create_task(self._flush_after_delay())
+            # The catch-all is the only recorder for external edits; a
+            # done-callback surfaces any failure that escapes the
+            # per-config guard so the watcher can't die silently.
+            task.add_done_callback(self._on_flush_done)
+            self._flush_task = task
+
+    @staticmethod
+    def _on_flush_done(task: asyncio.Task[None]) -> None:
+        """Log an unexpected flush-task failure (cancellation is normal)."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            _LOGGER.warning("Version-history flush task failed unexpectedly", exc_info=exc)
 
     async def _flush_after_delay(self) -> None:
         """Wait out the debounce window, then flush the queued configs."""
@@ -258,8 +275,10 @@ class VersionHistoryController:
                 try:
                     await self.record_configuration(configuration, message)
                 except Exception:
-                    # Warning, not debug: a persistently failing catch-all
-                    # means external edits silently stop being recorded.
+                    # A git failure inside commit() is already logged there
+                    # and returns None; this guard isolates the rarer case of
+                    # a bad configuration (rel_path raising) so one bad entry
+                    # can't strand the rest of the batch.
                     _LOGGER.warning(
                         "Version-history catch-all failed for %s", configuration, exc_info=True
                     )

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -87,12 +87,11 @@ class VersionHistoryController:
             self._unsubs.append(self._db.bus.add_listener(event_type, self._on_disk_change))
 
     async def stop(self) -> None:
-        """Detach listeners, cancel the debounce timer, and flush what's queued.
+        """
+        Detach listeners, cancel the debounce timer, and flush what's queued.
 
-        Draining ``_pending`` on the way out means an external edit that
-        landed inside the debounce window isn't silently dropped on
-        shutdown (there's no startup re-snapshot for an already-tracked
-        file, so it would otherwise be a permanent history gap).
+        The final drain commits an edit caught in the debounce window
+        rather than dropping it on shutdown.
         """
         for unsub in self._unsubs:
             unsub()
@@ -106,14 +105,11 @@ class VersionHistoryController:
         await self._flush_pending()
 
     async def commit(self, paths: list[Path], message: str) -> str | None:
-        """Commit *paths* under *message*; return the sha, or ``None`` for a no-op.
+        """
+        Commit *paths* under *message*; return the sha, ``None`` for a no-op.
 
-        ``None`` means nothing changed for those paths (or the feature
-        is disabled). A genuine git failure **raises** — the distinction
-        between "nothing to commit" and "the commit failed" is what lets
-        the scanner catch-all warn on a persistently broken recorder.
-        Callers that must not break a user's save (the mutation path)
-        wrap this; see :meth:`DevicesController._commit_history`.
+        ``None`` means nothing changed (or disabled); a genuine git
+        failure **raises** so callers can tell the two apart.
         """
         if not self._repo.enabled or not paths:
             return None
@@ -121,10 +117,7 @@ class VersionHistoryController:
             return await self._in_executor(self._repo.commit_paths, paths, message)
 
     async def record_configuration(self, configuration: str, message: str) -> str | None:
-        """Commit a single config YAML by its dashboard *configuration* name.
-
-        Returns the sha (or ``None`` for a no-op); raises on a git failure.
-        """
+        """Commit one config by name; return the sha (``None`` no-op), raise on failure."""
         path = self._db.settings.rel_path(configuration)
         return await self.commit([path], message)
 
@@ -261,14 +254,12 @@ class VersionHistoryController:
         await self._flush_pending()
 
     async def _flush_pending(self) -> None:
-        """Commit every queued config; drain in a loop so nothing is stranded.
+        """
+        Commit every queued config, draining in a loop.
 
-        An external edit that lands while we're committing (the per-config
-        commit awaits) is picked up on the next pass instead of waiting for
-        the next scanner event. The final empty-check and the coroutine
-        return happen without an await between them, so no event can slip
-        in and be stranded — ``_on_disk_change`` then sees the task done
-        and schedules a fresh flush.
+        Load-bearing: the final ``while`` check and the return have no
+        await between them, so an event can't slip in and be stranded —
+        ``_on_disk_change`` then sees the task done and reschedules.
         """
         while self._pending:
             pending = self._pending

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -46,6 +46,11 @@ _LOGGER = logging.getLogger(__name__)
 # HA File Editor) — a dashboard save makes the debounced commit a no-op.
 _DEBOUNCE_SECONDS = 2.0
 
+# Consecutive commit failures before the feature is flagged ``degraded``
+# — enough to tell a persistent breakage (corrupt repo, disk full) from a
+# one-off hiccup, which a future History pane can surface to the user.
+_DEGRADED_THRESHOLD = 3
+
 # Catch-all commit message per scanner change kind (external edits).
 _EXTERNAL_MESSAGE: dict[EventType, str] = {
     EventType.DEVICE_ADDED: "Add {configuration}",
@@ -65,11 +70,24 @@ class VersionHistoryController:
         # configuration → pending commit message; last write wins.
         self._pending: dict[str, str] = {}
         self._flush_task: asyncio.Task[None] | None = None
+        # Consecutive-failure tracking for the degraded signal.
+        self._consecutive_failures = 0
+        self._degraded = False
 
     @property
     def enabled(self) -> bool:
         """Whether git-backed history is active for this config dir."""
         return self._repo.enabled
+
+    @property
+    def degraded(self) -> bool:
+        """True when commits have failed repeatedly — history may be incomplete.
+
+        Distinguishes a persistent breakage from a one-off hiccup so a
+        future History pane can surface "version history is failing"
+        rather than silently presenting stale versions.
+        """
+        return self._degraded
 
     async def start(self) -> None:
         """Probe for git, adopt / init the repo, and watch for disk changes."""
@@ -114,7 +132,34 @@ class VersionHistoryController:
         if not self._repo.enabled or not paths:
             return None
         async with self._lock:
-            return await self._in_executor(self._repo.commit_paths, paths, message)
+            try:
+                sha = await self._in_executor(self._repo.commit_paths, paths, message)
+            except GIT_COMMIT_ERRORS:
+                self._note_commit_failure()
+                raise
+            self._note_commit_success()
+            return sha
+
+    def _note_commit_failure(self) -> None:
+        """Count a git failure; flag degraded once they stop looking one-off."""
+        self._consecutive_failures += 1
+        if not self._degraded and self._consecutive_failures >= _DEGRADED_THRESHOLD:
+            self._degraded = True
+            _LOGGER.error(
+                "Version history degraded: %d consecutive commit failures — recent "
+                "saves may not be recoverable until git is healthy",
+                self._consecutive_failures,
+            )
+
+    def _note_commit_success(self) -> None:
+        """Reset the failure run; log recovery if we were degraded."""
+        if self._degraded:
+            _LOGGER.info(
+                "Version history recovered after %d consecutive failures",
+                self._consecutive_failures,
+            )
+        self._consecutive_failures = 0
+        self._degraded = False
 
     async def record_configuration(self, configuration: str, message: str) -> str | None:
         """Commit one config by name; return the sha (``None`` no-op), raise on failure."""

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from ...models import EventType
+from ...helpers.api import CommandError, api_command
+from ...models import ErrorCode, EventType
 from .git_repo import GitRepo
 
 if TYPE_CHECKING:
@@ -25,6 +27,11 @@ if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
     from ...helpers.event_bus import Event
     from ...models import DeviceEventData
+
+# A commit id from list_versions — full or abbreviated hex. Validated
+# before reaching git so a crafted ``configuration``/``sha`` can't smuggle
+# extra argv into the read commands.
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{4,40}$")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,6 +111,103 @@ class VersionHistoryController:
         """Commit a single config YAML by its dashboard *configuration* name."""
         path = self._db.settings.rel_path(configuration)
         return await self.commit([path], message)
+
+    # ------------------------------------------------------------------
+    # WS commands
+    # ------------------------------------------------------------------
+
+    @api_command("version_history/list_versions")
+    async def list_versions(self, *, configuration: str, **kwargs: Any) -> list[dict[str, Any]]:
+        """Return the commit history for *configuration*, newest first."""
+        if not self._repo.enabled:
+            return []
+        path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        commits = await loop.run_in_executor(None, self._repo.log_file, path)
+        return [
+            {
+                "sha": c.sha,
+                "short_sha": c.short_sha,
+                "author": c.author,
+                "timestamp": c.timestamp,
+                "message": c.message,
+            }
+            for c in commits
+        ]
+
+    @api_command("version_history/get_version")
+    async def get_version(self, *, configuration: str, sha: str, **kwargs: Any) -> dict[str, Any]:
+        """Return *configuration*'s content at commit *sha*."""
+        self._require_enabled()
+        self._validate_sha(sha)
+        path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        content = await loop.run_in_executor(None, self._repo.file_at, path, sha)
+        if content is None:
+            raise CommandError(ErrorCode.NOT_FOUND, f"{configuration} not found at {sha}")
+        return {"configuration": configuration, "sha": sha, "content": content}
+
+    @api_command("version_history/get_diff")
+    async def get_diff(self, *, configuration: str, sha: str, **kwargs: Any) -> dict[str, Any]:
+        """Return a unified diff of *configuration* between *sha* and the working copy."""
+        self._require_enabled()
+        self._validate_sha(sha)
+        path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        diff = await loop.run_in_executor(None, self._repo.diff_file, path, sha)
+        return {"configuration": configuration, "sha": sha, "diff": diff}
+
+    @api_command("version_history/list_deleted")
+    async def list_deleted(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Return configs that have history but no working-tree copy (restorable)."""
+        if not self._repo.enabled:
+            return []
+        loop = asyncio.get_running_loop()
+        deleted = await loop.run_in_executor(None, self._repo.deleted_files)
+        return [{"configuration": name} for name in deleted]
+
+    @api_command("version_history/restore")
+    async def restore(
+        self, *, configuration: str, sha: str | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        """Restore *configuration* to commit *sha* (or its latest version if omitted).
+
+        Recreates a deleted file as well as reverting an edit; the
+        write goes through the normal persist path so the device row
+        updates via events and the restore itself is committed.
+        """
+        self._require_enabled()
+        path = self._db.settings.rel_path(configuration)
+        loop = asyncio.get_running_loop()
+        if sha is not None:
+            self._validate_sha(sha)
+            content = await loop.run_in_executor(None, self._repo.file_at, path, sha)
+            if content is None:
+                raise CommandError(ErrorCode.NOT_FOUND, f"{configuration} not found at {sha}")
+            restored_from = sha
+        else:
+            result = await loop.run_in_executor(None, self._repo.latest_content, path)
+            if result is None:
+                raise CommandError(ErrorCode.NOT_FOUND, f"no history for {configuration}")
+            restored_from, content = result
+        devices = self._db.devices
+        if devices is None:  # pragma: no cover — devices is always up post-start
+            raise CommandError(ErrorCode.INTERNAL_ERROR, "devices controller unavailable")
+        await devices.apply_restored_yaml(configuration, content, restored_from=restored_from[:7])
+        return {"configuration": configuration, "restored_from": restored_from, "content": content}
+
+    def _require_enabled(self) -> None:
+        """Raise if version history isn't available for this config dir."""
+        if not self._repo.enabled:
+            raise CommandError(
+                ErrorCode.NOT_FOUND,
+                "version history is not available for this config directory",
+            )
+
+    def _validate_sha(self, sha: Any) -> None:
+        """Reject anything that isn't a plain hex commit id."""
+        if not isinstance(sha, str) or not _SHA_RE.match(sha):
+            raise CommandError(ErrorCode.INVALID_ARGS, f"invalid commit id: {sha!r}")
 
     # ------------------------------------------------------------------
     # scanner-driven catch-all for external edits

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -32,6 +32,12 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
+# Errors a commit attempt raises for genuine git / environment reasons
+# (a failed ``git`` invocation, the binary vanishing) as opposed to a
+# programming bug. Callers swallow these as best-effort and let anything
+# else propagate so real bugs surface instead of being mislabelled.
+GIT_COMMIT_ERRORS: tuple[type[Exception], ...] = (OSError, subprocess.CalledProcessError)
+
 # Identity stamped on every automatic commit. Passed per-invocation
 # with ``git -c`` so we never touch the user's global/repo config.
 _COMMIT_NAME = "ESPHome Device Builder"

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -111,14 +111,46 @@ class GitRepo:
         return Path(root) if root else None
 
     def _init_repo(self) -> None:
-        """Create a fresh repo in ``config_dir`` and commit a ``.gitignore``."""
+        """Create a fresh repo in ``config_dir`` and seed the initial snapshot.
+
+        Because the repo is brand new there's no user work-in-progress
+        to protect, so the seed commit stages everything not ignored
+        (the existing configs) — giving each device a first version in
+        history immediately rather than only once it's first edited.
+        """
         self._run(["init", str(self.config_dir)], cwd=self.config_dir, check=True)
         self.toplevel = self.config_dir
         self.enabled = True
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
             gitignore.write_text(_DEFAULT_GITIGNORE, encoding="utf-8")
-            self.commit_paths([gitignore], "Initialize version history")
+        self._run(["add", "-A"], check=False)
+        self._commit_index("Initialize version history")
+
+    def _commit_index(self, message: str) -> None:
+        """Commit whatever is currently staged (no pathspec); skip if empty.
+
+        Only used for the fresh-init seed — every other commit is
+        pathspec-scoped via :meth:`commit_paths` so it can't sweep the
+        user's staged work.
+        """
+        if self._run(["diff", "--cached", "--quiet"], check=False).returncode == 0:
+            return
+        self._run(
+            [
+                "-c",
+                f"user.name={_COMMIT_NAME}",
+                "-c",
+                f"user.email={_COMMIT_EMAIL}",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--no-verify",
+                "-m",
+                message,
+            ],
+            check=False,
+        )
 
     # ------------------------------------------------------------------
     # writes

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -37,18 +37,41 @@ _LOGGER = logging.getLogger(__name__)
 _COMMIT_NAME = "ESPHome Device Builder"
 _COMMIT_EMAIL = "device-builder@esphome.io"
 
-# Written only when *we* create the repo; a pre-existing repo keeps the
-# user's own ignore rules untouched. Build artifacts under ``.esphome``
-# and the machine-state sidecars are noise; ``secrets.yaml`` is ignored
-# by default so credentials don't land in local history (or a remote the
-# user later adds) — they can un-ignore it deliberately.
-_DEFAULT_GITIGNORE = """\
-# Managed by ESPHome Device Builder — created because this directory
-# was not already a git repository. Edit freely; it won't be regenerated.
-.esphome/
-.device-builder*.json
-secrets.yaml
-"""
+# Files Device Builder must never let into git history: its own
+# machine state (sidecars, locks), identity key, and remote-build peer
+# credentials, plus ESPHome build artifacts and OS noise. None of these
+# are user config. They're forced into the repo's *local* exclude
+# (``.git/info/exclude``) on both init and adopt — see
+# ``_ensure_local_excludes`` — so a key can't be committed even when the
+# user's own ``.gitignore`` (or a stock ESPHome one) doesn't cover it,
+# and without ever modifying that tracked ``.gitignore``.
+_MANAGED_EXCLUDES = (
+    ".esphome/",
+    ".device-builder*",
+    ".receiver_peers.json",
+    ".offloader_pairings.json",
+    ".DS_Store",
+)
+
+# Markers delimiting our block in ``.git/info/exclude`` so the write is
+# idempotent across restarts.
+_EXCLUDE_MARKER = "# >>> ESPHome Device Builder (managed) >>>"
+_EXCLUDE_END = "# <<< ESPHome Device Builder (managed) <<<"
+
+# Written only when *we* create the repo and no ``.gitignore`` exists; a
+# pre-existing one is left untouched (the local exclude is what actually
+# protects the secrets above). ``secrets.yaml`` is ignored here — not in
+# the forced local exclude — because whether to version it is the user's
+# call, but the safe default keeps credentials out of a repo that may
+# later be pushed to a remote.
+_DEFAULT_GITIGNORE = "".join(
+    [
+        "# Managed by ESPHome Device Builder — created because this directory\n",
+        "# was not already a git repository. Edit freely; it won't be regenerated.\n",
+        *(f"{pattern}\n" for pattern in _MANAGED_EXCLUDES),
+        "secrets.yaml\n",
+    ]
+)
 
 
 @dataclass(slots=True)
@@ -92,6 +115,7 @@ class GitRepo:
             if toplevel is not None:
                 self.toplevel = toplevel
                 self.enabled = True
+                self._ensure_local_excludes()
                 _LOGGER.debug("Adopted existing git work tree at %s", toplevel)
                 return
             self._init_repo()
@@ -121,11 +145,42 @@ class GitRepo:
         self._run(["init", str(self.config_dir)], cwd=self.config_dir, check=True)
         self.toplevel = self.config_dir
         self.enabled = True
+        # Local excludes BEFORE the seed ``git add -A`` so our identity
+        # key / machine state / OS noise can never land in the snapshot,
+        # even when the dir already had a (stock or foreign) ``.gitignore``
+        # that doesn't cover them.
+        self._ensure_local_excludes()
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
             gitignore.write_text(_DEFAULT_GITIGNORE, encoding="utf-8")
         self._run(["add", "-A"], check=False)
         self._commit_index("Initialize version history")
+
+    def _ensure_local_excludes(self) -> None:
+        """Append our managed patterns to ``.git/info/exclude`` (idempotent).
+
+        ``info/exclude`` is git's repo-local ignore: never committed,
+        invisible to the user's tracked ``.gitignore``, and applied on
+        top of it. Writing here guarantees our secrets / state are never
+        staged, regardless of how the user configured their repo, without
+        mutating anything they track.
+        """
+        result = self._run(["rev-parse", "--git-path", "info/exclude"], check=False)
+        if result.returncode != 0 or not result.stdout.strip():
+            return
+        exclude_path = Path(result.stdout.strip())
+        if not exclude_path.is_absolute():
+            exclude_path = (self.toplevel or self.config_dir) / exclude_path
+        try:
+            existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+            if _EXCLUDE_MARKER in existing:
+                return
+            exclude_path.parent.mkdir(parents=True, exist_ok=True)
+            block = "\n".join(["", _EXCLUDE_MARKER, *_MANAGED_EXCLUDES, _EXCLUDE_END, ""])
+            with exclude_path.open("a", encoding="utf-8") as handle:
+                handle.write(block)
+        except OSError as exc:
+            _LOGGER.debug("Could not write git info/exclude: %s", exc)
 
     def _commit_index(self, message: str) -> None:
         """Commit whatever is currently staged (no pathspec); skip if empty.

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -64,10 +64,11 @@ _MANAGED_EXCLUDES = (
 _EXCLUDE_MARKER = "# >>> ESPHome Device Builder (managed) >>>"
 _EXCLUDE_END = "# <<< ESPHome Device Builder (managed) <<<"
 
-# YAMLs the seed must never capture: the user's secrets, and the
-# dashboard's CORE sentinel (see controllers/config/settings.py).
+# The seed must never capture the user's secrets file (credentials don't
+# belong in a repo that may be pushed to a remote). The CORE sentinel
+# (``controllers/config/settings.py``) is a virtual ``CORE.config_path``
+# value, never written to disk, so it can't be globbed and needs no filter.
 _SECRETS_FILENAME = "secrets.yaml"
-_SENTINEL_FILENAME = "___DASHBOARD_SENTINEL___.yaml"
 
 # Glob patterns for the YAML configs this feature versions.
 _YAML_GLOBS = ("*.yaml", "*.yml")
@@ -183,7 +184,7 @@ class GitRepo:
             names += [
                 path.name
                 for path in sorted(self.config_dir.glob(pattern))
-                if path.name not in (_SECRETS_FILENAME, _SENTINEL_FILENAME)
+                if path.name != _SECRETS_FILENAME
             ]
         return [name for name in names if (self.config_dir / name).exists()]
 

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -234,6 +234,19 @@ class GitRepo:
             )
         return commits
 
+    def latest_content(self, path: Path) -> tuple[str, str] | None:
+        """Return ``(sha, content)`` of the newest commit where *path* existed.
+
+        Used to restore a deleted file without the caller having to
+        know which commit last held it (the deletion commit itself has
+        no content). ``None`` if the path has no recoverable version.
+        """
+        for commit in self.log_file(path):
+            content = self.file_at(path, commit.sha)
+            if content is not None:
+                return commit.sha, content
+        return None
+
     def file_at(self, path: Path, sha: str) -> str | None:
         """Return *path*'s content at commit *sha*, or ``None`` if absent there."""
         if not self.enabled:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -136,21 +136,33 @@ class GitRepo:
         """
         if self._run(["diff", "--cached", "--quiet"], check=False).returncode == 0:
             return
-        self._run(
-            [
-                "-c",
-                f"user.name={_COMMIT_NAME}",
-                "-c",
-                f"user.email={_COMMIT_EMAIL}",
-                "-c",
-                "commit.gpgsign=false",
-                "commit",
-                "--no-verify",
-                "-m",
-                message,
-            ],
-            check=False,
-        )
+        self._run(self._commit_argv(message, ()), check=False)
+
+    @staticmethod
+    def _commit_argv(message: str, pathspec: tuple[str, ...]) -> list[str]:
+        """Build a ``git commit`` argv: our identity, no hooks, no signing.
+
+        Identity is passed per-invocation with ``-c`` so we never write
+        ``user.*`` into the user's config; ``--no-verify`` /
+        ``commit.gpgsign=false`` keep automatic commits from tripping a
+        hook or a signing prompt. A non-empty *pathspec* scopes the
+        commit to exactly those paths.
+        """
+        argv = [
+            "-c",
+            f"user.name={_COMMIT_NAME}",
+            "-c",
+            f"user.email={_COMMIT_EMAIL}",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--no-verify",
+            "-m",
+            message,
+        ]
+        if pathspec:
+            argv += ["--", *pathspec]
+        return argv
 
     # ------------------------------------------------------------------
     # writes
@@ -175,23 +187,7 @@ class GitRepo:
             )
             if staged.returncode == 0:
                 return None  # nothing staged for these paths
-            self._run(
-                [
-                    "-c",
-                    f"user.name={_COMMIT_NAME}",
-                    "-c",
-                    f"user.email={_COMMIT_EMAIL}",
-                    "-c",
-                    "commit.gpgsign=false",
-                    "commit",
-                    "--no-verify",
-                    "-m",
-                    message,
-                    "--",
-                    *spec,
-                ],
-                check=True,
-            )
+            self._run(self._commit_argv(message, tuple(spec)), check=True)
         except subprocess.CalledProcessError as exc:
             _LOGGER.warning("git commit failed for %s: %s", message, exc.stderr or exc)
             return None

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -58,6 +58,14 @@ _MANAGED_EXCLUDES = (
 _EXCLUDE_MARKER = "# >>> ESPHome Device Builder (managed) >>>"
 _EXCLUDE_END = "# <<< ESPHome Device Builder (managed) <<<"
 
+# YAMLs the seed must never capture: the user's secrets, and the
+# dashboard's CORE sentinel (see controllers/config/settings.py).
+_SECRETS_FILENAME = "secrets.yaml"
+_SENTINEL_FILENAME = "___DASHBOARD_SENTINEL___.yaml"
+
+# Glob patterns for the YAML configs this feature versions.
+_YAML_GLOBS = ("*.yaml", "*.yml")
+
 # Written only when *we* create the repo and no ``.gitignore`` exists; a
 # pre-existing one is left untouched (the local exclude is what actually
 # protects the secrets above). ``secrets.yaml`` is ignored here — not in
@@ -135,26 +143,43 @@ class GitRepo:
         return Path(root) if root else None
 
     def _init_repo(self) -> None:
-        """Create a fresh repo in ``config_dir`` and seed the initial snapshot.
+        """Create a fresh repo in ``config_dir`` and seed the existing configs.
 
-        Because the repo is brand new there's no user work-in-progress
-        to protect, so the seed commit stages everything not ignored
-        (the existing configs) — giving each device a first version in
-        history immediately rather than only once it's first edited.
+        Seeds only the top-level YAML configs (plus our ``.gitignore``) —
+        the same unit the dashboard versions — so each device starts with
+        a first version in history immediately. Deliberately **not**
+        ``git add -A``: the config dir may also hold large non-config
+        files (logs, databases, media) that have no business in git
+        history, and git history is forever.
         """
         self._run(["init", str(self.config_dir)], cwd=self.config_dir, check=True)
         self.toplevel = self.config_dir
         self.enabled = True
-        # Local excludes BEFORE the seed ``git add -A`` so our identity
-        # key / machine state / OS noise can never land in the snapshot,
-        # even when the dir already had a (stock or foreign) ``.gitignore``
-        # that doesn't cover them.
         self._ensure_local_excludes()
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
             gitignore.write_text(_DEFAULT_GITIGNORE, encoding="utf-8")
-        self._run(["add", "-A"], check=False)
+        # ``.gitignore`` always exists here (just written or pre-existing),
+        # so the seed is never empty.
+        self._run(["add", "--", *self._seed_paths()], check=False)
         self._commit_index("Initialize version history")
+
+    def _seed_paths(self) -> list[str]:
+        """Top-level YAML configs (+ our ``.gitignore``) to stage on first init.
+
+        Top-level only and YAML-only by design: matches the dashboard's
+        unit of versioning and keeps logs / databases / images out of
+        history. ``secrets.yaml`` is left out — credentials don't belong
+        in a repo that may later be pushed to a remote.
+        """
+        names = [".gitignore"]
+        for pattern in _YAML_GLOBS:
+            names += [
+                path.name
+                for path in sorted(self.config_dir.glob(pattern))
+                if path.name not in (_SECRETS_FILENAME, _SENTINEL_FILENAME)
+            ]
+        return [name for name in names if (self.config_dir / name).exists()]
 
     def _ensure_local_excludes(self) -> None:
         """Append our managed patterns to ``.git/info/exclude`` (idempotent).

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -252,25 +252,20 @@ class GitRepo:
         """Stage and commit exactly *paths*; return the new sha or ``None``.
 
         ``None`` means nothing changed for those paths (or the feature
-        is disabled). The commit is pathspec-scoped, so the user's
-        unrelated staged changes are never folded in. Picks up
+        is disabled). A genuine git error raises ``CalledProcessError``
+        rather than being swallowed, so the controller can tell a no-op
+        from a failure. The commit is pathspec-scoped, so the user's
+        unrelated staged changes are never folded in, and picks up
         creations, edits, and deletions uniformly (``git add -A``).
         """
         if not self.enabled or not paths:
             return None
         spec = [str(p) for p in paths]
-        try:
-            self._run(["add", "-A", "--", *spec], check=True)
-            staged = self._run(
-                ["diff", "--cached", "--quiet", "--", *spec],
-                check=False,
-            )
-            if staged.returncode == 0:
-                return None  # nothing staged for these paths
-            self._run(self._commit_argv(message, tuple(spec)), check=True)
-        except subprocess.CalledProcessError as exc:
-            _LOGGER.warning("git commit failed for %s: %s", message, exc.stderr or exc)
-            return None
+        self._run(["add", "-A", "--", *spec], check=True)
+        staged = self._run(["diff", "--cached", "--quiet", "--", *spec], check=False)
+        if staged.returncode == 0:
+            return None  # nothing staged for these paths
+        self._run(self._commit_argv(message, tuple(spec)), check=True)
         head = self._run(["rev-parse", "HEAD"], check=False)
         return head.stdout.strip() if head.returncode == 0 else None
 

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -316,10 +316,15 @@ class GitRepo:
         # git_bin is a resolved absolute path from shutil.which and the
         # args are a fixed argv (never shell-interpreted), so the only
         # external input is the pathspec — safe.
+        # close_fds=False mirrors helpers.subprocess: the default
+        # close_fds=True makes the child iterate the fd table before
+        # exec, which is pure overhead on memory-pressured systems; our
+        # spawns don't rely on inherited fds being closed at the boundary.
         return subprocess.run(  # noqa: S603
             [self.git_bin, *args],
             cwd=str(cwd or self.toplevel or self.config_dir),
             capture_output=True,
             text=True,
             check=check,
+            close_fds=False,
         )

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -1,0 +1,284 @@
+"""
+Subprocess ``git`` wrapper backing the config-dir version history.
+
+Synchronous on purpose — every method shells out to ``git`` and is
+meant to be driven from an executor by
+:class:`VersionHistoryController`, never from the event loop. The
+wrapper is deliberately conservative about a *pre-existing* repo
+(``/config/esphome`` is commonly already a git work tree, or sits
+inside one such as ``/config``):
+
+- It **adopts** an existing work tree rather than re-initialising,
+  and never rewrites the user's ``.gitignore``.
+- Commits are **pathspec-scoped** (``git commit -- <paths>``) so a
+  partial commit never sweeps the user's unrelated staged edits into
+  our history.
+- It never writes ``user.*`` into the repo/global config — the commit
+  identity is passed per-invocation via ``git -c user.name=...``.
+- ``--no-verify`` + ``commit.gpgsign=false`` keep our automatic commits
+  from tripping the user's hooks or blocking on a signing prompt.
+
+If the ``git`` binary is absent the wrapper stays disabled and every
+method is a no-op, so version history is a soft, optional feature.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+# Identity stamped on every automatic commit. Passed per-invocation
+# with ``git -c`` so we never touch the user's global/repo config.
+_COMMIT_NAME = "ESPHome Device Builder"
+_COMMIT_EMAIL = "device-builder@esphome.io"
+
+# Written only when *we* create the repo; a pre-existing repo keeps the
+# user's own ignore rules untouched. Build artifacts under ``.esphome``
+# and the machine-state sidecars are noise; ``secrets.yaml`` is ignored
+# by default so credentials don't land in local history (or a remote the
+# user later adds) — they can un-ignore it deliberately.
+_DEFAULT_GITIGNORE = """\
+# Managed by ESPHome Device Builder — created because this directory
+# was not already a git repository. Edit freely; it won't be regenerated.
+.esphome/
+.device-builder*.json
+secrets.yaml
+"""
+
+
+@dataclass(slots=True)
+class CommitInfo:
+    """One commit touching a file, as surfaced to the history UI."""
+
+    sha: str
+    short_sha: str
+    author: str
+    timestamp: int
+    message: str
+
+
+@dataclass(slots=True)
+class GitRepo:
+    """A git work tree wrapping the dashboard's config directory."""
+
+    config_dir: Path
+    git_bin: str | None = None
+    toplevel: Path | None = None
+    enabled: bool = field(default=False)
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    def discover_or_init(self) -> None:
+        """Locate an enclosing work tree, or initialise a fresh repo.
+
+        Sets :attr:`enabled` / :attr:`toplevel`. A pre-existing work
+        tree is adopted as-is; otherwise a new repo is created in
+        :attr:`config_dir` with a default ``.gitignore``. Any failure
+        leaves the feature disabled rather than raising.
+        """
+        self.git_bin = shutil.which("git")
+        if self.git_bin is None:
+            _LOGGER.info("git binary not found; version history disabled")
+            return
+        try:
+            toplevel = self._discover_toplevel()
+            if toplevel is not None:
+                self.toplevel = toplevel
+                self.enabled = True
+                _LOGGER.debug("Adopted existing git work tree at %s", toplevel)
+                return
+            self._init_repo()
+        except OSError as exc:
+            _LOGGER.warning("Could not set up version-history git repo: %s", exc)
+
+    def _discover_toplevel(self) -> Path | None:
+        """Return the enclosing work tree's root, or ``None`` if there is none."""
+        result = self._run(
+            ["rev-parse", "--show-toplevel"],
+            cwd=self.config_dir,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        root = result.stdout.strip()
+        return Path(root) if root else None
+
+    def _init_repo(self) -> None:
+        """Create a fresh repo in ``config_dir`` and commit a ``.gitignore``."""
+        self._run(["init", str(self.config_dir)], cwd=self.config_dir, check=True)
+        self.toplevel = self.config_dir
+        self.enabled = True
+        gitignore = self.config_dir / ".gitignore"
+        if not gitignore.exists():
+            gitignore.write_text(_DEFAULT_GITIGNORE, encoding="utf-8")
+            self.commit_paths([gitignore], "Initialize version history")
+
+    # ------------------------------------------------------------------
+    # writes
+    # ------------------------------------------------------------------
+
+    def commit_paths(self, paths: list[Path], message: str) -> str | None:
+        """Stage and commit exactly *paths*; return the new sha or ``None``.
+
+        ``None`` means nothing changed for those paths (or the feature
+        is disabled). The commit is pathspec-scoped, so the user's
+        unrelated staged changes are never folded in. Picks up
+        creations, edits, and deletions uniformly (``git add -A``).
+        """
+        if not self.enabled or not paths:
+            return None
+        spec = [str(p) for p in paths]
+        try:
+            self._run(["add", "-A", "--", *spec], check=True)
+            staged = self._run(
+                ["diff", "--cached", "--quiet", "--", *spec],
+                check=False,
+            )
+            if staged.returncode == 0:
+                return None  # nothing staged for these paths
+            self._run(
+                [
+                    "-c",
+                    f"user.name={_COMMIT_NAME}",
+                    "-c",
+                    f"user.email={_COMMIT_EMAIL}",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--no-verify",
+                    "-m",
+                    message,
+                    "--",
+                    *spec,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            _LOGGER.warning("git commit failed for %s: %s", message, exc.stderr or exc)
+            return None
+        head = self._run(["rev-parse", "HEAD"], check=False)
+        return head.stdout.strip() if head.returncode == 0 else None
+
+    # ------------------------------------------------------------------
+    # reads
+    # ------------------------------------------------------------------
+
+    def log_file(self, path: Path, *, limit: int = 100) -> list[CommitInfo]:
+        """Return the commit history touching *path*, newest first."""
+        if not self.enabled:
+            return []
+        # ``%x1f`` (unit separator) between fields, ``%x1e`` (record
+        # separator) between commits — neither appears in commit
+        # metadata, so the parse can't be fooled by a message that
+        # contains a newline or tab.
+        fmt = "%H%x1f%h%x1f%an%x1f%at%x1f%s"
+        result = self._run(
+            ["log", f"--max-count={limit}", f"--format={fmt}%x1e", "--", str(path)],
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+        commits: list[CommitInfo] = []
+        for raw in result.stdout.split("\x1e"):
+            record = raw.strip("\n")
+            if not record:
+                continue
+            sha, short, author, ts, subject = record.split("\x1f", 4)
+            commits.append(
+                CommitInfo(
+                    sha=sha,
+                    short_sha=short,
+                    author=author,
+                    timestamp=int(ts),
+                    message=subject,
+                )
+            )
+        return commits
+
+    def file_at(self, path: Path, sha: str) -> str | None:
+        """Return *path*'s content at commit *sha*, or ``None`` if absent there."""
+        if not self.enabled:
+            return None
+        rel = self._rel_to_toplevel(path)
+        result = self._run(["show", f"{sha}:{rel}"], check=False)
+        if result.returncode != 0:
+            return None
+        return result.stdout
+
+    def diff_file(self, path: Path, sha: str) -> str:
+        """Return a unified diff of *path* between *sha* and the working tree."""
+        if not self.enabled:
+            return ""
+        result = self._run(["diff", sha, "--", str(path)], check=False)
+        return result.stdout if result.returncode == 0 else ""
+
+    def deleted_files(self, *, suffixes: tuple[str, ...] = (".yaml", ".yml")) -> list[str]:
+        """Return repo-relative paths once committed but absent from the work tree.
+
+        Drives the "restore a deleted device" view: a file that has
+        history but no working-tree copy. Restricted to top-level
+        configs with *suffixes* so archived copies and nested includes
+        don't show up as deletable devices.
+        """
+        if not self.enabled:
+            return []
+        # Every path that ever existed in history.
+        ever = self._run(
+            ["log", "--pretty=format:", "--name-only", "--diff-filter=A"],
+            check=False,
+        )
+        if ever.returncode != 0:
+            return []
+        assert self.toplevel is not None
+        seen: set[str] = set()
+        deleted: list[str] = []
+        for raw in ever.stdout.splitlines():
+            rel = raw.strip()
+            if not rel or rel in seen:
+                continue
+            seen.add(rel)
+            # Top-level configs only — no nested path segments.
+            if "/" in rel or not rel.endswith(suffixes):
+                continue
+            if not (self.toplevel / rel).exists():
+                deleted.append(rel)
+        return deleted
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _rel_to_toplevel(self, path: Path) -> str:
+        """Return *path* relative to the work-tree root (git's pathspec base)."""
+        assert self.toplevel is not None
+        try:
+            return str(path.resolve().relative_to(self.toplevel.resolve()))
+        except ValueError:
+            return path.name
+
+    def _run(
+        self,
+        args: list[str],
+        *,
+        check: bool,
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run ``git`` with *args* in the work tree; capture text output."""
+        assert self.git_bin is not None
+        # git_bin is a resolved absolute path from shutil.which and the
+        # args are a fixed argv (never shell-interpreted), so the only
+        # external input is the pathspec — safe.
+        return subprocess.run(  # noqa: S603
+            [self.git_bin, *args],
+            cwd=str(cwd or self.toplevel or self.config_dir),
+            capture_output=True,
+            text=True,
+            check=check,
+        )

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -39,6 +39,7 @@ from .controllers.firmware.download import http_download as firmware_http_downlo
 from .controllers.labels import LabelsController
 from .controllers.onboarding import OnboardingController
 from .controllers.remote_build import OffloaderController, ReceiverController
+from .controllers.version_history import VersionHistoryController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.async_ import create_eager_task
 from .helpers.auth import auth_middleware
@@ -227,6 +228,7 @@ class DeviceBuilder:
         self.onboarding: OnboardingController | None = None
         self.remote_build_offloader: OffloaderController | None = None
         self.remote_build_receiver: ReceiverController | None = None
+        self.version_history: VersionHistoryController | None = None
 
         # mDNS advertise — populated in start() once we know zeroconf
         # is up. Optional: a zeroconf-bind failure leaves this None
@@ -311,9 +313,11 @@ class DeviceBuilder:
         self.onboarding = OnboardingController(self)
         self.remote_build_offloader = OffloaderController(self)
         self.remote_build_receiver = ReceiverController(self)
+        self.version_history = VersionHistoryController(self)
         await self.devices.start()
         await self.firmware.start()
         await self.editor.start()
+        await self.version_history.start()
 
         # Advertise this dashboard on mDNS so peer dashboards (and
         # the future ESPHome Desktop welcome screen) can discover it.
@@ -390,6 +394,7 @@ class DeviceBuilder:
             self.onboarding,
             self.remote_build_offloader,
             self.remote_build_receiver,
+            self.version_history,
         ):
             self.command_handlers.update(collect_api_commands(controller))
 
@@ -444,6 +449,8 @@ class DeviceBuilder:
             await self.devices.stop()
         if self.editor is not None:
             await self.editor.stop()
+        if self.version_history is not None:
+            await self.version_history.stop()
         # Cleanly drain the pool once nothing else can hand it work.
         # Two paths because the pool is created eagerly in ``__init__``
         # — calling ``stop()`` on an instance that never ran

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -451,6 +451,7 @@ def make_controller() -> MakeControllerFactory:
         controller = DevicesController.__new__(DevicesController)
         controller._db = MagicMock()
         controller.state = DevicesState()
+        controller._yaml_write_locks = {}
         controller._db.settings.config_dir = config_dir
         controller._db.settings.rel_path = lambda configuration: config_dir / configuration
         # Version history off by default — a MagicMock's

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -453,6 +453,11 @@ def make_controller() -> MakeControllerFactory:
         controller.state = DevicesState()
         controller._db.settings.config_dir = config_dir
         controller._db.settings.rel_path = lambda configuration: config_dir / configuration
+        # Version history off by default — a MagicMock's
+        # ``record_configuration`` isn't awaitable, and the YAML-write
+        # tests don't care about commits. The version_history suite
+        # exercises the commit path directly.
+        controller._db.version_history = None
         # ``data_dir`` collapsed onto ``config_dir`` for tmp_path
         # cleanup; real stores so round-trips hit disk.
         controller._shutdown_callbacks = []

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -63,7 +63,12 @@ async def test_concurrent_same_file_saves_each_get_committed(
 
     async def _record(configuration: str, _message: str) -> None:
         # Mirror commit_paths: capture whatever is on disk at commit time.
-        committed.append((tmp_path / configuration).read_text())
+        # Read off-loop — this runs from inside the (package-frame) commit
+        # path, so a blocking read here trips the blockbuster guard.
+        content = await asyncio.to_thread(
+            lambda: (tmp_path / configuration).read_text(encoding="utf-8")
+        )
+        committed.append(content)
 
     controller._db.version_history = SimpleNamespace(record_configuration=_record)
 

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -31,3 +31,36 @@ async def test_disabled_version_history_is_a_noop(
     await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
 
     assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"
+
+
+def _attach_recorder(controller: object) -> AsyncMock:
+    """Attach a recordable version_history stub; return its record mock."""
+    record = AsyncMock(return_value="sha")
+    controller._db.version_history = type("VH", (), {"record_configuration": record})()  # type: ignore[attr-defined]
+    return record
+
+
+async def test_delete_records_removal(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """``_delete_single`` records a "Delete <file>" commit so it stays restorable."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: k\n", encoding="utf-8")
+    record = _attach_recorder(controller)
+
+    await controller._delete_single("kitchen.yaml")
+
+    record.assert_awaited_once_with("kitchen.yaml", "Delete kitchen.yaml")
+
+
+async def test_archive_records_removal(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """``_archive_single`` records an "Archive <file>" commit."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: k\n", encoding="utf-8")
+    record = _attach_recorder(controller)
+
+    await controller._archive_single("kitchen.yaml")
+
+    record.assert_awaited_once_with("kitchen.yaml", "Archive kitchen.yaml")

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -64,3 +64,17 @@ async def test_archive_records_removal(
     await controller._archive_single("kitchen.yaml")
 
     record.assert_awaited_once_with("kitchen.yaml", "Archive kitchen.yaml")
+
+
+async def test_apply_restored_yaml_writes_and_records_restore(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """``apply_restored_yaml`` writes the content back and records a "Restore" commit."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("old\n", encoding="utf-8")
+    record = _attach_recorder(controller)
+
+    await controller.apply_restored_yaml("kitchen.yaml", "new\n", restored_from="abc1234")
+
+    assert (tmp_path / "kitchen.yaml").read_text() == "new\n"
+    record.assert_awaited_once_with("kitchen.yaml", "Restore kitchen.yaml to abc1234")

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -33,6 +33,20 @@ async def test_disabled_version_history_is_a_noop(
     assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"
 
 
+async def test_commit_failure_does_not_break_the_save(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """A version-history commit error is swallowed — the save still lands on disk."""
+    controller = make_controller(tmp_path)
+    record = AsyncMock(side_effect=RuntimeError("git exploded"))
+    controller._db.version_history = type("VH", (), {"record_configuration": record})()
+
+    await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
+
+    record.assert_awaited_once()
+    assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"
+
+
 def _attach_recorder(controller: object) -> AsyncMock:
     """Attach a recordable version_history stub; return its record mock."""
     record = AsyncMock(return_value="sha")

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -15,11 +15,8 @@ from .conftest import MakeControllerFactory
 
 
 def _vh_stub(record: Any) -> SimpleNamespace:
-    """Build a version_history stand-in: the given record + a no-op discard_pending."""
-    return SimpleNamespace(
-        record_configuration=record,
-        discard_pending=lambda _configuration: None,
-    )
+    """Build a version_history stand-in: the given record + a tracking discard_pending."""
+    return SimpleNamespace(record_configuration=record, discard_pending=MagicMock())
 
 
 async def test_update_config_commits_edit_message(
@@ -33,6 +30,8 @@ async def test_update_config_commits_edit_message(
     await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
 
     record.assert_awaited_once_with("kitchen.yaml", "Edit kitchen.yaml")
+    # On success the now-redundant catch-all entry is dropped.
+    controller._db.version_history.discard_pending.assert_called_once_with("kitchen.yaml")
 
 
 async def test_disabled_version_history_is_a_noop(
@@ -59,6 +58,9 @@ async def test_commit_failure_does_not_break_the_save(
 
     record.assert_awaited_once()
     assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"
+    # On failure the queued catch-all entry is preserved so the debounced
+    # flush still records this save — not discarded.
+    controller._db.version_history.discard_pending.assert_not_called()
 
 
 async def test_programming_bug_in_commit_propagates(

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -1,0 +1,33 @@
+"""Mutation sites record a rich-message version-history commit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from .conftest import MakeControllerFactory
+
+
+async def test_update_config_commits_edit_message(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """``devices/update_config`` records an "Edit <file>" commit."""
+    controller = make_controller(tmp_path)
+    record = AsyncMock(return_value="sha")
+    controller._db.version_history = type("VH", (), {"record_configuration": record})()
+
+    await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
+
+    record.assert_awaited_once_with("kitchen.yaml", "Edit kitchen.yaml")
+
+
+async def test_disabled_version_history_is_a_noop(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """With version_history None the write still succeeds (history is optional)."""
+    controller = make_controller(tmp_path)
+    assert controller._db.version_history is None
+
+    await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
+
+    assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from .conftest import MakeControllerFactory
@@ -45,6 +47,33 @@ async def test_commit_failure_does_not_break_the_save(
 
     record.assert_awaited_once()
     assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"
+
+
+async def test_concurrent_same_file_saves_each_get_committed(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """Write+commit is serialized per file, so no concurrent save loses its version.
+
+    The commit records on-disk content; without per-file serialization a
+    second writer could slip between the first's write and commit and win
+    the history slot, dropping a version.
+    """
+    controller = make_controller(tmp_path)
+    committed: list[str] = []
+
+    async def _record(configuration: str, _message: str) -> None:
+        # Mirror commit_paths: capture whatever is on disk at commit time.
+        committed.append((tmp_path / configuration).read_text())
+
+    controller._db.version_history = SimpleNamespace(record_configuration=_record)
+
+    await asyncio.gather(
+        controller.update_config(configuration="kitchen.yaml", content="A\n"),
+        controller.update_config(configuration="kitchen.yaml", content="B\n"),
+    )
+
+    # Each commit captured the content its own save wrote — both survive.
+    assert sorted(committed) == ["A\n", "B\n"]
 
 
 def _attach_recorder(controller: object) -> AsyncMock:

--- a/tests/controllers/devices/test_version_history_hooks.py
+++ b/tests/controllers/devices/test_version_history_hooks.py
@@ -3,11 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from .conftest import MakeControllerFactory
+
+
+def _vh_stub(record: Any) -> SimpleNamespace:
+    """Build a version_history stand-in: the given record + a no-op discard_pending."""
+    return SimpleNamespace(
+        record_configuration=record,
+        discard_pending=lambda _configuration: None,
+    )
 
 
 async def test_update_config_commits_edit_message(
@@ -16,7 +28,7 @@ async def test_update_config_commits_edit_message(
     """``devices/update_config`` records an "Edit <file>" commit."""
     controller = make_controller(tmp_path)
     record = AsyncMock(return_value="sha")
-    controller._db.version_history = type("VH", (), {"record_configuration": record})()
+    controller._db.version_history = _vh_stub(record)
 
     await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
 
@@ -38,15 +50,29 @@ async def test_disabled_version_history_is_a_noop(
 async def test_commit_failure_does_not_break_the_save(
     make_controller: MakeControllerFactory, tmp_path: Path
 ) -> None:
-    """A version-history commit error is swallowed — the save still lands on disk."""
+    """A genuine git error is swallowed — the save still lands on disk."""
     controller = make_controller(tmp_path)
-    record = AsyncMock(side_effect=RuntimeError("git exploded"))
-    controller._db.version_history = type("VH", (), {"record_configuration": record})()
+    record = AsyncMock(side_effect=subprocess.CalledProcessError(1, "git commit"))
+    controller._db.version_history = _vh_stub(record)
 
     await controller.update_config(configuration="kitchen.yaml", content="esphome:\n  name: k\n")
 
     record.assert_awaited_once()
     assert (tmp_path / "kitchen.yaml").read_text() == "esphome:\n  name: k\n"
+
+
+async def test_programming_bug_in_commit_propagates(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    """A non-git exception isn't mislabelled as a recoverable hiccup — it propagates."""
+    controller = make_controller(tmp_path)
+    record = AsyncMock(side_effect=AttributeError("real bug"))
+    controller._db.version_history = _vh_stub(record)
+
+    with pytest.raises(AttributeError):
+        await controller.update_config(
+            configuration="kitchen.yaml", content="esphome:\n  name: k\n"
+        )
 
 
 async def test_concurrent_same_file_saves_each_get_committed(
@@ -70,7 +96,7 @@ async def test_concurrent_same_file_saves_each_get_committed(
         )
         committed.append(content)
 
-    controller._db.version_history = SimpleNamespace(record_configuration=_record)
+    controller._db.version_history = _vh_stub(_record)
 
     await asyncio.gather(
         controller.update_config(configuration="kitchen.yaml", content="A\n"),
@@ -84,7 +110,7 @@ async def test_concurrent_same_file_saves_each_get_committed(
 def _attach_recorder(controller: object) -> AsyncMock:
     """Attach a recordable version_history stub; return its record mock."""
     record = AsyncMock(return_value="sha")
-    controller._db.version_history = type("VH", (), {"record_configuration": record})()  # type: ignore[attr-defined]
+    controller._db.version_history = _vh_stub(record)  # type: ignore[attr-defined]
     return record
 
 

--- a/tests/controllers/version_history/__init__.py
+++ b/tests/controllers/version_history/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ``controllers/version_history/`` — git-backed config history."""

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -429,6 +429,45 @@ async def test_catch_all_flush_survives_a_failing_config(
     assert await controller.list_versions(configuration="good.yaml")
 
 
+async def test_degraded_flips_after_repeated_failures_and_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated git failures flag the feature degraded; a success clears it."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+
+    real_run = subprocess.run
+    fail = True
+
+    def _maybe_fail(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if fail and "commit" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _maybe_fail
+    )
+
+    # A one-off failure is not yet "degraded".
+    yaml.write_text("v1\n", encoding="utf-8")
+    with suppress(subprocess.CalledProcessError):
+        await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    assert not controller.degraded
+
+    # Cross the threshold of consecutive failures.
+    for _ in range(2):
+        with suppress(subprocess.CalledProcessError):
+            await controller.record_configuration("kitchen.yaml", "Edit kitchen.yaml")
+    assert controller.degraded
+
+    # A subsequent successful commit clears the degraded flag.
+    fail = False
+    yaml.write_text("v2\n", encoding="utf-8")
+    await controller.record_configuration("kitchen.yaml", "Edit kitchen.yaml")
+    assert not controller.degraded
+
+
 async def test_catch_all_programming_bug_propagates_to_done_callback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
@@ -242,6 +243,103 @@ async def test_get_version_rejects_bad_sha(tmp_path: Path) -> None:
     with pytest.raises(CommandError) as exc:
         await controller.get_version(configuration="kitchen.yaml", sha="; rm -rf /")
     assert exc.value.code == ErrorCode.INVALID_ARGS
+
+
+async def test_stop_detaches_listeners_and_cancels_flush(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """stop() unsubscribes the scanner listeners and cancels a pending flush."""
+    # Long debounce so the flush task is still pending when we stop.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        30.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    flush_task = controller._flush_task
+    assert flush_task is not None
+
+    await controller.stop()
+
+    assert controller._unsubs == []
+    # cancel() only requests cancellation; awaiting drives it to done.
+    with pytest.raises(asyncio.CancelledError):
+        await flush_task
+    assert flush_task.cancelled()
+    # A post-stop event must not reach the (now detached) listener.
+    controller._pending.clear()
+    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    assert not controller._pending
+
+
+async def test_restore_unknown_sha_raises_not_found(tmp_path: Path) -> None:
+    """Restoring a config to a commit that doesn't contain it raises NOT_FOUND."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    sha = await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    assert sha
+
+    with pytest.raises(CommandError) as exc:
+        await controller.restore(configuration="other.yaml", sha=sha)
+    assert exc.value.code == ErrorCode.NOT_FOUND
+    controller._db.devices.apply_restored_yaml.assert_not_awaited()
+
+
+async def test_restore_without_history_raises_not_found(tmp_path: Path) -> None:
+    """Restoring a config with no recorded history raises NOT_FOUND."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+
+    with pytest.raises(CommandError) as exc:
+        await controller.restore(configuration="ghost.yaml")
+    assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+async def test_get_version_unknown_sha_raises_not_found(tmp_path: Path) -> None:
+    """get_version of a valid-but-nonexistent commit raises NOT_FOUND."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+    await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+
+    with pytest.raises(CommandError) as exc:
+        await controller.get_version(configuration="kitchen.yaml", sha="0" * 40)
+    assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+async def test_catch_all_flush_survives_a_failing_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One config that fails to commit doesn't strand the rest of the flush batch."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "good.yaml").write_text("ok\n", encoding="utf-8")
+
+    original = controller.record_configuration
+
+    async def _maybe_fail(configuration: str, message: str) -> str | None:
+        if configuration == "bad.yaml":
+            raise RuntimeError("boom")
+        return await original(configuration, message)
+
+    monkeypatch.setattr(controller, "record_configuration", _maybe_fail)
+    for name in ("bad.yaml", "good.yaml"):
+        device = Device(name=name, friendly_name=name, configuration=name)
+        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    assert controller._flush_task is not None
+    await controller._flush_task
+
+    # The good config still committed despite bad.yaml raising.
+    assert await controller.list_versions(configuration="good.yaml")
 
 
 async def test_commit_swallows_unexpected_errors(

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
@@ -249,11 +248,12 @@ async def test_get_version_rejects_bad_sha(tmp_path: Path) -> None:
     assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
-async def test_stop_detaches_listeners_and_cancels_flush(
+async def test_stop_detaches_listeners_and_flushes_pending(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """stop() unsubscribes the scanner listeners and cancels a pending flush."""
-    # Long debounce so the flush task is still pending when we stop.
+    """stop() detaches listeners and flushes an edit queued in the debounce window."""
+    # Long debounce so the flush timer is still pending when we stop —
+    # the edit must be committed by stop()'s drain, not dropped.
     monkeypatch.setattr(
         "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
         30.0,
@@ -263,20 +263,33 @@ async def test_stop_detaches_listeners_and_cancels_flush(
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
     controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
-    flush_task = controller._flush_task
-    assert flush_task is not None
+    assert controller._flush_task is not None
 
     await controller.stop()
 
     assert controller._unsubs == []
-    # cancel() only requests cancellation; awaiting drives it to done.
-    with pytest.raises(asyncio.CancelledError):
-        await flush_task
-    assert flush_task.cancelled()
+    # The queued edit was flushed on shutdown rather than lost.
+    assert await controller.list_versions(configuration="kitchen.yaml")
     # A post-stop event must not reach the (now detached) listener.
-    controller._pending.clear()
     controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
     assert not controller._pending
+
+
+async def test_read_commands_reject_path_traversal(tmp_path: Path) -> None:
+    """A ``configuration`` escaping the config dir is refused before reaching git."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    traversal = "../secrets.yaml"
+
+    for call in (
+        controller.list_versions(configuration=traversal),
+        controller.get_version(configuration=traversal, sha="abc1234"),
+        controller.get_diff(configuration=traversal, sha="abc1234"),
+        controller.restore(configuration=traversal),
+    ):
+        with pytest.raises(CommandError) as exc:
+            await call
+        assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
 async def test_restore_unknown_sha_raises_not_found(tmp_path: Path) -> None:

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -47,8 +47,8 @@ async def test_start_enables_and_commits(tmp_path: Path) -> None:
     sha = await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
 
     assert sha
-    versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
-    assert versions[0].message == "Create kitchen.yaml"
+    versions = await controller.list_versions(configuration="kitchen.yaml")
+    assert versions[0]["message"] == "Create kitchen.yaml"
 
 
 async def test_disabled_when_no_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,8 +80,8 @@ async def test_external_edit_committed_via_scanner_catch_all(
     assert controller._flush_task is not None
     await controller._flush_task
 
-    versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
-    assert [c.message for c in versions] == ["Edit kitchen.yaml"]
+    versions = await controller.list_versions(configuration="kitchen.yaml")
+    assert [v["message"] for v in versions] == ["Edit kitchen.yaml"]
 
 
 async def test_dashboard_commit_makes_catch_all_a_noop(
@@ -104,9 +104,9 @@ async def test_dashboard_commit_makes_catch_all_a_noop(
     assert controller._flush_task is not None
     await controller._flush_task
 
-    versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
+    versions = await controller.list_versions(configuration="kitchen.yaml")
     # Only the dashboard commit — the catch-all found nothing to commit.
-    assert [c.message for c in versions] == ["Edit kitchen.yaml via editor"]
+    assert [v["message"] for v in versions] == ["Edit kitchen.yaml via editor"]
 
 
 async def test_list_and_get_version_round_trip(tmp_path: Path) -> None:

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -402,7 +402,7 @@ async def test_get_version_unknown_sha_raises_not_found(tmp_path: Path) -> None:
 async def test_catch_all_flush_survives_a_failing_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """One config that fails to commit doesn't strand the rest of the flush batch."""
+    """A git failure on one config doesn't strand the rest of the flush batch."""
     monkeypatch.setattr(
         "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
         0.0,
@@ -415,7 +415,7 @@ async def test_catch_all_flush_survives_a_failing_config(
 
     async def _maybe_fail(configuration: str, message: str) -> str | None:
         if configuration == "bad.yaml":
-            raise RuntimeError("boom")
+            raise subprocess.CalledProcessError(1, "git commit")
         return await original(configuration, message)
 
     monkeypatch.setattr(controller, "record_configuration", _maybe_fail)
@@ -425,8 +425,36 @@ async def test_catch_all_flush_survives_a_failing_config(
     assert controller._flush_task is not None
     await controller._flush_task
 
-    # The good config still committed despite bad.yaml raising.
+    # The good config still committed despite bad.yaml's git failure.
     assert await controller.list_versions(configuration="good.yaml")
+
+
+async def test_catch_all_programming_bug_propagates_to_done_callback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-git bug in the catch-all isn't masked — it reaches the done-callback."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+
+    async def _bug(_configuration: str, _message: str) -> str | None:
+        raise AttributeError("real bug")
+
+    monkeypatch.setattr(controller, "record_configuration", _bug)
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    with caplog.at_level(logging.WARNING):
+        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        task = controller._flush_task
+        assert task is not None
+        with suppress(AttributeError):
+            await task
+        await asyncio.sleep(0)  # let the done-callback run
+
+    # Surfaced as a task failure, not swallowed as a routine "catch-all failed".
+    assert any("flush task failed" in rec.message for rec in caplog.records)
 
 
 async def test_commit_propagates_git_failure(

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
+import subprocess
 from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
@@ -416,21 +417,52 @@ async def test_catch_all_flush_survives_a_failing_config(
     assert await controller.list_versions(configuration="good.yaml")
 
 
-async def test_commit_swallows_unexpected_errors(
+async def test_commit_propagates_git_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A blow-up inside the git layer never propagates to the caller."""
+    """commit() raises on a real git error so callers can tell it from a no-op."""
     controller = _make_controller(tmp_path)
     await controller.start()
 
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("git exploded")
 
-    # An unexpected (non-CalledProcessError) blow-up in the git layer.
     monkeypatch.setattr(
         "esphome_device_builder.controllers.version_history.git_repo.subprocess.run",
         _boom,
     )
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
-    # Must return None, not raise — history can't break a save.
-    assert await controller.commit([tmp_path / "kitchen.yaml"], "msg") is None
+    with pytest.raises(RuntimeError):
+        await controller.commit([tmp_path / "kitchen.yaml"], "msg")
+
+
+async def test_catch_all_warns_on_real_commit_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A genuine git failure in the catch-all now reaches the WARNING (not dead code)."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+
+    real_run = subprocess.run
+
+    def _fail_commit(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "commit" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run",
+        _fail_commit,
+    )
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    with caplog.at_level(logging.WARNING):
+        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        assert controller._flush_task is not None
+        await controller._flush_task
+
+    assert any("catch-all failed for kitchen.yaml" in rec.message for rec in caplog.records)

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -109,6 +109,47 @@ async def test_dashboard_commit_makes_catch_all_a_noop(
     assert [v["message"] for v in versions] == ["Edit kitchen.yaml via editor"]
 
 
+async def test_flush_picks_up_edit_arriving_during_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An external edit that lands while the flush is committing isn't stranded.
+
+    Without the drain loop, a change queued during a per-config commit
+    would wait for the next scanner event (potentially forever).
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "a.yaml").write_text("a\n", encoding="utf-8")
+    (tmp_path / "b.yaml").write_text("b\n", encoding="utf-8")
+
+    original = controller.record_configuration
+    injected = False
+
+    async def _wrapper(configuration: str, message: str) -> str | None:
+        nonlocal injected
+        result = await original(configuration, message)
+        if configuration == "a.yaml" and not injected:
+            injected = True
+            # Simulate b.yaml being edited externally mid-flush.
+            device = Device(name="b", friendly_name="b", configuration="b.yaml")
+            controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        return result
+
+    monkeypatch.setattr(controller, "record_configuration", _wrapper)
+    device = Device(name="a", friendly_name="a", configuration="a.yaml")
+    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    assert controller._flush_task is not None
+    await controller._flush_task
+
+    # Both got committed by the one flush task — b on the second drain pass.
+    assert await controller.list_versions(configuration="a.yaml")
+    assert await controller.list_versions(configuration="b.yaml")
+
+
 async def test_list_and_get_version_round_trip(tmp_path: Path) -> None:
     """list_versions surfaces commits; get_version returns content at a sha."""
     controller = _make_controller(tmp_path)

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -51,6 +51,10 @@ async def test_start_enables_and_commits(tmp_path: Path) -> None:
     versions = await controller.list_versions(configuration="kitchen.yaml")
     assert versions[0]["message"] == "Create kitchen.yaml"
 
+    # stop() with no debounce flush pending is a clean no-op.
+    await controller.stop()
+    assert controller._flush_task is None
+
 
 async def test_disabled_when_no_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """No git binary → controller disabled, commit is a quiet no-op."""

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -311,6 +311,18 @@ async def test_restore_unknown_sha_raises_not_found(tmp_path: Path) -> None:
     controller._db.devices.apply_restored_yaml.assert_not_awaited()
 
 
+async def test_discard_pending_drops_a_queued_catch_all_entry(tmp_path: Path) -> None:
+    """A specific commit supersedes a queued generic external-edit entry."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    controller._pending["kitchen.yaml"] = "Edit kitchen.yaml"
+
+    controller.discard_pending("kitchen.yaml")
+
+    assert "kitchen.yaml" not in controller._pending
+    controller.discard_pending("kitchen.yaml")  # idempotent / unknown key is fine
+
+
 async def test_restore_commits_pending_external_edit_first(tmp_path: Path) -> None:
     """A restore captures a queued external edit before overwriting it.
 

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -9,15 +9,18 @@ from types import SimpleNamespace
 import pytest
 
 from esphome_device_builder.controllers.version_history import VersionHistoryController
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models import Device, DeviceEventData, EventType
 
 
 def _make_controller(config_dir: Path) -> VersionHistoryController:
     """Build a controller against a stub DeviceBuilder rooted at *config_dir*."""
     db = SimpleNamespace(
+        bus=EventBus(),
         settings=SimpleNamespace(
             config_dir=config_dir,
             rel_path=lambda configuration: config_dir / configuration,
-        )
+        ),
     )
     return VersionHistoryController(db)  # type: ignore[arg-type]
 
@@ -45,6 +48,53 @@ async def test_disabled_when_no_git(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert not controller.enabled
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
     assert await controller.record_configuration("kitchen.yaml", "msg") is None
+
+
+async def test_external_edit_committed_via_scanner_catch_all(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scanner DEVICE_UPDATED commits the externally-edited YAML (debounced)."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    # Let the debounced flush task run.
+    assert controller._flush_task is not None
+    await controller._flush_task
+
+    versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
+    assert [c.message for c in versions] == ["Edit kitchen.yaml"]
+
+
+async def test_dashboard_commit_makes_catch_all_a_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dashboard rich-message commit means the later catch-all adds nothing."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+
+    # Dashboard commits immediately with its own message.
+    await controller.record_configuration("kitchen.yaml", "Edit kitchen.yaml via editor")
+    # Scanner then fires for the same on-disk change.
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    assert controller._flush_task is not None
+    await controller._flush_task
+
+    versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
+    # Only the dashboard commit — the catch-all found nothing to commit.
+    assert [c.message for c in versions] == ["Edit kitchen.yaml via editor"]
 
 
 async def test_commit_swallows_unexpected_errors(

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import shutil
+from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -305,6 +308,60 @@ async def test_restore_unknown_sha_raises_not_found(tmp_path: Path) -> None:
         await controller.restore(configuration="other.yaml", sha=sha)
     assert exc.value.code == ErrorCode.NOT_FOUND
     controller._db.devices.apply_restored_yaml.assert_not_awaited()
+
+
+async def test_restore_commits_pending_external_edit_first(tmp_path: Path) -> None:
+    """A restore captures a queued external edit before overwriting it.
+
+    Otherwise restoring over an edit that's still in the debounce window
+    would drop that version from history entirely.
+    """
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    create_sha = await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    assert create_sha
+    # External edit detected by the scanner but not yet flushed.
+    yaml.write_text("v2-external\n", encoding="utf-8")
+    controller._pending["kitchen.yaml"] = "Edit kitchen.yaml"
+
+    result = await controller.restore(configuration="kitchen.yaml", sha=create_sha)
+
+    assert result["content"] == "v1\n"
+    # The just-overwritten external edit is now in history (committed
+    # before the restore wrote the old content back).
+    versions = await controller.list_versions(configuration="kitchen.yaml")
+    assert [v["message"] for v in versions] == ["Edit kitchen.yaml", "Create kitchen.yaml"]
+    captured = await controller.get_version(configuration="kitchen.yaml", sha=versions[0]["sha"])
+    assert captured["content"] == "v2-external\n"
+
+
+async def test_flush_task_failure_is_surfaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An error escaping the per-config guard is logged via the done-callback."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    controller = _make_controller(tmp_path)
+    await controller.start()
+
+    async def _boom() -> None:
+        raise RuntimeError("drain bug")
+
+    monkeypatch.setattr(controller, "_flush_pending", _boom)
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    with caplog.at_level(logging.WARNING):
+        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        task = controller._flush_task
+        assert task is not None
+        with suppress(RuntimeError):
+            await task
+        await asyncio.sleep(0)  # let the done-callback run
+
+    assert any("flush task failed" in rec.message for rec in caplog.records)
 
 
 async def test_restore_without_history_raises_not_found(tmp_path: Path) -> None:

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -1,0 +1,67 @@
+"""Tests for :class:`VersionHistoryController` (async wrapper over GitRepo)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from esphome_device_builder.controllers.version_history import VersionHistoryController
+
+
+def _make_controller(config_dir: Path) -> VersionHistoryController:
+    """Build a controller against a stub DeviceBuilder rooted at *config_dir*."""
+    db = SimpleNamespace(
+        settings=SimpleNamespace(
+            config_dir=config_dir,
+            rel_path=lambda configuration: config_dir / configuration,
+        )
+    )
+    return VersionHistoryController(db)  # type: ignore[arg-type]
+
+
+async def test_start_enables_and_commits(tmp_path: Path) -> None:
+    """After start the controller commits a config by its dashboard name."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    assert controller.enabled
+
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+    sha = await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+
+    assert sha
+    versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
+    assert versions[0].message == "Create kitchen.yaml"
+
+
+async def test_disabled_when_no_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No git binary → controller disabled, commit is a quiet no-op."""
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    controller = _make_controller(tmp_path)
+    await controller.start()
+
+    assert not controller.enabled
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+    assert await controller.record_configuration("kitchen.yaml", "msg") is None
+
+
+async def test_commit_swallows_unexpected_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A blow-up inside the git layer never propagates to the caller."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("git exploded")
+
+    # An unexpected (non-CalledProcessError) blow-up in the git layer.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run",
+        _boom,
+    )
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+    # Must return None, not raise — history can't break a save.
+    assert await controller.commit([tmp_path / "kitchen.yaml"], "msg") is None

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -5,21 +5,33 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from esphome_device_builder.controllers.version_history import VersionHistoryController
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.models import Device, DeviceEventData, EventType
+from esphome_device_builder.models import Device, DeviceEventData, ErrorCode, EventType
+
+
+def _rel_path(config_dir: Path):
+    def _resolve(configuration: str) -> Path:
+        if "/" in configuration or ".." in configuration:
+            raise CommandError(ErrorCode.INVALID_ARGS, "bad configuration")
+        return config_dir / configuration
+
+    return _resolve
 
 
 def _make_controller(config_dir: Path) -> VersionHistoryController:
     """Build a controller against a stub DeviceBuilder rooted at *config_dir*."""
     db = SimpleNamespace(
         bus=EventBus(),
+        devices=SimpleNamespace(apply_restored_yaml=AsyncMock()),
         settings=SimpleNamespace(
             config_dir=config_dir,
-            rel_path=lambda configuration: config_dir / configuration,
+            rel_path=_rel_path(config_dir),
         ),
     )
     return VersionHistoryController(db)  # type: ignore[arg-type]
@@ -95,6 +107,100 @@ async def test_dashboard_commit_makes_catch_all_a_noop(
     versions = controller._repo.log_file(tmp_path / "kitchen.yaml")
     # Only the dashboard commit — the catch-all found nothing to commit.
     assert [c.message for c in versions] == ["Edit kitchen.yaml via editor"]
+
+
+async def test_list_and_get_version_round_trip(tmp_path: Path) -> None:
+    """list_versions surfaces commits; get_version returns content at a sha."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    yaml.write_text("v2\n", encoding="utf-8")
+    await controller.record_configuration("kitchen.yaml", "Edit kitchen.yaml")
+
+    versions = await controller.list_versions(configuration="kitchen.yaml")
+    assert [v["message"] for v in versions] == ["Edit kitchen.yaml", "Create kitchen.yaml"]
+
+    first_sha = versions[1]["sha"]
+    got = await controller.get_version(configuration="kitchen.yaml", sha=first_sha)
+    assert got["content"] == "v1\n"
+
+
+async def test_get_diff_returns_unified_diff(tmp_path: Path) -> None:
+    """get_diff compares a commit against the working copy."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    sha = await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    yaml.write_text("v2\n", encoding="utf-8")
+
+    result = await controller.get_diff(configuration="kitchen.yaml", sha=sha)
+    assert "-v1" in result["diff"] and "+v2" in result["diff"]
+
+
+async def test_restore_specific_sha_writes_through_devices(tmp_path: Path) -> None:
+    """Restore fetches the old content and writes it via the devices persist path."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    sha = await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    yaml.write_text("v2\n", encoding="utf-8")
+    await controller.record_configuration("kitchen.yaml", "Edit kitchen.yaml")
+
+    result = await controller.restore(configuration="kitchen.yaml", sha=sha)
+
+    assert result["content"] == "v1\n"
+    controller._db.devices.apply_restored_yaml.assert_awaited_once()
+    _, kwargs = controller._db.devices.apply_restored_yaml.call_args
+    assert kwargs["restored_from"] == sha[:7]
+
+
+async def test_restore_deleted_uses_latest_available_version(tmp_path: Path) -> None:
+    """With no sha, a deleted config is restored from its last surviving version."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("final\n", encoding="utf-8")
+    await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
+    yaml.unlink()
+    await controller.record_configuration("kitchen.yaml", "Delete kitchen.yaml")
+
+    # It now shows up as deletable and restores its last content.
+    deleted = await controller.list_deleted()
+    assert {"configuration": "kitchen.yaml"} in deleted
+
+    result = await controller.restore(configuration="kitchen.yaml")
+    assert result["content"] == "final\n"
+    args, _ = controller._db.devices.apply_restored_yaml.call_args
+    assert args[0] == "kitchen.yaml"
+    assert args[1] == "final\n"
+
+
+async def test_history_commands_raise_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With git unavailable, reads return empty and mutators raise NOT_FOUND."""
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    controller = _make_controller(tmp_path)
+    await controller.start()
+
+    assert await controller.list_versions(configuration="kitchen.yaml") == []
+    assert await controller.list_deleted() == []
+    with pytest.raises(CommandError) as exc:
+        await controller.restore(configuration="kitchen.yaml", sha="abc1234")
+    assert exc.value.code == ErrorCode.NOT_FOUND
+
+
+async def test_get_version_rejects_bad_sha(tmp_path: Path) -> None:
+    """A non-hex sha is refused before reaching git."""
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    with pytest.raises(CommandError) as exc:
+        await controller.get_version(configuration="kitchen.yaml", sha="; rm -rf /")
+    assert exc.value.code == ErrorCode.INVALID_ARGS
 
 
 async def test_commit_swallows_unexpected_errors(

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -89,6 +89,46 @@ def test_adopts_repo_when_config_dir_is_subdir(tmp_path: Path) -> None:
     assert repo.toplevel == tmp_path
 
 
+def test_init_keeps_a_preexisting_gitignore(tmp_path: Path) -> None:
+    """A .gitignore already sitting in a non-repo dir is committed, not overwritten."""
+    (tmp_path / ".gitignore").write_text("user-rules/\n", encoding="utf-8")
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert (tmp_path / ".gitignore").read_text() == "user-rules/\n"
+
+
+def test_commit_index_noop_when_nothing_staged(tmp_path: Path) -> None:
+    """The seed-commit helper is a no-op when there's nothing staged."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    before = _git(tmp_path, "rev-list", "--count", "HEAD").strip()
+
+    repo._commit_index("nothing to do")
+
+    assert _git(tmp_path, "rev-list", "--count", "HEAD").strip() == before
+
+
+def test_deleted_files_empty_on_repo_without_commits(tmp_path: Path) -> None:
+    """An adopted repo with no commits yet yields no deletable configs (git log fails)."""
+    _git(tmp_path, "init")  # bare repo, no commits
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert repo.deleted_files() == []
+
+
+def test_file_at_path_outside_toplevel_falls_back_to_name(tmp_path: Path) -> None:
+    """A path outside the work tree doesn't crash _rel_to_toplevel; returns None."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.file_at(Path("/nonexistent/elsewhere.yaml"), "0" * 40) is None
+
+
 def test_missing_git_binary_disables_feature(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -98,14 +98,70 @@ def test_missing_git_binary_disables_feature(
     repo.discover_or_init()
 
     assert not repo.enabled
-    assert repo.commit_paths([tmp_path / "x.yaml"], "msg") is None
-    assert repo.log_file(tmp_path / "x.yaml") == []
+    p = tmp_path / "x.yaml"
+    assert repo.commit_paths([p], "msg") is None
+    assert repo.log_file(p) == []
+    assert repo.file_at(p, "abc1234") is None
+    assert repo.diff_file(p, "abc1234") == ""
+    assert repo.deleted_files() == []
     assert not (tmp_path / ".git").exists()
+
+
+def test_discover_or_init_tolerates_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OSError while probing / initialising leaves the feature disabled, not crashed."""
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("git exec failed")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run",
+        _boom,
+    )
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert not repo.enabled
 
 
 # ---------------------------------------------------------------------------
 # commits
 # ---------------------------------------------------------------------------
+
+
+def test_commit_paths_returns_none_on_git_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing ``git commit`` is swallowed — commit_paths returns None, no raise."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+
+    real_run = subprocess.run
+
+    def _fail_commit(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "commit" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, stderr="commit blew up")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run",
+        _fail_commit,
+    )
+    assert repo.commit_paths([yaml], "Create kitchen.yaml") is None
+
+
+def test_file_at_returns_none_for_unknown_commit(tmp_path: Path) -> None:
+    """Asking for a path at a commit that doesn't have it yields None, not a crash."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Create kitchen.yaml")
+
+    assert repo.file_at(yaml, "0" * 40) is None
 
 
 def test_commit_paths_records_new_and_edited_files(tmp_path: Path) -> None:
@@ -238,3 +294,24 @@ def test_deleted_files_lists_configs_absent_from_work_tree(tmp_path: Path) -> No
     deleted = repo.deleted_files()
     assert "gone.yaml" in deleted
     assert "live.yaml" not in deleted
+
+
+def test_deleted_files_ignores_nested_and_non_config(tmp_path: Path) -> None:
+    """Only top-level configs are restorable — not nested includes or stray files."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    top = tmp_path / "dev.yaml"
+    nested = tmp_path / "pkg" / "inc.yaml"
+    nested.parent.mkdir()
+    other = tmp_path / "notes.txt"
+    for path, body in ((top, "d\n"), (nested, "n\n"), (other, "x\n")):
+        path.write_text(body, encoding="utf-8")
+        repo.commit_paths([path], f"Create {path.name}")
+    for path in (top, nested, other):
+        path.unlink()
+        repo.commit_paths([path], f"Delete {path.name}")
+
+    deleted = repo.deleted_files()
+    assert "dev.yaml" in deleted
+    assert "pkg/inc.yaml" not in deleted  # nested include, not a device
+    assert "notes.txt" not in deleted  # not a config

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -127,6 +127,26 @@ def test_commit_paths_records_new_and_edited_files(tmp_path: Path) -> None:
     assert repo.file_at(yaml, sha2) == "v2\n"
 
 
+def test_commit_handles_flag_like_message_and_dashed_path(tmp_path: Path) -> None:
+    """A flag-like message / leading-dash filename can't smuggle git options.
+
+    Everything goes through argv (no shell): the message is the value of
+    ``-m`` and the path sits after ``--``, so neither is reparsed as a
+    git flag.
+    """
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    dashed = tmp_path / "-weird.yaml"
+    dashed.write_text("x\n", encoding="utf-8")
+
+    sha = repo.commit_paths([dashed], "--amend is not actually a flag here")
+
+    assert sha
+    versions = repo.log_file(dashed)
+    assert versions[0].message == "--amend is not actually a flag here"
+    assert repo.file_at(dashed, sha) == "x\n"
+
+
 def test_commit_paths_no_change_returns_none(tmp_path: Path) -> None:
     """Re-committing an unchanged file is a no-op (no empty commit)."""
     repo = GitRepo(config_dir=tmp_path)

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -135,6 +135,30 @@ def test_init_seed_never_commits_keys_or_state(tmp_path: Path) -> None:
         assert name not in tracked, f"{name} must not be committed"
 
 
+def test_init_seed_is_yaml_only_not_logs_or_binaries(tmp_path: Path) -> None:
+    """The seed captures YAML configs but never large non-config files.
+
+    A config dir often also holds logs / databases / media; ``git add -A``
+    would bake those into history forever. The seed is YAML-scoped instead.
+    """
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    (tmp_path / "home-assistant.log").write_text("X" * 5_000_000, encoding="utf-8")
+    (tmp_path / "home-assistant_v2.db").write_bytes(b"\x00" * 1024)
+    (tmp_path / "secrets.yaml").write_text("wifi_password: hunter2\n", encoding="utf-8")
+    (tmp_path / "snapshot.jpg").write_bytes(b"\xff\xd8\xff")
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    tracked = _git(tmp_path, "ls-files").split()
+    assert "kitchen.yaml" in tracked
+    assert ".gitignore" in tracked
+    assert "home-assistant.log" not in tracked
+    assert "home-assistant_v2.db" not in tracked
+    assert "snapshot.jpg" not in tracked
+    assert "secrets.yaml" not in tracked  # credentials stay out of history
+
+
 def test_adopt_writes_local_excludes_for_state(tmp_path: Path) -> None:
     """Adopting a repo installs local excludes so our key can't be staged later."""
     _make_repo(tmp_path)  # pre-existing repo, no device-builder ignores

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -1,0 +1,220 @@
+"""Tests for the subprocess ``git`` wrapper behind version history.
+
+The load-bearing guarantees these pin:
+- A pre-existing repo is adopted, not re-initialised, and its
+  ``.gitignore`` is left untouched.
+- Commits are pathspec-scoped, so the user's unrelated staged edits
+  never get folded into our automatic commit.
+- A missing ``git`` binary disables the feature instead of crashing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.version_history.git_repo import GitRepo
+
+_GIT = shutil.which("git") or "git"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """Run git in *cwd* with a throwaway identity; return stdout."""
+    result = subprocess.run(  # noqa: S603
+        [_GIT, "-c", "user.name=Test", "-c", "user.email=test@example.com", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _make_repo(path: Path) -> None:
+    """Init a git repo at *path* with one committed file."""
+    _git(path, "init")
+    (path / "seed.yaml").write_text("seed\n", encoding="utf-8")
+    _git(path, "add", "seed.yaml")
+    _git(path, "commit", "-m", "seed")
+
+
+# ---------------------------------------------------------------------------
+# discovery / init
+# ---------------------------------------------------------------------------
+
+
+def test_init_creates_repo_and_gitignore(tmp_path: Path) -> None:
+    """A non-repo config dir gets a fresh repo + committed .gitignore."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert repo.toplevel == tmp_path
+    assert (tmp_path / ".git").is_dir()
+    gitignore = tmp_path / ".gitignore"
+    assert gitignore.exists()
+    assert ".esphome/" in gitignore.read_text()
+    # The .gitignore landed as a real commit, not just on disk.
+    assert "Initialize version history" in _git(tmp_path, "log", "--format=%s")
+
+
+def test_adopts_existing_repo_without_touching_gitignore(tmp_path: Path) -> None:
+    """A pre-existing work tree is adopted; the user's .gitignore is untouched."""
+    _make_repo(tmp_path)
+    (tmp_path / ".gitignore").write_text("my-rules/\n", encoding="utf-8")
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert repo.toplevel == tmp_path
+    # Our default ignore content never overwrote the user's.
+    assert (tmp_path / ".gitignore").read_text() == "my-rules/\n"
+
+
+def test_adopts_repo_when_config_dir_is_subdir(tmp_path: Path) -> None:
+    """Config dir nested inside a repo (``/config`` root, ``esphome/`` subdir)."""
+    _make_repo(tmp_path)
+    sub = tmp_path / "esphome"
+    sub.mkdir()
+
+    repo = GitRepo(config_dir=sub)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    # Toplevel resolves to the outer repo root, not the subdir.
+    assert repo.toplevel == tmp_path
+
+
+def test_missing_git_binary_disables_feature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No git on PATH → disabled, every op a no-op, no exception."""
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert not repo.enabled
+    assert repo.commit_paths([tmp_path / "x.yaml"], "msg") is None
+    assert repo.log_file(tmp_path / "x.yaml") == []
+    assert not (tmp_path / ".git").exists()
+
+
+# ---------------------------------------------------------------------------
+# commits
+# ---------------------------------------------------------------------------
+
+
+def test_commit_paths_records_new_and_edited_files(tmp_path: Path) -> None:
+    """A create and a subsequent edit each land as their own commit."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    sha1 = repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert sha1
+    yaml.write_text("v2\n", encoding="utf-8")
+    sha2 = repo.commit_paths([yaml], "Update kitchen.yaml")
+    assert sha2 and sha2 != sha1
+
+    versions = repo.log_file(yaml)
+    assert [c.message for c in versions] == ["Update kitchen.yaml", "Create kitchen.yaml"]
+    assert repo.file_at(yaml, sha1) == "v1\n"
+    assert repo.file_at(yaml, sha2) == "v2\n"
+
+
+def test_commit_paths_no_change_returns_none(tmp_path: Path) -> None:
+    """Re-committing an unchanged file is a no-op (no empty commit)."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Create kitchen.yaml")
+
+    assert repo.commit_paths([yaml], "Update kitchen.yaml") is None
+
+
+def test_commit_paths_does_not_sweep_unrelated_staged_edits(tmp_path: Path) -> None:
+    """Pathspec scoping: our commit must not fold in the user's staged work.
+
+    The dominant safety case for a pre-existing repo — a user with
+    an in-progress ``git add`` of an unrelated file must not find it
+    silently swept into our automatic commit.
+    """
+    _make_repo(tmp_path)
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    # User stages an unrelated edit they're not ready to commit.
+    user_file = tmp_path / "user_wip.yaml"
+    user_file.write_text("user work in progress\n", encoding="utf-8")
+    _git(tmp_path, "add", "user_wip.yaml")
+
+    # We commit our own file.
+    ours = tmp_path / "kitchen.yaml"
+    ours.write_text("ours\n", encoding="utf-8")
+    repo.commit_paths([ours], "Create kitchen.yaml")
+
+    # The HEAD commit touched only our file.
+    changed = _git(tmp_path, "show", "--name-only", "--format=", "HEAD").split()
+    assert changed == ["kitchen.yaml"]
+    # The user's staged edit is still staged, never committed.
+    assert "user_wip.yaml" in _git(tmp_path, "diff", "--cached", "--name-only")
+
+
+# ---------------------------------------------------------------------------
+# reads
+# ---------------------------------------------------------------------------
+
+
+def test_log_file_preserves_messages_with_special_chars(tmp_path: Path) -> None:
+    """Field/record separators survive a commit subject (no tab/newline confusion)."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Restore kitchen.yaml to abc1234")
+
+    versions = repo.log_file(yaml)
+    assert versions[0].message == "Restore kitchen.yaml to abc1234"
+    assert versions[0].short_sha and len(versions[0].short_sha) >= 7
+    assert versions[0].timestamp > 0
+
+
+def test_diff_file_shows_working_tree_change(tmp_path: Path) -> None:
+    """diff_file returns a unified diff between a commit and the working copy."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    sha = repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert sha
+    yaml.write_text("v2\n", encoding="utf-8")
+
+    diff = repo.diff_file(yaml, sha)
+    assert "-v1" in diff
+    assert "+v2" in diff
+
+
+def test_deleted_files_lists_configs_absent_from_work_tree(tmp_path: Path) -> None:
+    """A committed YAML removed from disk shows up as restorable; a live one doesn't."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    gone = tmp_path / "gone.yaml"
+    gone.write_text("bye\n", encoding="utf-8")
+    repo.commit_paths([gone], "Create gone.yaml")
+    live = tmp_path / "live.yaml"
+    live.write_text("here\n", encoding="utf-8")
+    repo.commit_paths([live], "Create live.yaml")
+
+    # Delete one through git so it's recorded as removed.
+    gone.unlink()
+    repo.commit_paths([gone], "Delete gone.yaml")
+
+    deleted = repo.deleted_files()
+    assert "gone.yaml" in deleted
+    assert "live.yaml" not in deleted

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -100,6 +100,124 @@ def test_init_keeps_a_preexisting_gitignore(tmp_path: Path) -> None:
     assert (tmp_path / ".gitignore").read_text() == "user-rules/\n"
 
 
+# Machine state / secrets that must never reach git history, mirroring
+# what Device Builder writes into a real config dir.
+_SECRET_STATE_FILES = (
+    ".device-builder-peer-link-key.bin",
+    ".device-builder.json",
+    ".device-builder.lock",
+    ".receiver_peers.json",
+    ".offloader_pairings.json",
+    ".DS_Store",
+)
+
+
+def test_init_seed_never_commits_keys_or_state(tmp_path: Path) -> None:
+    """The fresh-init seed commits configs but never our keys / state / OS noise.
+
+    Even when a stock ESPHome ``.gitignore`` (which doesn't know about
+    Device Builder's files) is already present, the seed must not sweep
+    the peer-link key, receiver/offloader credentials, sidecars, or
+    ``.DS_Store`` into the initial snapshot.
+    """
+    # A stock-style .gitignore that covers neither our state nor .DS_Store.
+    (tmp_path / ".gitignore").write_text("/.esphome/\n/secrets.yaml\n", encoding="utf-8")
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    for name in _SECRET_STATE_FILES:
+        (tmp_path / name).write_text("secret\n", encoding="utf-8")
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    tracked = _git(tmp_path, "ls-files").split()
+    assert "kitchen.yaml" in tracked
+    for name in _SECRET_STATE_FILES:
+        assert name not in tracked, f"{name} must not be committed"
+
+
+def test_adopt_writes_local_excludes_for_state(tmp_path: Path) -> None:
+    """Adopting a repo installs local excludes so our key can't be staged later."""
+    _make_repo(tmp_path)  # pre-existing repo, no device-builder ignores
+    (tmp_path / ".device-builder-peer-link-key.bin").write_text("key\n", encoding="utf-8")
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    # git now treats the key as ignored (via .git/info/exclude), so a
+    # later ``git add -A`` can't stage it.
+    ignored = _git(tmp_path, "status", "--porcelain", "--ignored").splitlines()
+    assert any(
+        line.startswith("!!") and "device-builder-peer-link-key.bin" in line for line in ignored
+    )
+
+
+def test_local_excludes_are_idempotent(tmp_path: Path) -> None:
+    """Re-running discovery doesn't duplicate our managed exclude block."""
+    _make_repo(tmp_path)
+    GitRepo(config_dir=tmp_path).discover_or_init()
+    GitRepo(config_dir=tmp_path).discover_or_init()
+
+    exclude = (tmp_path / ".git" / "info" / "exclude").read_text(encoding="utf-8")
+    assert exclude.count("ESPHome Device Builder (managed)") == 2  # one start + one end marker
+
+
+def _patch_git_path(monkeypatch: pytest.MonkeyPatch, handler: object) -> None:
+    """Intercept ``git rev-parse --git-path`` calls; pass everything else through."""
+    real_run = subprocess.run
+
+    def _fake(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "--git-path" in cmd:
+            return handler(cmd)  # type: ignore[operator]
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _fake
+    )
+
+
+def test_local_excludes_noop_when_git_path_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing ``rev-parse --git-path`` leaves discovery working, just no excludes."""
+    _make_repo(tmp_path)
+    _patch_git_path(monkeypatch, lambda cmd: subprocess.CompletedProcess(cmd, 1, "", ""))
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.enabled  # adoption still succeeded
+
+
+def test_local_excludes_honor_absolute_git_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An absolute path from ``rev-parse --git-path`` is used as-is."""
+    _make_repo(tmp_path)
+    abs_exclude = tmp_path / "abs_exclude"
+    _patch_git_path(
+        monkeypatch, lambda cmd: subprocess.CompletedProcess(cmd, 0, f"{abs_exclude}\n", "")
+    )
+
+    GitRepo(config_dir=tmp_path).discover_or_init()
+
+    assert "ESPHome Device Builder (managed)" in abs_exclude.read_text(encoding="utf-8")
+
+
+def test_local_excludes_tolerate_write_error(tmp_path: Path) -> None:
+    """An unwritable info/exclude is logged, not fatal to discovery."""
+    _make_repo(tmp_path)
+    # Replace the exclude file with a directory so the read/append raises.
+    exclude = tmp_path / ".git" / "info" / "exclude"
+    if exclude.exists():
+        exclude.unlink()
+    exclude.mkdir()
+
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.enabled
+
+
 def test_commit_index_noop_when_nothing_staged(tmp_path: Path) -> None:
     """The seed-commit helper is a no-op when there's nothing staged."""
     repo = GitRepo(config_dir=tmp_path)

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -282,6 +282,29 @@ def test_commit_paths_does_not_sweep_unrelated_staged_edits(tmp_path: Path) -> N
     assert "user_wip.yaml" in _git(tmp_path, "diff", "--cached", "--name-only")
 
 
+def test_commit_never_modifies_the_working_tree(tmp_path: Path) -> None:
+    """Auto-commit records history; it must not rewrite any working-tree file.
+
+    The clobber concern: the feature only ever ``add``/``commit``s — never
+    ``checkout``/``reset``/``stash`` — so a user's on-disk content (even
+    uncommitted, unstaged edits to other files) is byte-for-byte preserved.
+    """
+    _make_repo(tmp_path)
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    # A user file with uncommitted, unstaged working-tree edits.
+    user_file = tmp_path / "living_room.yaml"
+    user_file.write_text("user edits not yet saved\n", encoding="utf-8")
+
+    ours = tmp_path / "kitchen.yaml"
+    ours.write_text("ours\n", encoding="utf-8")
+    repo.commit_paths([ours], "Create kitchen.yaml")
+
+    # The user's file on disk is untouched, and so is ours.
+    assert user_file.read_text() == "user edits not yet saved\n"
+    assert ours.read_text() == "ours\n"
+
+
 # ---------------------------------------------------------------------------
 # reads
 # ---------------------------------------------------------------------------

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -312,10 +312,8 @@ def test_discover_or_init_tolerates_oserror(
 # ---------------------------------------------------------------------------
 
 
-def test_commit_paths_returns_none_on_git_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A failing ``git commit`` is swallowed — commit_paths returns None, no raise."""
+def test_commit_paths_raises_on_git_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing ``git commit`` raises so the controller can tell it from a no-op."""
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
     yaml = tmp_path / "kitchen.yaml"
@@ -332,7 +330,8 @@ def test_commit_paths_returns_none_on_git_error(
         "esphome_device_builder.controllers.version_history.git_repo.subprocess.run",
         _fail_commit,
     )
-    assert repo.commit_paths([yaml], "Create kitchen.yaml") is None
+    with pytest.raises(subprocess.CalledProcessError):
+        repo.commit_paths([yaml], "Create kitchen.yaml")
 
 
 def test_file_at_returns_none_for_unknown_commit(tmp_path: Path) -> None:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -656,6 +656,7 @@ def _make_controller(catalog: ComponentCatalog, tmp_path: Any) -> DevicesControl
     ctrl = DevicesController.__new__(DevicesController)
     ctrl._db = MagicMock()
     ctrl.state = DevicesState()
+    ctrl._yaml_write_locks = {}
     ctrl._db.version_history = None
     ctrl._db.settings.rel_path = lambda name: tmp_path / name
     ctrl._db.components = catalog

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -656,6 +656,7 @@ def _make_controller(catalog: ComponentCatalog, tmp_path: Any) -> DevicesControl
     ctrl = DevicesController.__new__(DevicesController)
     ctrl._db = MagicMock()
     ctrl.state = DevicesState()
+    ctrl._db.version_history = None
     ctrl._db.settings.rel_path = lambda name: tmp_path / name
     ctrl._db.components = catalog
     ctrl._scanner = MagicMock()


### PR DESCRIPTION
# What does this implement/fix?

## Motivation

We've shipped **3–4 separate bugs** where the Visual Editor / YAML form blanked out a device's entire config during the beta cycle and then persisted that empty (or near-empty) content over the user's real YAML — a save that silently destroys hours of work with no way back short of the user's own backups. Today the only on-disk copy is the one we just clobbered.

This adds the recovery path: every save is committed to git, so a config the UI wipes is one `version_history/restore` away from its previous content. It also covers the broader asks in [esphome/discussions#3687](https://github.com/orgs/esphome/discussions/3687) (per-file history, diff, restore) and external edits (VS Code, the HA File Editor), but the load-bearing reason to land it is the "the editor ate my YAML" class of bug.

## Scope — initial version, backend only

This is the **first step: just start saving history so we can restore later if something goes wrong.** There is **no frontend yet** — no History pane, no UI button. The WS commands (`version_history/*`) exist and are tested so a config can be recovered today (via the API, or by hand with `git` in the config dir), and so a future UI has something to call. The per-file History / diff / restore UI is a separate follow-up PR in `esphome/device-builder-frontend`. Nothing here changes the dashboard's appearance; it only records and exposes history.

## Summary

Implements git-backed per-YAML version history for the config directory, and makes the deletion model history-aware: **a removed YAML stays restorable from git even after its build artifacts are gone.**

New `controllers/version_history/` package:

- **`GitRepo`** — a conservative subprocess `git` wrapper. Probes for the `git` binary (the whole feature self-disables if it's absent), then **adopts** an enclosing work tree — covering `/config/esphome` already being a repo, or sitting inside one such as `/config` — or initializes a fresh repo (seeding the existing configs as the first snapshot). On a fresh init it writes a `.gitignore` covering `.esphome/`, `.device-builder*.json`, and `secrets.yaml` (kept out of history since a local repo may later be pushed to a remote); a pre-existing `.gitignore` is left untouched. It never writes `user.*` into git config (commit identity is passed per-invocation with `git -c`) and skips the user's hooks / signing.
- **`VersionHistoryController`** — async, lock-serialised commit API + the read/restore WS commands. Wired into `DeviceBuilder`.

**Commits are pathspec-scoped** (`git add -A -- <paths>` + `git commit -- <paths>`), so an automatic commit can never sweep the user's unrelated staged edits into our history — the dominant safety concern for a pre-existing repo. There's a dedicated test for exactly that.

**Hybrid commit triggers:**
- Dashboard mutations commit immediately with a rich message (editor save, add-component, friendly-name edit, create, clone, import, delete, archive).
- A debounced, scanner-driven catch-all covers edits made outside the dashboard (VS Code, the HA File Editor). It subscribes to `device_added` / `device_updated` / `device_removed`, which fire only on a real on-disk cache-key change, not on mDNS/ping state ticks. A dashboard save has already committed by the time the debounced flush runs, so the catch-all becomes a no-op there; idempotent commits make the de-dup automatic.

**Deletion is history-aware:** `delete_single` / `archive_single` commit the removal so the pre-removal content stays restorable. The `archive/` folder remains the browsable parked-configs list; git history is the time-machine that also covers hard deletes and external `rm`.

**WS API** (documented in `docs/API.md`): `version_history/list_versions`, `get_version`, `get_diff`, `list_deleted`, `restore`. Restore reuses the normal persist → scan → event pipeline (via a new public `DevicesController.apply_restored_yaml`) and is itself committed; it recreates a deleted file as well as reverting an edit.

Best-effort throughout: a git failure is logged and never breaks a user's save.

**Related issue or feature (if applicable):**

- implements https://github.com/orgs/esphome/discussions/3687

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

New WS commands (`version_history/*`) need a companion frontend PR to surface the per-file History pane (list / diff / restore) and the restore-deleted view. The backend is usable without it; the commands degrade gracefully (empty lists) when git is unavailable.

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#<tbd>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.



