### PR TITLE
Scope find_by_pio_board to the device's platform

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -122,13 +122,25 @@ class BoardCatalog:
                 return board
         return None
 
-    def find_by_pio_board(self, pio_board: str, pio_variant: str = "") -> BoardCatalogIndex | None:
+    def find_by_pio_board(
+        self,
+        pio_board: str,
+        pio_variant: str = "",
+        platform: Platform | str | None = None,
+    ) -> BoardCatalogIndex | None:
         """
         Find a board by its PlatformIO board id, preferring a matching variant.
 
         Returns the slim index entry; the caller fetches the full
         body via :meth:`get_board` when it needs pins /
         featured_components / default_components.
+
+        ``platform`` scopes the match to one ESPHome platform. nRF52 and rp2040
+        both ship a PlatformIO board called ``adafruit_itsybitsy``; without the
+        scope an ``nrf52`` device would resolve to the rp2040 entry and serve its
+        ``GPIOn`` pins, which ESPHome's nRF52 validator rejects. A scoped miss
+        returns ``None`` so the caller falls back (a free-text pin field) rather
+        than wrong-platform pins.
 
         When multiple catalog entries share the same PlatformIO board
         id (e.g. several products are physically built on the same
@@ -148,6 +160,9 @@ class BoardCatalog:
         3. Fall back to the first match in iteration order.
         """
         matches = [b for b in self._boards if b.esphome.board == pio_board]
+        if platform is not None:
+            platform_value = platform.value if isinstance(platform, Platform) else platform
+            matches = [b for b in matches if b.esphome.platform.value == platform_value]
         if not matches:
             return None
         if pio_variant:
@@ -179,9 +194,7 @@ class BoardCatalog:
         """
         if not platform:
             return None
-        matches = [
-            b for b in self._boards if b.esphome.platform and b.esphome.platform.value == platform
-        ]
+        matches = [b for b in self._boards if b.esphome.platform.value == platform]
         if not matches:
             return None
         if variant:

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -98,7 +98,7 @@ class DeviceMetadataBase(DeviceBuilderBase):
 
         matched = None
         if pio_board:
-            matched = self._db.boards.find_by_pio_board(pio_board, variant)
+            matched = self._db.boards.find_by_pio_board(pio_board, variant, platform)
         if matched is None and platform:
             matched = self._db.boards.find_by_platform_variant(platform, variant)
         if matched is None:

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -114,7 +114,9 @@ async def create_device(  # noqa: PLR0912, PLR0915, C901
         if source != "stub":
             matched = None
             if pio_board:
-                matched = controller._db.boards.find_by_pio_board(pio_board, variant)
+                matched = controller._db.boards.find_by_pio_board(
+                    pio_board, variant, parsed_platform
+                )
             if matched is None and parsed_platform:
                 matched = controller._db.boards.find_by_platform_variant(parsed_platform, variant)
             if matched:

--- a/tests/controllers/devices/test_derive_board_id.py
+++ b/tests/controllers/devices/test_derive_board_id.py
@@ -89,7 +89,7 @@ def test_derive_uses_pio_board_match_first(
 
     assert result == "generic-esp32c3"
     # PlatformIO match was tried.
-    pio_lookup.assert_called_once_with("esp32-c3-devkitm-1", "")
+    pio_lookup.assert_called_once_with("esp32-c3-devkitm-1", "", "esp32")
     # Platform fallback wasn't reached.
     platform_lookup.assert_not_called()
 
@@ -118,7 +118,7 @@ def test_derive_falls_back_to_platform_when_pio_board_misses(
 
     assert result == "generic-esp32"
     # Both lookups ran in order: PIO first, then platform fallback.
-    pio_lookup.assert_called_once_with("unknown-board", "")
+    pio_lookup.assert_called_once_with("unknown-board", "", "esp32")
     platform_lookup.assert_called_once_with("esp32", "")
 
 

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -518,6 +518,48 @@ def test_find_by_pio_board_returns_none_for_unknown(catalog: BoardCatalog) -> No
     assert catalog.find_by_pio_board("nonexistent-board") is None
 
 
+def test_find_by_pio_board_scopes_to_platform(catalog: BoardCatalog) -> None:
+    """``platform`` disambiguates a pio_board shared across platforms.
+
+    nRF52 and rp2040 both ship ``adafruit_itsybitsy``; a scoped lookup must
+    return the matching platform, not whichever entry iterates first.
+    """
+    catalog._boards = [
+        _board(
+            board_id="adafruit_itsybitsy",
+            platform=Platform.RP2040,
+            pio_board="adafruit_itsybitsy",
+        ),
+        _board(
+            board_id="adafruit_itsybitsy_nrf52",
+            platform=Platform.NRF52,
+            pio_board="adafruit_itsybitsy",
+        ),
+    ]
+    rp = catalog.find_by_pio_board("adafruit_itsybitsy", platform=Platform.RP2040)
+    nrf = catalog.find_by_pio_board("adafruit_itsybitsy", platform="nrf52")
+    assert rp is not None and rp.esphome.platform is Platform.RP2040
+    assert nrf is not None and nrf.esphome.platform is Platform.NRF52
+
+
+def test_find_by_pio_board_scoped_miss_returns_none(catalog: BoardCatalog) -> None:
+    """A pio_board that exists only on another platform → ``None`` when scoped.
+
+    The caller then falls back (free-text pin field) rather than being handed a
+    wrong-platform entry whose pins ESPHome would reject.
+    """
+    catalog._boards = [
+        _board(
+            board_id="adafruit_itsybitsy",
+            platform=Platform.RP2040,
+            pio_board="adafruit_itsybitsy",
+        ),
+    ]
+    assert catalog.find_by_pio_board("adafruit_itsybitsy", platform=Platform.NRF52) is None
+    # Unscoped still resolves (back-compat for callers without a platform).
+    assert catalog.find_by_pio_board("adafruit_itsybitsy") is not None
+
+
 # ---------------------------------------------------------------------------
 # find_by_platform_variant
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Scopes `BoardCatalog.find_by_pio_board` to the device's ESPHome platform.

`find_by_pio_board` matched purely on the PlatformIO board string (`esphome.board`), which is platform-blind. nRF52 and rp2040 both ship a board called `adafruit_itsybitsy` (ESPHome's `nrf52` `BOARDS_ZEPHYR` and `rp2040` `BOARDS` each define it). So a device with `nrf52:\n  board: adafruit_itsybitsy` resolved to the **rp2040** catalog entry and the editor served its `GPIOn` pins — which ESPHome's nRF52 pin validator rejects (`components/nrf52/gpio.py::_translate_pin`). That violates the project's "never generate invalid configs" principle.

This adds an optional `platform` filter to `find_by_pio_board` and passes it at the two callers (`devices/metadata.py`, `devices/mutations_create.py`) — both already parse the platform from the YAML via `parse_platform_from_yaml`, so it's just wiring an existing value through. A scoped miss returns `None`, so the existing fallback ladder runs (`find_by_platform_variant`, then a free-text pin field) rather than handing back a wrong-platform entry. Unscoped calls are unchanged (back-compat).

Surfaced by the review on #1174 (nRF52 board pins). No board generation change here; this is the resolution-side fix that lets a shared PlatformIO board string resolve correctly per platform.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

None. The frontend resolves a device's board via the backend-supplied `board_id` → `getBoard(board_id)` (id-keyed); it does no pio-string matching of its own, and `renderPinField` already falls back to a free-text pin field when there's no board/pins. So a scoped miss degrades correctly with no frontend change.

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
