### PR TITLE
Shorten Windows build paths to stay under MAX_PATH

### DIFF
--- a/.github/workflows/windows-real-compile.yml
+++ b/.github/workflows/windows-real-compile.yml
@@ -1,7 +1,7 @@
 name: Windows real-compile (MAX_PATH)
 
 # tests/e2e/slow/windows: a real ESP-IDF compile on a windows-latest runner that proves the
-# short-path MAX_PATH fix (issue #1190) builds and keeps building. A cold ESP-IDF toolchain
+# short-path MAX_PATH fix builds and keeps building. A cold ESP-IDF toolchain
 # download makes this a ~20-40 min job, so it is gated to changes that touch the mechanism plus
 # a weekly drift check rather than running on every PR. The default test matrix ignores
 # tests/e2e, so this workflow is the only place this e2e runs.

--- a/.github/workflows/windows-real-compile.yml
+++ b/.github/workflows/windows-real-compile.yml
@@ -1,0 +1,58 @@
+name: Windows real-compile (MAX_PATH)
+
+# tests/e2e/slow/windows: a real ESP-IDF compile on a windows-latest runner that proves the
+# short-path MAX_PATH fix (issue #1190) builds and keeps building. A cold ESP-IDF toolchain
+# download makes this a ~20-40 min job, so it is gated to changes that touch the mechanism plus
+# a weekly drift check rather than running on every PR. The default test matrix ignores
+# tests/e2e, so this workflow is the only place this e2e runs.
+#
+# YAML anchors (``&trigger-paths`` / ``*trigger-paths``) keep the push and pull_request path
+# filters in lockstep.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 06:00 UTC: catch upstream esphome / platformio / IDF drift even with no code change.
+    - cron: "0 6 * * 1"
+  push:
+    branches: [main]
+    paths: &trigger-paths
+      - "esphome_device_builder/helpers/windows_build_paths.py"
+      - "esphome_device_builder/controllers/firmware/cli.py"
+      - "esphome_device_builder/helpers/storage_path.py"
+      - "esphome_device_builder/__main__.py"
+      - "tests/e2e/slow/windows/**"
+      - ".github/workflows/windows-real-compile.yml"
+  pull_request:
+    branches: [main]
+    paths: *trigger-paths
+
+jobs:
+  windows-maxpath:
+    name: Real ESP-IDF compile (Windows MAX_PATH)
+    runs-on: windows-latest
+    # Cold ESP-IDF toolchain download + a full mbedtls compile runs minutes; the test's own
+    # @pytest.mark.timeout(2400) caps the test itself.
+    timeout-minutes: 45
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Set up uv and Python 3.13
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.13"
+
+      - name: Create venv + install package + test deps
+        run: |
+          uv venv
+          uv pip install -e '.[esphome,test]'
+
+      - name: Show installed esphome version
+        run: uv pip show esphome
+
+      - name: Run Windows MAX_PATH e2e
+        run: uv run pytest -q tests/e2e/slow/windows --durations=10 --timeout=2400 --no-cov

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -271,6 +271,10 @@ def main() -> None:
     from .controllers.config import DashboardSettings  # noqa: PLC0415
     from .device_builder import DeviceBuilder  # noqa: PLC0415
     from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
+    from .helpers.windows_build_paths import (  # noqa: PLC0415
+        apply_windows_short_build_paths,
+        remove_windows_short_build_paths,
+    )
 
     settings = DashboardSettings()
     settings.parse_args(args)
@@ -287,8 +291,16 @@ def main() -> None:
     with ensure_single_execution(CORE.data_dir) as lock:
         if lock.exit_code is not None:
             sys.exit(lock.exit_code)
