### PR TITLE
Shorten the remote-build on-disk directory to 8 chars

### DIFF
--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -3,9 +3,11 @@ Single source of truth for the receiver-side remote-build on-disk layout.
 
 Per-device YAML extract lives at
 
-    ``<config_dir>/.esphome/.remote_builds/<dashboard_id>/<device_name>/``
+    ``<config_dir>/.esphome/.remote_builds/<dir_id>/<device_name>/``
 
-with the bundle tarball as a sibling
+where ``<dir_id>`` is the first :data:`_DASHBOARD_DIR_ID_CHARS`
+chars of the ``dashboard_id`` (short, to stay under Windows
+MAX_PATH), with the bundle tarball as a sibling
 (``<device_name>.tar.gz``). :class:`RemoteBuildPath` is the
 canonical ``(dashboard_id, device_name)`` key;
 :meth:`~RemoteBuildPath.subtree` /
@@ -41,8 +43,19 @@ BUNDLE_SUFFIX = ".tar.gz"
 _REMOTE_BUILDS_PARTS: tuple[str, ...] = tuple(REMOTE_BUILDS_SUBDIR.as_posix().split("/"))
 
 # Tail segments a valid configuration carries after the prefix:
-# dashboard_id + device_name + YAML filename.
+# dir_id + device_name + YAML filename.
 _TAIL_SEGMENT_COUNT = 3
+
+# On-disk directory key: the first 8 chars of the ``dashboard_id``.
+# The full id runs to 32 chars on older installs, which nested under
+# ``.esphome/.remote_builds/<id>/`` plus the deep ESP-IDF build tree
+# eats into the Windows MAX_PATH budget (issue #1190). 8 base64url
+# chars (~48 bits) keeps two offloaders' subtrees from colliding; the
+# id stays full-length on the wire / in audit. Truncation is
+# idempotent (``id[:8][:8] == id[:8]``), so a path round-tripped
+# through :func:`parse_from_configuration` (which recovers the
+# already-8-char segment) renders the same directory.
+_DASHBOARD_DIR_ID_CHARS = 8
 
 
 @dataclass(frozen=True)
@@ -57,17 +70,19 @@ class RemoteBuildPath:
     dashboard_id: str
     device_name: str
 
+    @property
+    def dir_id(self) -> str:
+        """On-disk directory key: first :data:`_DASHBOARD_DIR_ID_CHARS` chars of the id."""
+        return self.dashboard_id[:_DASHBOARD_DIR_ID_CHARS]
+
     def subtree(self, config_dir: Path) -> Path:
         """Return the absolute extract directory under *config_dir*."""
-        return config_dir / REMOTE_BUILDS_SUBDIR / self.dashboard_id / self.device_name
+        return config_dir / REMOTE_BUILDS_SUBDIR / self.dir_id / self.device_name
 
     def bundle(self, config_dir: Path) -> Path:
         """Return the absolute bundle tarball path, sibling to :meth:`subtree`."""
         return (
-            config_dir
-            / REMOTE_BUILDS_SUBDIR
-            / self.dashboard_id
-            / f"{self.device_name}{BUNDLE_SUFFIX}"
+            config_dir / REMOTE_BUILDS_SUBDIR / self.dir_id / f"{self.device_name}{BUNDLE_SUFFIX}"
         )
 
     def data_dir(self, dashboard_data_dir: Path) -> Path:
