### PR TITLE
Add Windows MAX_PATH junction-canonicalization probe workflow

### DIFF
--- a/.github/workflows/windows-maxpath-probe.yaml
+++ b/.github/workflows/windows-maxpath-probe.yaml
@@ -1,10 +1,9 @@
 name: Windows MAX_PATH junction probe
 
 # Manual investigation aid for the desktop-Windows path-shortening design (issue #1190).
-# Runs one ESP-IDF compile on a windows-latest runner with ESPHOME_DATA_DIR /
-# PLATFORMIO_CORE_DIR pointed at short directory junctions, then inspects the generated
-# build files to decide whether the compiler is handed the short junction path (junction
-# survives) or the canonical long target (PlatformIO/CMake canonicalized it away). See
+# Compiles a deep ESP-IDF config on a windows-latest runner under the proposed short-root
+# layout (build tree via a short junction C:\esphb, PlatformIO core at a real short dir
+# C:\esphb-pio) and confirms it builds where the long default overflows MAX_PATH. See
 # script/windows_maxpath_probe.py. workflow_dispatch only (never on push/PR).
 
 permissions:
@@ -12,10 +11,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  # TEMPORARY: branch-scoped push trigger so the probe runs before the
-  # workflow_dispatch entry lands on the default branch. Remove before merge.
-  push:
-    branches: [windows-maxpath-junction-probe]
 
 jobs:
   probe:

--- a/.github/workflows/windows-maxpath-probe.yaml
+++ b/.github/workflows/windows-maxpath-probe.yaml
@@ -12,6 +12,10 @@ permissions:
 
 on:
   workflow_dispatch:
+  # TEMPORARY: branch-scoped push trigger so the probe runs before the
+  # workflow_dispatch entry lands on the default branch. Remove before merge.
+  push:
+    branches: [windows-maxpath-junction-probe]
 
 jobs:
   probe:

--- a/.github/workflows/windows-maxpath-probe.yaml
+++ b/.github/workflows/windows-maxpath-probe.yaml
@@ -1,0 +1,47 @@
+name: Windows MAX_PATH junction probe
+
+# Manual investigation aid for the desktop-Windows path-shortening design (issue #1190).
+# Runs one ESP-IDF compile on a windows-latest runner with ESPHOME_DATA_DIR /
+# PLATFORMIO_CORE_DIR pointed at short directory junctions, then inspects the generated
+# build files to decide whether the compiler is handed the short junction path (junction
+# survives) or the canonical long target (PlatformIO/CMake canonicalized it away). See
+# script/windows_maxpath_probe.py. workflow_dispatch only (never on push/PR).
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    name: Junction canonicalization probe
+    runs-on: windows-latest
+    # ESP-IDF cold toolchain download + configure on a fresh runner is the slow part; a full
+    # compile may not finish, but the build files we inspect appear at cmake-configure time.
+    timeout-minutes: 60
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install esphome
+        run: pip install esphome
+
+      - name: Run MAX_PATH junction probe
+        run: python script/windows_maxpath_probe.py
+
+      - name: Upload generated build files
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: maxpath-probe-build-files
+          path: |
+            C:\esphb\**\compile_commands.json
+            C:\esphb\**\build.ninja
+            C:\esphb\**\CMakeCache.txt
+          if-no-files-found: warn