-        device_builder = DeviceBuilder(settings)
-        device_builder.run()
+        # Windows: route the build tree through a short junction so deep ESP-IDF
+        # builds stay under MAX_PATH (issue #1190). No-op elsewhere. Done inside
+        # the lock so only the running instance owns the junction; CORE.data_dir
+        # then resolves through it for the dashboard's reads and every compile.
+        apply_windows_short_build_paths(settings.config_dir)
+        try:
+            device_builder = DeviceBuilder(settings)
+            device_builder.run()
+        finally:
+            remove_windows_short_build_paths()
 
 
 def _log_uncaught_exception(

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -288,9 +288,7 @@ def main() -> None:
     with ensure_single_execution(CORE.data_dir) as lock:
         if lock.exit_code is not None:
             sys.exit(lock.exit_code)
-        # On Windows, route the build tree through a short junction so deep
-        # builds stay under MAX_PATH; CORE.data_dir then resolves through it for
-        # the dashboard's reads and every compile. No-op on other platforms.
+        # Windows: short-junction the build tree so deep builds stay under MAX_PATH.
         with windows_short_build_paths(settings.config_dir) as pio_core_dir:
             device_builder = DeviceBuilder(settings, windows_pio_core_dir=pio_core_dir)
             device_builder.run()

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -271,10 +271,7 @@ def main() -> None:
     from .controllers.config import DashboardSettings  # noqa: PLC0415
     from .device_builder import DeviceBuilder  # noqa: PLC0415
     from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
-    from .helpers.windows_build_paths import (  # noqa: PLC0415
-        apply_windows_short_build_paths,
-        remove_windows_short_build_paths,
-    )
+    from .helpers.windows_build_paths import windows_short_build_paths  # noqa: PLC0415
 
     settings = DashboardSettings()
     settings.parse_args(args)
@@ -291,16 +288,12 @@ def main() -> None:
     with ensure_single_execution(CORE.data_dir) as lock:
         if lock.exit_code is not None:
             sys.exit(lock.exit_code)
-        # Windows: route the build tree through a short junction so deep ESP-IDF
-        # builds stay under MAX_PATH (issue #1190). No-op elsewhere. Done inside
-        # the lock so only the running instance owns the junction; CORE.data_dir
-        # then resolves through it for the dashboard's reads and every compile.
-        apply_windows_short_build_paths(settings.config_dir)
-        try:
-            device_builder = DeviceBuilder(settings)
+        # On Windows, route the build tree through a short junction so deep
+        # builds stay under MAX_PATH; CORE.data_dir then resolves through it for
+        # the dashboard's reads and every compile. No-op on other platforms.
+        with windows_short_build_paths(settings.config_dir) as pio_core_dir:
+            device_builder = DeviceBuilder(settings, windows_pio_core_dir=pio_core_dir)
             device_builder.run()
-        finally:
-            remove_windows_short_build_paths()
 
 
 def _log_uncaught_exception(

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -35,11 +35,8 @@ def compose_subprocess_env(
     to the per-build subtree under ``CORE.data_dir`` so per-config
     artefacts land in one ``(dashboard_id, device)``-keyed dir.
 
-    On Windows also pins ``PLATFORMIO_CORE_DIR`` to a real short dir
-    so the framework / mbedtls source paths stay under ``MAX_PATH``;
-    a junction would be canonicalized away by ESP-IDF. The short
-    ``ESPHOME_DATA_DIR`` is already in the process env (see
-    :mod:`helpers.windows_build_paths`), so it is inherited here.
+    On Windows also pins ``PLATFORMIO_CORE_DIR`` to *windows_pio_core_dir*
+    (a real short dir) so framework paths stay under ``MAX_PATH``.
     """
     env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
     remote_build_path = parse_remote_build_path(job.configuration)

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -13,7 +13,6 @@ from esphome.storage_json import StorageJSON
 
 from ...helpers.remote_build_layout import parse_from_configuration as parse_remote_build_path
 from ...helpers.storage_path import resolve_storage_path
-from ...helpers.windows_build_paths import windows_pio_core_dir
 from ...models import FirmwareJob, JobType
 from .constants import _OTA_ADDRESS_CACHE_JOB_TYPES, ESPHOME_SUBPROCESS_ENV
 from .helpers import _find_esptool_cmd
@@ -25,7 +24,9 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def compose_subprocess_env(job: FirmwareJob) -> dict[str, str]:
+def compose_subprocess_env(
+    job: FirmwareJob, windows_pio_core_dir: Path | None = None
+) -> dict[str, str]:
     """
     Return the env dict for *job*'s ``esphome`` subprocess.
 
@@ -35,17 +36,17 @@ def compose_subprocess_env(job: FirmwareJob) -> dict[str, str]:
     artefacts land in one ``(dashboard_id, device)``-keyed dir.
 
     On Windows also pins ``PLATFORMIO_CORE_DIR`` to a real short dir
-    so the framework / mbedtls source paths stay under ``MAX_PATH``
-    (issue #1190); a junction would be canonicalized away by ESP-IDF.
-    ``ESPHOME_DATA_DIR`` is already short via the process env (see
+    so the framework / mbedtls source paths stay under ``MAX_PATH``;
+    a junction would be canonicalized away by ESP-IDF. The short
+    ``ESPHOME_DATA_DIR`` is already in the process env (see
     :mod:`helpers.windows_build_paths`), so it is inherited here.
     """
     env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
     remote_build_path = parse_remote_build_path(job.configuration)
     if remote_build_path is not None:
         env["ESPHOME_DATA_DIR"] = str(remote_build_path.data_dir(Path(CORE.data_dir)))
-    if (pio_core_dir := windows_pio_core_dir()) is not None:
-        env["PLATFORMIO_CORE_DIR"] = str(pio_core_dir)
+    if windows_pio_core_dir is not None:
+        env["PLATFORMIO_CORE_DIR"] = str(windows_pio_core_dir)
     return env
 
 

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -13,6 +13,7 @@ from esphome.storage_json import StorageJSON
 
 from ...helpers.remote_build_layout import parse_from_configuration as parse_remote_build_path
 from ...helpers.storage_path import resolve_storage_path
+from ...helpers.windows_build_paths import windows_pio_core_dir
 from ...models import FirmwareJob, JobType
 from .constants import _OTA_ADDRESS_CACHE_JOB_TYPES, ESPHOME_SUBPROCESS_ENV
 from .helpers import _find_esptool_cmd
@@ -32,11 +33,19 @@ def compose_subprocess_env(job: FirmwareJob) -> dict[str, str]:
     for receiver-side remote-build jobs pins ``ESPHOME_DATA_DIR``
     to the per-build subtree under ``CORE.data_dir`` so per-config
     artefacts land in one ``(dashboard_id, device)``-keyed dir.
+
+    On Windows also pins ``PLATFORMIO_CORE_DIR`` to a real short dir
+    so the framework / mbedtls source paths stay under ``MAX_PATH``
+    (issue #1190); a junction would be canonicalized away by ESP-IDF.
+    ``ESPHOME_DATA_DIR`` is already short via the process env (see
+    :mod:`helpers.windows_build_paths`), so it is inherited here.
     """
     env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
     remote_build_path = parse_remote_build_path(job.configuration)
     if remote_build_path is not None:
         env["ESPHOME_DATA_DIR"] = str(remote_build_path.data_dir(Path(CORE.data_dir)))
+    if (pio_core_dir := windows_pio_core_dir()) is not None:
+        env["PLATFORMIO_CORE_DIR"] = str(pio_core_dir)
     return env
 
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -41,6 +41,8 @@ from .helpers import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ...device_builder import DeviceBuilder
     from ...helpers.event_bus import EventBus
 
@@ -58,8 +60,13 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     connected clients.
     """
 
-    def __init__(self, device_builder: DeviceBuilder) -> None:
+    def __init__(
+        self, device_builder: DeviceBuilder, windows_pio_core_dir: Path | None = None
+    ) -> None:
         self._db = device_builder
+        # Real short PLATFORMIO_CORE_DIR on Windows (see helpers.windows_build_paths); ``None``
+        # elsewhere. Pinned per compile subprocess so deep ESP-IDF paths stay under MAX_PATH.
+        self._windows_pio_core_dir = windows_pio_core_dir
         self.state = FirmwareState()
         # Short-lived capability tokens for the HTTP artifact-download route.
         self.download_tokens = download_mod.DownloadTokens()
@@ -409,7 +416,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         await cli.verify_chip(self, job, lane)
 
     def _compose_subprocess_env(self, job: FirmwareJob) -> dict[str, str]:
-        return cli.compose_subprocess_env(job)
+        return cli.compose_subprocess_env(job, self._windows_pio_core_dir)
 
     def _build_command(
         self,

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -64,8 +64,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         self, device_builder: DeviceBuilder, windows_pio_core_dir: Path | None = None
     ) -> None:
         self._db = device_builder
-        # Real short PLATFORMIO_CORE_DIR on Windows (see helpers.windows_build_paths); ``None``
-        # elsewhere. Pinned per compile subprocess so deep ESP-IDF paths stay under MAX_PATH.
+        # Real short PLATFORMIO_CORE_DIR on Windows (helpers.windows_build_paths); None else.
         self._windows_pio_core_dir = windows_pio_core_dir
         self.state = FirmwareState()
         # Short-lived capability tokens for the HTTP artifact-download route.

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -192,9 +192,15 @@ class DeviceBuilder:
     All device state lives in DevicesController.
     """
 
-    def __init__(self, settings: DashboardSettings) -> None:
+    def __init__(
+        self, settings: DashboardSettings, windows_pio_core_dir: Path | None = None
+    ) -> None:
         """Initialize the Device Builder."""
         self.settings = settings
+        # Real short PLATFORMIO_CORE_DIR set up by ``windows_short_build_paths`` on Windows so
+        # deep ESP-IDF builds stay under MAX_PATH; ``None`` elsewhere. Threaded to the firmware
+        # controller for subprocess-env composition.
+        self.windows_pio_core_dir = windows_pio_core_dir
         self.bus = EventBus()
         self.peer_link_identity_store = PeerLinkIdentityStore(settings.config_dir)
         # Reference-counted "is anyone watching the dashboard?" gate.
@@ -307,7 +313,7 @@ class DeviceBuilder:
         self.config = ConfigController(self)
         self.devices = DevicesController(self)
         self.automations = AutomationsController(self)
-        self.firmware = FirmwareController(self)
+        self.firmware = FirmwareController(self, self.windows_pio_core_dir)
         self.editor = EditorController(self)
         self.labels = LabelsController(self)
         self.onboarding = OnboardingController(self)

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -197,9 +197,7 @@ class DeviceBuilder:
     ) -> None:
         """Initialize the Device Builder."""
         self.settings = settings
-        # Real short PLATFORMIO_CORE_DIR set up by ``windows_short_build_paths`` on Windows so
-        # deep ESP-IDF builds stay under MAX_PATH; ``None`` elsewhere. Threaded to the firmware
-        # controller for subprocess-env composition.
+        # Real short PLATFORMIO_CORE_DIR on Windows (helpers.windows_build_paths); None else.
         self.windows_pio_core_dir = windows_pio_core_dir
         self.bus = EventBus()
         self.peer_link_identity_store = PeerLinkIdentityStore(settings.config_dir)

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -11,12 +11,13 @@ esphome-desktop uninstall today). No-op off Windows.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+
+from fnv_hash_fast import fnv1a_32
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,8 +76,7 @@ def _is_windows() -> bool:
 
 def _suffix(real_data: Path) -> str:
     """Stable 8-hex per-install dir suffix (case-folded); 8 hex makes a collision negligible."""
-    key = str(real_data.resolve()).lower().encode()
-    return hashlib.sha1(key).hexdigest()[:8]  # noqa: S324 — short non-crypto dir tag
+    return f"{fnv1a_32(str(real_data.resolve()).lower().encode('utf-8')):08x}"
 
 
 def _ensure_junction(link: Path, target: Path) -> None:

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -18,9 +18,12 @@ and yields the short PlatformIO core dir, for the duration of the ``with`` block
   junction back to its long target. The caller threads it onto app state and
   :func:`controllers.firmware.cli.compose_subprocess_env` injects it per-subprocess.
 
-The junction and the real toolchain dir are left on disk on exit (a concurrent dashboard may
-share them; the desktop uninstaller reclaims ``C:\esphb-*``); only the ``ESPHOME_DATA_DIR``
-override is restored. No-op on every non-Windows platform (yields ``None``).
+On exit only the ``ESPHOME_DATA_DIR`` override is restored; the ``C:\esphb-<suffix>`` junction
+and the ``C:\esphb-<suffix>-pio`` toolchain dir are deliberately left on disk (a concurrent
+dashboard may share them, and the toolchain is expensive to re-download). They are **not**
+cleaned up on esphome-desktop uninstall today — the toolchain dir in particular can be
+multi-GB — so removing ``C:\esphb-*`` is a known follow-up for the desktop uninstaller. No-op
+on every non-Windows platform (yields ``None``).
 """
 
 from __future__ import annotations
@@ -81,7 +84,7 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
         yield pio_dir
     finally:
         # Restore the override; leave the junction + toolchain on disk (a concurrent dashboard
-        # may share them; the uninstaller reclaims them).
+        # may share them; not cleaned on uninstall today — see module docstring).
         if prior is None:
             os.environ.pop("ESPHOME_DATA_DIR", None)
         else:
@@ -125,7 +128,20 @@ def _ensure_junction(link: Path, target: Path) -> None:
             return
         msg = f"{link} already exists pointing elsewhere"
         raise OSError(msg)
+    if os.path.lexists(link):
+        # Dangling junction: the name is occupied but its target is gone (uninstall/reinstall
+        # or a moved config dir), so ``exists()`` was False above. Drop the stale entry so the
+        # create below doesn't fail on the occupied name.
+        _remove_link(link)
     _create_junction(link, target)
+
+
+def _remove_link(link: Path) -> None:
+    """Remove a junction (rmdir) or symlink (unlink) entry without touching its target."""
+    if link.is_symlink():
+        link.unlink()
+    else:
+        link.rmdir()
 
 
 def _create_junction(link: Path, target: Path) -> None:

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -28,16 +28,19 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
-# Recognizable, short, collision-safe roots (``esphb`` = ESPHome builder). The per-install
-# suffix keeps two users / config dirs on one machine from sharing a junction.
+# Recognizable short root (``esphb`` = ESPHome builder). The per-install suffix keeps two
+# users / config dirs on one machine from sharing a junction.
 _ROOT_PREFIX = "esphb"
+
+# Drive root the short junction + toolchain dirs live under. A module attribute so tests can
+# point it at a tmp dir instead of ``C:\``.
+_JUNCTION_ROOT = Path("C:\\")
 
 
 @contextmanager
@@ -47,7 +50,7 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
     Yields the real short ``PLATFORMIO_CORE_DIR`` to thread onto app state, or ``None`` off
     Windows / when setup can't run.
     """
-    if os.name != "nt":
+    if not _is_windows():
         yield None
         return
 
@@ -56,16 +59,19 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
     real_data.mkdir(parents=True, exist_ok=True)
 
     suffix = _suffix(real_data)
-    data_junction = Path(f"C:\\{_ROOT_PREFIX}-{suffix}")
-    pio_dir = Path(f"C:\\{_ROOT_PREFIX}-{suffix}-pio")
+    data_junction = _JUNCTION_ROOT / f"{_ROOT_PREFIX}-{suffix}"
+    pio_dir = _JUNCTION_ROOT / f"{_ROOT_PREFIX}-{suffix}-pio"
 
     try:
         _ensure_junction(data_junction, real_data)
         pio_dir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        # A locked-down host that refuses C:\ writes: leave the long default in place rather
-        # than crash. Deep ESP-IDF builds may still overflow, but the dashboard runs.
-        _LOGGER.warning("Could not set up short Windows build paths (%s); using defaults", exc)
+    except OSError:
+        # A locked-down host (or, vanishingly rarely, a suffix collision) leaves the long
+        # default in place. Logged at error so a later MAX_PATH compile failure can be traced
+        # back to this setup miss rather than read as a mysterious compiler error.
+        _LOGGER.exception(
+            "Could not set up short Windows build paths; deep ESP-IDF builds may overflow MAX_PATH"
+        )
         yield None
         return
 
@@ -87,31 +93,47 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
 # ---------------------------------------------------------------------------
 
 
+def _is_windows() -> bool:
+    """Whether the short-path machinery applies (split out so tests can drive the nt branch)."""
+    return os.name == "nt"
+
+
 def _suffix(real_data: Path) -> str:
-    """Stable 4-hex per-install suffix from the real data dir (case-folded for Windows)."""
+    """Stable 8-hex per-install suffix from the real data dir (case-folded for Windows).
+
+    8 hex chars (~32 bits) keeps the chance that two different config dirs collide onto the
+    same junction name negligible, so the collision fallback in :func:`_ensure_junction`
+    almost never fires.
+    """
     key = str(real_data.resolve()).lower().encode()
-    return hashlib.sha1(key).hexdigest()[:4]  # noqa: S324 — short non-crypto dir tag
+    return hashlib.sha1(key).hexdigest()[:8]  # noqa: S324 — short non-crypto dir tag
 
 
 def _ensure_junction(link: Path, target: Path) -> None:
-    """Create directory junction ``link`` -> ``target`` if absent or pointing elsewhere.
+    """Create directory junction ``link`` -> ``target`` if absent.
 
-    Synchronous on purpose: only runs at startup before the event loop, never from the
-    running loop, so it needs no executor hop.
+    Reuses an existing junction already pointing at *target* (our own, from a prior run). If
+    the name is held by a junction pointing elsewhere (a suffix collision with another config
+    dir), raises ``OSError`` so the caller falls back to long paths rather than stealing a
+    junction a concurrent instance may be building under.
+
+    Synchronous on purpose: only runs at startup before the event loop, never from the running
+    loop, so it needs no executor hop.
     """
     if link.exists():
         if os.path.realpath(link).lower() == os.path.realpath(target).lower():
             return
-        link.rmdir()
-    # ``mklink`` is a cmd builtin (no standalone exe); resolve COMSPEC so the executable is a
-    # full path. ``close_fds=False`` mirrors helpers.subprocess and controllers.version_history.
-    comspec = os.environ.get("COMSPEC", "cmd.exe")
-    result = subprocess.run(  # noqa: S603
-        [comspec, "/c", "mklink", "/J", str(link), str(target)],
-        capture_output=True,
-        text=True,
-        check=False,
-        close_fds=False,
-    )
-    if result.returncode != 0:
-        raise OSError(f"mklink /J {link} {target} failed: {result.stderr.strip()}")
+        msg = f"{link} already exists pointing elsewhere"
+        raise OSError(msg)
+    _create_junction(link, target)
+
+
+def _create_junction(link: Path, target: Path) -> None:
+    """Create a directory junction at *link* pointing to *target* via the Windows native API.
+
+    Uses ``_winapi.CreateJunction`` rather than ``cmd /c mklink`` so a space-bearing target
+    (common Windows profile dirs) can't be mangled by cmd.exe's quote-stripping.
+    """
+    import _winapi  # noqa: PLC0415 — Windows-only; imported lazily so off-Windows never loads it
+
+    _winapi.CreateJunction(str(target), str(link))  # type: ignore[attr-defined]

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -1,29 +1,12 @@
 r"""
-Windows short build paths: keep compile artefact paths under the 260-char ``MAX_PATH``.
+Keep Windows compile paths under the 260-char ``MAX_PATH`` for deep ESP-IDF builds.
 
-On Windows the default build tree plus the framework source paths CMake mirrors into
-``CMakeFiles\<target>.dir\`` overflow ``MAX_PATH`` for deep ESP-IDF builds, and the long
-framework include list also overflows the command-line limit at link time.
-
-:func:`windows_short_build_paths` routes the build tree through a short directory **junction**
-and yields the short PlatformIO core dir, for the duration of the ``with`` block:
-
-* ``ESPHOME_DATA_DIR`` -> junction ``C:\esphb-<suffix>`` into the real data dir. The junction
-  survives PlatformIO/CMake path handling, so the compiler gets the short string while the
-  bytes stay under the real (config) dir. ``CORE.data_dir`` reads ``ESPHOME_DATA_DIR`` first,
-  so the dashboard's own artefact reads and every compile subprocess resolve through the same
-  short path with no divergence (see :mod:`helpers.storage_path`).
-* The yielded ``PLATFORMIO_CORE_DIR`` is a real short ``C:\esphb-<suffix>-pio``. It must be a
-  *real* dir, not a junction: ESP-IDF's ``idf.cmake`` REALPATHs ``IDF_PATH`` and resolves a
-  junction back to its long target. The caller threads it onto app state and
-  :func:`controllers.firmware.cli.compose_subprocess_env` injects it per-subprocess.
-
-On exit only the ``ESPHOME_DATA_DIR`` override is restored; the ``C:\esphb-<suffix>`` junction
-and the ``C:\esphb-<suffix>-pio`` toolchain dir are deliberately left on disk (a concurrent
-dashboard may share them, and the toolchain is expensive to re-download). They are **not**
-cleaned up on esphome-desktop uninstall today — the toolchain dir in particular can be
-multi-GB — so removing ``C:\esphb-*`` is a known follow-up for the desktop uninstaller. No-op
-on every non-Windows platform (yields ``None``).
+:func:`windows_short_build_paths` points ``ESPHOME_DATA_DIR`` at a short junction
+(``C:\esphb-<suffix>``) for the ``with`` block and yields a real short ``PLATFORMIO_CORE_DIR``.
+The data dir is a junction (it survives PlatformIO/CMake path handling); the core dir must be a
+*real* dir, since ESP-IDF REALPATHs ``IDF_PATH`` and would resolve a junction back to its long
+target. The junction + toolchain stay on disk on exit (shared across runs; not cleaned on
+esphome-desktop uninstall today). No-op off Windows.
 """
 
 from __future__ import annotations
@@ -37,22 +20,15 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
-# Recognizable short root (``esphb`` = ESPHome builder). The per-install suffix keeps two
-# users / config dirs on one machine from sharing a junction.
 _ROOT_PREFIX = "esphb"
 
-# Drive root the short junction + toolchain dirs live under. A module attribute so tests can
-# point it at a tmp dir instead of ``C:\``.
+# Drive root for the junction + toolchain dirs; a module attribute so tests can repoint it.
 _JUNCTION_ROOT = Path("C:\\")
 
 
 @contextmanager
 def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
-    """Route the build tree through short Windows paths for the block.
-
-    Yields the real short ``PLATFORMIO_CORE_DIR`` to thread onto app state, or ``None`` off
-    Windows / when setup can't run.
-    """
+    """Yield the real short ``PLATFORMIO_CORE_DIR`` for the block, or ``None`` off Windows."""
     if not _is_windows():
         yield None
         return
@@ -69,12 +45,8 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
         _ensure_junction(data_junction, real_data)
         pio_dir.mkdir(parents=True, exist_ok=True)
     except OSError:
-        # A locked-down host (or, vanishingly rarely, a suffix collision) leaves the long
-        # default in place. Logged at error so a later MAX_PATH compile failure can be traced
-        # back to this setup miss rather than read as a mysterious compiler error.
-        _LOGGER.exception(
-            "Could not set up short Windows build paths; deep ESP-IDF builds may overflow MAX_PATH"
-        )
+        # Logged at error so a later MAX_PATH compile failure traces back to this setup miss.
+        _LOGGER.exception("Could not set up short Windows build paths; using defaults")
         yield None
         return
 
@@ -83,8 +55,8 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
     try:
         yield pio_dir
     finally:
-        # Restore the override; leave the junction + toolchain on disk (a concurrent dashboard
-        # may share them; not cleaned on uninstall today — see module docstring).
+        # Restore only the env override; the junction + toolchain stay (a concurrent dashboard
+        # may share them).
         if prior is None:
             os.environ.pop("ESPHOME_DATA_DIR", None)
         else:
@@ -97,31 +69,21 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
 
 
 def _is_windows() -> bool:
-    """Whether the short-path machinery applies (split out so tests can drive the nt branch)."""
+    """Whether the short-path machinery applies (a seam tests flip to drive the nt branch)."""
     return os.name == "nt"
 
 
 def _suffix(real_data: Path) -> str:
-    """Stable 8-hex per-install suffix from the real data dir (case-folded for Windows).
-
-    8 hex chars (~32 bits) keeps the chance that two different config dirs collide onto the
-    same junction name negligible, so the collision fallback in :func:`_ensure_junction`
-    almost never fires.
-    """
+    """Stable 8-hex per-install dir suffix (case-folded); 8 hex makes a collision negligible."""
     key = str(real_data.resolve()).lower().encode()
     return hashlib.sha1(key).hexdigest()[:8]  # noqa: S324 — short non-crypto dir tag
 
 
 def _ensure_junction(link: Path, target: Path) -> None:
-    """Create directory junction ``link`` -> ``target`` if absent.
+    """Create junction ``link`` -> ``target``, reusing ours; raise on a foreign-target collision.
 
-    Reuses an existing junction already pointing at *target* (our own, from a prior run). If
-    the name is held by a junction pointing elsewhere (a suffix collision with another config
-    dir), raises ``OSError`` so the caller falls back to long paths rather than stealing a
-    junction a concurrent instance may be building under.
-
-    Synchronous on purpose: only runs at startup before the event loop, never from the running
-    loop, so it needs no executor hop.
+    A dangling junction (target deleted) is cleared first; a junction pointing at a *different*
+    live target (suffix collision) raises so the caller falls back rather than stealing it.
     """
     if link.exists():
         if os.path.realpath(link).lower() == os.path.realpath(target).lower():
@@ -129,9 +91,6 @@ def _ensure_junction(link: Path, target: Path) -> None:
         msg = f"{link} already exists pointing elsewhere"
         raise OSError(msg)
     if os.path.lexists(link):
-        # Dangling junction: the name is occupied but its target is gone (uninstall/reinstall
-        # or a moved config dir), so ``exists()`` was False above. Drop the stale entry so the
-        # create below doesn't fail on the occupied name.
         _remove_link(link)
     _create_junction(link, target)
 
@@ -145,11 +104,7 @@ def _remove_link(link: Path) -> None:
 
 
 def _create_junction(link: Path, target: Path) -> None:
-    """Create a directory junction at *link* pointing to *target* via the Windows native API.
-
-    Uses ``_winapi.CreateJunction`` rather than ``cmd /c mklink`` so a space-bearing target
-    (common Windows profile dirs) can't be mangled by cmd.exe's quote-stripping.
-    """
+    """Create a directory junction ``link`` -> ``target`` via the native API (no shell)."""
     import _winapi  # noqa: PLC0415 — Windows-only; imported lazily so off-Windows never loads it
 
     _winapi.CreateJunction(str(target), str(link))  # type: ignore[attr-defined]

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -1,26 +1,26 @@
 r"""
 Windows short build paths: keep compile artefact paths under the 260-char ``MAX_PATH``.
 
-On Windows the default build tree (``<config_dir>\.esphome\build\<name>\.pioenvs\<name>\...``)
-plus the framework source paths CMake mirrors into ``CMakeFiles\<target>.dir\`` overflow
-``MAX_PATH`` for deep ESP-IDF builds (libsodium / mbedtls), and the long framework include list
-also overflows the Windows command-line limit at link time (issue #1190).
+On Windows the default build tree plus the framework source paths CMake mirrors into
+``CMakeFiles\<target>.dir\`` overflow ``MAX_PATH`` for deep ESP-IDF builds, and the long
+framework include list also overflows the command-line limit at link time.
 
-The fix routes the whole build tree through a short directory **junction** and points the
-PlatformIO toolchain at a short **real** directory:
+:func:`windows_short_build_paths` routes the build tree through a short directory **junction**
+and yields the short PlatformIO core dir, for the duration of the ``with`` block:
 
 * ``ESPHOME_DATA_DIR`` -> junction ``C:\esphb-<suffix>`` into the real data dir. The junction
-  *survives* PlatformIO/CMake path handling, so the compiler is handed the short string while
-  the bytes stay under the real (config) dir, keeping uninstall clean. ``CORE.data_dir`` reads
-  ``ESPHOME_DATA_DIR`` first, so the dashboard's own artefact reads and every compile subprocess
-  resolve through the same short path with no divergence (see :mod:`helpers.storage_path`).
-* ``PLATFORMIO_CORE_DIR`` -> real short ``C:\esphb-<suffix>-pio``. It must be a *real* dir, not a
-  junction: ESP-IDF's ``idf.cmake`` REALPATHs ``IDF_PATH`` and resolves a junction back to its
-  long target. Injected per-subprocess in
-  :func:`controllers.firmware.cli.compose_subprocess_env`.
+  survives PlatformIO/CMake path handling, so the compiler gets the short string while the
+  bytes stay under the real (config) dir. ``CORE.data_dir`` reads ``ESPHOME_DATA_DIR`` first,
+  so the dashboard's own artefact reads and every compile subprocess resolve through the same
+  short path with no divergence (see :mod:`helpers.storage_path`).
+* The yielded ``PLATFORMIO_CORE_DIR`` is a real short ``C:\esphb-<suffix>-pio``. It must be a
+  *real* dir, not a junction: ESP-IDF's ``idf.cmake`` REALPATHs ``IDF_PATH`` and resolves a
+  junction back to its long target. The caller threads it onto app state and
+  :func:`controllers.firmware.cli.compose_subprocess_env` injects it per-subprocess.
 
-Empirically validated on a windows-latest runner (deepest path 229/206 vs 304 + "command line
-too long" on the long default). No-op on every non-Windows platform.
+The junction and the real toolchain dir are left on disk on exit (a concurrent dashboard may
+share them; the desktop uninstaller reclaims ``C:\esphb-*``); only the ``ESPHOME_DATA_DIR``
+override is restored. No-op on every non-Windows platform (yields ``None``).
 """
 
 from __future__ import annotations
@@ -29,7 +29,8 @@ import hashlib
 import logging
 import os
 import subprocess
-from dataclasses import dataclass
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,28 +40,19 @@ _LOGGER = logging.getLogger(__name__)
 _ROOT_PREFIX = "esphb"
 
 
-@dataclass
-class _WindowsShortPathState:
-    """Active short-path state; ``pio_core_dir`` is None when shortening is inactive."""
+@contextmanager
+def windows_short_build_paths(config_dir: Path) -> Iterator[Path | None]:
+    """Route the build tree through short Windows paths for the block.
 
-    pio_core_dir: Path | None = None
-
-
-# Module-level mutable state (attribute mutation, no rebindable global).
-_STATE = _WindowsShortPathState()
-
-
-def apply_windows_short_build_paths(config_dir: Path) -> None:
-    """Route the build tree through short Windows paths; no-op off Windows.
-
-    Sets ``ESPHOME_DATA_DIR`` to a short junction into the real data dir and records a real
-    short ``PLATFORMIO_CORE_DIR`` for :func:`windows_pio_core_dir`. Idempotent across restarts.
+    Yields the real short ``PLATFORMIO_CORE_DIR`` to thread onto app state, or ``None`` off
+    Windows / when setup can't run.
     """
     if os.name != "nt":
+        yield None
         return
 
-    existing = os.environ.get("ESPHOME_DATA_DIR")
-    real_data = Path(existing) if existing else config_dir / ".esphome"
+    prior = os.environ.get("ESPHOME_DATA_DIR")
+    real_data = Path(prior) if prior else config_dir / ".esphome"
     real_data.mkdir(parents=True, exist_ok=True)
 
     suffix = _suffix(real_data)
@@ -74,30 +66,20 @@ def apply_windows_short_build_paths(config_dir: Path) -> None:
         # A locked-down host that refuses C:\ writes: leave the long default in place rather
         # than crash. Deep ESP-IDF builds may still overflow, but the dashboard runs.
         _LOGGER.warning("Could not set up short Windows build paths (%s); using defaults", exc)
+        yield None
         return
 
     os.environ["ESPHOME_DATA_DIR"] = str(data_junction)
-    _STATE.pio_core_dir = pio_dir
     _LOGGER.info("Windows short build paths: %s -> %s, core %s", data_junction, real_data, pio_dir)
-
-
-def windows_pio_core_dir() -> Path | None:
-    """Return the real short ``PLATFORMIO_CORE_DIR``, or ``None`` if shortening is inactive."""
-    return _STATE.pio_core_dir
-
-
-def remove_windows_short_build_paths() -> None:
-    """Drop the data junction (reparse point only; leaves the real data + toolchain)."""
-    pio_core_dir = _STATE.pio_core_dir
-    if os.name != "nt" or pio_core_dir is None:
-        return
-    junction = Path(str(pio_core_dir)[: -len("-pio")])
     try:
-        if junction.exists():
-            junction.rmdir()
-    except OSError as exc:
-        _LOGGER.debug("Could not remove junction %s: %s", junction, exc)
-    _STATE.pio_core_dir = None
+        yield pio_dir
+    finally:
+        # Restore the override; leave the junction + toolchain on disk (a concurrent dashboard
+        # may share them; the uninstaller reclaims them).
+        if prior is None:
+            os.environ.pop("ESPHOME_DATA_DIR", None)
+        else:
+            os.environ["ESPHOME_DATA_DIR"] = prior
 
 
 # ---------------------------------------------------------------------------
@@ -114,8 +96,8 @@ def _suffix(real_data: Path) -> str:
 def _ensure_junction(link: Path, target: Path) -> None:
     """Create directory junction ``link`` -> ``target`` if absent or pointing elsewhere.
 
-    Synchronous on purpose: only called once at startup (before the event loop) and once at
-    shutdown, never from the running loop, so it does not need an executor hop.
+    Synchronous on purpose: only runs at startup before the event loop, never from the
+    running loop, so it needs no executor hop.
     """
     if link.exists():
         if os.path.realpath(link).lower() == os.path.realpath(target).lower():

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -1,0 +1,135 @@
+r"""
+Windows short build paths: keep compile artefact paths under the 260-char ``MAX_PATH``.
+
+On Windows the default build tree (``<config_dir>\.esphome\build\<name>\.pioenvs\<name>\...``)
+plus the framework source paths CMake mirrors into ``CMakeFiles\<target>.dir\`` overflow
+``MAX_PATH`` for deep ESP-IDF builds (libsodium / mbedtls), and the long framework include list
+also overflows the Windows command-line limit at link time (issue #1190).
+
+The fix routes the whole build tree through a short directory **junction** and points the
+PlatformIO toolchain at a short **real** directory:
+
+* ``ESPHOME_DATA_DIR`` -> junction ``C:\esphb-<suffix>`` into the real data dir. The junction
+  *survives* PlatformIO/CMake path handling, so the compiler is handed the short string while
+  the bytes stay under the real (config) dir, keeping uninstall clean. ``CORE.data_dir`` reads
+  ``ESPHOME_DATA_DIR`` first, so the dashboard's own artefact reads and every compile subprocess
+  resolve through the same short path with no divergence (see :mod:`helpers.storage_path`).
+* ``PLATFORMIO_CORE_DIR`` -> real short ``C:\esphb-<suffix>-pio``. It must be a *real* dir, not a
+  junction: ESP-IDF's ``idf.cmake`` REALPATHs ``IDF_PATH`` and resolves a junction back to its
+  long target. Injected per-subprocess in
+  :func:`controllers.firmware.cli.compose_subprocess_env`.
+
+Empirically validated on a windows-latest runner (deepest path 229/206 vs 304 + "command line
+too long" on the long default). No-op on every non-Windows platform.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+# Recognizable, short, collision-safe roots (``esphb`` = ESPHome builder). The per-install
+# suffix keeps two users / config dirs on one machine from sharing a junction.
+_ROOT_PREFIX = "esphb"
+
+
+@dataclass
+class _WindowsShortPathState:
+    """Active short-path state; ``pio_core_dir`` is None when shortening is inactive."""
+
+    pio_core_dir: Path | None = None
+
+
+# Module-level mutable state (attribute mutation, no rebindable global).
+_STATE = _WindowsShortPathState()
+
+
+def apply_windows_short_build_paths(config_dir: Path) -> None:
+    """Route the build tree through short Windows paths; no-op off Windows.
+
+    Sets ``ESPHOME_DATA_DIR`` to a short junction into the real data dir and records a real
+    short ``PLATFORMIO_CORE_DIR`` for :func:`windows_pio_core_dir`. Idempotent across restarts.
+    """
+    if os.name != "nt":
+        return
+
+    existing = os.environ.get("ESPHOME_DATA_DIR")
+    real_data = Path(existing) if existing else config_dir / ".esphome"
+    real_data.mkdir(parents=True, exist_ok=True)
+
+    suffix = _suffix(real_data)
+    data_junction = Path(f"C:\\{_ROOT_PREFIX}-{suffix}")
+    pio_dir = Path(f"C:\\{_ROOT_PREFIX}-{suffix}-pio")
+
+    try:
+        _ensure_junction(data_junction, real_data)
+        pio_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # A locked-down host that refuses C:\ writes: leave the long default in place rather
+        # than crash. Deep ESP-IDF builds may still overflow, but the dashboard runs.
+        _LOGGER.warning("Could not set up short Windows build paths (%s); using defaults", exc)
+        return
+
+    os.environ["ESPHOME_DATA_DIR"] = str(data_junction)
+    _STATE.pio_core_dir = pio_dir
+    _LOGGER.info("Windows short build paths: %s -> %s, core %s", data_junction, real_data, pio_dir)
+
+
+def windows_pio_core_dir() -> Path | None:
+    """Return the real short ``PLATFORMIO_CORE_DIR``, or ``None`` if shortening is inactive."""
+    return _STATE.pio_core_dir
+
+
+def remove_windows_short_build_paths() -> None:
+    """Drop the data junction (reparse point only; leaves the real data + toolchain)."""
+    pio_core_dir = _STATE.pio_core_dir
+    if os.name != "nt" or pio_core_dir is None:
+        return
+    junction = Path(str(pio_core_dir)[: -len("-pio")])
+    try:
+        if junction.exists():
+            junction.rmdir()
+    except OSError as exc:
+        _LOGGER.debug("Could not remove junction %s: %s", junction, exc)
+    _STATE.pio_core_dir = None
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _suffix(real_data: Path) -> str:
+    """Stable 4-hex per-install suffix from the real data dir (case-folded for Windows)."""
+    key = str(real_data.resolve()).lower().encode()
+    return hashlib.sha1(key).hexdigest()[:4]  # noqa: S324 — short non-crypto dir tag
+
+
+def _ensure_junction(link: Path, target: Path) -> None:
+    """Create directory junction ``link`` -> ``target`` if absent or pointing elsewhere.
+
+    Synchronous on purpose: only called once at startup (before the event loop) and once at
+    shutdown, never from the running loop, so it does not need an executor hop.
+    """
+    if link.exists():
+        if os.path.realpath(link).lower() == os.path.realpath(target).lower():
+            return
+        link.rmdir()
+    # ``mklink`` is a cmd builtin (no standalone exe); resolve COMSPEC so the executable is a
+    # full path. ``close_fds=False`` mirrors helpers.subprocess and controllers.version_history.
+    comspec = os.environ.get("COMSPEC", "cmd.exe")
+    result = subprocess.run(  # noqa: S603
+        [comspec, "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+        close_fds=False,
+    )
+    if result.returncode != 0:
+        raise OSError(f"mklink /J {link} {target} failed: {result.stderr.strip()}")

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -155,6 +155,8 @@ def firmware_controller_factory(
         controller = FirmwareController.__new__(FirmwareController)
         controller.state = FirmwareState()
         controller.download_tokens = DownloadTokens()
+        # Mirror ``__init__``: no Windows short-path override in tests.
+        controller._windows_pio_core_dir = None
         controller.state.jobs = {j.job_id: j for j in jobs}
         # ``__new__`` bypasses ``__init__`` where the real controller
         # creates this; ``persist_jobs`` acquires it to serialize writes.
@@ -234,6 +236,8 @@ def bare_firmware_controller_factory() -> BareFirmwareControllerFactory:
         controller = FirmwareController.__new__(FirmwareController)
         controller.state = FirmwareState()
         controller.download_tokens = DownloadTokens()
+        # Mirror ``__init__``: no Windows short-path override in tests.
+        controller._windows_pio_core_dir = None
         if esphome_cmd is not None:
             controller.state.esphome_cmd = esphome_cmd
         if current_job is not None:

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -20,8 +20,10 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
 from esphome.core import CORE
 
+from esphome_device_builder.controllers.firmware.cli import compose_subprocess_env
 from esphome_device_builder.controllers.firmware.constants import (
     ESPHOME_SUBPROCESS_ENV,
 )
@@ -42,6 +44,19 @@ def _make_job(
         configuration=configuration,
         job_type=job_type,
     )
+
+
+def test_compose_injects_windows_pio_core_dir_when_set(tmp_path: Path) -> None:
+    """The Windows short PLATFORMIO_CORE_DIR is pinned when threaded in (platform-agnostic)."""
+    env = compose_subprocess_env(_make_job(configuration="kitchen.yaml"), tmp_path / "pio")
+    assert env["PLATFORMIO_CORE_DIR"] == str(tmp_path / "pio")
+
+
+def test_compose_omits_pio_core_dir_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No PLATFORMIO_CORE_DIR override off Windows / when shortening is inactive."""
+    monkeypatch.delenv("PLATFORMIO_CORE_DIR", raising=False)
+    env = compose_subprocess_env(_make_job(configuration="kitchen.yaml"), None)
+    assert "PLATFORMIO_CORE_DIR" not in env
 
 
 def test_local_job_env_does_not_override_data_dir(

--- a/tests/e2e/slow/windows/__init__.py
+++ b/tests/e2e/slow/windows/__init__.py
@@ -1,1 +1,1 @@
-"""Windows-only MAX_PATH real-compile e2e (issue #1190)."""
+"""Windows-only MAX_PATH real-compile e2e."""

--- a/tests/e2e/slow/windows/__init__.py
+++ b/tests/e2e/slow/windows/__init__.py
@@ -1,0 +1,1 @@
+"""Windows-only MAX_PATH real-compile e2e (issue #1190)."""

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -22,6 +22,11 @@ _MAX_PATH = 260
 # deepest object path overflows MAX_PATH; through the junction it stays short.
 _PAD = "padding-" * 9  # 72 chars
 
+# A space-bearing component mimics a real Windows profile dir (``C:\Users\First Last\...``) so
+# the live compile proves the native junction handles a space in the target — the case that
+# would break ``cmd /c mklink`` quote-stripping.
+_PROFILE = "First Last"
+
 _CONFIG = textwrap.dedent(
     """\
     esphome:
@@ -46,8 +51,9 @@ def test_windows_short_paths_compile_deep_idf(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A deep ESP-IDF compile succeeds through the short-path layout and stays under MAX_PATH."""
-    config_dir = tmp_path / _PAD / "esphome"
+    config_dir = tmp_path / _PROFILE / _PAD / "esphome"
     config_dir.mkdir(parents=True, exist_ok=True)
+    assert " " in str(config_dir), "config_dir must carry a space to exercise the junction target"
     config = config_dir / "probe.yaml"
     config.write_text(_CONFIG, encoding="utf-8")
 

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -1,0 +1,114 @@
+"""Real-compile pin: the Windows short-path layout builds a deep ESP-IDF config under MAX_PATH.
+
+Windows-only. Exercises the production
+:func:`helpers.windows_build_paths.apply_windows_short_build_paths` +
+:func:`controllers.firmware.cli.compose_subprocess_env` path, then runs a real
+``esphome compile`` of an ESP-IDF + ``api: encryption:`` config (the deep mbedtls /
+tf-psa-crypto tree that overflows ``MAX_PATH`` on the long default layout). Asserts the build
+succeeds, the deepest emitted path stays under 260, and the same path *without* the junction
+would exceed 260 -- so the junction is provably load-bearing, not incidental.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.firmware.cli import compose_subprocess_env
+from esphome_device_builder.helpers.windows_build_paths import (
+    apply_windows_short_build_paths,
+    remove_windows_short_build_paths,
+    windows_pio_core_dir,
+)
+from esphome_device_builder.models import FirmwareJob, JobType
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows MAX_PATH only")
+
+_MAX_PATH = 260
+
+# Pad the config dir so the *real* (canonical) build paths are long: without the junction the
+# deepest object path overflows MAX_PATH; through the junction it stays short.
+_PAD = "padding-" * 9  # 72 chars
+
+_CONFIG = textwrap.dedent(
+    """\
+    esphome:
+      name: maxpath-probe-esp32-idf
+    esp32:
+      board: esp32dev
+      framework:
+        type: esp-idf
+    logger:
+    wifi:
+      ssid: "probe-ssid"
+      password: "probe-password"
+    api:
+      encryption:
+        key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+    """
+)
+
+
+@pytest.mark.timeout(2400)
+def test_windows_short_paths_compile_deep_idf(tmp_path: Path) -> None:
+    """A deep ESP-IDF compile succeeds through the short-path layout and stays under MAX_PATH."""
+    config_dir = tmp_path / _PAD / "esphome"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config = config_dir / "probe.yaml"
+    config.write_text(_CONFIG, encoding="utf-8")
+
+    saved = {k: os.environ.get(k) for k in ("ESPHOME_DATA_DIR", "PLATFORMIO_CORE_DIR")}
+    os.environ.pop("ESPHOME_DATA_DIR", None)
+    try:
+        apply_windows_short_build_paths(config_dir)
+        junction = Path(os.environ["ESPHOME_DATA_DIR"])
+        real_data = config_dir / ".esphome"
+        assert windows_pio_core_dir() is not None, "PLATFORMIO_CORE_DIR not set up"
+
+        # Drive the real subprocess-env composition (a local COMPILE job).
+        job = FirmwareJob(job_id="probe", configuration="probe.yaml", job_type=JobType.COMPILE)
+        env = compose_subprocess_env(job)
+
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "esphome", "compile", str(config)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            close_fds=False,
+        )
+        assert result.returncode == 0, (
+            f"deep ESP-IDF compile failed under the short-path layout:\n"
+            f"stdout:\n{result.stdout[-4000:]}\nstderr:\n{result.stderr[-2000:]}"
+        )
+
+        deepest_junction = _deepest(junction)
+        deepest_canonical = deepest_junction - len(str(junction)) + len(str(real_data))
+        assert deepest_junction < _MAX_PATH, (
+            f"deepest path through the junction is {deepest_junction} (>= {_MAX_PATH})"
+        )
+        # The fix is load-bearing: the same tree at the real (un-junctioned) path overflows.
+        assert deepest_canonical > _MAX_PATH, (
+            f"control check weak: canonical depth {deepest_canonical} did not exceed "
+            f"{_MAX_PATH}; the test no longer proves the junction is required"
+        )
+    finally:
+        remove_windows_short_build_paths()
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _deepest(root: Path) -> int:
+    """Return the longest full file-path string length under *root* (0 if empty)."""
+    longest = 0
+    for current, _dirs, files in os.walk(root):
+        longest = max((longest, *(len(current) + 1 + len(name) for name in files)))
+    return longest

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -1,13 +1,4 @@
-"""Real-compile pin: the Windows short-path layout builds a deep ESP-IDF config under MAX_PATH.
-
-Windows-only. Exercises the production
-:func:`helpers.windows_build_paths.apply_windows_short_build_paths` +
-:func:`controllers.firmware.cli.compose_subprocess_env` path, then runs a real
-``esphome compile`` of an ESP-IDF + ``api: encryption:`` config (the deep mbedtls /
-tf-psa-crypto tree that overflows ``MAX_PATH`` on the long default layout). Asserts the build
-succeeds, the deepest emitted path stays under 260, and the same path *without* the junction
-would exceed 260 -- so the junction is provably load-bearing, not incidental.
-"""
+"""Pins that the Windows short-path layout compiles a deep ESP-IDF config under MAX_PATH."""
 
 from __future__ import annotations
 
@@ -20,11 +11,7 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.controllers.firmware.cli import compose_subprocess_env
-from esphome_device_builder.helpers.windows_build_paths import (
-    apply_windows_short_build_paths,
-    remove_windows_short_build_paths,
-    windows_pio_core_dir,
-)
+from esphome_device_builder.helpers.windows_build_paths import windows_short_build_paths
 from esphome_device_builder.models import FirmwareJob, JobType
 
 pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows MAX_PATH only")
@@ -55,24 +42,24 @@ _CONFIG = textwrap.dedent(
 
 
 @pytest.mark.timeout(2400)
-def test_windows_short_paths_compile_deep_idf(tmp_path: Path) -> None:
+def test_windows_short_paths_compile_deep_idf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A deep ESP-IDF compile succeeds through the short-path layout and stays under MAX_PATH."""
     config_dir = tmp_path / _PAD / "esphome"
     config_dir.mkdir(parents=True, exist_ok=True)
     config = config_dir / "probe.yaml"
     config.write_text(_CONFIG, encoding="utf-8")
 
-    saved = {k: os.environ.get(k) for k in ("ESPHOME_DATA_DIR", "PLATFORMIO_CORE_DIR")}
-    os.environ.pop("ESPHOME_DATA_DIR", None)
-    try:
-        apply_windows_short_build_paths(config_dir)
+    monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
+    with windows_short_build_paths(config_dir) as pio_core_dir:
         junction = Path(os.environ["ESPHOME_DATA_DIR"])
         real_data = config_dir / ".esphome"
-        assert windows_pio_core_dir() is not None, "PLATFORMIO_CORE_DIR not set up"
+        assert pio_core_dir is not None, "PLATFORMIO_CORE_DIR not set up"
 
         # Drive the real subprocess-env composition (a local COMPILE job).
         job = FirmwareJob(job_id="probe", configuration="probe.yaml", job_type=JobType.COMPILE)
-        env = compose_subprocess_env(job)
+        env = compose_subprocess_env(job, pio_core_dir)
 
         result = subprocess.run(  # noqa: S603
             [sys.executable, "-m", "esphome", "compile", str(config)],
@@ -97,13 +84,6 @@ def test_windows_short_paths_compile_deep_idf(tmp_path: Path) -> None:
             f"control check weak: canonical depth {deepest_canonical} did not exceed "
             f"{_MAX_PATH}; the test no longer proves the junction is required"
         )
-    finally:
-        remove_windows_short_build_paths()
-        for key, value in saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
 
 
 def _deepest(root: Path) -> int:

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -20,12 +20,12 @@ _MAX_PATH = 260
 
 # Pad the config dir so the *real* (canonical) build paths are long: without the junction the
 # deepest object path overflows MAX_PATH; through the junction it stays short.
+#
+# No space in the path: junction creation handles spaces (native _winapi API, pinned by a unit
+# test), but ESP-IDF passes the project dir unquoted into ``-fdebug-prefix-map``, so a space
+# anywhere in the path breaks the *compile* regardless of the junction — an upstream issue
+# orthogonal to MAX_PATH. A full-compile e2e therefore can't carry a space and stay green.
 _PAD = "padding-" * 9  # 72 chars
-
-# A space-bearing component mimics a real Windows profile dir (``C:\Users\First Last\...``) so
-# the live compile proves the native junction handles a space in the target — the case that
-# would break ``cmd /c mklink`` quote-stripping.
-_PROFILE = "First Last"
 
 _CONFIG = textwrap.dedent(
     """\
@@ -51,9 +51,8 @@ def test_windows_short_paths_compile_deep_idf(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A deep ESP-IDF compile succeeds through the short-path layout and stays under MAX_PATH."""
-    config_dir = tmp_path / _PROFILE / _PAD / "esphome"
+    config_dir = tmp_path / _PAD / "esphome"
     config_dir.mkdir(parents=True, exist_ok=True)
-    assert " " in str(config_dir), "config_dir must carry a space to exercise the junction target"
     config = config_dir / "probe.yaml"
     config.write_text(_CONFIG, encoding="utf-8")
 

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -18,13 +18,9 @@ pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows MAX_PAT
 
 _MAX_PATH = 260
 
-# Pad the config dir so the *real* (canonical) build paths are long: without the junction the
-# deepest object path overflows MAX_PATH; through the junction it stays short.
-#
-# No space in the path: junction creation handles spaces (native _winapi API, pinned by a unit
-# test), but ESP-IDF passes the project dir unquoted into ``-fdebug-prefix-map``, so a space
-# anywhere in the path breaks the *compile* regardless of the junction — an upstream issue
-# orthogonal to MAX_PATH. A full-compile e2e therefore can't carry a space and stay green.
+# Long config dir so the un-junctioned path overflows MAX_PATH (the junction keeps it short).
+# No space: ESP-IDF breaks the compile on a spaced path via an unquoted -fdebug-prefix-map
+# (orthogonal to MAX_PATH; junction-handles-spaces is covered in the unit tests).
 _PAD = "padding-" * 9  # 72 chars
 
 _CONFIG = textwrap.dedent(

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -1,0 +1,26 @@
+"""Unit contract for the Windows short-build-paths helper (the no-op side runs everywhere)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.windows_build_paths import (
+    apply_windows_short_build_paths,
+    remove_windows_short_build_paths,
+    windows_pio_core_dir,
+)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="pins the off-Windows no-op contract")
+def test_apply_is_noop_off_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Off Windows the helper touches nothing: no env override, no recorded core dir."""
+    monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
+    apply_windows_short_build_paths(tmp_path)
+    assert "ESPHOME_DATA_DIR" not in os.environ
+    assert windows_pio_core_dir() is None
+    remove_windows_short_build_paths()  # also a no-op; must not raise
+    assert windows_pio_core_dir() is None

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -8,19 +8,16 @@ from pathlib import Path
 
 import pytest
 
-from esphome_device_builder.helpers.windows_build_paths import (
-    apply_windows_short_build_paths,
-    remove_windows_short_build_paths,
-    windows_pio_core_dir,
-)
+from esphome_device_builder.helpers.windows_build_paths import windows_short_build_paths
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="pins the off-Windows no-op contract")
-def test_apply_is_noop_off_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Off Windows the helper touches nothing: no env override, no recorded core dir."""
+def test_context_manager_is_noop_off_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Off Windows the context manager touches nothing and yields ``None``."""
     monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
-    apply_windows_short_build_paths(tmp_path)
+    with windows_short_build_paths(tmp_path) as pio_core_dir:
+        assert pio_core_dir is None
+        assert "ESPHOME_DATA_DIR" not in os.environ
     assert "ESPHOME_DATA_DIR" not in os.environ
-    assert windows_pio_core_dir() is None
-    remove_windows_short_build_paths()  # also a no-op; must not raise
-    assert windows_pio_core_dir() is None

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -1,4 +1,11 @@
-"""Unit contract for the Windows short-build-paths helper (the no-op side runs everywhere)."""
+"""Unit contract for the Windows short-build-paths helper.
+
+The off-Windows no-op runs everywhere. The Windows branches are driven off Windows by faking
+the platform gate and the junction syscall (a posix symlink stands in for the junction), so the
+env save/restore, reuse, collision-fallback, and OSError-fallback branches get coverage in the
+fast matrix rather than only the weekly Windows e2e. Those are skipped on Windows itself, where
+``os.symlink`` needs admin and the real e2e exercises the native junction.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +15,10 @@ from pathlib import Path
 
 import pytest
 
+from esphome_device_builder.helpers import windows_build_paths as wbp
 from esphome_device_builder.helpers.windows_build_paths import windows_short_build_paths
+
+_not_windows = pytest.mark.skipif(sys.platform == "win32", reason="posix symlink stands in")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="pins the off-Windows no-op contract")
@@ -21,3 +31,100 @@ def test_context_manager_is_noop_off_windows(
         assert pio_core_dir is None
         assert "ESPHOME_DATA_DIR" not in os.environ
     assert "ESPHOME_DATA_DIR" not in os.environ
+
+
+@pytest.fixture
+def fake_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, Path]]:
+    """Run the helper's Windows branch off Windows; fake the junction as a posix symlink."""
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(wbp, "_is_windows", lambda: True)
+    monkeypatch.setattr(wbp, "_JUNCTION_ROOT", root)
+    created: list[tuple[Path, Path]] = []
+
+    def _fake_create(link: Path, target: Path) -> None:
+        created.append((Path(link), Path(target)))
+        Path(link).symlink_to(target, target_is_directory=True)
+
+    monkeypatch.setattr(wbp, "_create_junction", _fake_create)
+    monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
+    return created
+
+
+@_not_windows
+def test_sets_short_env_inside_block_and_restores_after(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]]
+) -> None:
+    """Inside the block ESPHOME_DATA_DIR is the junction; after, it's gone again."""
+    config_dir = tmp_path / "cfg"
+    expected_junction = wbp._JUNCTION_ROOT / f"esphb-{wbp._suffix(config_dir / '.esphome')}"
+    with windows_short_build_paths(config_dir) as pio:
+        assert os.environ["ESPHOME_DATA_DIR"] == str(expected_junction)
+        assert pio == Path(f"{expected_junction}-pio")
+        assert pio.is_dir()
+        assert len(fake_windows) == 1
+    assert "ESPHOME_DATA_DIR" not in os.environ
+
+
+@_not_windows
+def test_restores_prior_env_var(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An existing ESPHOME_DATA_DIR is restored verbatim on exit."""
+    prior = tmp_path / "prior"
+    prior.mkdir()
+    monkeypatch.setenv("ESPHOME_DATA_DIR", str(prior))
+    with windows_short_build_paths(tmp_path / "cfg") as pio:
+        assert pio is not None
+        assert os.environ["ESPHOME_DATA_DIR"] != str(prior)
+    assert os.environ["ESPHOME_DATA_DIR"] == str(prior)
+
+
+@_not_windows
+def test_oserror_fallback_yields_none_and_leaves_env(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If junction creation fails the block yields ``None`` and never sets the override."""
+
+    def _boom(link: Path, target: Path) -> None:
+        msg = "denied"
+        raise OSError(msg)
+
+    monkeypatch.setattr(wbp, "_create_junction", _boom)
+    with windows_short_build_paths(tmp_path / "cfg") as pio:
+        assert pio is None
+        assert "ESPHOME_DATA_DIR" not in os.environ
+    assert "ESPHOME_DATA_DIR" not in os.environ
+
+
+@_not_windows
+def test_reuses_existing_junction_without_recreating(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]]
+) -> None:
+    """A second run reuses the junction already pointing at the target, no recreate."""
+    config_dir = tmp_path / "cfg"
+    with windows_short_build_paths(config_dir):
+        pass
+    assert len(fake_windows) == 1
+    with windows_short_build_paths(config_dir):
+        pass
+    assert len(fake_windows) == 1
+
+
+@_not_windows
+def test_name_collision_falls_back_without_stealing(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]]
+) -> None:
+    """A junction at our name pointing elsewhere is left alone; we fall back to long paths."""
+    config_dir = tmp_path / "cfg"
+    data = config_dir / ".esphome"
+    data.mkdir(parents=True)
+    junction = wbp._JUNCTION_ROOT / f"esphb-{wbp._suffix(data)}"
+    other = tmp_path / "other"
+    other.mkdir()
+    Path(junction).symlink_to(other, target_is_directory=True)
+
+    with windows_short_build_paths(config_dir) as pio:
+        assert pio is None
+    # The colliding junction is untouched (not stolen / repointed).
+    assert os.path.realpath(junction) == os.path.realpath(other)

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -146,3 +146,22 @@ def test_dangling_junction_is_replaced(
     with windows_short_build_paths(config_dir) as pio:
         assert pio is not None
         assert os.path.realpath(junction) == os.path.realpath(data)
+
+
+@_not_windows
+def test_space_bearing_target_passed_through_unmangled(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]]
+) -> None:
+    """A space-bearing target (Windows profile dir) reaches the junction call intact.
+
+    The native ``_winapi.CreateJunction`` takes the path as a direct argument, so unlike
+    ``cmd /c mklink`` a space can't split it. (A full ESP-IDF *compile* with a space still
+    fails upstream via ``-fdebug-prefix-map``; that's orthogonal to junction creation.)
+    """
+    config_dir = tmp_path / "First Last" / "esphome"
+    with windows_short_build_paths(config_dir) as pio:
+        assert pio is not None
+        assert len(fake_windows) == 1
+        _link, target = fake_windows[0]
+        assert target == config_dir / ".esphome"
+        assert " " in str(target)

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -128,3 +128,21 @@ def test_name_collision_falls_back_without_stealing(
         assert pio is None
     # The colliding junction is untouched (not stolen / repointed).
     assert os.path.realpath(junction) == os.path.realpath(other)
+
+
+@_not_windows
+def test_dangling_junction_is_replaced(
+    tmp_path: Path, fake_windows: list[tuple[Path, Path]]
+) -> None:
+    """A junction whose target was deleted is cleared and recreated, not left to fail setup."""
+    config_dir = tmp_path / "cfg"
+    data = config_dir / ".esphome"
+    data.mkdir(parents=True)
+    junction = wbp._JUNCTION_ROOT / f"esphb-{wbp._suffix(data)}"
+    gone = tmp_path / "gone"  # never created → dangling
+    Path(junction).symlink_to(gone, target_is_directory=True)
+    assert not junction.exists()  # dangling: exists() follows the link and is False
+
+    with windows_short_build_paths(config_dir) as pio:
+        assert pio is not None
+        assert os.path.realpath(junction) == os.path.realpath(data)

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -1,10 +1,8 @@
 """Unit contract for the Windows short-build-paths helper.
 
-The off-Windows no-op runs everywhere. The Windows branches are driven off Windows by faking
-the platform gate and the junction syscall (a posix symlink stands in for the junction), so the
-env save/restore, reuse, collision-fallback, and OSError-fallback branches get coverage in the
-fast matrix rather than only the weekly Windows e2e. Those are skipped on Windows itself, where
-``os.symlink`` needs admin and the real e2e exercises the native junction.
+The nt-only branches are driven off Windows by faking the platform gate + junction syscall
+(a posix symlink stands in), so env save/restore, reuse, collision, and the fallbacks get
+fast-matrix coverage; skipped on Windows, where the real e2e exercises the native junction.
 """
 
 from __future__ import annotations

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -163,3 +164,26 @@ def test_space_bearing_target_passed_through_unmangled(
         _link, target = fake_windows[0]
         assert target == config_dir / ".esphome"
         assert " " in str(target)
+
+
+def test_remove_link_rmdirs_a_plain_directory(tmp_path: Path) -> None:
+    """The non-symlink branch (a real junction on Windows) is removed with rmdir."""
+    junction = tmp_path / "j"
+    junction.mkdir()
+    wbp._remove_link(junction)
+    assert not junction.exists()
+
+
+def test_create_junction_calls_the_native_api(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_create_junction`` calls ``_winapi.CreateJunction(target, link)`` (faked off Windows)."""
+    calls: list[tuple[str, str]] = []
+    fake_winapi = types.ModuleType("_winapi")
+    fake_winapi.CreateJunction = lambda src, dst: calls.append((src, dst))  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "_winapi", fake_winapi)
+
+    link = tmp_path / "link"
+    target = tmp_path / "target"
+    wbp._create_junction(link, target)
+    assert calls == [(str(target), str(link))]


### PR DESCRIPTION
# What does this implement/fix?

Deep ESP-IDF builds on native Windows overflow the 260-char `MAX_PATH` (libsodium / mbedtls), and the framework include list overflows the command-line limit at link time, so the dashboard fails to compile (the reporter's symptom in #1190). ESPHome Desktop's primary target is native Windows and it compiles locally, so this is the modal case post-beta, not an edge.

The fix routes the whole build tree through a short directory **junction** and points the PlatformIO toolchain at a short **real** dir, entirely inside the builder (no esphome-desktop change):

- `ESPHOME_DATA_DIR` -> junction `C:\esphb-<suffix>` into the real data dir. The junction *survives* PlatformIO/CMake path handling, so the compiler gets the short string while the bytes stay under the config dir (clean uninstall). `CORE.data_dir` reads `ESPHOME_DATA_DIR` first, so the dashboard's own artifact reads and every compile subprocess resolve through the same short path with no divergence (see `helpers/storage_path.py`).
- `PLATFORMIO_CORE_DIR` -> real short `C:\esphb-<suffix>-pio`, injected in `compose_subprocess_env`. It must be a *real* dir, not a junction: ESP-IDF's `idf.cmake` REALPATHs `IDF_PATH` and resolves a junction back to its long target.

Set up once at startup (before the event loop, so it never blocks it) inside the single-instance lock; torn down on shutdown. No-op on every non-Windows platform.

**Empirically validated on a windows-latest runner** before writing this: the deep mbedtls + `api: encryption:` config compiles with deepest path 229/206 < 260, where the long default fails at 304 with "command line too long". A real-compile e2e at `tests/e2e/slow/windows/` drives the production helper + `compose_subprocess_env` through an actual ESP-IDF compile and asserts the build succeeds, the deepest path is under 260, and the same tree without the junction would exceed 260 (so the junction is provably load-bearing). It runs on a dedicated path-filtered workflow plus a weekly schedule so it keeps working against upstream esphome / platformio / IDF drift.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1190

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally. (off-Windows no-op unit test; the Windows behaviour is validated by the e2e on windows-latest, run during development)
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable. (unit no-op contract + `tests/e2e/slow/windows` real-compile e2e)
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (n/a)