@@ -103,7 +118,7 @@ class RemoteBuildPath:
         pre-extract wipe off the deep ``build/<env>/.pioenvs``
         tree (PR #578).
         """
-        return dashboard_data_dir / REMOTE_BUILDS_NAME / self.dashboard_id / ".esphome"
+        return dashboard_data_dir / REMOTE_BUILDS_NAME / self.dir_id / ".esphome"
 
 
 def parse_from_configuration(configuration: str) -> RemoteBuildPath | None:
@@ -113,6 +128,11 @@ def parse_from_configuration(configuration: str) -> RemoteBuildPath | None:
     any path outside the canonical layout — typically a
     locally-submitted job sitting at the top of ``<config_dir>``;
     callers treat ``None`` as "not a remote-build job".
+
+    The recovered ``dashboard_id`` is the on-disk ``dir_id``
+    (already truncated to :data:`_DASHBOARD_DIR_ID_CHARS` chars,
+    not the full wire id). :attr:`RemoteBuildPath.dir_id` is
+    idempotent, so the round-tripped key renders the same paths.
     """
     parts = PurePosixPath(configuration).parts
     expected = _REMOTE_BUILDS_PARTS

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -46,15 +46,10 @@ _REMOTE_BUILDS_PARTS: tuple[str, ...] = tuple(REMOTE_BUILDS_SUBDIR.as_posix().sp
 # dir_id + device_name + YAML filename.
 _TAIL_SEGMENT_COUNT = 3
 
-# On-disk directory key: the first 8 chars of the ``dashboard_id``.
-# The full id runs to 32 chars on older installs, which nested under
-# ``.esphome/.remote_builds/<id>/`` plus the deep ESP-IDF build tree
-# eats into the Windows MAX_PATH budget (issue #1190). 8 base64url
-# chars (~48 bits) keeps two offloaders' subtrees from colliding; the
-# id stays full-length on the wire / in audit. Truncation is
-# idempotent (``id[:8][:8] == id[:8]``), so a path round-tripped
-# through :func:`parse_from_configuration` (which recovers the
-# already-8-char segment) renders the same directory.
+# On-disk directory key: first 8 chars of the dashboard_id. Short keeps the
+# subtree path under Windows MAX_PATH; the id stays full-length on the wire.
+# Truncation is idempotent (``id[:8][:8] == id[:8]``), so a path recovered by
+# :func:`parse_from_configuration` (already 8 chars) renders the same directory.
 _DASHBOARD_DIR_ID_CHARS = 8
 
 
@@ -89,7 +84,7 @@ class RemoteBuildPath:
         """Return the ``ESPHOME_DATA_DIR`` the compile subprocess writes into.
 
         Resolves to
-        ``<dashboard_data_dir>/.remote_builds/<dashboard_id>/.esphome``
+        ``<dashboard_data_dir>/.remote_builds/<dir_id>/.esphome``
         — one shared ``.esphome`` per paired offloader,
         anchored under :attr:`esphome.core.CORE.data_dir` so
         the addon's per-instance ``/data`` volume holds the
@@ -106,7 +101,7 @@ class RemoteBuildPath:
           PR #578's basename-collision bug — two offloaders
           each submitting ``kitchen.yaml`` would clobber each
           other's ``storage/kitchen.yaml.json``. The
-          ``dashboard_id`` partition is the isolation gate.
+          ``dir_id`` partition is the isolation gate.
 
         Separate root from :meth:`subtree` — that one is
         anchored on ``config_dir``, this one on

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -100,8 +100,11 @@ class RemoteBuildPath:
         * **Single-shared** across all dashboards reintroduces
           PR #578's basename-collision bug — two offloaders
           each submitting ``kitchen.yaml`` would clobber each
-          other's ``storage/kitchen.yaml.json``. The
-          ``dir_id`` partition is the isolation gate.
+          other's ``storage/kitchen.yaml.json``. The ``dir_id``
+          partition is the isolation gate; it's the first 8
+          chars of the dashboard_id (~48 bits), so two offloaders
+          collide only if their ids share that prefix —
+          astronomically unlikely for a handful of offloaders.
 
         Separate root from :meth:`subtree` — that one is
         anchored on ``config_dir``, this one on

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -407,6 +407,6 @@ def test_clean_job_command_passes_remote_build_yaml_path_through() -> None:
     "config not found."
     """
     controller = _firmware_controller_with(None)
-    rel_yaml = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
+    rel_yaml = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
     cmd = controller._build_command(JobType.CLEAN, rel_yaml, "")
     assert cmd == ["esphome", "--dashboard", "clean", rel_yaml]

--- a/tests/controllers/firmware/test_address_cache.py
+++ b/tests/controllers/firmware/test_address_cache.py
@@ -395,7 +395,7 @@ def test_clean_job_command_passes_remote_build_yaml_path_through() -> None:
 
     The receiver's submit_job dispatch lands a ``FirmwareJob``
     whose ``configuration`` is the relative POSIX path under
-    ``.esphome/.remote_builds/<dashboard_id>/<device>/``. The
+    ``.esphome/.remote_builds/<dir_id>/<device>/``. The
     build-command builder must thread that path verbatim — the
     paired ``ESPHOME_DATA_DIR`` override resolves esphome's
     ``CORE.data_dir`` to the per-offloader subtree, and

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -93,10 +93,10 @@ def test_remote_build_job_pins_data_dir_to_per_dashboard_esphome(
     ``CORE.data_dir`` to pin the *anchor*, not just the path.
     """
     controller = firmware_controller_factory(with_settings=True)
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
     env = controller._compose_subprocess_env(_make_job(configuration=configuration))
 
-    expected = Path(CORE.data_dir) / ".remote_builds" / "dashboard-alpha" / ".esphome"
+    expected = Path(CORE.data_dir) / ".remote_builds" / "a1b2c3d4" / ".esphome"
     assert env["ESPHOME_DATA_DIR"] == str(expected)
     # The override is the only data-dir-related change; the
     # ANSI / unbuffered overlays still land.
@@ -127,12 +127,12 @@ def test_remote_build_clean_job_pins_data_dir_to_per_dashboard_esphome(
     at the wrong data dir, so nothing got removed."
     """
     controller = firmware_controller_factory(with_settings=True)
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
     env = controller._compose_subprocess_env(
         _make_job(configuration=configuration, job_type=JobType.CLEAN)
     )
 
-    expected = Path(CORE.data_dir) / ".remote_builds" / "dashboard-alpha" / ".esphome"
+    expected = Path(CORE.data_dir) / ".remote_builds" / "a1b2c3d4" / ".esphome"
     assert env["ESPHOME_DATA_DIR"] == str(expected)
 
 
@@ -151,7 +151,7 @@ def test_malformed_remote_build_path_falls_through_to_local(
     produces.
     """
     controller = firmware_controller_factory(with_settings=True)
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen.yaml"
     env = controller._compose_subprocess_env(_make_job(configuration=configuration))
 
     assert env.get("ESPHOME_DATA_DIR") == os.environ.get("ESPHOME_DATA_DIR")

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -71,9 +71,9 @@ def test_remote_build_job_pins_data_dir_to_per_dashboard_esphome(
 
     The configuration is the relative POSIX path the receiver-side
     submit_job dispatch sets on the :class:`FirmwareJob`
-    (``.esphome/.remote_builds/<dashboard_id>/<device>/<device>.yaml``).
+    (``.esphome/.remote_builds/<dir_id>/<device>/<device>.yaml``).
     The env override points at the per-dashboard
-    ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome``
+    ``<CORE.data_dir>/.remote_builds/<dir_id>/.esphome``
     directory: one toolchain cache + storage keyspace shared
     across every device that offloader submits, isolated
     from the dashboard's local-build keyspace AND from other
@@ -142,9 +142,9 @@ def test_malformed_remote_build_path_falls_through_to_local(
     """A configuration that doesn't parse as a remote-build path stays local.
 
     The layout parser returns ``None`` for any path that doesn't
-    match ``.esphome/.remote_builds/<dashboard_id>/<device>/<file>``
+    match ``.esphome/.remote_builds/<dir_id>/<device>/<file>``
     — a 4-segment shorthand like
-    ``.esphome/.remote_builds/<id>/kitchen.yaml`` (no device
+    ``.esphome/.remote_builds/<dir_id>/kitchen.yaml`` (no device
     subtree) doesn't qualify and the env override skips. Pins
     the contract that ``ESPHOME_DATA_DIR`` is only pinned when
     we know we're looking at the canonical layout the writer

--- a/tests/test_remote_build_cleanup.py
+++ b/tests/test_remote_build_cleanup.py
@@ -24,6 +24,7 @@ from esphome_device_builder.helpers.remote_build_cleanup import (
 from esphome_device_builder.helpers.remote_build_layout import (
     REMOTE_BUILDS_SUBDIR,
     RemoteBuildPath,
+    parse_from_configuration,
 )
 
 
@@ -506,3 +507,25 @@ def test_sweep_continues_after_subtree_rmtree_failure(
     # exists, the successful one is gone.
     assert deleted == 1
     assert len(calls) == 2
+
+
+def test_sweep_protects_in_flight_subtree_with_long_dashboard_id(tmp_path: Path) -> None:
+    """A long-id cold subtree stays protected when in-flight via its 8-char dir_id.
+
+    The in-flight set is keyed through ``parse_from_configuration`` (the dir_id) exactly as the
+    controller's loop builds it; the sweep reconstructs the same dir_id from the directory name,
+    so idempotent truncation must keep the two equal or an active build gets swept.
+    """
+    now = 1_000_000.0
+    key = RemoteBuildPath(dashboard_id="Nc7uJKFUh3U0o6DKioxJFsfpZwWoN5Ws", device_name="kitchen")
+    _populate(tmp_path, key, age_seconds=3600, now=now)  # cold
+
+    configuration = (key.subtree(tmp_path) / "kitchen.yaml").relative_to(tmp_path).as_posix()
+    in_flight = parse_from_configuration(configuration)
+    assert in_flight is not None
+
+    deleted = sweep_remote_builds(
+        tmp_path, ttl_seconds=600, in_flight_keys=frozenset({in_flight}), now=now
+    )
+    assert deleted == 0
+    assert key.subtree(tmp_path).exists()

--- a/tests/test_remote_build_layout.py
+++ b/tests/test_remote_build_layout.py
@@ -123,3 +123,28 @@ def test_remote_build_path_is_hashable() -> None:
     keys = frozenset({a, b})
     assert keys == frozenset({a})
     assert hash(a) == hash(b)
+
+
+# A 32-char base64url id like older installs persist.
+_LONG_ID = "Nc7uJKFUh3U0o6DKioxJFsfpZwWoN5Ws"
+
+
+def test_long_dashboard_id_renders_8_char_dir(tmp_path: Path) -> None:
+    """A >8-char id renders an 8-char on-disk dir, keeping paths under Windows MAX_PATH (#1190)."""
+    key = RemoteBuildPath(dashboard_id=_LONG_ID, device_name="kitchen")
+    assert key.dir_id == "Nc7uJKFU"
+    assert key.subtree(tmp_path) == (
+        tmp_path / ".esphome" / ".remote_builds" / "Nc7uJKFU" / "kitchen"
+    )
+    assert key.data_dir(tmp_path) == (tmp_path / ".remote_builds" / "Nc7uJKFU" / ".esphome")
+
+
+def test_parse_round_trip_idempotent_for_long_id(tmp_path: Path) -> None:
+    """Parsing a long-id subtree path recovers the 8-char dir_id and renders identical paths."""
+    key = RemoteBuildPath(dashboard_id=_LONG_ID, device_name="kitchen")
+    configuration = (key.subtree(tmp_path) / "kitchen.yaml").relative_to(tmp_path).as_posix()
+    parsed = parse_from_configuration(configuration)
+    assert parsed is not None
+    assert parsed.dashboard_id == "Nc7uJKFU"  # the truncated dir_id, not the full wire id
+    assert parsed.subtree(tmp_path) == key.subtree(tmp_path)
+    assert parsed.data_dir(tmp_path) == key.data_dir(tmp_path)

--- a/tests/test_remote_build_layout.py
+++ b/tests/test_remote_build_layout.py
@@ -73,7 +73,7 @@ def test_parse_handles_deep_nested_yaml_under_subtree() -> None:
     """A configuration deeper than the canonical 5 segments still parses.
 
     The bundle layout only constrains the first four segments
-    (``.esphome / .remote_builds / <dashboard_id> / <device_name>``);
+    (``.esphome / .remote_builds / <dir_id> / <device_name>``);
     the YAML name inside the subtree is free-form. A nested
     YAML (theoretical, not the writer's current shape but
     allowed by the contract) should still resolve.
@@ -130,7 +130,7 @@ _LONG_ID = "Nc7uJKFUh3U0o6DKioxJFsfpZwWoN5Ws"
 
 
 def test_long_dashboard_id_renders_8_char_dir(tmp_path: Path) -> None:
-    """A >8-char id renders an 8-char on-disk dir, keeping paths under Windows MAX_PATH (#1190)."""
+    """A >8-char id renders an 8-char on-disk dir, keeping paths under Windows MAX_PATH."""
     key = RemoteBuildPath(dashboard_id=_LONG_ID, device_name="kitchen")
     assert key.dir_id == "Nc7uJKFU"
     assert key.subtree(tmp_path) == (

--- a/tests/test_storage_path.py
+++ b/tests/test_storage_path.py
@@ -47,9 +47,9 @@ def test_resolve_data_dir_remote_build_configuration_uses_per_dashboard_esphome(
     anchored on ``CORE.data_dir`` to keep HA-addon builds out of
     the ``/config`` volume.
     """
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
     assert resolve_data_dir(configuration) == (
-        tmp_path / ".esphome" / ".remote_builds" / "dashboard-alpha" / ".esphome"
+        tmp_path / ".esphome" / ".remote_builds" / "a1b2c3d4" / ".esphome"
     )
 
 
@@ -64,7 +64,7 @@ def test_resolve_data_dir_malformed_remote_build_path_falls_through_to_local() -
     subtree) doesn't qualify and the resolver falls through to
     ``CORE.data_dir`` — same as a bare basename.
     """
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen.yaml"
     assert resolve_data_dir(configuration) == Path(CORE.data_dir)
 
 
@@ -90,12 +90,12 @@ def test_resolve_storage_path_remote_build_uses_basename_keyspace(tmp_path: Path
     basename-keyed contract so a future refactor can't silently
     regress the resolver into emitting the buggy full-path key.
     """
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
     assert resolve_storage_path(configuration) == (
         tmp_path
         / ".esphome"
         / ".remote_builds"
-        / "dashboard-alpha"
+        / "a1b2c3d4"
         / ".esphome"
         / "storage"
         / "kitchen.yaml.json"
@@ -111,12 +111,12 @@ def test_resolve_idedata_path_local_configuration() -> None:
 
 def test_resolve_idedata_path_remote_build(tmp_path: Path) -> None:
     """Idedata for a remote build lands under the per-build subtree."""
-    configuration = ".esphome/.remote_builds/dashboard-alpha/kitchen/kitchen.yaml"
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
     assert resolve_idedata_path(configuration, name="kitchen") == (
         tmp_path
         / ".esphome"
         / ".remote_builds"
-        / "dashboard-alpha"
+        / "a1b2c3d4"
         / ".esphome"
         / "idedata"
         / "kitchen.json"

--- a/tests/test_storage_path.py
+++ b/tests/test_storage_path.py
@@ -58,9 +58,9 @@ def test_resolve_data_dir_malformed_remote_build_path_falls_through_to_local() -
 
     ``parse_from_configuration`` returns ``None`` for any path
     that doesn't match the canonical
-    ``.esphome/.remote_builds/<dashboard_id>/<device>/<file>`` shape.
+    ``.esphome/.remote_builds/<dir_id>/<device>/<file>`` shape.
     A 3-segment shorthand like
-    ``.esphome/.remote_builds/<id>/kitchen.yaml`` (no device
+    ``.esphome/.remote_builds/<dir_id>/kitchen.yaml`` (no device
     subtree) doesn't qualify and the resolver falls through to
     ``CORE.data_dir`` — same as a bare basename.
     """
@@ -84,8 +84,8 @@ def test_resolve_storage_path_remote_build_uses_basename_keyspace(tmp_path: Path
     ``<per-dashboard-data-dir>/kitchen.yaml`` writes its sidecar
     at ``<per-dashboard-data-dir>/storage/kitchen.yaml.json``,
     where ``<per-dashboard-data-dir>`` is
-    ``<CORE.data_dir>/.remote_builds/<dashboard_id>/.esphome``.
-    The full configuration string (``.esphome/.remote_builds/<id>/<device>/<device>.yaml``)
+    ``<CORE.data_dir>/.remote_builds/<dir_id>/.esphome``.
+    The full configuration string (``.esphome/.remote_builds/<dir_id>/<device>/<device>.yaml``)
     is not re-embedded in the sidecar path — pins the
     basename-keyed contract so a future refactor can't silently
     regress the resolver into emitting the buggy full-path key.


### PR DESCRIPTION
# What does this implement/fix?

The receiver-side remote-build subtree nests under `.remote_builds/<dashboard_id>/`, and the `dashboard_id` runs to 32 chars on older installs. Combined with the deep ESP-IDF build tree that eats the Windows `MAX_PATH` budget (issue #1190), those 32 chars are pure overhead on the path the compiler actually sees.

This renders the on-disk directory from the **first 8 chars** of the `dashboard_id` (`RemoteBuildPath.dir_id`) instead of the full id, the same length the mDNS hostname suffix already derives from it. The `dashboard_id` stays full-length on the wire, in audit, and for correlation; only the directory name shrinks. 8 base64url chars (~48 bits) is ample to keep two offloaders' subtrees from colliding.

Truncation is **idempotent** (`id[:8][:8] == id[:8]`), so a path round-tripped through `parse_from_configuration` (which recovers the already-8-char segment) renders the same directory, and the writer-side override + reader-side resolver stay in agreement. Existing 32-char directories from prior builds are left to the TTL sweep; nothing migrates.

This is the chosen alternative to shortening the `dashboard_id` itself (which would have weakened the correlation token / mDNS suffix and required re-pairing). It complements PR #1194 (the desktop-local junction fix): that handles the local build tree, this trims the receiver subtree.

**Related issue or feature (if applicable):**

- refs https://github.com/esphome/device-builder/issues/1190

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally. (full non-slow suite: 4318 passed; truncation + idempotent round-trip pinned in `test_remote_build_layout.py`)
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (n/a — internal layout)

## Upgrade note

A remote-build job that is *in-flight across the upgrade* (its queued `configuration` still embeds the old 32-char directory) resolves its `data_dir` to the new 8-char `dir_id` while its artifacts sit under the old 32-char tree, so it gets a one-time cache-miss recompile. Output stays correct and it self-heals on the next build; nothing migrates.
