### PR TITLE
Shorten new dashboard_id from 32 to 8 chars

### DIFF
--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -42,7 +42,13 @@ from typing import Any
 from ..controllers.config import metadata_transaction
 from .peer_link_identity import PeerLinkIdentity, PeerLinkIdentityStore
 
-_DASHBOARD_ID_BYTES = 24
+# 6 bytes of entropy -> exactly 8 base64url chars (no padding), the
+# same length as the mDNS hostname suffix. Short keeps the
+# remote-build subtree path (``.remote_builds/<dashboard_id>/``)
+# under Windows MAX_PATH; the id is a correlation / isolation token,
+# not an auth credential (pairing authenticates via the X25519 Noise
+# XX handshake), so 48 bits is ample.
+_DASHBOARD_ID_BYTES = 6
 _DASHBOARD_IDENTITY_KEY = "_dashboard_identity"
 _DASHBOARD_ID_KEY = "dashboard_id"
 # Legacy location the id co-lived in with the receiver settings;
@@ -52,15 +58,15 @@ _LEGACY_REMOTE_BUILD_KEY = "_remote_build"
 # Public validation contract for ``dashboard_id`` strings on the
 # wire. ``dashboard_id`` is generated via
 # :func:`secrets.token_urlsafe` at :data:`_DASHBOARD_ID_BYTES`
-# bytes of entropy (32 base64url chars at the current size).
-# The cap of 64 defends against runaway inputs without
-# rejecting legitimate values; the pattern catches probes
+# bytes of entropy (8 base64url chars at the current size). The
+# cap of 64 defends against runaway inputs without rejecting
+# legitimate values (older installs carry a 32-char id minted
+# before the length was reduced). The pattern catches probes
 # carrying control bytes / non-printables. Both consumers
 # (``controllers/remote_build`` for WS-command argument
 # validation, and ``controllers/remote_build/peer_link`` for
-# msg3-supplied values on the Noise WS) import these so a
-# future entropy bump or alphabet change happens in one
-# place.
+# msg3-supplied values on the Noise WS) import these so a future
+# entropy change or alphabet change happens in one place.
 DASHBOARD_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 DASHBOARD_ID_MAX_CHARS = 64
 

--- a/tests/test_dashboard_identity.py
+++ b/tests/test_dashboard_identity.py
@@ -304,8 +304,8 @@ async def test_dashboard_id_is_url_safe(tmp_path: Path) -> None:
     """``secrets.token_urlsafe`` output: only ``[A-Za-z0-9_-]``."""
     identity = await get_or_create_identity(tmp_path, PeerLinkIdentityStore(tmp_path))
     assert DASHBOARD_ID_PATTERN.fullmatch(identity.dashboard_id)
-    # 24 bytes base64url-encoded = 32 chars (no padding in token_urlsafe).
-    assert len(identity.dashboard_id) == 32
+    # 6 bytes base64url-encoded = 8 chars (no padding in token_urlsafe).
+    assert len(identity.dashboard_id) == 8
     assert len(identity.dashboard_id) <= DASHBOARD_ID_MAX_CHARS
 
 


### PR DESCRIPTION
# What does this implement/fix?

The `dashboard_id` is a correlation / isolation token, not an auth credential (pairing authenticates via the X25519 Noise XX handshake), so its 192-bit (24-byte `token_urlsafe`) entropy was far more than needed. It also appears in the receiver-side remote-build subtree path (`.remote_builds/<dashboard_id>/`), where 32 chars eat into the Windows `MAX_PATH` budget (issue #1190).

New ids are now minted with `secrets.token_urlsafe(6)` -> exactly 8 base64url chars (48 bits), the same length the mDNS hostname suffix already derives from the id. 48 bits is ample for the handful of dashboards on a LAN (collision needs ~16M concurrent dashboards). Existing 32-char ids stay as-is -- regenerating would break paired peers that pinned the old id -- and the validation pattern (`[A-Za-z0-9_-]`) + 64-char cap already accept both lengths, so nothing else changes. This is a smaller, dependency-free alternative to the ULID idea (a ULID's leading timestamp would also have weakened the mDNS suffix it shares).

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder/issues/1190

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally. (`tests/test_dashboard_identity.py` updated + passing)
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (n/a)
