### PR TITLE
Re-derive stale board ids while preserving deliberate board picks

### DIFF
--- a/esphome_device_builder/controllers/config/metadata.py
+++ b/esphome_device_builder/controllers/config/metadata.py
@@ -113,6 +113,7 @@ def set_device_metadata(
     filename: str,
     *,
     board_id: str | None = None,
+    board_id_user_set: bool | None = None,
     friendly_name: str | None = None,
     comment: str | None = None,
     ip: str | None = None,
@@ -127,6 +128,10 @@ def set_device_metadata(
 ) -> None:
     """
     Set metadata fields for a device.
+
+    ``board_id_user_set`` marks ``board_id`` as a deliberate user pick
+    rather than an auto-derived guess. Only ever written ``True``;
+    absence means auto-derived.
 
     ``ip`` is the last-known resolved IP — persisted so the address
     cache survives backend restarts. Pass an empty string to leave the
@@ -207,6 +212,7 @@ def set_device_metadata(
         # tri-state field doesn't bump this function's branch
         # count (ruff PLR0912 caps at 12).
         for key, value in (
+            ("board_id_user_set", board_id_user_set),
             ("expected_config_hash", expected_config_hash),
             ("mac_address", mac_address),
             ("regen_failed_mtime", regen_failed_mtime),

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -232,6 +232,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # Seed the store (and migrate on first post-upgrade boot)
         # before the scanner runs — resolver reads off it.
         await self._metadata_store.async_load()
+        await self.migrate_board_id_user_set()
         await loop.run_in_executor(None, self._load_ignored_devices)
         await self._scanner.scan()
         self._scanner.start()

--- a/esphome_device_builder/controllers/devices/metadata.py
+++ b/esphome_device_builder/controllers/devices/metadata.py
@@ -2,22 +2,70 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from ...helpers.build_size import coerce_sidecar_int
 from ...helpers.config_hash import read_build_info_hash
 from ...helpers.device_yaml import parse_platform_from_yaml
 from .._device_builder_base import DeviceBuilderBase
 from .._device_scanner import DeviceFileMetadata
+from ..config import metadata_transaction
 from ._metadata_store import STORE_FIELDS
 
 if TYPE_CHECKING:
+    from ..boards import BoardCatalog
     from ._metadata_store import DeviceMetadataStore
     from ._shared_sidecar import SharedSidecarClient
 
 _LOGGER = logging.getLogger(__name__)
+
+# Sidecar marker so the board_id_user_set back-fill runs once.
+_USER_SET_MIGRATED_KEY = "_board_id_user_set_migrated"
+
+
+def _is_devices_esphome_io_import(board: Any) -> bool:
+    """Whether *board* is a devices.esphome.io import (vs a curated entry)."""
+    return urlparse(str(board.docs_url)).hostname == "devices.esphome.io"
+
+
+def _migrate_board_id_user_set_sync(config_dir: Path, boards: BoardCatalog) -> int:
+    """Flag pre-existing curated picks displaced by a newer generic board.
+
+    Sidecars written before ``board_id_user_set`` existed carry no
+    flag, so a deliberately picked board now outranked by a generic
+    on its own PlatformIO board (e.g. ``apollo-esk-1`` vs the generic
+    ``esp32-c6-devkitm-1``) would re-derive to the generic on the next
+    scan. devices.esphome.io imports are intentionally left unflagged:
+    they are the stale auto-derived ids the re-derivation heals.
+    """
+    stamped = 0
+    with metadata_transaction(config_dir) as data:
+        if data.get(_USER_SET_MIGRATED_KEY):
+            return 0
+        for filename, entry in data.items():
+            if filename.startswith("_") or not isinstance(entry, dict):
+                continue
+            board_id = entry.get("board_id")
+            if not board_id or entry.get("board_id_user_set") is True:
+                continue
+            picked = boards.get_by_id(board_id)
+            if picked is None or picked.is_generic or _is_devices_esphome_io_import(picked):
+                continue
+            variant = picked.esphome.variant.value if picked.esphome.variant else ""
+            winner = boards.find_by_pio_board(
+                picked.esphome.board, variant, picked.esphome.platform.value
+            )
+            # Preserve only a curated pick now outranked by a generic
+            # on the same PlatformIO board.
+            if winner is not None and winner.id != board_id and winner.is_generic:
+                entry["board_id_user_set"] = True
+                stamped += 1
+        data[_USER_SET_MIGRATED_KEY] = True
+    return stamped
 
 
 def _partition_fields(fields: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -51,8 +99,11 @@ class DeviceMetadataBase(DeviceBuilderBase):
         expected_config_hash = read_build_info_hash(config_dir / filename) or str(
             store_md.get("expected_config_hash", "")
         )
+        # Trust a persisted board_id only when the user set it; an
+        # unflagged one is re-derived so a catalog change self-heals.
+        # ``is True`` so a corrupt hand-edited flag isn't trusted.
         board_id = str(shared_md.get("board_id", ""))
-        if not board_id:
+        if not (board_id and shared_md.get("board_id_user_set") is True):
             board_id = self._derive_board_id_from_yaml(config_dir, filename)
         mac_address = str(shared_md.get("mac_address", ""))
         # Defensive coercion: a corrupt sidecar entry shouldn't
@@ -80,13 +131,18 @@ class DeviceMetadataBase(DeviceBuilderBase):
             api_encryption_active=api_encryption_active,
         )
 
-    def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
-        """Parse the YAML, match a catalog board, backfill on cache miss.
+    async def migrate_board_id_user_set(self) -> None:
+        """One-shot back-fill of ``board_id_user_set`` for pre-flag picks."""
+        boards = self._db.boards
+        if boards is None:
+            return
+        config_dir = self._db.settings.config_dir
+        stamped = await asyncio.to_thread(_migrate_board_id_user_set_sync, config_dir, boards)
+        if stamped:
+            _LOGGER.info("Back-filled board_id_user_set on %d pre-flag picks", stamped)
 
-        Backfills via ``set_device_metadata`` only when the
-        shared sidecar lacks ``board_id`` so subsequent scans
-        skip the YAML parse.
-        """
+    def _derive_board_id_from_yaml(self, config_dir: Path, filename: str) -> str:
+        """Match the YAML's board against the current catalog; never persisted."""
         if self._db.boards is None:
             return ""
         yaml_path = config_dir / filename
@@ -103,10 +159,6 @@ class DeviceMetadataBase(DeviceBuilderBase):
             matched = self._db.boards.find_by_platform_variant(platform, variant)
         if matched is None:
             return ""
-        try:
-            self._shared_sidecar.update_sync(filename, board_id=matched.id)
-        except OSError:
-            _LOGGER.warning("Could not persist derived board_id for %s", filename)
         return matched.id
 
     async def _persist_device_metadata_async(self, configuration: str, **fields: Any) -> None:

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -126,17 +126,19 @@ async def clone_device(  # noqa: C901
     # the key; those indirections stay shared with the source.
     new_content = rewrite_api_encryption_key(new_content, new_key)
 
-    # Carry forward only the source's ``board_id`` since that's
-    # the catalog-key indirection the user picked at wizard
-    # time and the scanner can't recover it from the YAML.
-    # Friendly name lives in the YAML we just wrote (no need to
-    # duplicate to metadata). ``ip`` is intentionally not
-    # carried; the clone hasn't booted yet and inheriting the
-    # source's address would mis-route ``devices/logs`` until
-    # the first mDNS announce. StorageJSON is skipped entirely
-    # since it's a build artefact and the next compile writes a
-    # real one.
+    # Carry forward only a *user-picked* ``board_id`` since that's
+    # the catalog-key indirection the user chose at wizard time and
+    # the scanner can't recover it from the YAML. An auto-derived
+    # board (no ``board_id_user_set`` flag) is dropped; the cloned
+    # YAML re-derives it against the current catalog. Friendly name
+    # lives in the YAML we just wrote (no need to duplicate to
+    # metadata). ``ip`` is intentionally not carried; the clone
+    # hasn't booted yet and inheriting the source's address would
+    # mis-route ``devices/logs`` until the first mDNS announce.
+    # StorageJSON is skipped entirely since it's a build artefact and
+    # the next compile writes a real one.
     carry_board_id = source_meta.get("board_id") if source_meta else None
+    carry_user_set = source_meta.get("board_id_user_set") if source_meta else None
 
     def _commit() -> None:
         with new_path.open("x", encoding="utf-8") as f:
@@ -151,8 +153,10 @@ async def clone_device(  # noqa: C901
         # frontend renders a single message.
         msg = f"A device named {new_filename} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
-    if carry_board_id:
-        await controller._persist_device_metadata_async(new_filename, board_id=carry_board_id)
+    if carry_board_id and carry_user_set is True:
+        await controller._persist_device_metadata_async(
+            new_filename, board_id=carry_board_id, board_id_user_set=True
+        )
     await controller._commit_history(new_filename, f"Clone {configuration} to {new_filename}")
     # Rescan so the scanner indexes the new YAML and fires the
     # ADDED event WS subscribers expect; ``probe_device`` runs

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .controller import DevicesController
 
 
-async def create_device(  # noqa: PLR0912, PLR0915, C901
+async def create_device(  # noqa: C901
     controller: DevicesController,
     *,
     name: str,
@@ -38,9 +38,9 @@ async def create_device(  # noqa: PLR0912, PLR0915, C901
     deliberately skips validation so an existing config from
     an older ESPHome version (with since-changed schemas) can
     still land in the editor for repair. ``board_id`` is
-    derived from the YAML's platform / board / variant fields
-    when not explicitly provided, except for the stub branch
-    (its hard-coded ``board: esp32dev`` would mis-bind).
+    persisted (as a deliberate user pick) only when explicitly
+    provided; otherwise the scanner derives it from the YAML on
+    each resolve against the current catalog.
     """
     # The wizard passes the user's raw input here — capitalisation,
     # inter-word spaces, and unicode all stay intact. ``clean_friendly_name``
@@ -101,29 +101,11 @@ async def create_device(  # noqa: PLR0912, PLR0915, C901
             on_failure=ErrorCode.INTERNAL_ERROR,
         )
 
-    # Derive board_id from YAML when not explicitly provided.
-    # Skip the stub branch since ``generate_minimal_stub_yaml``
-    # hard-codes ``esp32: board: esp32dev`` and many catalog
-    # entries share that PIO board; the lookup would pin the new
-    # device to whichever entry the index surfaces first, and the
-    # wrong entry would stay bound after the user rewrites the
-    # platform block.
+    # Only for _init_storage's platform fallback; board_id is left
+    # to the scanner, which derives it on resolve (never persisted here).
     parsed_platform = ""
-    if not board_id and controller._db.boards:
-        parsed_platform, pio_board, variant = parse_platform_from_yaml(yaml_content)
-        if source != "stub":
-            matched = None
-            if pio_board:
-                matched = controller._db.boards.find_by_pio_board(
-                    pio_board, variant, parsed_platform
-                )
-            if matched is None and parsed_platform:
-                matched = controller._db.boards.find_by_platform_variant(parsed_platform, variant)
-            if matched:
-                # board stays None — _init_storage uses parsed_platform
-                # when board is unset, and only board_id needs to be
-                # persisted here for the device-metadata sidecar.
-                board_id = matched.id
+    if not board_id:
+        parsed_platform, _pio_board, _variant = parse_platform_from_yaml(yaml_content)
 
     loop = asyncio.get_running_loop()
 
@@ -168,7 +150,9 @@ async def create_device(  # noqa: PLR0912, PLR0915, C901
     # silently mis-binds.
     await controller._delete_device_metadata(filename)
     if board_id:
-        await controller._persist_device_metadata_async(filename, board_id=board_id)
+        await controller._persist_device_metadata_async(
+            filename, board_id=board_id, board_id_user_set=True
+        )
     await controller._commit_history(filename, f"Create {filename}")
     # _scanner.scan fires _on_scan_change(ADDED) for the new
     # YAML and that already runs probe_device; don't double-probe.

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -26,9 +26,23 @@ async def update_device(
 ) -> UpdateDeviceResponse:
     """Update device metadata (sidecar JSON, not the YAML file)."""
     filename = f"{name}.yaml"
+    # Flag board_id as user-set only when it differs from the displayed
+    # board, so a client echoing the shown (maybe auto-derived) value
+    # while editing name/comment can't pin a derived id. A deliberate
+    # pick equal to the current derivation is intentionally left
+    # unflagged; it re-derives to the same id, so nothing is lost.
+    user_set: bool | None = None
+    if board_id:
+        displayed = next(
+            (d.board_id for d in controller._scanner.devices if d.configuration == filename),
+            "",
+        )
+        if board_id != displayed:
+            user_set = True
     await controller._persist_device_metadata_async(
         filename,
         board_id=board_id,
+        board_id_user_set=user_set,
         friendly_name=friendly_name,
         comment=comment,
     )

--- a/tests/controllers/devices/test_archive.py
+++ b/tests/controllers/devices/test_archive.py
@@ -180,6 +180,7 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
         tmp_path,
         "kitchen.yaml",
         board_id="esp32-c3-devkitm-1",
+        board_id_user_set=True,
         friendly_name="Kitchen Sensor",
         comment="By the toaster",
         mac_address="94:C9:60:1F:8C:F1",
@@ -204,6 +205,7 @@ async def test_archive_clears_volatile_metadata_keeps_identity(
     post_shared = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
     assert post_shared == {
         "board_id": "esp32-c3-devkitm-1",
+        "board_id_user_set": True,
         "friendly_name": "Kitchen Sensor",
         "comment": "By the toaster",
     }

--- a/tests/controllers/devices/test_board_id_user_set_migration.py
+++ b/tests/controllers/devices/test_board_id_user_set_migration.py
@@ -1,0 +1,217 @@
+"""One-shot back-fill of ``board_id_user_set`` for pre-flag sidecars.
+
+Runs against the real catalog: a curated pick now outranked by a
+generic on its own PlatformIO board (apollo-esk-1 vs the generic
+esp32-c6-devkitm-1) must be preserved, while a devices.esphome.io
+import (the stale auto-derived shape) is left to re-derive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.controllers.boards import BoardCatalog
+from esphome_device_builder.controllers.config import (
+    _load_metadata,
+    get_device_metadata,
+    set_device_metadata,
+)
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._metadata_store import DeviceMetadataStore
+from esphome_device_builder.controllers.devices._shared_sidecar import SharedSidecarClient
+from esphome_device_builder.controllers.devices.metadata import (
+    _USER_SET_MIGRATED_KEY,
+    _migrate_board_id_user_set_sync,
+)
+
+_APOLLO = "apollo-esk-1"
+_AVATTO = "avatto_s06_ir_remote_no_temp_no_humidity_new_version"
+
+
+def _controller(tmp_path: Path, catalog: BoardCatalog | None) -> DevicesController:
+    """Build a bare controller wired to a real catalog for migrate + resolve."""
+    controller = DevicesController.__new__(DevicesController)
+    controller._shutdown_callbacks = []
+    controller._metadata_store = DeviceMetadataStore(
+        config_dir=tmp_path,
+        data_dir=tmp_path,
+        shutdown_register=controller._shutdown_callbacks.append,
+    )
+    controller._shared_sidecar = SharedSidecarClient(tmp_path)
+    controller._db = SimpleNamespace(boards=catalog, settings=SimpleNamespace(config_dir=tmp_path))
+    return controller
+
+
+@pytest.fixture(scope="module")
+def real_catalog() -> BoardCatalog:
+    """Load the real on-disk catalog once for the module."""
+    cat = BoardCatalog()
+    cat.load()
+    return cat
+
+
+def test_curated_pick_displaced_by_generic_is_flagged(
+    tmp_path: Path, real_catalog: BoardCatalog
+) -> None:
+    """A pre-flag apollo-esk-1 pick is stamped user-set so it isn't re-derived."""
+    set_device_metadata(tmp_path, "apollo.yaml", board_id=_APOLLO)
+
+    stamped = _migrate_board_id_user_set_sync(tmp_path, real_catalog)
+
+    assert stamped == 1
+    assert get_device_metadata(tmp_path, "apollo.yaml")["board_id_user_set"] is True
+
+
+def test_devices_esphome_io_import_is_left_unflagged(
+    tmp_path: Path, real_catalog: BoardCatalog
+) -> None:
+    """An imported vendor board is the stale shape; it stays unflagged to re-derive."""
+    set_device_metadata(tmp_path, "avatto.yaml", board_id=_AVATTO)
+
+    _migrate_board_id_user_set_sync(tmp_path, real_catalog)
+
+    assert "board_id_user_set" not in get_device_metadata(tmp_path, "avatto.yaml")
+
+
+def test_generic_board_id_is_left_unflagged(tmp_path: Path, real_catalog: BoardCatalog) -> None:
+    """A board_id that already names the generic has no conflict; not flagged."""
+    set_device_metadata(tmp_path, "generic.yaml", board_id="esp32-c6-devkitm-1")
+
+    _migrate_board_id_user_set_sync(tmp_path, real_catalog)
+
+    assert "board_id_user_set" not in get_device_metadata(tmp_path, "generic.yaml")
+
+
+def test_already_flagged_pick_is_untouched(tmp_path: Path, real_catalog: BoardCatalog) -> None:
+    """An entry already flagged user-set is not re-counted or altered."""
+    set_device_metadata(tmp_path, "picked.yaml", board_id=_APOLLO, board_id_user_set=True)
+
+    stamped = _migrate_board_id_user_set_sync(tmp_path, real_catalog)
+
+    assert stamped == 0
+    assert get_device_metadata(tmp_path, "picked.yaml")["board_id_user_set"] is True
+
+
+def test_import_with_generic_winner_is_left_unflagged(
+    tmp_path: Path, real_catalog: BoardCatalog
+) -> None:
+    """An import is left unflagged even when its pio now resolves to a generic.
+
+    Aubess's board resolves to a generic BK7231N, so without the
+    import guard it would be stamped like a curated pick; the import
+    check is what keeps it healing instead.
+    """
+    set_device_metadata(
+        tmp_path, "bktest.yaml", board_id="aubess_wifi_smart_switch_with_power_monitoring"
+    )
+
+    assert _migrate_board_id_user_set_sync(tmp_path, real_catalog) == 0
+    assert "board_id_user_set" not in get_device_metadata(tmp_path, "bktest.yaml")
+
+
+def test_curated_pick_displaced_by_non_generic_is_left_unflagged(
+    tmp_path: Path, real_catalog: BoardCatalog
+) -> None:
+    """A curated pick outranked by another non-generic board is not preserved.
+
+    The migration only rescues picks displaced by a generic; LOLIN
+    S2 Mini redrawing as the canonical WEMOS LOLIN S2 Mini (both
+    non-generic) re-derives instead of pinning.
+    """
+    set_device_metadata(tmp_path, "lolin.yaml", board_id="esp32-s2-mini")
+
+    assert _migrate_board_id_user_set_sync(tmp_path, real_catalog) == 0
+    assert "board_id_user_set" not in get_device_metadata(tmp_path, "lolin.yaml")
+
+
+def test_pick_that_still_wins_its_own_board_is_left_unflagged(
+    tmp_path: Path, real_catalog: BoardCatalog
+) -> None:
+    """A board still canonical for its own pio has no conflict, so no flag."""
+    set_device_metadata(tmp_path, "olimex.yaml", board_id="esp32-poe-iso")
+
+    assert _migrate_board_id_user_set_sync(tmp_path, real_catalog) == 0
+    assert "board_id_user_set" not in get_device_metadata(tmp_path, "olimex.yaml")
+
+
+def test_migration_is_one_shot(tmp_path: Path, real_catalog: BoardCatalog) -> None:
+    """The sidecar marker stops a second pass from stamping later entries."""
+    set_device_metadata(tmp_path, "apollo.yaml", board_id=_APOLLO)
+    assert _migrate_board_id_user_set_sync(tmp_path, real_catalog) == 1
+
+    # A curated pick added after the first run is NOT back-filled.
+    set_device_metadata(tmp_path, "apollo2.yaml", board_id=_APOLLO)
+    assert _migrate_board_id_user_set_sync(tmp_path, real_catalog) == 0
+    assert "board_id_user_set" not in get_device_metadata(tmp_path, "apollo2.yaml")
+
+
+async def test_migrate_then_resolve_matches_fleet_outcome(
+    tmp_path: Path, real_catalog: BoardCatalog
+) -> None:
+    """End-to-end through the real resolver: cb3s heals, the Apollo pick is preserved.
+
+    Mirrors the two headline cases from the dry-run: a stale import
+    (cb3s-test pinned to AVATTO) re-derives to CB3S, while a curated
+    Apollo pick with no YAML on disk (aps.yaml) survives via the
+    migration stamp.
+    """
+
+    def _seed() -> None:
+        set_device_metadata(tmp_path, "aps.yaml", board_id=_APOLLO)
+        set_device_metadata(tmp_path, "cb3s-test.yaml", board_id=_AVATTO)
+        (tmp_path / "cb3s-test.yaml").write_text(
+            "esphome:\n  name: cb3s-test\n\nbk72xx:\n  board: cb3s\n", encoding="utf-8"
+        )
+
+    await asyncio.to_thread(_seed)
+    controller = _controller(tmp_path, real_catalog)
+    await controller.migrate_board_id_user_set()
+
+    def _resolved_board_ids() -> tuple[str, str]:
+        return (
+            controller._resolve_device_metadata(tmp_path, "aps.yaml").board_id,
+            controller._resolve_device_metadata(tmp_path, "cb3s-test.yaml").board_id,
+        )
+
+    apollo_board, cb3s_board = await asyncio.to_thread(_resolved_board_ids)
+
+    assert apollo_board == _APOLLO
+    assert cb3s_board == "cb3s"
+
+
+async def test_migrate_is_noop_when_catalog_unloaded(tmp_path: Path) -> None:
+    """With no catalog yet, the migration is a no-op and writes no marker.
+
+    The marker is withheld so the back-fill still runs on a later boot
+    once the catalog has loaded.
+    """
+    await asyncio.to_thread(set_device_metadata, tmp_path, "apollo.yaml", board_id=_APOLLO)
+
+    controller = _controller(tmp_path, None)
+    await controller.migrate_board_id_user_set()
+
+    def _entry_and_root() -> tuple[dict[str, Any], dict[str, Any]]:
+        return get_device_metadata(tmp_path, "apollo.yaml"), _load_metadata(tmp_path)
+
+    entry, root = await asyncio.to_thread(_entry_and_root)
+    assert "board_id_user_set" not in entry
+    assert _USER_SET_MIGRATED_KEY not in root
+
+
+def test_migration_skips_non_device_keys(tmp_path: Path, real_catalog: BoardCatalog) -> None:
+    """Top-level meta keys (``_labels`` etc.) are skipped, not parsed as devices."""
+    set_device_metadata(tmp_path, "apollo.yaml", board_id=_APOLLO)
+    path = tmp_path / ".device-builder.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["_labels"] = [{"id": "x", "name": "Office"}]
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    assert _migrate_board_id_user_set_sync(tmp_path, real_catalog) == 1
+    after = json.loads(path.read_text(encoding="utf-8"))
+    assert after["_labels"] == [{"id": "x", "name": "Office"}]

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -68,7 +68,7 @@ def _device(name: str, *, ip: str = "", ip_addresses: list[str] | None = None) -
 
 
 # ---------------------------------------------------------------------------
-# create_device file_content + board derivation
+# create_device file_content
 # ---------------------------------------------------------------------------
 
 
@@ -76,20 +76,18 @@ def _device(name: str, *, ip: str = "", ip_addresses: list[str] | None = None) -
 async def test_create_device_writes_file_content_verbatim(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """``file_content`` is written as-is and the catalog derives ``board_id`` from it.
+    """``file_content`` is written as-is; create derives no board_id.
 
     The dashboard's adoption flow ships an entire YAML through
     ``file_content`` (the upstream ``DashboardImportDiscovery``
-    URL fetches the project YAML and the user just confirms).
-    Pin: the YAML lands verbatim *and* the catalog's PIO-board
-    lookup runs against the parsed platform/board so the new
-    device picks up its catalog entry without the user having
-    to choose one manually.
+    URL fetches the project YAML and the user just confirms). The
+    board card comes from the scanner's resolve, not create, so
+    no board lookup runs here.
     """
     controller = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     boards = StubBoardLookups(controller)
     pio_lookup = boards.find_by_pio_board_returns("esp32-c3-devkitm-1")
-    boards.find_by_platform_variant_returns(None)
+    variant_lookup = boards.find_by_platform_variant_returns(None)
 
     yaml_text = (
         "esphome:\n  name: kitchen\nesp32:\n  board: esp32-c3-devkitm-1\n  variant: esp32c3\n"
@@ -98,35 +96,11 @@ async def test_create_device_writes_file_content_verbatim(
 
     assert result.configuration == "kitchen.yaml"
     written = (tmp_path / "kitchen.yaml").read_text(encoding="utf-8")
-    # Verbatim — no template generation override.
+    # Verbatim, no template generation override.
     assert written == yaml_text
-    # Catalog's PIO-board lookup ran against the parsed YAML.
-    pio_lookup.assert_called_once()
-
-
-@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
-async def test_create_device_falls_back_to_platform_variant_lookup(
-    tmp_path: Path, make_controller: MakeControllerFactory
-) -> None:
-    """When the PIO-board lookup misses, the platform/variant fallback runs.
-
-    Generic ``esp32:`` configs without a specific ``board:``
-    entry still need a catalog match so the dashboard can show
-    a generic-esp32-c3 entry rather than an unmapped board.
-    Pin the fallback so a regression that dropped it would leave
-    catalog-less placeholders on every wizard run with a generic
-    ESP32 template.
-    """
-    controller = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
-    # PIO miss; platform/variant hit.
-    boards = StubBoardLookups(controller)
-    boards.find_by_pio_board_returns(None)
-    variant_lookup = boards.find_by_platform_variant_returns("generic-esp32-c3")
-
-    yaml_text = "esphome:\n  name: kitchen\nesp32:\n  variant: esp32c3\n"
-    await controller.create_device(name="kitchen", file_content=yaml_text)
-
-    variant_lookup.assert_called_once()
+    # Create no longer derives a board_id; the scanner does on resolve.
+    pio_lookup.assert_not_called()
+    variant_lookup.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -759,36 +733,6 @@ async def test_persist_device_metadata_async_routes_store_field_to_store(
     controller = make_controller(tmp_path)
     await controller._persist_device_metadata_async("kitchen.yaml", ip="192.168.1.42")
     assert controller._metadata_store.get("kitchen.yaml") == {"ip": "192.168.1.42"}
-
-
-def test_derive_board_id_swallows_persist_oserror(
-    tmp_path: Path,
-    make_controller: MakeControllerFactory,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A read-only mount on the shared sidecar logs + still returns the id.
-
-    Catalog match succeeded; we shouldn't drop the answer just
-    because the sidecar write failed.
-    """
-    controller = make_controller(tmp_path, with_boards=True)
-    StubBoardLookups(controller).find_by_pio_board_returns("generic-esp32c3")
-    (tmp_path / "kitchen.yaml").write_text(
-        "esphome:\n  name: kitchen\nesp32:\n  board: esp32-c3-devkitm-1\n",
-        encoding="utf-8",
-    )
-
-    def _boom(*_args: Any, **_kwargs: Any) -> None:
-        raise OSError("read-only filesystem")
-
-    monkeypatch.setattr(controller._shared_sidecar, "update_sync", _boom)
-
-    with caplog.at_level("WARNING"):
-        result = controller._derive_board_id_from_yaml(tmp_path, "kitchen.yaml")
-
-    assert result == "generic-esp32c3"
-    assert any("Could not persist derived board_id" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -482,18 +482,50 @@ async def test_clone_device_carries_source_board_id_into_metadata(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """Source's ``board_id`` survives the clone via the metadata sidecar.
+    """A user-picked source ``board_id`` survives the clone via the sidecar.
 
-    ``board_id`` is the one piece of dashboard state that can't be
-    recovered from the YAML — it's a catalog-key indirection set by
-    the user at wizard time. The clone path reads the source's
-    metadata in the gather phase and writes it onto the new file's
-    metadata entry in the commit phase, so the cloned device shows
-    up bound to the same catalog board the source picked.
+    A user-set ``board_id`` is the one piece of dashboard state that
+    can't be recovered from the YAML — it's a catalog-key indirection
+    set by the user at wizard time. The clone reads the source's
+    metadata in the gather phase and writes it (with the user-set
+    flag) onto the new file's entry in the commit phase, so the
+    cloned device shows up bound to the same catalog board.
     """
     config_dir = tmp_path
     # Seed the source's metadata sidecar so the clone has something
     # to carry forward.
+    await asyncio.to_thread(
+        set_device_metadata,
+        config_dir,
+        "kitchen.yaml",
+        board_id="esp32-s3-devkitc-1",
+        board_id_user_set=True,
+    )
+    (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
+
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    ctrl._db.settings.config_dir = config_dir
+
+    await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
+
+    # Verify the metadata sidecar got the carry-forward write.
+    meta = await asyncio.to_thread(get_device_metadata, config_dir, "bedroom-bulb.yaml")
+    assert meta is not None
+    assert meta["board_id"] == "esp32-s3-devkitc-1"
+    assert meta["board_id_user_set"] is True
+
+
+async def test_clone_device_drops_auto_derived_source_board_id(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """An auto-derived source ``board_id`` (no flag) is not carried forward.
+
+    Only a deliberate pick is identity worth copying; an
+    auto-derived board re-resolves from the cloned YAML, so carrying
+    a stale guess would just re-introduce the staleness bug.
+    """
+    config_dir = tmp_path
     await asyncio.to_thread(
         set_device_metadata,
         config_dir,
@@ -507,10 +539,8 @@ async def test_clone_device_carries_source_board_id_into_metadata(
 
     await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")
 
-    # Verify the metadata sidecar got the carry-forward write.
     meta = await asyncio.to_thread(get_device_metadata, config_dir, "bedroom-bulb.yaml")
-    assert meta is not None
-    assert meta["board_id"] == "esp32-s3-devkitc-1"
+    assert "board_id" not in meta
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -517,14 +517,16 @@ async def test_create_device_clears_residual_metadata_from_archived_same_name(
 
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     ctrl._db.settings.config_dir = config_dir
+    # Catalog *would* match, but a no-pick create never persists a
+    # derived board_id; the scanner recomputes it on resolve.
     boards = StubBoardLookups(ctrl)
-    boards.find_by_pio_board_returns(None)
+    boards.find_by_pio_board_returns("generic-esp32")
     boards.find_by_platform_variant_returns(None)
 
     await ctrl.create_device(name="kitchen", file_content=VALID_FILE_CONTENT)
 
-    # Stale entry was cleared. No matching board → no board_id
-    # written back, so the entry should be absent (not just empty).
+    # Stale entry was cleared and nothing was written back, so the
+    # entry is absent (not just empty).
     post = await asyncio.to_thread(get_device_metadata, config_dir, "kitchen.yaml")
     assert post == {}
 
@@ -570,7 +572,7 @@ async def test_create_device_with_board_id_overwrites_archived_board_id(
     await ctrl.create_device(name="kitchen", board_id="rp2040-new-board")
 
     post = await asyncio.to_thread(get_device_metadata, config_dir, "kitchen.yaml")
-    assert post == {"board_id": "rp2040-new-board"}
+    assert post == {"board_id": "rp2040-new-board", "board_id_user_set": True}
 
 
 @pytest.mark.xdist_group("catalog")

--- a/tests/controllers/devices/test_derive_board_id.py
+++ b/tests/controllers/devices/test_derive_board_id.py
@@ -1,19 +1,19 @@
 """End-to-end coverage for ``DevicesController._derive_board_id_from_yaml``.
 
 The helper is invoked from ``_resolve_device_metadata`` whenever a
-device lacks a sidecar ``board_id``. It parses the YAML for
-``platform`` / ``board`` / ``variant``, asks the catalog for a
-matching entry, and backfills the shared sidecar via
-``set_device_metadata`` on cache miss so subsequent scans skip
-the YAML parse.
+device has no user-set sidecar ``board_id``. It parses the YAML for
+``platform`` / ``board`` / ``variant`` and asks the catalog for a
+matching entry. The result is never persisted; it is recomputed each
+resolve so a catalog update self-heals.
 
-Five branches to pin:
+Branches to pin:
 
 1. ``self._db.boards is None`` → empty string (catalog not loaded).
 2. Missing YAML (``OSError``) → empty string.
 3. PlatformIO-board match → catalog id returned.
 4. ``pio_board`` misses, ``platform`` matches → fallback hit.
 5. No match at all → empty string.
+6. A catalog hit doesn't write the sidecar.
 """
 
 from __future__ import annotations
@@ -76,8 +76,7 @@ def test_derive_uses_pio_board_match_first(
     ``find_by_pio_board`` is the higher-fidelity lookup — a YAML
     with ``board: esp32-c3-devkitm-1`` should land on the
     "Generic ESP32-C3" catalog entry, not on whatever the bare
-    ``esp32:`` fallback would pick. Pin both call ordering and
-    the persist-to-sidecar step.
+    ``esp32:`` fallback would pick. Pin the call ordering.
     """
     controller = make_controller(tmp_path, with_boards=True)
     boards = StubBoardLookups(controller)
@@ -144,6 +143,25 @@ def test_derive_skips_pio_board_when_yaml_omits_board_field(
     # PIO lookup was skipped — pio_board was empty.
     pio_lookup.assert_not_called()
     platform_lookup.assert_called_once_with("esp32", "")
+
+
+def test_derive_does_not_persist_to_sidecar(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A catalog match returns the id without writing it to the sidecar.
+
+    A derived id depends on the shipped catalog, so it must not be
+    cached; a stale write would survive a catalog update that
+    changes the match.
+    """
+    controller = make_controller(tmp_path, with_boards=True)
+    StubBoardLookups(controller).find_by_pio_board_returns("generic-esp32c3")
+    _write_yaml(tmp_path, "kitchen.yaml", platform="esp32", board="esp32-c3-devkitm-1")
+
+    result = controller._derive_board_id_from_yaml(tmp_path, "kitchen.yaml")
+
+    assert result == "generic-esp32c3"
+    assert controller._shared_sidecar.get_sync("kitchen.yaml") == {}
 
 
 def test_derive_returns_empty_when_no_catalog_entry_matches(

--- a/tests/controllers/devices/test_metadata_resolver.py
+++ b/tests/controllers/devices/test_metadata_resolver.py
@@ -248,18 +248,8 @@ def test_added_device_fully_populated_does_not_regenerate(
     assert regenerated == []
 
 
-def test_board_id_from_sidecar_takes_priority_over_yaml(tmp_path: Path, monkeypatch: Any) -> None:
-    """A pinned board_id from the sidecar isn't clobbered by YAML re-derivation.
-
-    Locks down the existing precedence even though the diff under
-    test is about the hash side — board_id and the hash are
-    resolved together, so a refactor that broke the precedence in
-    one direction would likely break the other.
-    """
-    config_dir = tmp_path
-    filename = "kitchen.yaml"
-    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-
+def _resolver_controller(tmp_path: Path) -> DevicesController:
+    """Build a bare ``DevicesController`` with a real store + shared sidecar."""
     controller = DevicesController.__new__(DevicesController)
     controller._shutdown_callbacks = []
     controller._metadata_store = DeviceMetadataStore(
@@ -268,14 +258,82 @@ def test_board_id_from_sidecar_takes_priority_over_yaml(tmp_path: Path, monkeypa
         shutdown_register=controller._shutdown_callbacks.append,
     )
     controller._shared_sidecar = SharedSidecarClient(tmp_path)
+    return controller
+
+
+def test_user_set_board_id_is_trusted_over_yaml(tmp_path: Path, monkeypatch: Any) -> None:
+    """A user-picked board_id (flagged) wins over a fresh YAML re-derivation.
+
+    Pins that a deliberate pick survives even when it differs from
+    what ``find_by_pio_board`` would return today.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    controller = _resolver_controller(tmp_path)
     derive = MagicMock(return_value="should-not-be-called")
     monkeypatch.setattr(controller, "_derive_board_id_from_yaml", derive, raising=False)
-    _seed_metadata(monkeypatch, controller, filename, {"board_id": "esp32-poe"})
+    _seed_metadata(
+        monkeypatch, controller, filename, {"board_id": "esp32-poe", "board_id_user_set": True}
+    )
 
     metadata = controller._resolve_device_metadata(config_dir, filename)
 
     assert metadata.board_id == "esp32-poe"
     derive.assert_not_called()
+
+
+def test_unflagged_board_id_is_rederived_not_trusted(tmp_path: Path, monkeypatch: Any) -> None:
+    """A stale sidecar board_id with no user-set flag is re-derived.
+
+    The reported-bug shape: a board_id auto-derived under an older
+    catalog lingers in the sidecar; resolve must recompute against
+    the current catalog rather than trust the stale value.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    controller = _resolver_controller(tmp_path)
+    derive = MagicMock(return_value="cb3s")
+    monkeypatch.setattr(controller, "_derive_board_id_from_yaml", derive, raising=False)
+    _seed_metadata(monkeypatch, controller, filename, {"board_id": "avatto-stale"})
+
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.board_id == "cb3s"
+    derive.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "flag_value",
+    [1, "true", "True", "false", "1", [], {}, 0],
+    ids=["int_1", "str_true", "str_True", "str_false", "str_1", "list", "dict", "int_0"],
+)
+def test_corrupt_user_set_flag_is_not_trusted(
+    tmp_path: Path, monkeypatch: Any, flag_value: Any
+) -> None:
+    """Only a literal ``True`` pins the pick; truthy non-bool values re-derive.
+
+    A hand-edited sidecar could hold ``1`` or ``"true"`` (both
+    truthy); the ``is True`` gate must still re-derive against the
+    current catalog rather than trust a stale board_id.
+    """
+    config_dir = tmp_path
+    filename = "kitchen.yaml"
+    (config_dir / filename).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    controller = _resolver_controller(tmp_path)
+    derive = MagicMock(return_value="cb3s")
+    monkeypatch.setattr(controller, "_derive_board_id_from_yaml", derive, raising=False)
+    seed = {"board_id": "avatto-stale", "board_id_user_set": flag_value}
+    _seed_metadata(monkeypatch, controller, filename, seed)
+
+    metadata = controller._resolve_device_metadata(config_dir, filename)
+
+    assert metadata.board_id == "cb3s"
+    derive.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/controllers/devices/test_metadata_store.py
+++ b/tests/controllers/devices/test_metadata_store.py
@@ -190,6 +190,7 @@ async def test_e2e_pre_pr_shape_migrates_through_resolver(
     await seed_device(tmp_path, "kitchen.yaml")
     pre_pr = {
         "board_id": "esp32-c3-devkitm-1",
+        "board_id_user_set": True,
         "friendly_name": "Kitchen Sensor",
         "comment": "By the toaster",
         "mac_address": "94:C9:60:1F:8C:F1",
@@ -234,6 +235,7 @@ async def test_e2e_pre_pr_shape_migrates_through_resolver(
     assert shared["_labels"] == [{"id": "abc", "name": "Bedroom"}]
     assert shared["kitchen.yaml"] == {
         "board_id": "esp32-c3-devkitm-1",
+        "board_id_user_set": True,
         "friendly_name": "Kitchen Sensor",
         "comment": "By the toaster",
         "labels": ["abc"],

--- a/tests/controllers/devices/test_rename_metadata.py
+++ b/tests/controllers/devices/test_rename_metadata.py
@@ -39,6 +39,7 @@ def test_rename_device_metadata_carries_identity_fields(tmp_path: Path) -> None:
         tmp_path,
         "kitchen.yaml",
         board_id="esp32dev",
+        board_id_user_set=True,
         comment="downstairs",
         labels=["a", "b"],
     )
@@ -48,6 +49,8 @@ def test_rename_device_metadata_carries_identity_fields(tmp_path: Path) -> None:
     assert get_device_metadata(tmp_path, "kitchen.yaml") == {}
     moved = get_device_metadata(tmp_path, "livingroom.yaml")
     assert moved.get("board_id") == "esp32dev"
+    # The user-set flag rides along so the pick isn't re-derived after rename.
+    assert moved.get("board_id_user_set") is True
     assert moved.get("comment") == "downstairs"
     assert moved.get("labels") == ["a", "b"]
 

--- a/tests/controllers/devices/test_update_device.py
+++ b/tests/controllers/devices/test_update_device.py
@@ -24,6 +24,7 @@ from esphome_device_builder.controllers.config import (
     get_device_metadata,
     set_device_metadata,
 )
+from tests.conftest import make_device
 
 from .conftest import MakeControllerFactory
 
@@ -63,6 +64,8 @@ async def test_update_device_writes_full_metadata(
     assert meta["friendly_name"] == "Kitchen Sensor"
     assert meta["comment"] == "On the wall by the toaster"
     assert meta["board_id"] == "esp32-c3-devkitm-1"
+    # A board_id passed here is a deliberate pick, so it's flagged.
+    assert meta["board_id_user_set"] is True
 
 
 async def test_update_device_partial_keeps_unrelated_fields(
@@ -95,6 +98,44 @@ async def test_update_device_partial_keeps_unrelated_fields(
     assert response.comment == "New comment"
     assert response.friendly_name == "Kitchen Sensor"
     assert response.board_id == "esp32-c3-devkitm-1"
+
+    # A friendly_name/comment-only update doesn't stamp the
+    # user-set flag (no board_id was passed).
+    meta = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert "board_id_user_set" not in meta
+
+
+async def test_update_echoing_displayed_board_does_not_pin(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Re-sending the currently displayed (derived) board_id doesn't flag it.
+
+    Guards the round-trip case: a client that echoes the shown
+    auto-derived board while editing the comment must not pin a
+    derived id, which would re-break the self-heal.
+    """
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [make_device("kitchen", board_id="generic-esp32")]
+
+    await controller.update_device(name="kitchen", comment="x", board_id="generic-esp32")
+
+    meta = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert meta["board_id"] == "generic-esp32"
+    assert "board_id_user_set" not in meta
+
+
+async def test_update_changed_board_sets_flag(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A board_id that differs from the displayed board is a deliberate pick."""
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [make_device("kitchen", board_id="generic-esp32")]
+
+    await controller.update_device(name="kitchen", board_id="aquaping")
+
+    meta = await asyncio.to_thread(get_device_metadata, tmp_path, "kitchen.yaml")
+    assert meta["board_id"] == "aquaping"
+    assert meta["board_id_user_set"] is True
 
 
 async def test_update_device_falls_back_to_name_for_missing_friendly_name(

--- a/tests/controllers/test_board_catalog_invariants.py
+++ b/tests/controllers/test_board_catalog_invariants.py
@@ -1,0 +1,93 @@
+"""Invariants over the real shipped board catalog.
+
+Guards the catalog-data shape behind the stale board-card bug: a
+device whose YAML names a PlatformIO board shared by several catalog
+entries must resolve to a canonical (generic / id-matching) entry,
+never an arbitrary vendor product.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import pytest
+
+from esphome_device_builder.controllers.boards import BoardCatalog
+from esphome_device_builder.models import BoardCatalogIndex
+
+
+@pytest.fixture(scope="module")
+def real_catalog() -> BoardCatalog:
+    """Load the real on-disk catalog once for the module."""
+    cat = BoardCatalog()
+    cat.load()
+    return cat
+
+
+def _is_canonical(entry: BoardCatalogIndex, pio_board: str) -> bool:
+    """Whether *entry* is the canonical match for *pio_board*."""
+    return entry.is_generic or entry.id.replace("_", "-") == pio_board.replace("_", "-")
+
+
+def test_shared_pio_boards_resolve_to_a_canonical_entry(real_catalog: BoardCatalog) -> None:
+    """Every PlatformIO board with >1 catalog entry resolves to a canonical one.
+
+    The bug surfaced when a bare ``board: cb3s`` YAML matched only
+    vendor products. Pin that any shared pio_board resolves to the
+    generic/id-matching entry, so a future sync that imports a vendor
+    device on a generic-less pio_board fails here instead of silently
+    rendering its product card on unrelated configs.
+    """
+    groups: dict[tuple[str, str], list[BoardCatalogIndex]] = defaultdict(list)
+    for board in real_catalog._boards:
+        groups[(board.esphome.platform.value, board.esphome.board)].append(board)
+
+    offenders = []
+    for (platform, pio), entries in groups.items():
+        if len(entries) < 2:
+            continue
+        winner = real_catalog.find_by_pio_board(pio, "", platform)
+        if winner is None or not _is_canonical(winner, pio):
+            offenders.append(
+                (platform, pio, winner.id if winner else None, sorted(e.id for e in entries))
+            )
+
+    assert offenders == [], f"shared pio_boards resolving to a vendor product: {offenders!r}"
+
+
+def test_cb3s_resolves_to_generic_module(real_catalog: BoardCatalog) -> None:
+    """``board: cb3s`` resolves to the generic CB3S module, not a vendor product.
+
+    Regression for the AVATTO-S06 board card rendering on a
+    hand-written cb3s config; both share PlatformIO board ``cb3s``.
+    """
+    winner = real_catalog.find_by_pio_board("cb3s", "", "bk72xx")
+
+    assert winner is not None
+    assert winner.id == "cb3s"
+
+
+def test_featured_boards_never_lose_to_a_non_canonical_entry(real_catalog: BoardCatalog) -> None:
+    """A featured board wins its pio_board lookup, or defers only to a canonical entry.
+
+    A featured vendor board built on a generic reference design
+    (e.g. apollo-esk-1 on ``esp32-c6-devkitm-1``) intentionally
+    defers to the generic for derivation; it's pick-only, since a
+    bare ``board:`` config can't be told from a plain devkit. What
+    must never happen is a featured board losing to *another* vendor
+    product, which would render the wrong card.
+    """
+    offenders = []
+    for board in real_catalog._boards:
+        if not board.featured:
+            continue
+        variant = board.esphome.variant.value if board.esphome.variant else ""
+        winner = real_catalog.find_by_pio_board(
+            board.esphome.board, variant, board.esphome.platform.value
+        )
+        if winner is None:
+            offenders.append((board.id, board.esphome.board, None))
+        elif winner.id != board.id and not _is_canonical(winner, board.esphome.board):
+            offenders.append((board.id, board.esphome.board, winner.id))
+
+    assert offenders == [], f"featured boards losing to a non-canonical entry: {offenders!r}"


### PR DESCRIPTION
# What does this implement/fix?

For a long time the board catalog shipped without generic board entries, so any device first scanned in that window had its `board_id` auto-derived to whatever specific catalog entry happened to match the YAML's `board:` (often a devices.esphome.io vendor product), and that id was cached in the sidecar and never re-checked. The generics have since been added, but existing installs kept the stale id, so a lot of beta users are likely carrying wrong board cards right now. The reported case was a hand written cb3s config rendering as the AVATTO S06 IR Remote, but it is a whole class of bug affecting any device on a shared PlatformIO board.

Now an auto-derived `board_id` is recomputed against the current catalog on every scan; only a deliberate user pick is pinned, via a new `board_id_user_set` flag, so stale cards heal themselves.

A `board_id` counts as a deliberate pick when it arrives as an explicit argument on `devices/create`, `devices/update`, or a clone of an already flagged device; anything derived from the YAML's `board:` stays unflagged. `devices/update` only stamps the flag when the incoming `board_id` differs from the displayed board, so a client echoing the shown value while editing the name or comment cannot pin a derived id. A corrupt or hand-edited flag is ignored (only literal `true` is trusted).

Existing sidecars predate the flag, so a one-shot migration runs on first start: it stamps `board_id_user_set` on a pre-flag pick now outranked by a generic board on its own PlatformIO board (e.g. the featured `apollo-esk-1` vs the generic `esp32-c6-devkitm-1`), so curated picks keep their card. devices.esphome.io imports stay unflagged and re-derive, which is what heals the cb3s/AVATTO case.

Accepted trade-off: a user who deliberately picked a devices.esphome.io vendor board from the catalog before this change reverts to the generic board on upgrade. On old data that pick is byte-identical to the stale auto-derived ids, so healing the common wrong-card case necessarily re-derives the rare deliberate import pick too. It is cosmetic (platform and YAML unchanged; only the card name and image differ) and far more installs are fixed than affected. Picks made through the wizard after this change are preserved by the flag. There is no post-create board-change UI today, so restoring a reverted card means recreating the device from the catalog; wiring the existing `devices/update` board_id path into a dashboard affordance would make it a one-click fix, tracked in esphome/device-builder-frontend#615.

A dry-run of the migration against one real 64 device beta fleet corrected 8 stale or wrong board cards (the cb3s remote, RTL/BK Tuya module devices, an RP2040/WIZnet board, and stale generics promoted to their specific board), preserved the one curated Apollo pick, and left the other 56 untouched. That is one fleet; the same fix lands for every install on the first scan after upgrade.

**Related issue or feature (if applicable):**

- N/A (reported directly, no tracking issue)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