--- a/script/windows_maxpath_probe.py
+++ b/script/windows_maxpath_probe.py
@@ -1,22 +1,20 @@
 r"""
-Windows MAX_PATH junction-canonicalization probe (run on a windows-latest CI runner).
+Windows MAX_PATH fix-layout validation probe (run on a windows-latest CI runner).
 
-Answers two gates that decide the desktop Windows path-shortening design:
+Validates the proposed desktop-Windows path-shortening layout for issue #1190 end to end:
 
-* **Build-root gate**: point ``ESPHOME_DATA_DIR`` at a short directory *junction*
-  (``C:\\esphb``) into a deliberately long real dir, compile an ESP-IDF config, and check
-  whether the generated build files reference object paths via the short junction string
-  (junction survives → clean-uninstall short root is viable) or the canonical long target
-  (PlatformIO/CMake canonicalized the build dir → junction useless for the build root).
-* **``.platformio`` gate**: same run, ``PLATFORMIO_CORE_DIR`` junction (``C:\\esphb-pio``).
-  ESP-IDF's ``idf.cmake`` REALPATHs ``IDF_PATH``, so the mbedtls source paths mirrored into
-  ``CMakeFiles/<target>.dir/`` are expected to use the canonical long path (junction
-  defeated). This run confirms or refutes that empirically.
+* the build tree lives under a short directory *junction* ``C:\esphb`` (junctions survive
+  PlatformIO/CMake path handling for the build dir);
+* the PlatformIO core / framework (``.platformio``) lives at a *real* short dir
+  ``C:\esphb-pio`` -- it must be real, not a junction, because ESP-IDF's ``idf.cmake``
+  REALPATHs ``IDF_PATH`` and resolves a junction back to its long target.
 
-The decisive signal is the path *string* recorded in ``compile_commands.json`` /
-``build.ninja`` / ``CMakeCache.txt``, not compile pass/fail (whose threshold is finicky).
-The probe never raises on a failed compile; it inspects whatever cmake emitted and prints a
-verdict (and writes one to ``$GITHUB_STEP_SUMMARY``).
+Both facts were established by run 26959353731 (build-root junction SURVIVES; ``.platformio``
+junction CANONICALIZED, and the canonicalized long include paths blew past the Windows
+command-line limit). This run compiles an ESP-IDF config with ``api: encryption:`` (the deep
+mbedtls / tf-psa-crypto tree that overflows MAX_PATH) under the short-root layout and reports
+the compile exit code plus the deepest on-disk path length. Success = the layout builds where
+the long default would fail.
 """
 
 from __future__ import annotations
@@ -27,14 +25,12 @@ import sys
 import textwrap
 from pathlib import Path
 
-# Short, *recognizable* junction roots: what the desktop app would plausibly use so a user
-# inspecting their disk knows what it is (``esphb`` = ESPHome builder).
+# Short, *recognizable* roots (``esphb`` = ESPHome builder) so a user inspecting their disk
+# knows what they are. Build tree via a junction (clean uninstall); PlatformIO core as a real
+# dir (a junction is canonicalized away by ESP-IDF).
 JUNC_DATA = Path(r"C:\esphb")
-JUNC_PIO = Path(r"C:\esphb-pio")
+PIO_REAL = Path(r"C:\esphb-pio")
 
