### PR TITLE
Resolve esphome.area from included/templated configs

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/__init__.py
+++ b/esphome_device_builder/helpers/device_yaml/__init__.py
@@ -31,12 +31,14 @@ from ._loading import (
     load_device_yaml,
 )
 from ._parsing import (
+    EsphomeMeta,
     _parse_inline_value,
     config_has_top_level_block,
     configuration_stem,
     detect_platform_from_yaml,
     device_uses_mqtt,
     extract_directly_referenced_integrations,
+    extract_esphome_meta_from_config,
     get_api_encryption_block,
     get_api_encryption_key,
     parse_esphome_meta,
@@ -46,6 +48,7 @@ from ._parsing import (
 )
 
 __all__ = [
+    "EsphomeMeta",
     "StorageJSON",
     "_esphome_has_native_wifi",
     "_fallback_has_native_wifi",
@@ -59,6 +62,7 @@ __all__ = [
     "detect_platform_from_yaml",
     "device_uses_mqtt",
     "extract_directly_referenced_integrations",
+    "extract_esphome_meta_from_config",
     "generate_device_yaml",
     "generate_minimal_stub_yaml",
     "get_api_encryption_block",

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -143,17 +143,11 @@ def load_device_from_storage(
     # against substitutions contributed by ``packages:`` / ``!include``
     # — not just the ones inline in this file (#917).
     extra_subs = _extract_resolved_substitutions(resolved_config)
-    yaml_name, yaml_friendly, yaml_comment, yaml_area = parse_esphome_meta(
-        yaml_content,
-        extra_substitutions=extra_subs,
-    )
+    yaml_meta = parse_esphome_meta(yaml_content, extra_substitutions=extra_subs)
     # The resolved config carries the ``esphome:`` block the raw-text
     # reader can't see when it lives in a merge-key / ``!include`` /
     # ``packages:`` file, so this fills meta the main file omits (#1153).
-    cfg_name, cfg_friendly, cfg_comment, cfg_area = extract_esphome_meta_from_config(
-        resolved_config,
-        extra_subs,
-    )
+    cfg_meta = extract_esphome_meta_from_config(resolved_config, extra_subs)
 
     fallback_name = configuration_stem(filename)
     storage_name = storage.name if storage else None
@@ -168,22 +162,26 @@ def load_device_from_storage(
     # Falling back to the filename when the parsed name is invalid
     # keeps the catalog key unique.
     name = next(
-        (n for n in (yaml_name, cfg_name, storage_name) if n and _is_valid_esphome_name(n)),
+        (
+            n
+            for n in (yaml_meta.name, cfg_meta.name, storage_name)
+            if n and _is_valid_esphome_name(n)
+        ),
         fallback_name,
     )
 
     storage_friendly = storage.friendly_name if storage else None
-    ef_friendly = _pick_meta(yaml_friendly, cfg_friendly, storage_friendly)
+    ef_friendly = _pick_meta(yaml_meta.friendly_name, cfg_meta.friendly_name, storage_friendly)
     friendly_name = ef_friendly if ef_friendly is not None else name
 
     storage_comment = storage.comment if storage else None
-    comment = _pick_meta(yaml_comment, cfg_comment, storage_comment)
+    comment = _pick_meta(yaml_meta.comment, cfg_meta.comment, storage_comment)
 
     # ``StorageJSON`` carries ``area`` on esphome builds that persist it
     # (resolved post-compile); the resolved-config and raw-YAML tokens
     # cover older builds and never-compiled devices.
     storage_area = getattr(storage, "area", None) if storage else None
-    area = _pick_meta(yaml_area, cfg_area, storage_area) or ""
+    area = _pick_meta(yaml_meta.area, cfg_meta.area, storage_area) or ""
 
     yaml_mtime = path.stat().st_mtime if path.exists() else None
     bin_mtime: float | None = None

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -15,13 +15,14 @@ from ...models import Device, DeviceState
 from ..mac_addresses import derive_interface_macs
 from ..storage_path import resolve_storage_path
 from ._parsing import (
-    _effective_meta,
     _extract_resolved_substitutions,
     _is_valid_esphome_name,
+    _pick_meta,
     config_has_top_level_block,
     configuration_stem,
     detect_platform_from_yaml,
     extract_directly_referenced_integrations,
+    extract_esphome_meta_from_config,
     get_api_encryption_block,
     parse_esphome_meta,
     yaml_has_api_encryption,
@@ -138,12 +139,20 @@ def load_device_from_storage(
     # ``api_encrypted`` falls back to False.
     resolved_config = load_device_yaml(path)
     # Feed the merged ``substitutions:`` from the resolved config back
-    # into the meta reader so ``esphome.friendly_name: $room`` resolves
+    # into the meta readers so ``esphome.friendly_name: $room`` resolves
     # against substitutions contributed by ``packages:`` / ``!include``
     # — not just the ones inline in this file (#917).
+    extra_subs = _extract_resolved_substitutions(resolved_config)
     yaml_name, yaml_friendly, yaml_comment, yaml_area = parse_esphome_meta(
         yaml_content,
-        extra_substitutions=_extract_resolved_substitutions(resolved_config),
+        extra_substitutions=extra_subs,
+    )
+    # The resolved config carries the ``esphome:`` block the raw-text
+    # reader can't see when it lives in a merge-key / ``!include`` /
+    # ``packages:`` file, so this fills meta the main file omits (#1153).
+    cfg_name, cfg_friendly, cfg_comment, cfg_area = extract_esphome_meta_from_config(
+        resolved_config,
+        extra_subs,
     )
 
     fallback_name = configuration_stem(filename)
@@ -159,22 +168,22 @@ def load_device_from_storage(
     # Falling back to the filename when the parsed name is invalid
     # keeps the catalog key unique.
     name = next(
-        (n for n in (yaml_name, storage_name) if n and _is_valid_esphome_name(n)),
+        (n for n in (yaml_name, cfg_name, storage_name) if n and _is_valid_esphome_name(n)),
         fallback_name,
     )
 
     storage_friendly = storage.friendly_name if storage else None
-    ef_friendly = _effective_meta(yaml_friendly, storage_friendly)
+    ef_friendly = _pick_meta(yaml_friendly, cfg_friendly, storage_friendly)
     friendly_name = ef_friendly if ef_friendly is not None else name
 
     storage_comment = storage.comment if storage else None
-    comment = _effective_meta(yaml_comment, storage_comment)
+    comment = _pick_meta(yaml_comment, cfg_comment, storage_comment)
 
     # ``StorageJSON`` carries ``area`` on esphome builds that persist it
-    # (resolved post-compile); ``getattr`` falls through to the raw YAML
-    # token on older builds and never-compiled devices.
+    # (resolved post-compile); the resolved-config and raw-YAML tokens
+    # cover older builds and never-compiled devices.
     storage_area = getattr(storage, "area", None) if storage else None
-    area = _effective_meta(yaml_area, storage_area) or ""
+    area = _pick_meta(yaml_area, cfg_area, storage_area) or ""
 
     yaml_mtime = path.stat().st_mtime if path.exists() else None
     bin_mtime: float | None = None

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -335,15 +335,10 @@ def extract_esphome_meta_from_config(
     extra_substitutions: dict[str, str] | None = None,
 ) -> EsphomeMeta:
     """
-    Read ``(name, friendly_name, comment, area)`` from a resolved config's ``esphome:`` block.
+    Read ``(name, friendly_name, comment, area)`` off a resolved config's ``esphome:`` block.
 
-    The block sees what the loader merged in via ``!include`` / merge-key
-    (``<<:``) / ``packages:``, so this surfaces meta the raw-text reader
-    misses when the ``esphome:`` block lives in an included file (#1153).
-    ``None`` for any field the block doesn't carry. ``$var`` / ``${var}``
-    references resolve against *extra_substitutions* (typically the merged
-    ``substitutions:`` off the same config); unresolved tokens are left
-    untouched for the caller to defer past.
+    ``None`` for any field absent. ``$var`` / ``${var}`` resolve against
+    *extra_substitutions*; tokens the resolver can't expand are left intact.
     """
     if not isinstance(config, dict):
         return EsphomeMeta(None, None, None, None)
@@ -388,22 +383,11 @@ def _pick_meta(
     storage_value: str | None,
 ) -> str | None:
     """
-    Pick the metadata to display, preferring a fully-resolved value.
+    Pick the value to display: first fully-resolved of yaml → config → storage.
 
-    Source order: the raw-text YAML read (reflects unsaved edits, and
-    survives a draft too broken for the loader), then the resolved-config
-    read (sees ``esphome:`` pulled in via ``!include`` / merge-key /
-    ``packages:``), then StorageJSON (esphome resolved it at build time).
-    A value still holding a substitution token (a nested ``${device.area}``
-    the simple resolver can't expand) is skipped in favour of the next
-    source; a literal ``$`` that isn't substitution-shaped counts as
-    resolved.
-
-    When nothing resolves and StorageJSON is empty, the raw-text token
-    (or ``None``) is surfaced — never the *config* token: an unresolved
-    ``${device.area}`` carried only in an included ``esphome:`` block
-    would otherwise leak into the UI for never-compiled devices, where
-    the pre-resolved-config behaviour was an empty value.
+    A value still holding a substitution token (``${device.area}``) is
+    skipped for the next source. The final fallback surfaces only the
+    raw-text token or ``None`` — never an unresolved config token.
     """
     for value in (yaml_value, config_value):
         if value is not None and not _UNRESOLVED_SUBSTITUTION_RE.search(value):

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 from esphome import const
 from esphome.const import CONF_PACKAGES
+
+
+class EsphomeMeta(NamedTuple):
+    """The user-facing ``esphome:`` meta fields; ``None`` for any the YAML omits."""
+
+    name: str | None
+    friendly_name: str | None
+    comment: str | None
+    area: str | None
+
 
 _PLATFORM_KEYS = frozenset({"esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "ln882x", "nrf52"})
 
@@ -252,7 +263,7 @@ def extract_directly_referenced_integrations(
 def parse_esphome_meta(
     yaml_content: str,
     extra_substitutions: dict[str, str] | None = None,
-) -> tuple[str | None, str | None, str | None, str | None]:
+) -> EsphomeMeta:
     """
     Parse the top-level ``esphome:`` block for ``(name, friendly_name, comment, area)``.
 
@@ -316,13 +327,13 @@ def parse_esphome_meta(
         for field in _ESPHOME_META_FIELDS:
             meta[field] = _resolve_substitutions(meta[field], merged)
 
-    return meta["name"], meta["friendly_name"], meta["comment"], meta["area"]
+    return EsphomeMeta(meta["name"], meta["friendly_name"], meta["comment"], meta["area"])
 
 
 def extract_esphome_meta_from_config(
     config: dict | None,
     extra_substitutions: dict[str, str] | None = None,
-) -> tuple[str | None, str | None, str | None, str | None]:
+) -> EsphomeMeta:
     """
     Read ``(name, friendly_name, comment, area)`` from a resolved config's ``esphome:`` block.
 
@@ -335,16 +346,16 @@ def extract_esphome_meta_from_config(
     untouched for the caller to defer past.
     """
     if not isinstance(config, dict):
-        return (None, None, None, None)
+        return EsphomeMeta(None, None, None, None)
     esphome = config.get(const.CONF_ESPHOME)
     if not isinstance(esphome, dict):
-        return (None, None, None, None)
+        return EsphomeMeta(None, None, None, None)
     subs = extra_substitutions or {}
 
     def _resolved(value: str | None) -> str | None:
         return _resolve_substitutions(value, subs)
 
-    return (
+    return EsphomeMeta(
         _resolved(_str_or_none(esphome.get(const.CONF_NAME))),
         _resolved(_str_or_none(esphome.get(const.CONF_FRIENDLY_NAME))),
         _resolved(_str_or_none(esphome.get(const.CONF_COMMENT))),

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -319,21 +319,81 @@ def parse_esphome_meta(
     return meta["name"], meta["friendly_name"], meta["comment"], meta["area"]
 
 
-def _effective_meta(yaml_value: str | None, storage_value: str | None) -> str | None:
+def extract_esphome_meta_from_config(
+    config: dict | None,
+    extra_substitutions: dict[str, str] | None = None,
+) -> tuple[str | None, str | None, str | None, str | None]:
     """
-    Pick the metadata to display, preferring a resolved value.
+    Read ``(name, friendly_name, comment, area)`` from a resolved config's ``esphome:`` block.
 
-    The raw-text YAML read reflects unsaved edits immediately, so it
-    wins when fully resolved. A value still holding a substitution token
-    (a nested ``${device.area}`` the raw reader can't expand) defers to
-    StorageJSON, which esphome resolved at build time. A literal ``$``
-    that isn't substitution-shaped doesn't count as unresolved.
+    The block sees what the loader merged in via ``!include`` / merge-key
+    (``<<:``) / ``packages:``, so this surfaces meta the raw-text reader
+    misses when the ``esphome:`` block lives in an included file (#1153).
+    ``None`` for any field the block doesn't carry. ``$var`` / ``${var}``
+    references resolve against *extra_substitutions* (typically the merged
+    ``substitutions:`` off the same config); unresolved tokens are left
+    untouched for the caller to defer past.
     """
-    if yaml_value is not None and not _UNRESOLVED_SUBSTITUTION_RE.search(yaml_value):
-        return yaml_value
+    if not isinstance(config, dict):
+        return (None, None, None, None)
+    esphome = config.get(const.CONF_ESPHOME)
+    if not isinstance(esphome, dict):
+        return (None, None, None, None)
+    subs = extra_substitutions or {}
+
+    def _resolved(value: str | None) -> str | None:
+        return _resolve_substitutions(value, subs)
+
+    return (
+        _resolved(_str_or_none(esphome.get(const.CONF_NAME))),
+        _resolved(_str_or_none(esphome.get(const.CONF_FRIENDLY_NAME))),
+        _resolved(_str_or_none(esphome.get(const.CONF_COMMENT))),
+        _resolved(_area_name_from_config(esphome.get(const.CONF_AREA))),
+    )
+
+
+def _str_or_none(value: object) -> str | None:
+    """Return *value* when it's a string, else ``None``."""
+    return value if isinstance(value, str) else None
+
+
+def _area_name_from_config(value: object) -> str | None:
+    """
+    Extract the area label from a config ``area`` value.
+
+    String form is the label itself; the ``{id, name}`` mapping form
+    surfaces its ``name``. ``None`` for any other shape.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return _str_or_none(value.get(const.CONF_NAME))
+    return None
+
+
+def _pick_meta(
+    yaml_value: str | None,
+    config_value: str | None,
+    storage_value: str | None,
+) -> str | None:
+    """
+    Pick the metadata to display, preferring a fully-resolved value.
+
+    Source order: the raw-text YAML read (reflects unsaved edits, and
+    survives a draft too broken for the loader), then the resolved-config
+    read (sees ``esphome:`` pulled in via ``!include`` / merge-key /
+    ``packages:``), then StorageJSON (esphome resolved it at build time).
+    A value still holding a substitution token (a nested ``${device.area}``
+    the simple resolver can't expand) is skipped in favour of the next
+    source; a literal ``$`` that isn't substitution-shaped counts as
+    resolved.
+    """
+    for value in (yaml_value, config_value):
+        if value is not None and not _UNRESOLVED_SUBSTITUTION_RE.search(value):
+            return value
     if storage_value:
         return storage_value
-    return yaml_value
+    return yaml_value if yaml_value is not None else config_value
 
 
 def _match_top_level_key(line: str) -> str | None:

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -398,13 +398,19 @@ def _pick_meta(
     the simple resolver can't expand) is skipped in favour of the next
     source; a literal ``$`` that isn't substitution-shaped counts as
     resolved.
+
+    When nothing resolves and StorageJSON is empty, the raw-text token
+    (or ``None``) is surfaced — never the *config* token: an unresolved
+    ``${device.area}`` carried only in an included ``esphome:`` block
+    would otherwise leak into the UI for never-compiled devices, where
+    the pre-resolved-config behaviour was an empty value.
     """
     for value in (yaml_value, config_value):
         if value is not None and not _UNRESOLVED_SUBSTITUTION_RE.search(value):
             return value
     if storage_value:
         return storage_value
-    return yaml_value if yaml_value is not None else config_value
+    return yaml_value
 
 
 def _match_top_level_key(line: str) -> str | None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -25,14 +25,12 @@ from esphome_device_builder.helpers.device_yaml import (
     _select_wifi_helper,
     compute_has_pending_changes,
     configuration_stem,
+    extract_esphome_meta_from_config,
     generate_device_yaml,
     generate_minimal_stub_yaml,
     load_device_from_storage,
     parse_esphome_meta,
     parse_platform_from_yaml,
-)
-from esphome_device_builder.helpers.device_yaml._parsing import (
-    extract_esphome_meta_from_config,
 )
 from esphome_device_builder.models import (
     BoardCatalogEntry,

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -31,6 +31,9 @@ from esphome_device_builder.helpers.device_yaml import (
     parse_esphome_meta,
     parse_platform_from_yaml,
 )
+from esphome_device_builder.helpers.device_yaml._parsing import (
+    extract_esphome_meta_from_config,
+)
 from esphome_device_builder.models import (
     BoardCatalogEntry,
     BoardEsphomeConfig,
@@ -694,6 +697,27 @@ esphome:
     assert name == "lamp"
     assert area == "Kitchen"
     assert comment == "real comment"
+
+
+def test_extract_meta_from_config_string_area() -> None:
+    """String-form ``area`` resolves against the supplied substitutions."""
+    config = {"esphome": {"name": "lamp", "area": "${room}"}}
+    name, _, _, area = extract_esphome_meta_from_config(config, {"room": "Kitchen"})
+    assert name == "lamp"
+    assert area == "Kitchen"
+
+
+def test_extract_meta_from_config_dict_area_uses_name() -> None:
+    """The ``{id, name}`` mapping form surfaces its ``name``, resolved."""
+    config = {"esphome": {"area": {"id": "${aid}", "name": "${room}"}}}
+    *_, area = extract_esphome_meta_from_config(config, {"aid": "k", "room": "Kitchen"})
+    assert area == "Kitchen"
+
+
+@pytest.mark.parametrize("config", [None, {}, {"esphome": "not-a-dict"}, "nope"])
+def test_extract_meta_from_config_no_esphome_block(config: Any) -> None:
+    """Missing / malformed config or ``esphome:`` block yields all-``None``."""
+    assert extract_esphome_meta_from_config(config) == (None, None, None, None)
 
 
 def test_parse_meta_top_level_comment_does_not_close_esphome_block() -> None:
@@ -1695,6 +1719,71 @@ def test_load_device_area_from_storage(tmp_path: Path, monkeypatch: pytest.Monke
     device = load_device_from_storage(yaml_path)
 
     assert device.area == "Living Room"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_area_from_merge_key_include(tmp_path: Path) -> None:
+    """A never-compiled merge-key-templated config resolves its esphome meta (#1153).
+
+    The ``esphome:`` block (name / friendly_name / comment / area)
+    lives in a ``<<: !include`` template using flat substitutions, so
+    the raw-text reader sees nothing; the resolved config supplies it.
+    No StorageJSON is written — the fix must work pre-compile.
+    """
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "s31.yaml").write_text(
+        "esphome:\n"
+        '  name: "${devicename}"\n'
+        '  comment: "${device_description}"\n'
+        '  friendly_name: "${friendly_devicename}"\n'
+        "  area:\n"
+        "    id: ${device_area_id}\n"
+        '    name: "${device_area}"\n'
+        "esp8266:\n"
+        "  board: esp12e\n",
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "powermon-dryer.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        '  devicename: "powermon-dryer"\n'
+        '  friendly_devicename: "Power Monitor - Dryer"\n'
+        '  device_description: "Sonoff S31"\n'
+        '  device_area: "Laundry Room"\n'
+        '  device_area_id: "laundry_room"\n'
+        "<<: !include templates/s31.yaml\n",
+        encoding="utf-8",
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.area == "Laundry Room"
+    assert device.name == "powermon-dryer"
+    assert device.friendly_name == "Power Monitor - Dryer"
+    assert device.comment == "Sonoff S31"
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_area_from_package_include(tmp_path: Path) -> None:
+    """``esphome.area`` contributed via ``packages:`` resolves without a compile."""
+    (tmp_path / "common.yaml").write_text(
+        "substitutions:\n"
+        '  device_area: "Garage"\n'
+        "esphome:\n"
+        "  name: opener\n"
+        "  area: ${device_area}\n",
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "opener.yaml"
+    yaml_path.write_text(
+        "packages:\n  common: !include common.yaml\n",
+        encoding="utf-8",
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.area == "Garage"
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1785,6 +1785,33 @@ def test_load_device_area_from_package_include(tmp_path: Path) -> None:
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_unresolvable_area_in_include_is_blank_not_token(tmp_path: Path) -> None:
+    """A never-compiled dotted ``${device.area}`` in an include stays blank, not a raw token.
+
+    The key-value substitution the simple resolver can't expand lives
+    only in the included ``esphome:`` block, so neither the raw-text
+    reader nor StorageJSON (never compiled) carries it; the config
+    token must not leak into the area column.
+    """
+    (tmp_path / "common.yaml").write_text(
+        "esphome:\n  name: opener\n  area: ${device.area}\n",
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "opener.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        "  device:\n"
+        '    area: "Garage"\n'
+        "packages:\n  common: !include common.yaml\n",
+        encoding="utf-8",
+    )
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.area == ""
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
 def test_load_device_resolved_yaml_meta_wins_over_storage(tmp_path: Path) -> None:
     """A fully resolved YAML value still beats StorageJSON (immediate edits)."""
     yaml_path = tmp_path / "lamp.yaml"

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1721,13 +1721,7 @@ def test_load_device_area_from_storage(tmp_path: Path, monkeypatch: pytest.Monke
 
 @pytest.mark.usefixtures("_redirect_ext_storage")
 def test_load_device_area_from_merge_key_include(tmp_path: Path) -> None:
-    """A never-compiled merge-key-templated config resolves its esphome meta (#1153).
-
-    The ``esphome:`` block (name / friendly_name / comment / area)
-    lives in a ``<<: !include`` template using flat substitutions, so
-    the raw-text reader sees nothing; the resolved config supplies it.
-    No StorageJSON is written — the fix must work pre-compile.
-    """
+    """A ``<<: !include`` template's esphome meta resolves before any compile."""
     templates = tmp_path / "templates"
     templates.mkdir()
     (templates / "s31.yaml").write_text(
@@ -1786,13 +1780,7 @@ def test_load_device_area_from_package_include(tmp_path: Path) -> None:
 
 @pytest.mark.usefixtures("_redirect_ext_storage")
 def test_load_device_unresolvable_area_in_include_is_blank_not_token(tmp_path: Path) -> None:
-    """A never-compiled dotted ``${device.area}`` in an include stays blank, not a raw token.
-
-    The key-value substitution the simple resolver can't expand lives
-    only in the included ``esphome:`` block, so neither the raw-text
-    reader nor StorageJSON (never compiled) carries it; the config
-    token must not leak into the area column.
-    """
+    """A never-compiled dotted ``${device.area}`` in an include stays blank, not a raw token."""
     (tmp_path / "common.yaml").write_text(
         "esphome:\n  name: opener\n  area: ${device.area}\n",
         encoding="utf-8",


### PR DESCRIPTION
# What does this implement/fix?

When a device's `esphome:` block is pulled in from another file — via a
merge-key include (`<<: !include templates/foo.yaml`), a plain
`!include`, or `packages:` — and the area is written with flat
substitutions, the resolved area never reached the device card; the drawer
and area column stayed blank.

The meta reader (`parse_esphome_meta`) only scans the **raw text of the
main file**, so when the `esphome:` block lives in an included file the
main file has no `esphome:` block and the reader returns
`(None, None, None, None)`. Meanwhile `load_device_from_storage` already
loads a fully resolved config (`load_device_yaml`, used for
api/integration detection) that expands merge-keys, includes, and
packages — but we only ever read its `substitutions:`, never the merged
`esphome:` block.

This reads `name` / `friendly_name` / `comment` / `area` off the resolved
config's `esphome:` block as a source slotted **between** the raw-text
parse (immediate-edit / broken-draft resilience) and StorageJSON
(post-compile authority), resolving `$var` / `${var}` against the merged
`substitutions:` map with the existing resolver. Inline configs are
unaffected (raw text and resolved config agree). The dotted
`${device.area}` form (key-value substitutions) stays unresolved and
continues to defer to StorageJSON (esphome persists it there as of
esphome/esphome#16710), so there is no behaviour change for that case.

New `extract_esphome_meta_from_config` handles the string and `{id, name}`
mapping forms of `area`; `_effective_meta` is generalised to `_pick_meta`
to take the resolved-config value as a second preferred source.

Both meta readers now return an `EsphomeMeta` `NamedTuple`
(`name` / `friendly_name` / `comment` / `area`) instead of a bare
4-tuple, so fields read by name at the call sites. It stays positionally
compatible, so existing unpacking and tuple-equality call sites are
unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1153

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
