### PR TITLE
Drain test offloaders before closing the receiver server

### DIFF
--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -155,6 +155,9 @@ async def receiver_server(
             identity.public_bytes,
         )
     finally:
+        # Stop any connected offloaders before closing the server,
+        # else an open peer-link Noise WS hangs server.close().
+        await _stop_created_offloaders()
         await server.close()
         await handles.stop()
 
@@ -686,6 +689,31 @@ def offloader_controller_dir(tmp_path: Path) -> Path:
     return offloader_dir
 
 
+_CREATED_OFFLOADERS: list[OffloaderController] = []
+
+
+async def _stop_created_offloaders() -> None:
+    """Stop + drain every offloader built via _make_offloader_controller."""
+    while _CREATED_OFFLOADERS:
+        await _CREATED_OFFLOADERS.pop().stop()
+
+
+@pytest.fixture(autouse=True)
+async def _drain_offloaders() -> AsyncGenerator[None, None]:
+    """
+    Stop every _make_offloader_controller offloader at teardown.
+
+    The pair flow leaves live peer-link clients / pair-status
+    listeners (and, post-pair, an open Noise WS to the receiver);
+    an open connection hangs ``receiver_server``'s ``server.close()``.
+    """
+    _CREATED_OFFLOADERS.clear()
+    try:
+        yield
+    finally:
+        await _stop_created_offloaders()
+
+
 def _make_offloader_controller(*, config_dir: Path) -> OffloaderController:
     db = MagicMock()
     db.devices = MagicMock()
@@ -694,7 +722,9 @@ def _make_offloader_controller(*, config_dir: Path) -> OffloaderController:
     db.settings = MagicMock()
     db.settings.config_dir = config_dir
     db.peer_link_identity_store = PeerLinkIdentityStore(config_dir)
-    return OffloaderController(db)
+    controller = OffloaderController(db)
+    _CREATED_OFFLOADERS.append(controller)
+    return controller
 
 
 async def _saved_pairings(offloader: OffloaderController) -> list[StoredPairing]:


### PR DESCRIPTION
# What does this implement/fix?

`test_request_pair_already_approved_persists_to_disk` intermittently failed CI with a pytest-timeout during teardown; the test builds a real offloader via `_make_offloader_controller`, runs the full pair flow, but never stops it, so the leaked peer-link client and pair-status listener kept an open Noise WS to the receiver and the `receiver_server` fixture's `server.close()` blocked until the 10s timeout tripped.

Rather than add a one-off `await offloader.stop()` that the next test would forget, the drain is now automatic; `_make_offloader_controller` registers every controller it builds, an autouse fixture stops them all at teardown, and `receiver_server` stops them before closing its server so the offloader always disconnects first. This is test-only, production shutdown is already bounded by `close_active_websockets`, the 5s shutdown timeout, and the controllers' own `stop()`.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