-# ~70-char padding segment so the *real* (canonical) targets are long: if cmake canonicalizes
-# the junction away, the deepest object path blows past 260; via the junction it stays short.
-_PAD = "padding-" * 9  # 72 chars
 _DEVICE_NAME = "maxpath-probe-esp32-idf"
 
 _PROBE_YAML = textwrap.dedent(
@@ -57,16 +53,13 @@ _PROBE_YAML = textwrap.dedent(
 
 
 def main() -> int:
-    """Set up junctions, run one ESP-IDF compile, classify the recorded paths, report."""
+    """Set up the short-root layout, run one ESP-IDF compile, report exit code + depth."""
     workspace = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
-    real_root = workspace / "maxpath_probe" / _PAD
-    real_data = real_root / "data"
-    real_pio = real_root / "pio"
+    # Junction target length is irrelevant: the junction is what the compiler sees.
+    real_data = workspace / "maxpath_probe" / "data"
     real_data.mkdir(parents=True, exist_ok=True)
-    real_pio.mkdir(parents=True, exist_ok=True)
-
+    PIO_REAL.mkdir(parents=True, exist_ok=True)
     _make_junction(JUNC_DATA, real_data)
-    _make_junction(JUNC_PIO, real_pio)
 
     config = workspace / "maxpath_probe" / "probe.yaml"
     config.write_text(_PROBE_YAML, encoding="utf-8")
@@ -74,10 +67,10 @@ def main() -> int:
     env = {
         **os.environ,
         "ESPHOME_DATA_DIR": str(JUNC_DATA),
-        "PLATFORMIO_CORE_DIR": str(JUNC_PIO),
+        "PLATFORMIO_CORE_DIR": str(PIO_REAL),
     }
-    print(f"[probe] ESPHOME_DATA_DIR={JUNC_DATA} -> {real_data}", flush=True)
-    print(f"[probe] PLATFORMIO_CORE_DIR={JUNC_PIO} -> {real_pio}", flush=True)
+    print(f"[probe] ESPHOME_DATA_DIR={JUNC_DATA} (junction) -> {real_data}", flush=True)
+    print(f"[probe] PLATFORMIO_CORE_DIR={PIO_REAL} (real short dir)", flush=True)
     print("[probe] running: esphome compile probe.yaml", flush=True)
     proc = subprocess.run(
         [sys.executable, "-m", "esphome", "compile", str(config)],
@@ -86,9 +79,8 @@ def main() -> int:
     )
     print(f"[probe] esphome compile exit code: {proc.returncode}", flush=True)
 
-    report = _classify(real_data, real_pio)
-    _emit(report, proc.returncode)
-    # Always exit 0: the verdict in the logs / step summary is the deliverable, not pass/fail.
+    _emit(proc.returncode)
+    # Always exit 0: the verdict in the logs / step summary is the deliverable.
     return 0
 
 
@@ -117,88 +109,26 @@ def _make_junction(link: Path, target: Path) -> None:
         raise RuntimeError(f"failed to create junction {link} -> {target}: {result.stderr}")
 
 
-def _classify(real_data: Path, real_pio: Path) -> dict[str, object]:
-    """Walk the emitted build files + tree and tally junction-prefix vs canonical-prefix use."""
-    build_files = (
-        list(JUNC_DATA.rglob("compile_commands.json"))
-        + list(JUNC_DATA.rglob("build.ninja"))
-        + list(JUNC_DATA.rglob("CMakeCache.txt"))
-    )
-    blob = ""
-    for path in build_files:
-        try:
-            blob += path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-
-    data_junction = _count(blob, JUNC_DATA)
-    data_canonical = _count(blob, real_data)
-    pio_junction = _count(blob, JUNC_PIO)
-    pio_canonical = _count(blob, real_pio)
-
-    deepest_junction, deepest_canonical = _deepest_path(real_data)
-
-    return {
-        "build_files_found": [str(p) for p in build_files],
-        "data_junction_hits": data_junction,
-        "data_canonical_hits": data_canonical,
-        "pio_junction_hits": pio_junction,
-        "pio_canonical_hits": pio_canonical,
-        "build_root_junction_survives": _verdict(data_junction, data_canonical),
-        "platformio_junction_survives": _verdict(pio_junction, pio_canonical),
-        "deepest_path_via_junction": deepest_junction,
-        "deepest_path_via_canonical": deepest_canonical,
-    }
-
-
-def _count(blob: str, prefix: Path) -> int:
-    """Count case-insensitive occurrences of ``prefix`` in both slash flavors."""
-    needle = str(prefix).lower()
-    haystack = blob.lower()
-    return haystack.count(needle) + haystack.count(needle.replace("\\", "/"))
-
-
-def _verdict(junction_hits: int, canonical_hits: int) -> str:
-    """Map hit counts to survives / canonicalized / inconclusive."""
-    if junction_hits == 0 and canonical_hits == 0:
-        return "inconclusive (no path hits)"
-    if junction_hits > canonical_hits:
-        return "SURVIVES (short junction path used)"
-    if canonical_hits > junction_hits:
-        return "CANONICALIZED (long real path used)"
-    return "mixed"
-
-
-def _deepest_path(real_data: Path) -> tuple[int, int]:
-    r"""Return (deepest length via the C:\esphb junction, deepest length via the real path)."""
+def _deepest(root: Path) -> int:
+    """Return the longest full file-path string length under ``root`` (0 if empty)."""
     longest = 0
-    for root, _dirs, files in os.walk(JUNC_DATA):
-        # Measure the joined string length without os.path.join (separator + name).
-        longest = max((longest, *(len(root) + 1 + len(name) for name in files)))
-    if longest == 0:
-        return 0, 0
-    canonical = longest - len(str(JUNC_DATA)) + len(str(real_data))
-    return longest, canonical
+    for current, _dirs, files in os.walk(root):
+        longest = max((longest, *(len(current) + 1 + len(name) for name in files)))
+    return longest
 
 
-def _emit(report: dict[str, object], compile_rc: int) -> None:
+def _emit(compile_rc: int) -> None:
     """Print the verdict and append a markdown block to ``$GITHUB_STEP_SUMMARY``."""
+    outcome = "COMPILED (short-root layout builds)" if compile_rc == 0 else "FAILED"
     lines = [
-        "# Windows MAX_PATH junction probe",
+        "# Windows MAX_PATH fix-layout validation",
         "",
-        f"- esphome compile exit code: `{compile_rc}`",
-        f"- build files inspected: {len(report['build_files_found'])}",
-        f"- **build-root junction (`{JUNC_DATA}`): "
-        f"{report['build_root_junction_survives']}** "
-        f"(junction hits {report['data_junction_hits']}, "
-        f"canonical hits {report['data_canonical_hits']})",
-        f"- **`.platformio` junction (`{JUNC_PIO}`): "
-        f"{report['platformio_junction_survives']}** "
-        f"(junction hits {report['pio_junction_hits']}, "
-        f"canonical hits {report['pio_canonical_hits']})",
-        f"- deepest path via junction: `{report['deepest_path_via_junction']}` chars",
-        f"- deepest path via real target: `{report['deepest_path_via_canonical']}` chars "
-        "(this is what the compiler sees if the junction is canonicalized)",
+        f"- **esphome compile: {outcome}** (exit code `{compile_rc}`)",
+        f"- build tree: `{JUNC_DATA}` (junction)",
+        f"- PlatformIO core: `{PIO_REAL}` (real short dir)",
+        f"- deepest path under build tree: `{_deepest(JUNC_DATA)}` chars",
+        f"- deepest path under PlatformIO core: `{_deepest(PIO_REAL)}` chars",
+        "- threshold: Windows `MAX_PATH` = 260",
     ]
     block = "\n".join(lines)
     print("\n" + block, flush=True)

--- a/script/windows_maxpath_probe.py
+++ b/script/windows_maxpath_probe.py
@@ -46,6 +46,9 @@ _PROBE_YAML = textwrap.dedent(
       framework:
         type: esp-idf
     logger:
+    wifi:
+      ssid: "probe-ssid"
+      password: "probe-password"
     api:
       encryption:
         key: "bm90aGluZ3Rvc2VlaGVyZW5vdGhpbmd0b3NlZQ=="

--- a/script/windows_maxpath_probe.py
+++ b/script/windows_maxpath_probe.py
@@ -1,0 +1,209 @@
+r"""
+Windows MAX_PATH junction-canonicalization probe (run on a windows-latest CI runner).
+
+Answers two gates that decide the desktop Windows path-shortening design:
+
+* **Build-root gate**: point ``ESPHOME_DATA_DIR`` at a short directory *junction*
+  (``C:\\esphb``) into a deliberately long real dir, compile an ESP-IDF config, and check
+  whether the generated build files reference object paths via the short junction string
+  (junction survives → clean-uninstall short root is viable) or the canonical long target
+  (PlatformIO/CMake canonicalized the build dir → junction useless for the build root).
+* **``.platformio`` gate**: same run, ``PLATFORMIO_CORE_DIR`` junction (``C:\\esphb-pio``).
+  ESP-IDF's ``idf.cmake`` REALPATHs ``IDF_PATH``, so the mbedtls source paths mirrored into
+  ``CMakeFiles/<target>.dir/`` are expected to use the canonical long path (junction
+  defeated). This run confirms or refutes that empirically.
+
+The decisive signal is the path *string* recorded in ``compile_commands.json`` /
+``build.ninja`` / ``CMakeCache.txt``, not compile pass/fail (whose threshold is finicky).
+The probe never raises on a failed compile; it inspects whatever cmake emitted and prints a
+verdict (and writes one to ``$GITHUB_STEP_SUMMARY``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# Short, *recognizable* junction roots: what the desktop app would plausibly use so a user
+# inspecting their disk knows what it is (``esphb`` = ESPHome builder).
+JUNC_DATA = Path(r"C:\esphb")
+JUNC_PIO = Path(r"C:\esphb-pio")
+
+# ~70-char padding segment so the *real* (canonical) targets are long: if cmake canonicalizes
+# the junction away, the deepest object path blows past 260; via the junction it stays short.
+_PAD = "padding-" * 9  # 72 chars
+_DEVICE_NAME = "maxpath-probe-esp32-idf"
+
+_PROBE_YAML = textwrap.dedent(
+    f"""\
+    esphome:
+      name: {_DEVICE_NAME}
+    esp32:
+      board: esp32dev
+      framework:
+        type: esp-idf
+    logger:
+    api:
+      encryption:
+        key: "bm90aGluZ3Rvc2VlaGVyZW5vdGhpbmd0b3NlZQ=="
+    """
+)
+
+
+def main() -> int:
+    """Set up junctions, run one ESP-IDF compile, classify the recorded paths, report."""
+    workspace = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
+    real_root = workspace / "maxpath_probe" / _PAD
+    real_data = real_root / "data"
+    real_pio = real_root / "pio"
+    real_data.mkdir(parents=True, exist_ok=True)
+    real_pio.mkdir(parents=True, exist_ok=True)
+
+    _make_junction(JUNC_DATA, real_data)
+    _make_junction(JUNC_PIO, real_pio)
+
+    config = workspace / "maxpath_probe" / "probe.yaml"
+    config.write_text(_PROBE_YAML, encoding="utf-8")
+
+    env = {
+        **os.environ,
+        "ESPHOME_DATA_DIR": str(JUNC_DATA),
+        "PLATFORMIO_CORE_DIR": str(JUNC_PIO),
+    }
+    print(f"[probe] ESPHOME_DATA_DIR={JUNC_DATA} -> {real_data}", flush=True)
+    print(f"[probe] PLATFORMIO_CORE_DIR={JUNC_PIO} -> {real_pio}", flush=True)
+    print("[probe] running: esphome compile probe.yaml", flush=True)
+    proc = subprocess.run(
+        [sys.executable, "-m", "esphome", "compile", str(config)],
+        env=env,
+        check=False,
+    )
+    print(f"[probe] esphome compile exit code: {proc.returncode}", flush=True)
+
+    report = _classify(real_data, real_pio)
+    _emit(report, proc.returncode)
+    # Always exit 0: the verdict in the logs / step summary is the deliverable, not pass/fail.
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _make_junction(link: Path, target: Path) -> None:
+    """Create a directory junction ``link`` -> ``target`` (no admin needed; idempotent)."""
+    if link.exists():
+        print(f"[probe] junction already exists: {link}", flush=True)
+        return
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(
+        f"[probe] mklink /J {link} {target}: rc={result.returncode} "
+        f"{result.stdout.strip()}{result.stderr.strip()}",
+        flush=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to create junction {link} -> {target}: {result.stderr}")
+
+
+def _classify(real_data: Path, real_pio: Path) -> dict[str, object]:
+    """Walk the emitted build files + tree and tally junction-prefix vs canonical-prefix use."""
+    build_files = (
+        list(JUNC_DATA.rglob("compile_commands.json"))
+        + list(JUNC_DATA.rglob("build.ninja"))
+        + list(JUNC_DATA.rglob("CMakeCache.txt"))
+    )
+    blob = ""
+    for path in build_files:
+        try:
+            blob += path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+    data_junction = _count(blob, JUNC_DATA)
+    data_canonical = _count(blob, real_data)
+    pio_junction = _count(blob, JUNC_PIO)
+    pio_canonical = _count(blob, real_pio)
+
+    deepest_junction, deepest_canonical = _deepest_path(real_data)
+
+    return {
+        "build_files_found": [str(p) for p in build_files],
+        "data_junction_hits": data_junction,
+        "data_canonical_hits": data_canonical,
+        "pio_junction_hits": pio_junction,
+        "pio_canonical_hits": pio_canonical,
+        "build_root_junction_survives": _verdict(data_junction, data_canonical),
+        "platformio_junction_survives": _verdict(pio_junction, pio_canonical),
+        "deepest_path_via_junction": deepest_junction,
+        "deepest_path_via_canonical": deepest_canonical,
+    }
+
+
+def _count(blob: str, prefix: Path) -> int:
+    """Count case-insensitive occurrences of ``prefix`` in both slash flavors."""
+    needle = str(prefix).lower()
+    haystack = blob.lower()
+    return haystack.count(needle) + haystack.count(needle.replace("\\", "/"))
+
+
+def _verdict(junction_hits: int, canonical_hits: int) -> str:
+    """Map hit counts to survives / canonicalized / inconclusive."""
+    if junction_hits == 0 and canonical_hits == 0:
+        return "inconclusive (no path hits)"
+    if junction_hits > canonical_hits:
+        return "SURVIVES (short junction path used)"
+    if canonical_hits > junction_hits:
+        return "CANONICALIZED (long real path used)"
+    return "mixed"
+
+
+def _deepest_path(real_data: Path) -> tuple[int, int]:
+    r"""Return (deepest length via the C:\esphb junction, deepest length via the real path)."""
+    longest = 0
+    for root, _dirs, files in os.walk(JUNC_DATA):
+        # Measure the joined string length without os.path.join (separator + name).
+        longest = max((longest, *(len(root) + 1 + len(name) for name in files)))
+    if longest == 0:
+        return 0, 0
+    canonical = longest - len(str(JUNC_DATA)) + len(str(real_data))
+    return longest, canonical
+
+
+def _emit(report: dict[str, object], compile_rc: int) -> None:
+    """Print the verdict and append a markdown block to ``$GITHUB_STEP_SUMMARY``."""
+    lines = [
+        "# Windows MAX_PATH junction probe",
+        "",
+        f"- esphome compile exit code: `{compile_rc}`",
+        f"- build files inspected: {len(report['build_files_found'])}",
+        f"- **build-root junction (`{JUNC_DATA}`): "
+        f"{report['build_root_junction_survives']}** "
+        f"(junction hits {report['data_junction_hits']}, "
+        f"canonical hits {report['data_canonical_hits']})",
+        f"- **`.platformio` junction (`{JUNC_PIO}`): "
+        f"{report['platformio_junction_survives']}** "
+        f"(junction hits {report['pio_junction_hits']}, "
+        f"canonical hits {report['pio_canonical_hits']})",
+        f"- deepest path via junction: `{report['deepest_path_via_junction']}` chars",
+        f"- deepest path via real target: `{report['deepest_path_via_canonical']}` chars "
+        "(this is what the compiler sees if the junction is canonicalized)",
+    ]
+    block = "\n".join(lines)
+    print("\n" + block, flush=True)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with Path(summary).open("a", encoding="utf-8") as handle:
+            handle.write(block + "\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/windows_maxpath_probe.py
+++ b/script/windows_maxpath_probe.py
@@ -51,7 +51,7 @@ _PROBE_YAML = textwrap.dedent(
       password: "probe-password"
     api:
       encryption:
-        key: "bm90aGluZ3Rvc2VlaGVyZW5vdGhpbmd0b3NlZQ=="
+        key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
     """
 )
 


### PR DESCRIPTION
# What does this implement/fix?

A manual investigation aid for the desktop-Windows `MAX_PATH` (260-char) build-path problem behind issue #1190.

The ESP8266/libsodium failure in #1190 is a Windows `MAX_PATH` overflow (the deepest object path lands one char over 260). The durable fix for ESPHome Desktop (primary target: native Windows, local compiles) is to shorten the build tree, ideally via a short directory **junction** so uninstall stays clean. The open question that needs real Windows hardware: does PlatformIO/CMake hand the compiler the **short junction path** (junction survives) or **canonicalize it back** to the long real target (junction useless)?

This PR adds a `workflow_dispatch` job (`windows-latest`) and a probe script that:

- points `ESPHOME_DATA_DIR` at a short junction `C:\esphb` (build root) and `PLATFORMIO_CORE_DIR` at `C:\esphb-pio` (toolchain), each into a deliberately long real dir,
- runs one ESP-IDF compile of a config with `api: encryption:` (the deep mbedtls / tf-psa-crypto tree),
- inspects the generated `compile_commands.json` / `build.ninja` / `CMakeCache.txt` and reports whether object paths use the junction prefix or the canonical one, plus the deepest path length both ways.

Expected outcome it confirms: the **build-root junction survives** (so a short, clean-uninstall build root is viable), while the **`.platformio` junction is defeated** by ESP-IDF's `idf.cmake` `REALPATH` on `IDF_PATH` (so that lever must be a real short dir, not a junction). Run it from the Actions tab; the verdict lands in the job summary.

No product code changes; investigation tooling only.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder/issues/1190

## Types of changes

- [x] CI / workflow change — `ci`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally. (script lints + byte-compiles; the Windows behaviour is what the workflow exists to measure)
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable. (n/a — manual probe workflow)
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (n/a)
