### PR TITLE
Move slow real-compile e2e tests under tests/e2e/slow/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,23 +310,13 @@ jobs:
           --ignore=tests/e2e/slow
 
   e2e-libretiny:
-    name: E2E LibreTiny (esphome ${{ matrix.channel }})
+    name: E2E LibreTiny (esphome stable)
     runs-on: ubuntu-latest
     # The LibreTiny e2e (tests/e2e/slow/libretiny/) runs a real bk7231n
     # compile that clones the LibreTiny SDK from source (minutes on a cold
     # runner). Split onto its own runner so it can't slow the fast e2e
-    # matrix. ``stable`` is a strict gate; ``dev`` is advisory.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - channel: stable
-            install: ""
-            allow_failure: false
-          - channel: dev
-            install: uv pip install --upgrade git+https://github.com/esphome/esphome.git@dev
-            allow_failure: true
-    continue-on-error: ${{ matrix.allow_failure }}
+    # matrix. Stable only -- the ``[esphome]`` extra resolves the release
+    # the dashboard ships with.
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -343,23 +333,18 @@ jobs:
           uv venv
           uv pip install -e '.[esphome,test]'
 
-      - name: Install esphome (${{ matrix.channel }} channel)
-        if: matrix.install != ''
-        run: ${{ matrix.install }}
-
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
 
       - name: Cache PlatformIO core + per-platform toolchains
         # The LibreTiny compile clones the LibreTiny SDK from source on a
-        # cold runner. Cache ``~/.platformio`` per channel so stable/dev
-        # SDK downloads don't collide.
+        # cold runner. Cache ``~/.platformio`` so the SDK download is reused.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.platformio
-          key: pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/slow/libretiny/test_libretiny_compile_download.py') }}
+          key: pio-e2e-libretiny-${{ runner.os }}-${{ hashFiles('tests/e2e/slow/libretiny/test_libretiny_compile_download.py') }}
           restore-keys: |
-            pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-
+            pio-e2e-libretiny-${{ runner.os }}-
 
       - name: Run LibreTiny e2e
         # 20 min outer cap: a cold LibreTiny SDK clone plus compile runs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,28 +300,72 @@ jobs:
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
 
