### PR TITLE
Ignore stray root-level .md / .png scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ secrets.yaml
 .coverage
 .coverage.*
 htmlcov/
+
+# Stray notes / screenshots dropped at the repo root during development.
+# The only root-level docs we track are README.md and CLAUDE.md.
+/*.md
+!/README.md
+!/CLAUDE.md
+/*.png


### PR DESCRIPTION
# What does this implement/fix?

Notes and screenshots dropped at the repo root during development keep
getting swept into commits by `git add -A`. Ignore root-level `*.md` and
`*.png`, negating the two docs we actually track at the root (`README.md`,
`CLAUDE.md`). The patterns are anchored with a leading `/`, so nested docs
(`docs/*.md`) are unaffected.

**Related issue or feature (if applicable):**

- N/A — repo hygiene.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
