### PR TITLE
Retry lock-free metadata reads on a Windows replace race

### DIFF
--- a/esphome_device_builder/controllers/config/metadata.py
+++ b/esphome_device_builder/controllers/config/metadata.py
@@ -17,7 +17,7 @@ try:
 except ImportError:  # pragma: no cover — Windows path
     _HAS_FCNTL = False
 
-from ...helpers.atomic_io import atomic_write
+from ...helpers.atomic_io import atomic_write, read_bytes_with_retry
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
 
 _METADATA_FILE = ".device-builder.json"
@@ -88,7 +88,10 @@ def _load_metadata(config_dir: Path) -> dict[str, Any]:
     try:
         # orjson decodes bytes directly, so skip the read_text → encode
         # round-trip. JSONDecodeError is a subclass of ValueError.
-        data = loads(path.read_bytes())
+        # read_bytes_with_retry rides out a Windows sharing-violation race
+        # against a concurrent ``_save_metadata`` replace — the read is
+        # lock-free, so it can open the file mid-rename.
+        data = loads(read_bytes_with_retry(path))
         return data if isinstance(data, dict) else {}
     except (FileNotFoundError, JSONDecodeError):
         return {}

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -19,13 +19,15 @@ import tempfile
 import time
 from pathlib import Path
 
-# Windows raises ``PermissionError`` (WinError 5) from ``os.replace`` when a
-# transient handle holds the destination open (a concurrent reader, an
-# antivirus or the search indexer). POSIX rename is atomic and never hits
-# this, so the retry is Windows-only. Backoff grows exponentially (capped)
-# so the common sub-second window still clears on the first short wait,
-# while a slow scanner under loaded CI gets several seconds before we give
-# up — far cheaper than losing a metadata / preferences write.
+# Windows raises ``PermissionError`` (WinError 5) on both sides of a
+# replace race: from ``os.replace`` when a transient handle holds the
+# destination open, and from ``open()`` when a lock-free reader opens the
+# file while a replace is mid-flight (sharing violation). POSIX rename is
+# atomic and never hits either, so the retry is Windows-only. Backoff grows
+# exponentially (capped) so the common sub-second window still clears on the
+# first short wait, while a slow scanner under loaded CI gets several seconds
+# before we give up — far cheaper than losing a metadata / preferences write
+# or failing a concurrent read.
 _IS_WINDOWS = os.name == "nt"
 _REPLACE_RETRIES = 15
 _REPLACE_RETRY_BACKOFF_S = 0.05
@@ -76,6 +78,20 @@ def atomic_write(
         with contextlib.suppress(OSError):
             tmp_path.unlink()
         raise
+
+
+def read_bytes_with_retry(path: Path) -> bytes:
+    """Read *path*'s bytes, retried on a Windows handle race with a concurrent replace."""
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            return path.read_bytes()
+        except PermissionError:
+            # POSIX never hits this transiently, so a PermissionError there is
+            # real; re-raise. On Windows, back off and retry the open.
+            if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
+    raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover
 
 
 def _replace_with_retry(src: Path, dst: Path) -> None:

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from esphome_device_builder.helpers.atomic_io import atomic_write
+from esphome_device_builder.helpers.atomic_io import atomic_write, read_bytes_with_retry
 
 
 def test_atomic_write_cleans_up_tempfile_on_error(
@@ -187,5 +187,52 @@ def test_atomic_write_does_not_retry_replace_on_posix(
     monkeypatch.setattr("os.replace", _fail)
     with pytest.raises(PermissionError):
         atomic_write(tmp_path / "demo.bin", b"x")
+
+    assert calls["n"] == 1  # no retry on POSIX
+
+
+def test_read_bytes_with_retry_returns_contents(tmp_path: Path) -> None:
+    target = tmp_path / "demo.bin"
+    target.write_bytes(b"payload")
+    assert read_bytes_with_retry(target) == b"payload"
+
+
+def test_read_bytes_with_retry_retries_on_windows_sharing_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient Windows ``PermissionError`` on open is retried, not surfaced."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", True)
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.time.sleep", lambda _s: None)
+    target = tmp_path / "demo.bin"
+    target.write_bytes(b"payload")
+
+    real_read_bytes = Path.read_bytes
+    calls = {"n": 0}
+
+    def _flaky(self: Path) -> bytes:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError(5, "Access is denied")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _flaky)
+    assert read_bytes_with_retry(target) == b"payload"
+    assert calls["n"] == 3  # failed twice, succeeded on the third
+
+
+def test_read_bytes_with_retry_does_not_retry_on_posix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``PermissionError`` on POSIX is real and surfaces without a retry."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", False)
+    calls = {"n": 0}
+
+    def _fail(self: Path) -> bytes:
+        calls["n"] += 1
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "read_bytes", _fail)
+    with pytest.raises(PermissionError):
+        read_bytes_with_retry(tmp_path / "demo.bin")
 
     assert calls["n"] == 1  # no retry on POSIX


### PR DESCRIPTION
# What does this implement/fix?

`test_mark_acknowledged_does_not_clobber_a_concurrent_pref_write` flakes on Windows CI with a `PermissionError` on `.device-builder.json`. The crash is not in a writer; it is a lock-free read (`get_state` -> `load_preferences` -> `_load_metadata` -> `path.read_bytes()`) opening the sidecar while a concurrent `os.replace` is mid-flight, which Windows rejects as a sharing violation. POSIX rename is atomic so it never reproduces there.

The writer side already retried via `_replace_with_retry`; this adds the matching reader-side retry. New `read_bytes_with_retry` in `helpers/atomic_io.py` mirrors the existing Windows-only exponential backoff, and `_load_metadata` now reads through it. On POSIX a `PermissionError` is real and surfaces immediately. This also hardens the other lock-free sidecar readers (`get_device_metadata`, `get_device_ip`, `get_board_id`) that share the same path.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