+      - name: Run e2e tests
+        # The slow real-compile tests live under ``tests/e2e/slow/`` and
+        # run in their own per-toolchain jobs below; this job covers the
+        # fast wire-level e2e suite. ``--timeout=120`` is plenty for it.
+        timeout-minutes: 10
+        run: >-
+          uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
+          --ignore=tests/e2e/slow
+
+  e2e-libretiny:
+    name: E2E LibreTiny (esphome ${{ matrix.channel }})
+    runs-on: ubuntu-latest
+    # The LibreTiny e2e (tests/e2e/slow/libretiny/) runs a real bk7231n
+    # compile that clones the LibreTiny SDK from source (minutes on a cold
+    # runner). Split onto its own runner so it can't slow the fast e2e
+    # matrix. ``stable`` is a strict gate; ``dev`` is advisory.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - channel: stable
+            install: ""
+            allow_failure: false
+          - channel: dev
+            install: uv pip install --upgrade git+https://github.com/esphome/esphome.git@dev
+            allow_failure: true
+    continue-on-error: ${{ matrix.allow_failure }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up uv and Python 3.14
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.14"
+
+      - name: Create venv + install package + test deps
+        run: |
+          uv venv
+          uv pip install -e '.[esphome,test]'
+
+      - name: Install esphome (${{ matrix.channel }} channel)
+        if: matrix.install != ''
+        run: ${{ matrix.install }}
+
+      - name: Show installed esphome version
+        run: uv pip show esphome | grep -E '^(Name|Version):'
+
       - name: Cache PlatformIO core + per-platform toolchains
-        # The LibreTiny e2e (test_libretiny_compile_download.py) runs a real
-        # bk7231n compile, which clones the LibreTiny SDK from source on a
+        # The LibreTiny compile clones the LibreTiny SDK from source on a
         # cold runner. Cache ``~/.platformio`` per channel so stable/dev
-        # SDK downloads don't collide. The native-IDF e2e runs in its own
-        # job below (different toolchain tree), so it isn't cached here.
+        # SDK downloads don't collide.
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.platformio
-          key: pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/test_libretiny_compile_download.py') }}
+          key: pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-${{ hashFiles('tests/e2e/slow/libretiny/test_libretiny_compile_download.py') }}
           restore-keys: |
             pio-e2e-libretiny-${{ runner.os }}-${{ matrix.channel }}-
 
-      - name: Run e2e tests
+      - name: Run LibreTiny e2e
         # 20 min outer cap: a cold LibreTiny SDK clone plus compile runs
-        # minutes. Fast tests keep ``--timeout=120``; the LibreTiny test
-        # opts out via its own ``@pytest.mark.timeout(600)``. The native-IDF
-        # e2e is excluded here and runs in the dev-only job below.
+        # minutes. The test's own ``@pytest.mark.timeout(600)`` caps it.
         timeout-minutes: 20
-        run: >-
-          uv run pytest -q -n auto tests/e2e --maxfail=5 --durations=10 --timeout=120 --no-cov
-          --ignore=tests/e2e/test_esp_idf_compile_download.py
+        run: uv run pytest -q tests/e2e/slow/libretiny --durations=10 --timeout=600 --no-cov
 
   e2e-native-idf:
     name: E2E native ESP-IDF (esphome dev)
@@ -377,7 +421,7 @@ jobs:
         timeout-minutes: 25
         env:
           ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
-        run: uv run pytest -q tests/e2e/test_esp_idf_compile_download.py --durations=10 --timeout=900 --no-cov
+        run: uv run pytest -q tests/e2e/slow/esp32 --durations=10 --timeout=900 --no-cov
 
   benchmarks:
     name: Run benchmarks (CodSpeed)

--- a/tests/e2e/slow/__init__.py
+++ b/tests/e2e/slow/__init__.py
@@ -1,0 +1,1 @@
+"""Slow e2e tests (real toolchain compiles); excluded from default e2e runs."""

--- a/tests/e2e/slow/esp32/__init__.py
+++ b/tests/e2e/slow/esp32/__init__.py
@@ -1,0 +1,1 @@
+"""Slow ESP32 e2e tests (real toolchain compiles)."""

--- a/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
+++ b/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
@@ -22,8 +22,8 @@ from esphome_device_builder.controllers.firmware.download import (
     get_binaries,
 )
 
-from ..conftest import HAS_NATIVE_IDF_TOOLCHAIN
-from .conftest import PairedInstances, run_offload_compile_round_trip
+from ....conftest import HAS_NATIVE_IDF_TOOLCHAIN
+from ...conftest import PairedInstances, run_offload_compile_round_trip
 
 pytestmark = pytest.mark.skipif(
     not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"

--- a/tests/e2e/slow/libretiny/__init__.py
+++ b/tests/e2e/slow/libretiny/__init__.py
@@ -1,0 +1,1 @@
+"""Slow LibreTiny e2e tests (real toolchain compiles)."""

--- a/tests/e2e/slow/libretiny/test_libretiny_compile_download.py
+++ b/tests/e2e/slow/libretiny/test_libretiny_compile_download.py
@@ -27,7 +27,7 @@ import pytest
 
 from esphome_device_builder.controllers.firmware.download import get_binaries
 
-from .conftest import PairedInstances, run_offload_compile_round_trip
+from ...conftest import PairedInstances, run_offload_compile_round_trip
 
 _DEVICE = "bk7231n-e2e"
 _CONFIGURATION_FILENAME = f"{_DEVICE}.yaml"


### PR DESCRIPTION
# What does this implement/fix?

The two slow real-compile e2e round-trips (the native ESP-IDF one at ~195s, the LibreTiny bk7231n one at ~90s) lived alongside the fast wire-level e2e tests, so excluding them meant naming each file. This moves both under a single `tests/e2e/slow/` tree, split per toolchain into `slow/esp32/` and `slow/libretiny/`, so esphome upstream can drop every slow compile with one `--ignore=tests/e2e/slow` instead of listing each test.

CI is updated to match; the `e2e` job now runs the fast suite with `--ignore=tests/e2e/slow` and no longer carries the PlatformIO cache, the LibreTiny compile gets its own `e2e-libretiny` job (stable strict, dev advisory) with that cache, and the native-IDF job points at `tests/e2e/slow/esp32`. The slow tree is intentionally not added to pyproject `addopts`, since an ignore there would also block the dedicated jobs that pass the slow paths explicitly.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
