### PR TITLE
Fix peer-link pairing failure from clobbered dashboard_id

### DIFF
--- a/esphome_device_builder/controllers/config/remote_build_settings.py
+++ b/esphome_device_builder/controllers/config/remote_build_settings.py
@@ -124,11 +124,9 @@ def _merge_settings_into_block(data: dict[str, Any], settings: RemoteBuildSettin
     """
     Overlay *settings* onto the existing ``_remote_build`` block in place.
 
-    The block is co-owned: ``dashboard_id`` lives here too
-    (:func:`helpers.dashboard_identity._get_or_create_dashboard_id`).
-    Replacing the whole block with ``settings.to_dict()`` would
-    drop ``dashboard_id`` on every write, re-minting the
-    dashboard's stable identity and breaking paired peers.
+    Merges rather than replaces so a co-resident key the settings
+    model doesn't own survives the write — notably a legacy
+    ``dashboard_id`` awaiting migration out of this block (#1154).
     """
     rb = data.get(_REMOTE_BUILD_KEY)
     if not isinstance(rb, dict):

--- a/esphome_device_builder/controllers/config/remote_build_settings.py
+++ b/esphome_device_builder/controllers/config/remote_build_settings.py
@@ -121,13 +121,7 @@ def has_remote_build_settings_persisted(config_dir: Path) -> bool:
 
 
 def _merge_settings_into_block(data: dict[str, Any], settings: RemoteBuildSettings) -> None:
-    """
-    Overlay *settings* onto the existing ``_remote_build`` block in place.
-
-    Merges rather than replaces so a co-resident key the settings
-    model doesn't own survives the write — notably a legacy
-    ``dashboard_id`` awaiting migration out of this block (#1154).
-    """
+    """Merge *settings* into the existing ``_remote_build`` block, preserving foreign keys."""
     rb = data.get(_REMOTE_BUILD_KEY)
     if not isinstance(rb, dict):
         rb = {}

--- a/esphome_device_builder/controllers/config/remote_build_settings.py
+++ b/esphome_device_builder/controllers/config/remote_build_settings.py
@@ -120,10 +120,27 @@ def has_remote_build_settings_persisted(config_dir: Path) -> bool:
     return isinstance(_load_metadata(config_dir).get(_REMOTE_BUILD_KEY), dict)
 
 
+def _merge_settings_into_block(data: dict[str, Any], settings: RemoteBuildSettings) -> None:
+    """
+    Overlay *settings* onto the existing ``_remote_build`` block in place.
+
+    The block is co-owned: ``dashboard_id`` lives here too
+    (:func:`helpers.dashboard_identity._get_or_create_dashboard_id`).
+    Replacing the whole block with ``settings.to_dict()`` would
+    drop ``dashboard_id`` on every write, re-minting the
+    dashboard's stable identity and breaking paired peers.
+    """
+    rb = data.get(_REMOTE_BUILD_KEY)
+    if not isinstance(rb, dict):
+        rb = {}
+        data[_REMOTE_BUILD_KEY] = rb
+    rb.update(settings.to_dict())
+
+
 def save_remote_build_settings(config_dir: Path, settings: RemoteBuildSettings) -> None:
     """Persist the receiver-side remote-build settings."""
     with metadata_transaction(config_dir) as data:
-        data[_REMOTE_BUILD_KEY] = settings.to_dict()
+        _merge_settings_into_block(data, settings)
 
 
 @contextmanager
@@ -150,4 +167,4 @@ def remote_build_settings_transaction(
     with metadata_transaction(config_dir) as data:
         settings = _settings_from_raw(data.get(_REMOTE_BUILD_KEY, {}))
         yield settings
-        data[_REMOTE_BUILD_KEY] = settings.to_dict()
+        _merge_settings_into_block(data, settings)

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -252,19 +252,25 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         """Reload the identity snapshot and respawn every APPROVED peer-link client.
 
         Loops until no rotation arrived during the pass; the only
-        await is the identity load, so a mid-pass event can't be
-        lost between the re-check and the return.
+        await is the identity load, so a mid-pass event sets
+        ``_identity_refresh_again`` and is retried before return. A
+        failed load is logged and skipped rather than propagated,
+        so a queued rotation still gets its rerun.
         """
         try:
             while True:
                 self._identity_refresh_again = False
-                await self._load_offloader_identities_async()
-                for pin_sha256 in list(self.state.peer_link_clients):
-                    pairing = self.state.pairings.get(pin_sha256)
-                    if pairing is None or pairing.status is not PeerStatus.APPROVED:
-                        continue
-                    self._cancel_peer_link_client(pin_sha256)
-                    self._spawn_peer_link_client(pairing)
+                try:
+                    await self._load_offloader_identities_async()
+                except Exception:
+                    _LOGGER.exception("Offloader identity refresh failed to load identities")
+                else:
+                    for pin_sha256 in list(self.state.peer_link_clients):
+                        pairing = self.state.pairings.get(pin_sha256)
+                        if pairing is None or pairing.status is not PeerStatus.APPROVED:
+                            continue
+                        self._cancel_peer_link_client(pin_sha256)
+                        self._spawn_peer_link_client(pairing)
                 if not self._identity_refresh_again:
                     return
         finally:

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -50,6 +50,7 @@ from ...models import (
     PairingSummary,
     PeerQueueStatusSnapshotEntry,
     PeerStatus,
+    RemoteBuildIdentityRotatedData,
     RemoteBuildPeer,
     StoredPairing,
 )
@@ -110,9 +111,9 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
                 state.pairings[pairing.pin_sha256] = pairing
             state.remote_builds_enabled = settings.remote_builds_enabled
             state.version_match_policy = settings.version_match_policy
-        peer_link_identity, dashboard_identity = await self._load_offloader_identities_async()
-        state.offloader_peer_link_priv = peer_link_identity.private_bytes
-        state.offloader_dashboard_id = dashboard_identity.dashboard_id
+        # Populates ``state.offloader_peer_link_priv`` /
+        # ``offloader_dashboard_id`` so the spawns below see them.
+        await self._load_offloader_identities_async()
         # Wire the resolver before spawning clients so each picks
         # it up at construction; stays None when zeroconf is down
         # and outbound connects fall back to the OS resolver.
@@ -128,6 +129,9 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         self._subscribe(EventType.OFFLOADER_PAIR_PEER_REVOKED, self._on_offloader_pair_peer_revoked)
         self._subscribe(EventType.OFFLOADER_PEER_LINK_OPENED, self._on_offloader_peer_link_opened)
         self._subscribe(EventType.OFFLOADER_PEER_LINK_CLOSED, self._on_offloader_peer_link_closed)
+        self._subscribe(
+            EventType.REMOTE_BUILD_IDENTITY_ROTATED, self._on_remote_build_identity_rotated
+        )
         self._start_discovery()
 
     async def stop(self) -> None:
@@ -162,11 +166,23 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     async def _load_offloader_identities_async(
         self,
     ) -> tuple[PeerLinkIdentity, DashboardIdentity]:
-        """Return both offloader-side identities, hitting the store cache."""
-        return await get_or_create_identities(
+        """
+        Return both offloader-side identities, refreshing the cached snapshot.
+
+        The peer-link client + rebind probe read
+        ``state.offloader_peer_link_priv`` / ``offloader_dashboard_id``
+        synchronously; writing the freshly-loaded values back here
+        keeps the long-lived client's presented identity in lockstep
+        with what the pairing handshake just pinned, so a rotation
+        between ``start`` and a re-pair can't drift them apart.
+        """
+        peer_link_identity, dashboard_identity = await get_or_create_identities(
             self._db.settings.config_dir,
             self._db.peer_link_identity_store,
         )
+        self.state.offloader_peer_link_priv = peer_link_identity.private_bytes
+        self.state.offloader_dashboard_id = dashboard_identity.dashboard_id
+        return peer_link_identity, dashboard_identity
 
     def _setup_peer_link_resolver(self) -> None:
         """
@@ -221,6 +237,31 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     def _on_offloader_peer_link_closed(self, event: Event[OffloaderPeerLinkClosedData]) -> None:
         """Discard ``pin_sha256`` from ``_open_peer_links`` on session close."""
         bus_handlers.on_offloader_peer_link_closed(self, event)
+
+    def _on_remote_build_identity_rotated(
+        self, event: Event[RemoteBuildIdentityRotatedData]
+    ) -> None:
+        """Refresh the cached identity + respawn live peer-link clients on rotation."""
+        self._track_task(
+            self._refresh_identity_and_respawn_clients(), name="offloader-identity-refresh"
+        )
+
+    async def _refresh_identity_and_respawn_clients(self) -> None:
+        """
+        Re-snapshot the rotated identity and reconnect every APPROVED peer-link client.
+
+        Each :class:`PeerLinkClient` captures the private key at
+        construction and never reloads it, so a rotation only
+        reaches the wire by tearing the client down and spawning a
+        fresh one off the refreshed snapshot.
+        """
+        await self._load_offloader_identities_async()
+        for pin_sha256 in list(self.state.peer_link_clients):
+            pairing = self.state.pairings.get(pin_sha256)
+            if pairing is None or pairing.status is not PeerStatus.APPROVED:
+                continue
+            self._cancel_peer_link_client(pin_sha256)
+            self._spawn_peer_link_client(pairing)
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -19,7 +19,6 @@ reference passed to both at construction.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -90,13 +89,6 @@ _LOGGER = logging.getLogger(__name__)
 _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
 
 
-# Capped backoff for retrying a failed identity reload during a
-# rotation refresh, so a transient store / metadata read can't
-# strand the peer-link clients on the pre-rotation key.
-_IDENTITY_REFRESH_RETRY_INITIAL_SECONDS = 1.0
-_IDENTITY_REFRESH_RETRY_MAX_SECONDS = 30.0
-
-
 class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     """Outbound side of remote-build: pair, peer-link, submit/cancel/download."""
 
@@ -110,11 +102,6 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
             shutdown_register=self._shutdown_callbacks.append,
             name="offloader_pairings",
         )
-        # Single-flight handle for the identity-rotation respawn so
-        # overlapping events coalesce instead of cancelling each
-        # other's freshly-spawned clients.
-        self._identity_refresh_task: asyncio.Task[None] | None = None
-        self._identity_refresh_again = False
 
     async def start(self) -> None:
         """Seed pairings from disk, cache identities, spawn peer-link clients."""
@@ -246,49 +233,19 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         self, event: Event[RemoteBuildIdentityRotatedData]
     ) -> None:
         """Refresh the cached identity + respawn live peer-link clients on rotation."""
-        if self._identity_refresh_task is not None and not self._identity_refresh_task.done():
-            # A refresh is mid-flight; have it loop once more rather
-            # than racing a second pass against the clients it spawns.
-            self._identity_refresh_again = True
-            return
-        self._identity_refresh_task = self._track_task(
+        self._track_task(
             self._refresh_identity_and_respawn_clients(), name="offloader-identity-refresh"
         )
 
     async def _refresh_identity_and_respawn_clients(self) -> None:
-        """
-        Reload the identity snapshot and respawn every APPROVED peer-link client.
-
-        Loops until no rotation arrived during the pass; the
-        ``_identity_refresh_again`` re-check is synchronous, so a
-        mid-pass rotation is always retried. A failed identity load
-        backs off and retries rather than leaving clients pinned to
-        the pre-rotation key.
-        """
-        backoff = _IDENTITY_REFRESH_RETRY_INITIAL_SECONDS
-        try:
-            while True:
-                self._identity_refresh_again = False
-                try:
-                    await self._load_offloader_identities_async()
-                except Exception:
-                    _LOGGER.exception(
-                        "Offloader identity refresh failed to load identities; retrying"
-                    )
-                    await asyncio.sleep(backoff)
-                    backoff = min(backoff * 2, _IDENTITY_REFRESH_RETRY_MAX_SECONDS)
-                    continue
-                backoff = _IDENTITY_REFRESH_RETRY_INITIAL_SECONDS
-                for pin_sha256 in list(self.state.peer_link_clients):
-                    pairing = self.state.pairings.get(pin_sha256)
-                    if pairing is None or pairing.status is not PeerStatus.APPROVED:
-                        continue
-                    self._cancel_peer_link_client(pin_sha256)
-                    self._spawn_peer_link_client(pairing)
-                if not self._identity_refresh_again:
-                    return
-        finally:
-            self._identity_refresh_task = None
+        """Reload the identity snapshot and respawn every APPROVED peer-link client."""
+        await self._load_offloader_identities_async()
+        for pin_sha256 in list(self.state.peer_link_clients):
+            pairing = self.state.pairings.get(pin_sha256)
+            if pairing is None or pairing.status is not PeerStatus.APPROVED:
+                continue
+            self._cancel_peer_link_client(pin_sha256)
+            self._spawn_peer_link_client(pairing)
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -19,6 +19,7 @@ reference passed to both at construction.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -102,6 +103,11 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
             shutdown_register=self._shutdown_callbacks.append,
             name="offloader_pairings",
         )
+        # Single-flight handle for the identity-rotation respawn so
+        # overlapping events coalesce instead of cancelling each
+        # other's freshly-spawned clients.
+        self._identity_refresh_task: asyncio.Task[None] | None = None
+        self._identity_refresh_again = False
 
     async def start(self) -> None:
         """Seed pairings from disk, cache identities, spawn peer-link clients."""
@@ -233,19 +239,33 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         self, event: Event[RemoteBuildIdentityRotatedData]
     ) -> None:
         """Refresh the cached identity + respawn live peer-link clients on rotation."""
-        self._track_task(
+        if self._identity_refresh_task is not None and not self._identity_refresh_task.done():
+            # A refresh is mid-flight; have it loop once more rather
+            # than racing a second pass against the clients it spawns.
+            self._identity_refresh_again = True
+            return
+        self._identity_refresh_task = self._track_task(
             self._refresh_identity_and_respawn_clients(), name="offloader-identity-refresh"
         )
 
     async def _refresh_identity_and_respawn_clients(self) -> None:
-        """Reload the identity snapshot and respawn every APPROVED peer-link client."""
-        await self._load_offloader_identities_async()
-        for pin_sha256 in list(self.state.peer_link_clients):
-            pairing = self.state.pairings.get(pin_sha256)
-            if pairing is None or pairing.status is not PeerStatus.APPROVED:
-                continue
-            self._cancel_peer_link_client(pin_sha256)
-            self._spawn_peer_link_client(pairing)
+        """Reload the identity snapshot and respawn every APPROVED peer-link client.
+
+        Loops until no rotation arrived during the pass — the only
+        await is the identity load, so a single-loop event can't be
+        lost between the re-check and the return.
+        """
+        while True:
+            self._identity_refresh_again = False
+            await self._load_offloader_identities_async()
+            for pin_sha256 in list(self.state.peer_link_clients):
+                pairing = self.state.pairings.get(pin_sha256)
+                if pairing is None or pairing.status is not PeerStatus.APPROVED:
+                    continue
+                self._cancel_peer_link_client(pin_sha256)
+                self._spawn_peer_link_client(pairing)
+            if not self._identity_refresh_again:
+                return
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -166,16 +166,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     async def _load_offloader_identities_async(
         self,
     ) -> tuple[PeerLinkIdentity, DashboardIdentity]:
-        """
-        Return both offloader-side identities, refreshing the cached snapshot.
-
-        The peer-link client + rebind probe read
-        ``state.offloader_peer_link_priv`` / ``offloader_dashboard_id``
-        synchronously; writing the freshly-loaded values back here
-        keeps the long-lived client's presented identity in lockstep
-        with what the pairing handshake just pinned, so a rotation
-        between ``start`` and a re-pair can't drift them apart.
-        """
+        """Load both offloader identities and refresh the cached ``state`` snapshot."""
         peer_link_identity, dashboard_identity = await get_or_create_identities(
             self._db.settings.config_dir,
             self._db.peer_link_identity_store,
@@ -247,14 +238,7 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         )
 
     async def _refresh_identity_and_respawn_clients(self) -> None:
-        """
-        Re-snapshot the rotated identity and reconnect every APPROVED peer-link client.
-
-        Each :class:`PeerLinkClient` captures the private key at
-        construction and never reloads it, so a rotation only
-        reaches the wire by tearing the client down and spawning a
-        fresh one off the refreshed snapshot.
-        """
+        """Reload the identity snapshot and respawn every APPROVED peer-link client."""
         await self._load_offloader_identities_async()
         for pin_sha256 in list(self.state.peer_link_clients):
             pairing = self.state.pairings.get(pin_sha256)

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -90,6 +90,13 @@ _LOGGER = logging.getLogger(__name__)
 _PAIRINGS_SAVE_DELAY_SECONDS = 1.0
 
 
+# Capped backoff for retrying a failed identity reload during a
+# rotation refresh, so a transient store / metadata read can't
+# strand the peer-link clients on the pre-rotation key.
+_IDENTITY_REFRESH_RETRY_INITIAL_SECONDS = 1.0
+_IDENTITY_REFRESH_RETRY_MAX_SECONDS = 30.0
+
+
 class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     """Outbound side of remote-build: pair, peer-link, submit/cancel/download."""
 
@@ -249,28 +256,35 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         )
 
     async def _refresh_identity_and_respawn_clients(self) -> None:
-        """Reload the identity snapshot and respawn every APPROVED peer-link client.
-
-        Loops until no rotation arrived during the pass; the only
-        await is the identity load, so a mid-pass event sets
-        ``_identity_refresh_again`` and is retried before return. A
-        failed load is logged and skipped rather than propagated,
-        so a queued rotation still gets its rerun.
         """
+        Reload the identity snapshot and respawn every APPROVED peer-link client.
+
+        Loops until no rotation arrived during the pass; the
+        ``_identity_refresh_again`` re-check is synchronous, so a
+        mid-pass rotation is always retried. A failed identity load
+        backs off and retries rather than leaving clients pinned to
+        the pre-rotation key.
+        """
+        backoff = _IDENTITY_REFRESH_RETRY_INITIAL_SECONDS
         try:
             while True:
                 self._identity_refresh_again = False
                 try:
                     await self._load_offloader_identities_async()
                 except Exception:
-                    _LOGGER.exception("Offloader identity refresh failed to load identities")
-                else:
-                    for pin_sha256 in list(self.state.peer_link_clients):
-                        pairing = self.state.pairings.get(pin_sha256)
-                        if pairing is None or pairing.status is not PeerStatus.APPROVED:
-                            continue
-                        self._cancel_peer_link_client(pin_sha256)
-                        self._spawn_peer_link_client(pairing)
+                    _LOGGER.exception(
+                        "Offloader identity refresh failed to load identities; retrying"
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, _IDENTITY_REFRESH_RETRY_MAX_SECONDS)
+                    continue
+                backoff = _IDENTITY_REFRESH_RETRY_INITIAL_SECONDS
+                for pin_sha256 in list(self.state.peer_link_clients):
+                    pairing = self.state.pairings.get(pin_sha256)
+                    if pairing is None or pairing.status is not PeerStatus.APPROVED:
+                        continue
+                    self._cancel_peer_link_client(pin_sha256)
+                    self._spawn_peer_link_client(pairing)
                 if not self._identity_refresh_again:
                     return
         finally:

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -251,21 +251,24 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     async def _refresh_identity_and_respawn_clients(self) -> None:
         """Reload the identity snapshot and respawn every APPROVED peer-link client.
 
-        Loops until no rotation arrived during the pass — the only
-        await is the identity load, so a single-loop event can't be
+        Loops until no rotation arrived during the pass; the only
+        await is the identity load, so a mid-pass event can't be
         lost between the re-check and the return.
         """
-        while True:
-            self._identity_refresh_again = False
-            await self._load_offloader_identities_async()
-            for pin_sha256 in list(self.state.peer_link_clients):
-                pairing = self.state.pairings.get(pin_sha256)
-                if pairing is None or pairing.status is not PeerStatus.APPROVED:
-                    continue
-                self._cancel_peer_link_client(pin_sha256)
-                self._spawn_peer_link_client(pairing)
-            if not self._identity_refresh_again:
-                return
+        try:
+            while True:
+                self._identity_refresh_again = False
+                await self._load_offloader_identities_async()
+                for pin_sha256 in list(self.state.peer_link_clients):
+                    pairing = self.state.pairings.get(pin_sha256)
+                    if pairing is None or pairing.status is not PeerStatus.APPROVED:
+                        continue
+                    self._cancel_peer_link_client(pin_sha256)
+                    self._spawn_peer_link_client(pairing)
+                if not self._identity_refresh_again:
+                    return
+        finally:
+            self._identity_refresh_task = None
 
     def _on_offloader_queue_status_changed(
         self, event: Event[OffloaderQueueStatusChangedData]

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -11,7 +11,9 @@ dashboard installation to peer dashboards:
   lives in :mod:`helpers.peer_link_identity`; this module
   composes its fingerprint with the dashboard_id below.
 * ``dashboard_id`` — a stable random base64url string stored
-  in the metadata sidecar's ``_remote_build`` block. Purely a
+  in the metadata sidecar's own ``_dashboard_identity`` block,
+  disjoint from the receiver-settings ``_remote_build`` block so
+  a settings write can't evict it. Purely a
   correlation token (it appears in mDNS TXT, peer-link
   handshakes, audit logs, and pair-request records so a peer
   can recognise which dashboard it's talking to across
@@ -37,13 +39,17 @@ import re
 import secrets
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from ..controllers.config import metadata_transaction
 from .peer_link_identity import PeerLinkIdentity, PeerLinkIdentityStore
 
 _DASHBOARD_ID_BYTES = 24
-_REMOTE_BUILD_KEY = "_remote_build"
+_DASHBOARD_IDENTITY_KEY = "_dashboard_identity"
 _DASHBOARD_ID_KEY = "dashboard_id"
+# Pre-#1154 the id co-lived here with the receiver settings; read
+# once for migration, then it moves to ``_dashboard_identity``.
+_LEGACY_REMOTE_BUILD_KEY = "_remote_build"
 
 # Public validation contract for ``dashboard_id`` strings on the
 # wire. ``dashboard_id`` is generated via
@@ -136,19 +142,39 @@ def _get_or_create_dashboard_id(config_dir: Path) -> str:
     """
     Return the persistent ``dashboard_id``, generating one if absent.
 
-    The read-modify-write runs under the metadata-sidecar lock
-    so the "exists?" check and the "generate + persist" step
-    are atomic against any concurrent ``_remote_build``
-    mutation.
+    Owns the ``_dashboard_identity`` block exclusively so the
+    receiver-settings writer (``_remote_build``) can't clobber the
+    id. A value at the legacy ``_remote_build.dashboard_id``
+    location is migrated in place (same id, no re-pair). The
+    read-modify-write runs under the metadata-sidecar lock.
     """
     with metadata_transaction(config_dir) as data:
-        rb = data.get(_REMOTE_BUILD_KEY)
-        if not isinstance(rb, dict):
-            rb = {}
-            data[_REMOTE_BUILD_KEY] = rb
-        existing = rb.get(_DASHBOARD_ID_KEY)
-        if isinstance(existing, str) and existing:
-            return existing
-        new_id = secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
-        rb[_DASHBOARD_ID_KEY] = new_id
+        block = data.get(_DASHBOARD_IDENTITY_KEY)
+        if isinstance(block, dict):
+            existing = block.get(_DASHBOARD_ID_KEY)
+            if isinstance(existing, str) and existing:
+                return existing
+        else:
+            block = {}
+            data[_DASHBOARD_IDENTITY_KEY] = block
+        new_id = _migrate_legacy_dashboard_id(data) or secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
+        block[_DASHBOARD_ID_KEY] = new_id
         return new_id
+
+
+def _migrate_legacy_dashboard_id(data: dict[str, Any]) -> str | None:
+    """
+    Pop a legacy ``_remote_build.dashboard_id`` value, returning it if found.
+
+    Drops a ``_remote_build`` block left empty by the pop so the
+    HA-addon "settings persisted" gate
+    (:func:`controllers.config.remote_build_settings.has_remote_build_settings_persisted`)
+    isn't tripped by identity creation alone.
+    """
+    legacy = data.get(_LEGACY_REMOTE_BUILD_KEY)
+    if not isinstance(legacy, dict):
+        return None
+    value = legacy.pop(_DASHBOARD_ID_KEY, None)
+    if not legacy:
+        del data[_LEGACY_REMOTE_BUILD_KEY]
+    return value if isinstance(value, str) and value else None

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -11,10 +11,8 @@ dashboard installation to peer dashboards:
   lives in :mod:`helpers.peer_link_identity`; this module
   composes its fingerprint with the dashboard_id below.
 * ``dashboard_id`` — a stable random base64url string stored
-  in the metadata sidecar's own ``_dashboard_identity`` block,
-  disjoint from the receiver-settings ``_remote_build`` block so
-  a settings write can't evict it. Purely a
-  correlation token (it appears in mDNS TXT, peer-link
+  in the metadata sidecar's own ``_dashboard_identity`` block.
+  Purely a correlation token (it appears in mDNS TXT, peer-link
   handshakes, audit logs, and pair-request records so a peer
   can recognise which dashboard it's talking to across
   rotations of the underlying cryptographic identity). NOT
@@ -47,8 +45,8 @@ from .peer_link_identity import PeerLinkIdentity, PeerLinkIdentityStore
 _DASHBOARD_ID_BYTES = 24
 _DASHBOARD_IDENTITY_KEY = "_dashboard_identity"
 _DASHBOARD_ID_KEY = "dashboard_id"
-# Pre-#1154 the id co-lived here with the receiver settings; read
-# once for migration, then it moves to ``_dashboard_identity``.
+# Legacy location the id co-lived in with the receiver settings;
+# read once to migrate it into ``_dashboard_identity``.
 _LEGACY_REMOTE_BUILD_KEY = "_remote_build"
 
 # Public validation contract for ``dashboard_id`` strings on the
@@ -139,15 +137,7 @@ async def rotate_identity(
 
 
 def _get_or_create_dashboard_id(config_dir: Path) -> str:
-    """
-    Return the persistent ``dashboard_id``, generating one if absent.
-
-    Owns the ``_dashboard_identity`` block exclusively so the
-    receiver-settings writer (``_remote_build``) can't clobber the
-    id. A value at the legacy ``_remote_build.dashboard_id``
-    location is migrated in place (same id, no re-pair). The
-    read-modify-write runs under the metadata-sidecar lock.
-    """
+    """Return the persistent ``dashboard_id``, migrating a legacy copy or minting one."""
     with metadata_transaction(config_dir) as data:
         # Sweep any legacy co-tenant first so a stale copy can't
         # linger even when the new block already answers the read.
@@ -166,14 +156,7 @@ def _get_or_create_dashboard_id(config_dir: Path) -> str:
 
 
 def _migrate_legacy_dashboard_id(data: dict[str, Any]) -> str | None:
-    """
-    Pop a legacy ``_remote_build.dashboard_id`` value, returning it if found.
-
-    Drops a ``_remote_build`` block left empty by the pop so the
-    HA-addon "settings persisted" gate
-    (:func:`controllers.config.remote_build_settings.has_remote_build_settings_persisted`)
-    isn't tripped by identity creation alone.
-    """
+    """Pop a legacy ``_remote_build.dashboard_id``, dropping a block left empty by the pop."""
     legacy = data.get(_LEGACY_REMOTE_BUILD_KEY)
     if not isinstance(legacy, dict):
         return None

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -149,6 +149,9 @@ def _get_or_create_dashboard_id(config_dir: Path) -> str:
     read-modify-write runs under the metadata-sidecar lock.
     """
     with metadata_transaction(config_dir) as data:
+        # Sweep any legacy co-tenant first so a stale copy can't
+        # linger even when the new block already answers the read.
+        legacy_id = _migrate_legacy_dashboard_id(data)
         block = data.get(_DASHBOARD_IDENTITY_KEY)
         if isinstance(block, dict):
             existing = block.get(_DASHBOARD_ID_KEY)
@@ -157,7 +160,7 @@ def _get_or_create_dashboard_id(config_dir: Path) -> str:
         else:
             block = {}
             data[_DASHBOARD_IDENTITY_KEY] = block
-        new_id = _migrate_legacy_dashboard_id(data) or secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
+        new_id = legacy_id or secrets.token_urlsafe(_DASHBOARD_ID_BYTES)
         block[_DASHBOARD_ID_KEY] = new_id
         return new_id
 

--- a/tests/e2e/test_identity_rotation.py
+++ b/tests/e2e/test_identity_rotation.py
@@ -1,0 +1,87 @@
+"""
+End-to-end: offloader peer-link identity rotation + recovery (#1154).
+
+Rotating the offloader's X25519 peer-link key must respawn its
+long-lived :class:`PeerLinkClient` off the *current* identity, not
+the start()-time snapshot. The bug presented the stale key on the
+long-lived link after a rotation, so the receiver rejected it
+(``pin_mismatch`` / ``no_approved_peer``) even though the GUI
+showed a successful pair. This drives the real two-instance wire:
+rotate, watch the old session drop, re-pair, and confirm the
+session comes back pinned to the rotated key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from esphome_device_builder.helpers.peer_link_identity import PeerLinkIdentityStore
+from esphome_device_builder.models import EventType, RemoteBuildIdentityRotatedData
+
+from ..conftest import capture_events
+from .conftest import PairedInstances
+
+
+async def _repair(instances: PairedInstances) -> None:
+    """Run the receiver-window → preview → request → approve re-pair sequence."""
+    port = instances.receiver_server.port
+    assert port is not None  # TestServer always binds; narrow for type-checkers.
+    await instances.receiver.set_pairing_window(open=True, client="receiver-tab")
+    preview = await instances.offloader.preview_pair(hostname="127.0.0.1", port=port)
+    await instances.offloader.request_pair(
+        hostname="127.0.0.1",
+        port=port,
+        pin_sha256=preview["pin_sha256"],
+        receiver_label="receiver",
+        offloader_label="offloader",
+    )
+    pair_status_changed = capture_events(
+        instances.offloader_bus, EventType.OFFLOADER_PAIR_STATUS_CHANGED
+    )
+    await instances.receiver.approve_peer(dashboard_id=instances.offloader_dashboard_id)
+    await asyncio.wait_for(pair_status_changed.received.wait(), timeout=2.0)
+
+
+async def test_offloader_identity_rotation_recovers_session(
+    paired_instances: PairedInstances,
+) -> None:
+    """A rotated offloader identity drops the link, then re-pair recovers under the new key.
+
+    On the pre-fix tree the respawned client keeps presenting the
+    start()-time key, so the re-paired session never reopens — this
+    times out at the recovery wait.
+    """
+    await paired_instances.wait_until_session_opened()
+    dashboard_id = paired_instances.offloader_dashboard_id
+    receiver_pin = paired_instances.pin_sha256
+    v0_pin = paired_instances.receiver.state.approved_peers[dashboard_id].pin_sha256
+
+    # Rotate the offloader's peer-link key, then announce it on the
+    # offloader bus exactly as ``rotate_identity`` does.
+    store: PeerLinkIdentityStore = paired_instances.offloader._db.peer_link_identity_store
+    v1 = await store.async_rotate()
+    assert v1.pin_sha256 != v0_pin
+
+    reopened = capture_events(
+        paired_instances.receiver_bus, EventType.RECEIVER_PEER_LINK_SESSION_OPENED
+    )
+    paired_instances.offloader_bus.fire(
+        EventType.REMOTE_BUILD_IDENTITY_ROTATED,
+        RemoteBuildIdentityRotatedData(dashboard_id=dashboard_id, pin_sha256=v1.pin_sha256),
+    )
+
+    # The respawned client presents the new key; the receiver still
+    # pins v0, so the old session drops and the rotated identity is
+    # rejected until the operator re-pairs.
+    await paired_instances.wait_until_session_closed()
+
+    # Operator removes the stale peer and re-pairs the rotated identity.
+    await paired_instances.receiver.remove_peer(dashboard_id=dashboard_id)
+    await _repair(paired_instances)
+
+    # Session recovers, now pinned to the rotated key on both sides.
+    await asyncio.wait_for(reopened.received.wait(), timeout=2.0)
+    assert dashboard_id in paired_instances.receiver.state.peer_link_sessions
+    assert paired_instances.receiver.state.approved_peers[dashboard_id].pin_sha256 == v1.pin_sha256
+    live = paired_instances.offloader.state.peer_link_clients[receiver_pin]
+    assert live.client._identity_pub == v1.public_bytes

--- a/tests/e2e/test_identity_rotation.py
+++ b/tests/e2e/test_identity_rotation.py
@@ -1,14 +1,9 @@
 """
-End-to-end: offloader peer-link identity rotation + recovery (#1154).
+End-to-end: offloader peer-link identity rotation + recovery.
 
-Rotating the offloader's X25519 peer-link key must respawn its
-long-lived :class:`PeerLinkClient` off the *current* identity, not
-the start()-time snapshot. The bug presented the stale key on the
-long-lived link after a rotation, so the receiver rejected it
-(``pin_mismatch`` / ``no_approved_peer``) even though the GUI
-showed a successful pair. This drives the real two-instance wire:
-rotate, watch the old session drop, re-pair, and confirm the
-session comes back pinned to the rotated key.
+Rotate the offloader's key over the real two-instance wire, watch
+the session drop, re-pair, and confirm it recovers pinned to the
+rotated key.
 """
 
 from __future__ import annotations
@@ -45,12 +40,7 @@ async def _repair(instances: PairedInstances) -> None:
 async def test_offloader_identity_rotation_recovers_session(
     paired_instances: PairedInstances,
 ) -> None:
-    """A rotated offloader identity drops the link, then re-pair recovers under the new key.
-
-    On the pre-fix tree the respawned client keeps presenting the
-    start()-time key, so the re-paired session never reopens — this
-    times out at the recovery wait.
-    """
+    """A rotated offloader identity drops the link; re-pair recovers it under the new key."""
     await paired_instances.wait_until_session_opened()
     dashboard_id = paired_instances.offloader_dashboard_id
     receiver_pin = paired_instances.pin_sha256

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -4,7 +4,7 @@ Tests for the dashboard identity helper.
 The helper bundles two persistent values: the X25519 peer-link
 key's ``pin_sha256`` (which paired offloaders pin against during
 the Noise handshake) and the stable ``dashboard_id`` correlation
-token in the metadata sidecar's ``_remote_build`` block. The
+token in the metadata sidecar's ``_dashboard_identity`` block. The
 X25519 key drives both the actual peer-link authentication AND
 the displayed fingerprint. Coverage here pins that:
 
@@ -12,8 +12,9 @@ the displayed fingerprint. Coverage here pins that:
   the X25519 peer-link helper's output (i.e. no divergence
   between what the UI shows and what offloaders observe).
 * ``dashboard_id`` is generated once on first read, persisted
-  under ``_remote_build.dashboard_id``, idempotent across calls,
-  preserved across rotations.
+  under ``_dashboard_identity.dashboard_id``, idempotent across
+  calls, preserved across rotations, and migrated out of the
+  legacy ``_remote_build`` co-tenancy without a re-mint.
 * The metadata sidecar's fail-safe paths (missing key, non-dict
   block, corrupt JSON) all land on a fresh dashboard_id without
   crashing.
@@ -27,6 +28,7 @@ import threading
 from pathlib import Path
 
 from esphome_device_builder.controllers.config.remote_build_settings import (
+    has_remote_build_settings_persisted,
     remote_build_settings_transaction,
     save_remote_build_settings,
 )
@@ -58,9 +60,9 @@ async def test_first_call_generates_and_persists_identity(tmp_path: Path) -> Non
     # Noise handshake; verify it landed on disk so a subsequent
     # bind picks it up.
     assert (tmp_path / ".device-builder-peer-link-key.bin").exists()
-    # ``dashboard_id`` lands in ``_remote_build.dashboard_id``.
+    # ``dashboard_id`` lands in its own ``_dashboard_identity`` block.
     metadata = _read_metadata(tmp_path)
-    assert metadata["_remote_build"]["dashboard_id"] == identity.dashboard_id
+    assert metadata["_dashboard_identity"]["dashboard_id"] == identity.dashboard_id
 
 
 async def test_pin_sha256_matches_peer_link_identity(tmp_path: Path) -> None:
@@ -152,24 +154,15 @@ async def test_rotate_identity_persists_to_disk(tmp_path: Path) -> None:
 
 
 async def test_dashboard_id_survives_other_remote_build_mutations(tmp_path: Path) -> None:
-    """
-    Writing other ``_remote_build`` keys doesn't drop ``dashboard_id``.
-
-    Pin the read-modify-write semantics of the dashboard_id
-    persistence path — a bare overwrite of the ``_remote_build``
-    blob would silently reset every other field; equally, an
-    external mutation that follows the same RMW shape must
-    preserve ``dashboard_id``.
-    """
+    """Writing the disjoint ``_remote_build`` block doesn't disturb ``dashboard_id``."""
     identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
 
-    # Simulate another phase writing other fields under the same key.
+    # Another phase writes the settings block (a separate key now).
     metadata_path = tmp_path / ".device-builder.json"
     data = json.loads(metadata_path.read_bytes())
-    data["_remote_build"]["enabled"] = True
+    data["_remote_build"] = {"enabled": True}
     metadata_path.write_bytes(json.dumps(data).encode())
 
-    # Re-read the identity; dashboard_id still there.
     second = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     assert second.dashboard_id == identity.dashboard_id
 
@@ -178,33 +171,69 @@ async def test_remote_build_settings_writes_preserve_foreign_keys(tmp_path: Path
     """
     Both real settings writers merge into ``_remote_build``, never replace it (#1154).
 
-    ``dashboard_id`` co-owns the block with the receiver
-    settings; a wholesale overwrite re-minted it on every flip.
     The arbitrary ``_sentinel`` pins the *general* invariant so a
-    future co-resident key is protected too, not just
-    ``dashboard_id``.
+    co-resident key (e.g. a legacy ``dashboard_id`` mid-migration)
+    survives a settings flip rather than being wiped by a wholesale
+    overwrite.
     """
-    identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     metadata_path = tmp_path / ".device-builder.json"
-    data = json.loads(metadata_path.read_bytes())
-    data["_remote_build"]["_sentinel"] = "keep-me"
-    metadata_path.write_bytes(json.dumps(data).encode())
+    metadata_path.write_bytes(json.dumps({"_remote_build": {"_sentinel": "keep-me"}}).encode())
 
     save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=False))
     block = _read_metadata(tmp_path)["_remote_build"]
-    assert block["dashboard_id"] == identity.dashboard_id
     assert block["_sentinel"] == "keep-me"
     assert block["enabled"] is False
 
     with remote_build_settings_transaction(tmp_path) as settings:
         settings.enabled = True
     block = _read_metadata(tmp_path)["_remote_build"]
-    assert block["dashboard_id"] == identity.dashboard_id
     assert block["_sentinel"] == "keep-me"
     assert block["enabled"] is True
 
-    again = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
-    assert again.dashboard_id == identity.dashboard_id
+
+async def test_legacy_dashboard_id_migrates_out_of_remote_build(tmp_path: Path) -> None:
+    """
+    A pre-#1154 ``_remote_build.dashboard_id`` moves to its own block, same value.
+
+    No re-mint (so paired peers keep matching); the settings keys
+    in ``_remote_build`` are left intact.
+    """
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(
+        json.dumps({"_remote_build": {"dashboard_id": "legacy-id", "enabled": True}}).encode()
+    )
+
+    identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
+    assert identity.dashboard_id == "legacy-id"
+
+    metadata = _read_metadata(tmp_path)
+    assert metadata["_dashboard_identity"]["dashboard_id"] == "legacy-id"
+    assert "dashboard_id" not in metadata["_remote_build"]
+    assert metadata["_remote_build"]["enabled"] is True
+
+
+async def test_minting_dashboard_id_does_not_trip_settings_persisted_gate(tmp_path: Path) -> None:
+    """
+    Identity creation alone must not flip the HA-addon "settings persisted" signal (#1154).
+
+    The id used to be minted into ``_remote_build``, which made
+    ``has_remote_build_settings_persisted`` read ``True`` on the
+    next boot and bind the receiver on a fresh addon install that
+    never touched the toggle.
+    """
+    await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
+    assert has_remote_build_settings_persisted(tmp_path) is False
+
+
+async def test_legacy_dashboard_id_only_block_removed_on_migration(tmp_path: Path) -> None:
+    """A ``_remote_build`` holding only a legacy id is dropped, restoring the gate signal."""
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(json.dumps({"_remote_build": {"dashboard_id": "legacy-id"}}).encode())
+
+    identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
+    assert identity.dashboard_id == "legacy-id"
+    assert "_remote_build" not in _read_metadata(tmp_path)
+    assert has_remote_build_settings_persisted(tmp_path) is False
 
 
 async def test_init_after_id_only_mutation_preserves_other_fields(tmp_path: Path) -> None:
@@ -213,15 +242,15 @@ async def test_init_after_id_only_mutation_preserves_other_fields(tmp_path: Path
 
     Real-world path: a user flips the Settings toggle before the
     identity helper has ever run. The metadata sidecar already
-    has ``_remote_build.enabled`` set; the identity init must
-    merge into that rather than replacing the whole key.
+    has ``_remote_build.enabled`` set; the identity init writes
+    its own ``_dashboard_identity`` block and leaves that alone.
     """
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(b'{"_remote_build": {"enabled": true}}')
 
     identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     metadata = _read_metadata(tmp_path)
-    assert metadata["_remote_build"]["dashboard_id"] == identity.dashboard_id
+    assert metadata["_dashboard_identity"]["dashboard_id"] == identity.dashboard_id
     assert metadata["_remote_build"]["enabled"] is True
 
 
@@ -241,7 +270,7 @@ async def test_corrupt_metadata_does_not_block_generation(tmp_path: Path) -> Non
     identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     assert identity.dashboard_id  # generated fresh
     metadata = _read_metadata(tmp_path)
-    assert metadata["_remote_build"]["dashboard_id"] == identity.dashboard_id
+    assert metadata["_dashboard_identity"]["dashboard_id"] == identity.dashboard_id
 
 
 async def test_non_dict_metadata_root_falls_back(tmp_path: Path) -> None:

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -168,14 +168,7 @@ async def test_dashboard_id_survives_other_remote_build_mutations(tmp_path: Path
 
 
 async def test_remote_build_settings_writes_preserve_foreign_keys(tmp_path: Path) -> None:
-    """
-    Both real settings writers merge into ``_remote_build``, never replace it (#1154).
-
-    The arbitrary ``_sentinel`` pins the *general* invariant so a
-    co-resident key (e.g. a legacy ``dashboard_id`` mid-migration)
-    survives a settings flip rather than being wiped by a wholesale
-    overwrite.
-    """
+    """Both settings writers merge into ``_remote_build``, preserving a foreign key."""
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(json.dumps({"_remote_build": {"_sentinel": "keep-me"}}).encode())
 
@@ -199,12 +192,7 @@ async def test_remote_build_settings_writes_preserve_foreign_keys(tmp_path: Path
 
 
 async def test_legacy_dashboard_id_migrates_out_of_remote_build(tmp_path: Path) -> None:
-    """
-    A pre-#1154 ``_remote_build.dashboard_id`` moves to its own block, same value.
-
-    No re-mint (so paired peers keep matching); the settings keys
-    in ``_remote_build`` are left intact.
-    """
+    """A legacy ``_remote_build.dashboard_id`` migrates to its own block with the same value."""
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(
         json.dumps({"_remote_build": {"dashboard_id": "legacy-id", "enabled": True}}).encode()
@@ -239,21 +227,14 @@ async def test_legacy_dashboard_id_swept_even_when_new_block_wins(tmp_path: Path
 
 
 async def test_minting_dashboard_id_does_not_trip_settings_persisted_gate(tmp_path: Path) -> None:
-    """
-    Identity creation alone must not flip the HA-addon "settings persisted" signal (#1154).
-
-    The id used to be minted into ``_remote_build``, which made
-    ``has_remote_build_settings_persisted`` read ``True`` on the
-    next boot and bind the receiver on a fresh addon install that
-    never touched the toggle.
-    """
+    """Minting the identity doesn't flip ``has_remote_build_settings_persisted``."""
     await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     persisted = await asyncio.to_thread(has_remote_build_settings_persisted, tmp_path)
     assert persisted is False
 
 
 async def test_legacy_dashboard_id_only_block_removed_on_migration(tmp_path: Path) -> None:
-    """A ``_remote_build`` holding only a legacy id is dropped, restoring the gate signal."""
+    """A ``_remote_build`` holding only a legacy id is dropped after migration."""
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(json.dumps({"_remote_build": {"dashboard_id": "legacy-id"}}).encode())
 

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -26,6 +26,10 @@ import json
 import threading
 from pathlib import Path
 
+from esphome_device_builder.controllers.config.remote_build_settings import (
+    remote_build_settings_transaction,
+    save_remote_build_settings,
+)
 from esphome_device_builder.helpers.dashboard_identity import (
     DASHBOARD_ID_MAX_CHARS,
     DASHBOARD_ID_PATTERN,
@@ -37,6 +41,7 @@ from esphome_device_builder.helpers.dashboard_identity import (
 from esphome_device_builder.helpers.peer_link_identity import (
     PeerLinkIdentityStore,
 )
+from esphome_device_builder.models import RemoteBuildSettings
 
 
 def _read_metadata(config_dir: Path) -> dict:
@@ -167,6 +172,39 @@ async def test_dashboard_id_survives_other_remote_build_mutations(tmp_path: Path
     # Re-read the identity; dashboard_id still there.
     second = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     assert second.dashboard_id == identity.dashboard_id
+
+
+async def test_remote_build_settings_writes_preserve_foreign_keys(tmp_path: Path) -> None:
+    """
+    Both real settings writers merge into ``_remote_build``, never replace it (#1154).
+
+    ``dashboard_id`` co-owns the block with the receiver
+    settings; a wholesale overwrite re-minted it on every flip.
+    The arbitrary ``_sentinel`` pins the *general* invariant so a
+    future co-resident key is protected too, not just
+    ``dashboard_id``.
+    """
+    identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
+    metadata_path = tmp_path / ".device-builder.json"
+    data = json.loads(metadata_path.read_bytes())
+    data["_remote_build"]["_sentinel"] = "keep-me"
+    metadata_path.write_bytes(json.dumps(data).encode())
+
+    save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=False))
+    block = _read_metadata(tmp_path)["_remote_build"]
+    assert block["dashboard_id"] == identity.dashboard_id
+    assert block["_sentinel"] == "keep-me"
+    assert block["enabled"] is False
+
+    with remote_build_settings_transaction(tmp_path) as settings:
+        settings.enabled = True
+    block = _read_metadata(tmp_path)["_remote_build"]
+    assert block["dashboard_id"] == identity.dashboard_id
+    assert block["_sentinel"] == "keep-me"
+    assert block["enabled"] is True
+
+    again = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
+    assert again.dashboard_id == identity.dashboard_id
 
 
 async def test_init_after_id_only_mutation_preserves_other_fields(tmp_path: Path) -> None:

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -179,13 +179,20 @@ async def test_remote_build_settings_writes_preserve_foreign_keys(tmp_path: Path
     metadata_path = tmp_path / ".device-builder.json"
     metadata_path.write_bytes(json.dumps({"_remote_build": {"_sentinel": "keep-me"}}).encode())
 
-    save_remote_build_settings(tmp_path, RemoteBuildSettings(enabled=False))
+    # Hop to a thread: the writers do sync metadata I/O that
+    # blockbuster (Linux CI) flags when called on the event loop.
+    await asyncio.to_thread(
+        save_remote_build_settings, tmp_path, RemoteBuildSettings(enabled=False)
+    )
     block = _read_metadata(tmp_path)["_remote_build"]
     assert block["_sentinel"] == "keep-me"
     assert block["enabled"] is False
 
-    with remote_build_settings_transaction(tmp_path) as settings:
-        settings.enabled = True
+    def _enable() -> None:
+        with remote_build_settings_transaction(tmp_path) as settings:
+            settings.enabled = True
+
+    await asyncio.to_thread(_enable)
     block = _read_metadata(tmp_path)["_remote_build"]
     assert block["_sentinel"] == "keep-me"
     assert block["enabled"] is True
@@ -212,6 +219,25 @@ async def test_legacy_dashboard_id_migrates_out_of_remote_build(tmp_path: Path) 
     assert metadata["_remote_build"]["enabled"] is True
 
 
+async def test_legacy_dashboard_id_swept_even_when_new_block_wins(tmp_path: Path) -> None:
+    """A stale legacy id is removed even if ``_dashboard_identity`` already answers."""
+    metadata_path = tmp_path / ".device-builder.json"
+    metadata_path.write_bytes(
+        json.dumps(
+            {
+                "_dashboard_identity": {"dashboard_id": "current-id"},
+                "_remote_build": {"dashboard_id": "stale-id", "enabled": True},
+            }
+        ).encode()
+    )
+
+    identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
+    assert identity.dashboard_id == "current-id"
+    block = _read_metadata(tmp_path)["_remote_build"]
+    assert "dashboard_id" not in block
+    assert block["enabled"] is True
+
+
 async def test_minting_dashboard_id_does_not_trip_settings_persisted_gate(tmp_path: Path) -> None:
     """
     Identity creation alone must not flip the HA-addon "settings persisted" signal (#1154).
@@ -222,7 +248,8 @@ async def test_minting_dashboard_id_does_not_trip_settings_persisted_gate(tmp_pa
     never touched the toggle.
     """
     await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
-    assert has_remote_build_settings_persisted(tmp_path) is False
+    persisted = await asyncio.to_thread(has_remote_build_settings_persisted, tmp_path)
+    assert persisted is False
 
 
 async def test_legacy_dashboard_id_only_block_removed_on_migration(tmp_path: Path) -> None:
@@ -233,7 +260,8 @@ async def test_legacy_dashboard_id_only_block_removed_on_migration(tmp_path: Pat
     identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     assert identity.dashboard_id == "legacy-id"
     assert "_remote_build" not in _read_metadata(tmp_path)
-    assert has_remote_build_settings_persisted(tmp_path) is False
+    persisted = await asyncio.to_thread(has_remote_build_settings_persisted, tmp_path)
+    assert persisted is False
 
 
 async def test_init_after_id_only_mutation_preserves_other_fields(tmp_path: Path) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1928,7 +1928,7 @@ async def test_rotate_identity_fires_event_on_bus(tmp_path: Path) -> None:
 async def test_identity_rotation_refreshes_snapshot_and_respawns_approved_clients(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Rotation re-snapshots the identity and reconnects only APPROVED peer-link clients (#1154)."""
+    """Rotation re-snapshots the identity and reconnects only APPROVED peer-link clients."""
     controller = _make_controller(config_dir=tmp_path)
     controller.offloader._db.bus = MagicMock()
     # Stale start()-time snapshot the live peer-link client would

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2000,6 +2000,55 @@ async def test_identity_rotation_handler_schedules_refresh(
     await asyncio.wait_for(called.wait(), timeout=2.0)
 
 
+async def test_identity_rotation_coalesces_overlapping_refreshes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rotation event mid-refresh reruns the pass instead of spawning a second task."""
+    controller = _make_controller(config_dir=tmp_path)
+    off = controller.offloader
+    off._db.bus = MagicMock()
+    approved = StoredPairing(
+        receiver_hostname="r",
+        receiver_port=6055,
+        pin_sha256="a" * 64,
+        static_x25519_pub=b"\x01" * 32,
+        label="r",
+        paired_at=1.0,
+        status=PeerStatus.APPROVED,
+    )
+    off.state.pairings["a" * 64] = approved
+    off.state.peer_link_clients["a" * 64] = MagicMock()
+    spawn = MagicMock()
+    monkeypatch.setattr(off, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(off, "_spawn_peer_link_client", spawn)
+
+    gate = asyncio.Event()
+    load_calls = 0
+
+    async def _blocking_load() -> None:
+        nonlocal load_calls
+        load_calls += 1
+        await gate.wait()
+
+    monkeypatch.setattr(off, "_load_offloader_identities_async", _blocking_load)
+
+    off._on_remote_build_identity_rotated(MagicMock())
+    await asyncio.sleep(0)
+    task = off._identity_refresh_task
+    assert task is not None and not task.done()
+
+    # Second event while the first pass is parked on the load gate.
+    off._on_remote_build_identity_rotated(MagicMock())
+    assert off._identity_refresh_task is task
+    assert off._identity_refresh_again is True
+
+    gate.set()
+    await asyncio.wait_for(task, timeout=2.0)
+    # One refresh task, but two passes (the coalesced rerun).
+    assert load_calls == 2
+    assert spawn.call_count == 2
+
+
 async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:
     """A second concurrent ``rotate_identity`` raises ``ALREADY_EXISTS``."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -29,7 +29,6 @@ from esphome_device_builder.controllers.remote_build import (
     OffloaderController,
     ReceiverController,
 )
-from esphome_device_builder.controllers.remote_build import offloader as rb_offloader
 from esphome_device_builder.controllers.remote_build import (
     pairing_window as rb_pairing_window,
 )
@@ -1999,100 +1998,6 @@ async def test_identity_rotation_handler_schedules_refresh(
     )
     controller.offloader._on_remote_build_identity_rotated(MagicMock())
     await asyncio.wait_for(called.wait(), timeout=2.0)
-
-
-async def test_identity_rotation_coalesces_overlapping_refreshes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A rotation event mid-refresh reruns the pass instead of spawning a second task."""
-    controller = _make_controller(config_dir=tmp_path)
-    off = controller.offloader
-    off._db.bus = MagicMock()
-    approved = StoredPairing(
-        receiver_hostname="r",
-        receiver_port=6055,
-        pin_sha256="a" * 64,
-        static_x25519_pub=b"\x01" * 32,
-        label="r",
-        paired_at=1.0,
-        status=PeerStatus.APPROVED,
-    )
-    off.state.pairings["a" * 64] = approved
-    off.state.peer_link_clients["a" * 64] = MagicMock()
-    spawn = MagicMock()
-    monkeypatch.setattr(off, "_cancel_peer_link_client", MagicMock())
-    monkeypatch.setattr(off, "_spawn_peer_link_client", spawn)
-
-    gate = asyncio.Event()
-    load_calls = 0
-
-    async def _blocking_load() -> None:
-        nonlocal load_calls
-        load_calls += 1
-        await gate.wait()
-
-    monkeypatch.setattr(off, "_load_offloader_identities_async", _blocking_load)
-
-    off._on_remote_build_identity_rotated(MagicMock())
-    await asyncio.sleep(0)
-    task = off._identity_refresh_task
-    assert task is not None and not task.done()
-
-    # Second event while the first pass is parked on the load gate.
-    off._on_remote_build_identity_rotated(MagicMock())
-    assert off._identity_refresh_task is task
-    assert off._identity_refresh_again is True
-
-    gate.set()
-    await asyncio.wait_for(task, timeout=2.0)
-    # One refresh task, but two passes (the coalesced rerun).
-    assert load_calls == 2
-    assert spawn.call_count == 2
-    # Handle is cleared once the pass settles.
-    assert off._identity_refresh_task is None
-
-
-async def test_identity_refresh_retries_after_load_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A failed identity load backs off and retries instead of leaving clients stale."""
-    monkeypatch.setattr(rb_offloader, "_IDENTITY_REFRESH_RETRY_INITIAL_SECONDS", 0.0)
-    monkeypatch.setattr(rb_offloader, "_IDENTITY_REFRESH_RETRY_MAX_SECONDS", 0.0)
-    controller = _make_controller(config_dir=tmp_path)
-    off = controller.offloader
-    off._db.bus = MagicMock()
-    approved = StoredPairing(
-        receiver_hostname="r",
-        receiver_port=6055,
-        pin_sha256="a" * 64,
-        static_x25519_pub=b"\x01" * 32,
-        label="r",
-        paired_at=1.0,
-        status=PeerStatus.APPROVED,
-    )
-    off.state.pairings["a" * 64] = approved
-    off.state.peer_link_clients["a" * 64] = MagicMock()
-    spawn = MagicMock()
-    monkeypatch.setattr(off, "_cancel_peer_link_client", MagicMock())
-    monkeypatch.setattr(off, "_spawn_peer_link_client", spawn)
-
-    load_calls = 0
-
-    async def _load() -> None:
-        nonlocal load_calls
-        load_calls += 1
-        if load_calls == 1:
-            raise RuntimeError("boom")
-
-    monkeypatch.setattr(off, "_load_offloader_identities_async", _load)
-
-    off._on_remote_build_identity_rotated(MagicMock())
-    await asyncio.wait_for(off._identity_refresh_task, timeout=2.0)
-    # First load raised (no respawn); the backoff retry's load
-    # succeeded and respawned.
-    assert load_calls == 2
-    assert spawn.call_count == 1
-    assert off._identity_refresh_task is None
 
 
 async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2047,6 +2047,8 @@ async def test_identity_rotation_coalesces_overlapping_refreshes(
     # One refresh task, but two passes (the coalesced rerun).
     assert load_calls == 2
     assert spawn.call_count == 2
+    # Handle is cleared once the pass settles.
+    assert off._identity_refresh_task is None
 
 
 async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -29,6 +29,7 @@ from esphome_device_builder.controllers.remote_build import (
     OffloaderController,
     ReceiverController,
 )
+from esphome_device_builder.controllers.remote_build import offloader as rb_offloader
 from esphome_device_builder.controllers.remote_build import (
     pairing_window as rb_pairing_window,
 )
@@ -2051,10 +2052,12 @@ async def test_identity_rotation_coalesces_overlapping_refreshes(
     assert off._identity_refresh_task is None
 
 
-async def test_identity_refresh_retries_queued_event_after_load_failure(
+async def test_identity_refresh_retries_after_load_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A load failure mid-pass is logged, not propagated, and the queued rerun still respawns."""
+    """A failed identity load backs off and retries instead of leaving clients stale."""
+    monkeypatch.setattr(rb_offloader, "_IDENTITY_REFRESH_RETRY_INITIAL_SECONDS", 0.0)
+    monkeypatch.setattr(rb_offloader, "_IDENTITY_REFRESH_RETRY_MAX_SECONDS", 0.0)
     controller = _make_controller(config_dir=tmp_path)
     off = controller.offloader
     off._db.bus = MagicMock()
@@ -2073,29 +2076,19 @@ async def test_identity_refresh_retries_queued_event_after_load_failure(
     monkeypatch.setattr(off, "_cancel_peer_link_client", MagicMock())
     monkeypatch.setattr(off, "_spawn_peer_link_client", spawn)
 
-    gate = asyncio.Event()
     load_calls = 0
 
     async def _load() -> None:
         nonlocal load_calls
         load_calls += 1
         if load_calls == 1:
-            await gate.wait()
             raise RuntimeError("boom")
 
     monkeypatch.setattr(off, "_load_offloader_identities_async", _load)
 
     off._on_remote_build_identity_rotated(MagicMock())
-    await asyncio.sleep(0)
-    task = off._identity_refresh_task
-    assert task is not None
-    # Queue a rerun while the first (about-to-fail) load is parked.
-    off._on_remote_build_identity_rotated(MagicMock())
-    assert off._identity_refresh_again is True
-
-    gate.set()
-    await asyncio.wait_for(task, timeout=2.0)
-    # First pass's load raised (no respawn); the queued rerun's load
+    await asyncio.wait_for(off._identity_refresh_task, timeout=2.0)
+    # First load raised (no respawn); the backoff retry's load
     # succeeded and respawned.
     assert load_calls == 2
     assert spawn.call_count == 1

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -1925,6 +1925,81 @@ async def test_rotate_identity_fires_event_on_bus(tmp_path: Path) -> None:
     }
 
 
+async def test_identity_rotation_refreshes_snapshot_and_respawns_approved_clients(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rotation re-snapshots the identity and reconnects only APPROVED peer-link clients (#1154)."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller.offloader._db.bus = MagicMock()
+    # Stale start()-time snapshot the live peer-link client would
+    # otherwise keep presenting after a rotation.
+    controller.offloader.state.offloader_peer_link_priv = b"\x11" * 32
+    controller.offloader.state.offloader_dashboard_id = "stale-id"
+    approved = StoredPairing(
+        receiver_hostname="r",
+        receiver_port=6055,
+        pin_sha256="a" * 64,
+        static_x25519_pub=b"\x01" * 32,
+        label="r",
+        paired_at=1.0,
+        status=PeerStatus.APPROVED,
+    )
+    pending = StoredPairing(
+        receiver_hostname="p",
+        receiver_port=6055,
+        pin_sha256="b" * 64,
+        static_x25519_pub=b"\x02" * 32,
+        label="p",
+        paired_at=1.0,
+        status=PeerStatus.PENDING,
+    )
+    controller.offloader.state.pairings["a" * 64] = approved
+    controller.offloader.state.pairings["b" * 64] = pending
+    controller.offloader.state.peer_link_clients["a" * 64] = MagicMock()
+    controller.offloader.state.peer_link_clients["b" * 64] = MagicMock()
+    cancel = MagicMock()
+    spawn = MagicMock()
+    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)
+    monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", spawn)
+
+    rotated = await controller.offloader._db.peer_link_identity_store.async_rotate()
+    await controller.offloader._refresh_identity_and_respawn_clients()
+
+    assert controller.offloader.state.offloader_peer_link_priv == rotated.private_bytes
+    cancel.assert_called_once_with("a" * 64)
+    spawn.assert_called_once_with(approved)
+
+
+async def test_load_offloader_identities_refreshes_snapshot(tmp_path: Path) -> None:
+    """Loading identities writes the values back to the synchronously-read snapshot."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller.offloader.state.offloader_peer_link_priv = b"\x00" * 32
+    controller.offloader.state.offloader_dashboard_id = "old"
+
+    peer_link, dashboard = await controller.offloader._load_offloader_identities_async()
+
+    assert controller.offloader.state.offloader_peer_link_priv == peer_link.private_bytes
+    assert controller.offloader.state.offloader_dashboard_id == dashboard.dashboard_id
+
+
+async def test_identity_rotation_handler_schedules_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bus handler schedules the refresh as a tracked task."""
+    controller = _make_controller(config_dir=tmp_path)
+    controller.offloader._db.bus = MagicMock()
+    called = asyncio.Event()
+
+    async def _fake_refresh() -> None:
+        called.set()
+
+    monkeypatch.setattr(
+        controller.offloader, "_refresh_identity_and_respawn_clients", _fake_refresh
+    )
+    controller.offloader._on_remote_build_identity_rotated(MagicMock())
+    await asyncio.wait_for(called.wait(), timeout=2.0)
+
+
 async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:
     """A second concurrent ``rotate_identity`` raises ``ALREADY_EXISTS``."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2051,6 +2051,57 @@ async def test_identity_rotation_coalesces_overlapping_refreshes(
     assert off._identity_refresh_task is None
 
 
+async def test_identity_refresh_retries_queued_event_after_load_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A load failure mid-pass is logged, not propagated, and the queued rerun still respawns."""
+    controller = _make_controller(config_dir=tmp_path)
+    off = controller.offloader
+    off._db.bus = MagicMock()
+    approved = StoredPairing(
+        receiver_hostname="r",
+        receiver_port=6055,
+        pin_sha256="a" * 64,
+        static_x25519_pub=b"\x01" * 32,
+        label="r",
+        paired_at=1.0,
+        status=PeerStatus.APPROVED,
+    )
+    off.state.pairings["a" * 64] = approved
+    off.state.peer_link_clients["a" * 64] = MagicMock()
+    spawn = MagicMock()
+    monkeypatch.setattr(off, "_cancel_peer_link_client", MagicMock())
+    monkeypatch.setattr(off, "_spawn_peer_link_client", spawn)
+
+    gate = asyncio.Event()
+    load_calls = 0
+
+    async def _load() -> None:
+        nonlocal load_calls
+        load_calls += 1
+        if load_calls == 1:
+            await gate.wait()
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(off, "_load_offloader_identities_async", _load)
+
+    off._on_remote_build_identity_rotated(MagicMock())
+    await asyncio.sleep(0)
+    task = off._identity_refresh_task
+    assert task is not None
+    # Queue a rerun while the first (about-to-fail) load is parked.
+    off._on_remote_build_identity_rotated(MagicMock())
+    assert off._identity_refresh_again is True
+
+    gate.set()
+    await asyncio.wait_for(task, timeout=2.0)
+    # First pass's load raised (no respawn); the queued rerun's load
+    # succeeded and respawned.
+    assert load_calls == 2
+    assert spawn.call_count == 1
+    assert off._identity_refresh_task is None
+
+
 async def test_rotate_identity_concurrent_call_rejected(tmp_path: Path) -> None:
     """A second concurrent ``rotate_identity`` raises ``ALREADY_EXISTS``."""
     controller = _make_controller(config_dir=tmp_path)

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1158,9 +1158,9 @@ async def test_e2e_receiver_settings_write_preserves_offloader_pairing(
     )
 
     # The offloader host writes its own receiver-side settings
-    # (flipping the master enable is the operator's trigger). Hop
-    # to a thread: the writer does sync I/O blockbuster flags on
-    # the event loop.
+    # (flipping the master enable is the operator's trigger). Hop to
+    # a thread: the writer does sync metadata I/O that blockbuster
+    # (Linux CI) flags on the event loop.
     await asyncio.to_thread(
         save_remote_build_settings, offloader_dir, RemoteBuildSettings(enabled=True)
     )

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1146,13 +1146,12 @@ async def test_e2e_receiver_settings_write_preserves_offloader_pairing(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
     tmp_path: Path,
 ) -> None:
-    """A remote-build settings write keeps an existing pairing accepted (#1154).
+    """
+    A remote-build settings write keeps an existing pairing accepted (#1154).
 
-    The offloader's ``dashboard_id`` co-lives in the
-    ``_remote_build`` metadata block with the receiver-side
-    settings; a settings write that re-minted it left the
-    long-lived ``peer_link`` keyed on an id the receiver never
-    approved (``no_approved_peer``).
+    A settings write that re-minted the offloader's
+    ``dashboard_id`` left the long-lived ``peer_link`` keyed on
+    an id the receiver never approved (``no_approved_peer``).
     """
     client, controller, _ = peer_link_app
     offloader_dir = tmp_path / "offloader"
@@ -1165,8 +1164,12 @@ async def test_e2e_receiver_settings_write_preserves_offloader_pairing(
     )
 
     # The offloader host writes its own receiver-side settings
-    # (flipping the master enable is the operator's trigger).
-    save_remote_build_settings(offloader_dir, RemoteBuildSettings(enabled=True))
+    # (flipping the master enable is the operator's trigger). Hop
+    # to a thread: the writer does sync I/O blockbuster flags on
+    # the event loop.
+    await asyncio.to_thread(
+        save_remote_build_settings, offloader_dir, RemoteBuildSettings(enabled=True)
+    )
 
     _, dashboard_after = await get_or_create_identities(offloader_dir, store)
     assert dashboard_after.dashboard_id == dashboard.dashboard_id
@@ -1182,7 +1185,8 @@ async def test_e2e_peer_link_recovers_after_identity_rotation(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
     tmp_path: Path,
 ) -> None:
-    """Rotating the offloader key breaks the link until re-pair, then it recovers (#1154).
+    """
+    Rotating the offloader key breaks the link until re-pair, then recovers (#1154).
 
     ``dashboard_id`` is preserved across a rotation, so the
     receiver pins the stale key (``rejected``) until the operator

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -1146,13 +1146,7 @@ async def test_e2e_receiver_settings_write_preserves_offloader_pairing(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
     tmp_path: Path,
 ) -> None:
-    """
-    A remote-build settings write keeps an existing pairing accepted (#1154).
-
-    A settings write that re-minted the offloader's
-    ``dashboard_id`` left the long-lived ``peer_link`` keyed on
-    an id the receiver never approved (``no_approved_peer``).
-    """
+    """A receiver settings write keeps an existing pairing's ``peer_link`` accepted."""
     client, controller, _ = peer_link_app
     offloader_dir = tmp_path / "offloader"
     offloader_dir.mkdir()
@@ -1185,14 +1179,7 @@ async def test_e2e_peer_link_recovers_after_identity_rotation(
     peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
     tmp_path: Path,
 ) -> None:
-    """
-    Rotating the offloader key breaks the link until re-pair, then recovers (#1154).
-
-    ``dashboard_id`` is preserved across a rotation, so the
-    receiver pins the stale key (``rejected``) until the operator
-    re-pairs the rotated identity, after which ``peer_link`` is
-    accepted again.
-    """
+    """A rotated offloader key is rejected until re-pair, then ``peer_link`` is accepted."""
     client, controller, _ = peer_link_app
     offloader_dir = tmp_path / "offloader"
     offloader_dir.mkdir()

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -37,6 +37,9 @@ from noise.exceptions import NoiseInvalidMessage
 from noise.exceptions import NoiseInvalidMessage as _NoiseInvalidMessage
 
 from esphome_device_builder.api.ws import init_ws_app
+from esphome_device_builder.controllers.config.remote_build_settings import (
+    save_remote_build_settings,
+)
 from esphome_device_builder.controllers.remote_build import (
     ReceiverController,
 )
@@ -75,6 +78,9 @@ from esphome_device_builder.controllers.remote_build.submit_job import (
 )
 from esphome_device_builder.helpers import json as _json
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.dashboard_identity import (
+    get_or_create_identities,
+)
 from esphome_device_builder.helpers.peer_link_identity import (
     PeerLinkIdentityStore,
 )
@@ -89,6 +95,7 @@ from esphome_device_builder.models import (
     PeerLinkIntent,
     QueueStatus,
     RejectReason,
+    RemoteBuildSettings,
     StoredPeer,
 )
 
@@ -831,9 +838,12 @@ async def _drive_initiator_handshake(
     client: TestClient,
     msg1_payload: dict[str, Any],
     msg3_payload: dict[str, Any],
+    *,
+    initiator_priv: bytes | None = None,
 ) -> _InitiatorRoundTrip:
     """Drive the 3 XX messages from the initiator side."""
-    initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
+    if initiator_priv is None:
+        initiator_priv = X25519PrivateKey.generate().private_bytes_raw()
     initiator_pub = (
         X25519PrivateKey.from_private_bytes(initiator_priv).public_key().public_bytes_raw()
     )
@@ -1117,6 +1127,97 @@ def _decode_app_frame(session: PeerLinkNoiseSession, encrypted: bytes) -> dict[s
     parsed = _json.loads(session.decrypt(encrypted))
     assert isinstance(parsed, dict)
     return parsed
+
+
+async def _peer_link_intent_response(
+    client: TestClient, *, dashboard_id: str, initiator_priv: bytes
+) -> str:
+    """Drive one ``intent="peer_link"`` round-trip; return the decoded intent_response."""
+    round_trip = await _drive_initiator_handshake(
+        client,
+        msg1_payload={"intent": "peer_link"},
+        msg3_payload={"dashboard_id": dashboard_id},
+        initiator_priv=initiator_priv,
+    )
+    return _decode_intent_response(round_trip.session, round_trip.intent_response_ciphertext)
+
+
+async def test_e2e_receiver_settings_write_preserves_offloader_pairing(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+    tmp_path: Path,
+) -> None:
+    """A remote-build settings write keeps an existing pairing accepted (#1154).
+
+    The offloader's ``dashboard_id`` co-lives in the
+    ``_remote_build`` metadata block with the receiver-side
+    settings; a settings write that re-minted it left the
+    long-lived ``peer_link`` keyed on an id the receiver never
+    approved (``no_approved_peer``).
+    """
+    client, controller, _ = peer_link_app
+    offloader_dir = tmp_path / "offloader"
+    offloader_dir.mkdir()
+    store = PeerLinkIdentityStore(offloader_dir)
+    identity, dashboard = await get_or_create_identities(offloader_dir, store)
+    # The receiver approved this offloader at pair time.
+    await _seed_approved_offloader(
+        controller, dashboard_id=dashboard.dashboard_id, pubkey=identity.public_bytes
+    )
+
+    # The offloader host writes its own receiver-side settings
+    # (flipping the master enable is the operator's trigger).
+    save_remote_build_settings(offloader_dir, RemoteBuildSettings(enabled=True))
+
+    _, dashboard_after = await get_or_create_identities(offloader_dir, store)
+    assert dashboard_after.dashboard_id == dashboard.dashboard_id
+    response = await _peer_link_intent_response(
+        client,
+        dashboard_id=dashboard_after.dashboard_id,
+        initiator_priv=identity.private_bytes,
+    )
+    assert response == IntentResponse.OK
+
+
+async def test_e2e_peer_link_recovers_after_identity_rotation(
+    peer_link_app: tuple[TestClient, RemoteBuildController, bytes],
+    tmp_path: Path,
+) -> None:
+    """Rotating the offloader key breaks the link until re-pair, then it recovers (#1154).
+
+    ``dashboard_id`` is preserved across a rotation, so the
+    receiver pins the stale key (``rejected``) until the operator
+    re-pairs the rotated identity, after which ``peer_link`` is
+    accepted again.
+    """
+    client, controller, _ = peer_link_app
+    offloader_dir = tmp_path / "offloader"
+    offloader_dir.mkdir()
+    store = PeerLinkIdentityStore(offloader_dir)
+    id0, dashboard = await get_or_create_identities(offloader_dir, store)
+    did = dashboard.dashboard_id
+
+    # Pair + connect with the original identity.
+    await _seed_approved_offloader(controller, dashboard_id=did, pubkey=id0.public_bytes)
+    assert (
+        await _peer_link_intent_response(client, dashboard_id=did, initiator_priv=id0.private_bytes)
+        == IntentResponse.OK
+    )
+
+    # Operator rotates the offloader's peer-link key; dashboard_id survives.
+    id1 = await store.async_rotate()
+    assert id1.public_bytes != id0.public_bytes
+    # Receiver still pins the old key, so the rotated identity is rejected.
+    assert (
+        await _peer_link_intent_response(client, dashboard_id=did, initiator_priv=id1.private_bytes)
+        == IntentResponse.REJECTED
+    )
+
+    # Re-pair the rotated identity under the same dashboard_id; the link recovers.
+    await _seed_approved_offloader(controller, dashboard_id=did, pubkey=id1.public_bytes)
+    assert (
+        await _peer_link_intent_response(client, dashboard_id=did, initiator_priv=id1.private_bytes)
+        == IntentResponse.OK
+    )
 
 
 async def test_e2e_peer_link_session_stays_open_after_intent_response(


### PR DESCRIPTION
# What does this implement/fix?

Fixes the peer-link pairing failure in #1154: "Send builds" reports success in the GUI, but the long-lived peer-link is rejected on every attempt with `no_approved_peer` (one direction) and `pin_mismatch` (the other), and it survives restarts, key rotation, and re-pairing.

Two distinct root causes.

### Primary (deterministic, survives restarts): `_remote_build` co-tenancy clobbered `dashboard_id`

`dashboard_id` is a permanent correlation token. It was stored at `_remote_build.dashboard_id`, but the receiver-settings writer co-owned that block and replaced it wholesale (`data["_remote_build"] = settings.to_dict()`, which carries only `enabled` + `cleanup_ttl_seconds`). Any settings write (toggling enabled, changing the TTL, or enabling the feature) erased `dashboard_id`; the next read minted a fresh one. The offloader then paired under one `dashboard_id` and opened `peer_link` under another, so the receiver's `approved_peers` lookup missed (`no_approved_peer`). It recurred after every restart because re-enabling the feature re-erased the id, which is why the reporter's resets never helped.

Rather than just guard the write, the fix removes the **two-owners-of-one-block** design: `dashboard_id` now owns a dedicated `_dashboard_identity` metadata block, so each top-level key has a single writer and a settings write structurally can't reach the identity. `_get_or_create_dashboard_id` migrates a legacy `_remote_build.dashboard_id` in place (same value, no re-pair). The settings writers also merge rather than replace, as a safety net during the migration window.

This also fixes a latent bug: minting the identity used to create `_remote_build`, which tripped `has_remote_build_settings_persisted` and made a fresh HA-addon install bind the receiver on the next boot without the operator opting in. Minting the identity no longer trips that gate (the three existing HA-addon gate tests still pass; a regression test pins the new behavior).

### Secondary (single-run): peer-link key snapshot drift

The offloader snapshotted its peer-link private key once at `start()`; the long-lived `PeerLinkClient` kept presenting it after a key rotation while the pairing handshake used the live key (`pin_mismatch`). `_load_offloader_identities_async` now refreshes that snapshot on every load, and the offloader subscribes to `REMOTE_BUILD_IDENTITY_ROTATED` to re-snapshot and respawn its APPROVED peer-link clients so a rotation reaches the wire.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1154

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/`.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in docs (n/a).

## Tests

- E2E (`test_remote_build_peer_link.py`): a receiver settings write keeps an existing pairing accepted; a key rotation breaks the link until re-pair, then recovers, over the real Noise wire.
- Migration / gate (`test_dashboard_identity.py`): legacy `_remote_build.dashboard_id` migrates to its own block with the same value; a legacy-only block is removed; minting the identity does not trip the HA-addon persisted gate; both real settings writers preserve foreign `_remote_build` keys.
- Full e2e (`tests/e2e/test_identity_rotation.py`): the real two-instance harness pairs, rotates the offloader key + fires the rotation event, watches the session drop, then re-pairs and confirms recovery pinned to the rotated key.
- Unit (`test_remote_build_controller.py`): the identity-load path refreshes the snapshot; a rotation event re-snapshots and respawns only APPROVED peer-link clients.

New regression tests fail on the pre-fix tree.

