### PR TITLE
Render YAML scalars through PyYAML's emitter

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-import yaml
-
 from ...models.common import ConfigEntryType
-from .scalar import _PLAIN_SCALAR_INDICATOR_LEAD, ESPHOME_YAML_INDENT, _quote, block_body_is_list
+from .scalar import ESPHOME_YAML_INDENT, _quote, _safe_yaml_scalar, block_body_is_list
 
 if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry
@@ -360,55 +358,8 @@ def _format_yaml_value(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        return _quote(value) if _string_needs_quoting(value) else value
+        return _safe_yaml_scalar(value)
     return str(value)
-
-
-_YAML_RESERVED_KEYWORDS = frozenset({"true", "false", "null", "yes", "no", "on", "off"})
-
-
-def _string_needs_quoting(value: str) -> bool:
-    """Return True when *value* needs YAML quoting to round-trip as a string."""
-    # YAML 1.1 recognises every case variant of the reserved words
-    # (``true``/``True``/``TRUE`` etc.) as bool/null, so ``str(True)``
-    # from a JSON bool would otherwise re-parse as ``True``. ``~`` and
-    # empty string are YAML null shorthands. A leading YAML indicator
-    # character (the ``_PLAIN_SCALAR_INDICATOR_LEAD`` set: ``! & * ? |
-    # > % @ ` # - , [ ] { } " '``) changes the scalar's shape — e.g. a
-    # globals ``initial_value`` C++ literal ``"Hello"`` emitted bare
-    # round-trips as the plain string ``Hello``, dropping the quotes
-    # ESPHome compiles against (#1095). ``:`` opens a mapping value and
-    # ``#`` opens a comment anywhere in the value. Survivors then take
-    # the (cheap pre-filtered) ``yaml.safe_load`` round-trip test for
-    # numeric-looking strings — the original #901 case.
-    if value.lower() in _YAML_RESERVED_KEYWORDS or value in ("~", ""):
-        return True
-    if value[0] in _PLAIN_SCALAR_INDICATOR_LEAD or ":" in value or "#" in value:
-        return True
-    return _yaml_reparses_as_non_string(value)
-
-
-# YAML 1.1 plain scalars can only re-parse as a non-string when the
-# first character is a digit, sign, or ``.`` (covers int / float /
-# hex / binary / ``.inf`` / ``.nan`` / dates / timestamps). Every
-# other plain leading character resolves to a string, so the cheap
-# membership test rules out the ``yaml.safe_load`` call for typical
-# values like ``"GPIO4"`` or ``"Bedroom Light"`` — without the
-# pre-filter the parser ran on every emitted string field and
-# regressed ``merge_component_yaml`` by ~600µs per emission
-# (CodSpeed flagged this on #908).
-_YAML_AMBIGUOUS_FIRST = frozenset("0123456789-+.")
-
-
-def _yaml_reparses_as_non_string(value: str) -> bool:
-    """Return True when ``yaml.safe_load(value)`` is not a string."""
-    if not value or value[0] not in _YAML_AMBIGUOUS_FIRST:
-        return False
-    try:
-        parsed = yaml.safe_load(value)
-    except yaml.YAMLError:
-        return False
-    return parsed is not None and not isinstance(parsed, str)
 
 
 def _format_flow_yaml_value(value: Any) -> str:

--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import io
 import re
 from typing import TYPE_CHECKING
+
+import yaml
+from yaml.emitter import Emitter
+from yaml.resolver import Resolver
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -222,88 +227,77 @@ def read_yaml_scalar(yaml_text: str, path: Sequence[str]) -> str | None:
     return captured[0] if captured else None
 
 
-# Plain (unquoted) YAML scalars accept most printable characters,
-# but a small set of leading bytes and embedded sequences make the
-# parser interpret the value as something other than a plain
-# string. ``_PLAIN_SCALAR_INDICATOR_LEAD`` covers the YAML
-# indicator characters that, when leading, change scalar shape;
-# ``_PLAIN_SCALAR_FORBIDDEN_SUBSTR`` covers the embedded sequences
-# that flip a plain scalar into a key/value or comment. ``_RESERVED_PLAIN``
-# is the set of plain scalars YAML interprets as bool / null —
-# emitting one of these unquoted would round-trip as a non-string.
-_PLAIN_SCALAR_INDICATOR_LEAD = set("!&*?|>%@`#-,[]{}\"'")
-_PLAIN_SCALAR_FORBIDDEN_SUBSTR = (": ", " #")
-_RESERVED_PLAIN = frozenset(
-    {
-        "true",
-        "false",
-        "null",
-        "yes",
-        "no",
-        "on",
-        "off",
-        "~",
-        "",
-    }
-)
+# The plain-vs-quoted decision and the escaping are delegated to PyYAML
+# so neither can drift from what the parser accepts. analyze_scalar
+# answers the syntax half (safe unquoted?); the resolver answers the
+# type half (would the plain form reparse as a non-string?). Both are
+# stateless per call, so one shared instance of each is reused.
+_SCALAR_ANALYZER = Emitter(io.StringIO(), allow_unicode=True)
+_SCALAR_RESOLVER = Resolver()
+_STR_TAG = "tag:yaml.org,2002:str"
+# Huge width keeps a quoted scalar on one line under the hand-built
+# ``key: <scalar>`` layout.
+_NO_WRAP = 1 << 30
+# libyaml's C emitter, mirroring FastestSafeLoader: byte-identical, ~2x.
+try:
+    _FASTEST_SAFE_DUMPER: type = yaml.CSafeDumper
+except AttributeError:  # pragma: no cover
+    _FASTEST_SAFE_DUMPER = yaml.SafeDumper
+
+# Fast path: a value built only from these characters, led by a letter
+# and not a reserved word, is always a plain string scalar, so it skips
+# the PyYAML round-trip. Strict subset of "plain-safe" — see the fuzz
+# test in test_yaml_helpers; never causes a value to emit unquoted that
+# PyYAML would have quoted.
+_PLAIN_FAST_LEAD = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+_PLAIN_FAST_CHARS = _PLAIN_FAST_LEAD | frozenset("0123456789_-./ ")
+_RESERVED_PLAIN = frozenset({"true", "false", "null", "yes", "no", "on", "off"})
 
 
 def _safe_yaml_scalar(value: str) -> str:
-    r"""
+    """
     Render *value* as a YAML scalar — plain when safe, double-quoted otherwise.
 
-    Used by rewriters that accept arbitrary user-supplied strings
-    (friendly_name, comments, mqtt topics, etc.) where a value
-    like ``"Bedroom #2"`` would otherwise become a comment or
-    ``"Lamp: Bedroom"`` would split into a key/value pair on round
-    trip. Plain identifiers (``"Kitchen"``, ``"my-device"``) round
-    trip without quotes; values get double-quoted (with embedded
-    ``"`` and ``\\`` escaped) when any of these holds:
-
-    - empty string or matches a reserved plain scalar
-      (``true`` / ``false`` / ``null`` / ``yes`` / ``no`` /
-      ``on`` / ``off`` / ``~``);
-    - starts with a YAML indicator character (``! & * ? | > %
-      @ ` # - , [ ] { } " '``);
-    - ends in ``:`` (would parse as a key with empty value) or in
-      whitespace (would lose the trailing space on round trip);
-    - contains ``: `` (key/value split) or `` #`` (comment marker);
-    - contains a control character (``\\n`` / ``\\r`` / ``\\t``).
+    Used wherever arbitrary user-supplied strings (friendly_name, ssid,
+    component field values, …) are emitted into hand-built YAML. Plain
+    identifiers round trip unquoted; anything PyYAML can't emit plain is
+    double-quoted and escaped by PyYAML.
     """
-    if not value or value.lower() in _RESERVED_PLAIN:
-        return f'"{value}"'
-    if value[0] in _PLAIN_SCALAR_INDICATOR_LEAD:
-        return _quote(value)
-    if value.endswith((":", " ")):
-        return _quote(value)
-    if any(s in value for s in _PLAIN_SCALAR_FORBIDDEN_SUBSTR):
-        return _quote(value)
-    # ``\n``, ``\r``, and ``\t`` would either be silently stripped
-    # (tab) or split into multiple YAML lines. Quote and escape.
-    if any(c in value for c in "\n\r\t"):
-        return _quote(value)
-    return value
-
-
-# YAML double-quoted scalar escapes for the five characters that
-# would otherwise break round-trip: ``\`` and ``"`` need escaping
-# because the closing quote / escape leader; the three control
-# characters need escaping because plain-text rendering would split
-# the value across lines or eat the tab.
-_QUOTE_ESCAPES = str.maketrans(
-    {
-        "\\": r"\\",
-        '"': r"\"",
-        "\n": r"\n",
-        "\r": r"\r",
-        "\t": r"\t",
-    }
-)
+    if _plain_is_fast_safe(value) or _plain_is_safe(value):
+        return value
+    return _quote(value)
 
 
 def _quote(value: str) -> str:
-    """Render *value* as a double-quoted YAML scalar with minimal escapes."""
-    return f'"{value.translate(_QUOTE_ESCAPES)}"'
+    """Render *value* as a single-line double-quoted YAML scalar."""
+    return yaml.dump(
+        value,
+        Dumper=_FASTEST_SAFE_DUMPER,
+        default_style='"',
+        allow_unicode=True,
+        width=_NO_WRAP,
+    ).rstrip("\n")
+
+
+def _plain_is_fast_safe(value: str) -> bool:
+    """Return True for the common identifier class that is trivially plain-safe."""
+    # ``value[:1]`` folds the empty check into the leading-letter test:
+    # an empty slice is not in the set, so empty strings fall through.
+    return (
+        value[:1] in _PLAIN_FAST_LEAD
+        and value[-1] != " "
+        and value.lower() not in _RESERVED_PLAIN
+        and _PLAIN_FAST_CHARS.issuperset(value)
+    )
+
+
+def _plain_is_safe(value: str) -> bool:
+    """Return True when *value* round-trips as a string emitted plain (unquoted)."""
+    if not value:
+        return False
+    if not _SCALAR_ANALYZER.analyze_scalar(value).allow_flow_plain:
+        return False
+    return bool(_SCALAR_RESOLVER.resolve(yaml.ScalarNode, value, (True, False)) == _STR_TAG)
 
 
 def _strip_yaml_quotes(value: str) -> str:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -717,17 +717,27 @@ def test_plain_fast_path_is_strict_subset_and_round_trips() -> None:
     Fuzzes a deterministic corpus over indicators, control chars,
     digits, whitespace and unicode. ``_plain_is_fast_safe`` returning
     True MUST imply ``_plain_is_safe`` (the PyYAML decision) is also
-    True — a violation would emit a value unquoted that the parser
+    True; a violation would emit a value unquoted that the parser
     rejects or rewrites. Every ``_safe_yaml_scalar`` result must also
-    survive a re-parse.
+    survive a re-parse; the round trip is batched into one document per
+    chunk so the fuzz stays fast.
     """
     rng = random.Random(20260604)  # noqa: S311, fuzz corpus, not cryptographic
     alphabet = string.ascii_letters + string.digits + "_-./ :#!%@&*,[]{}\"'~+\t\n\r\x00\x0b\x7fé好"
-    for _ in range(20000):
-        value = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 8)))
-        if _plain_is_fast_safe(value):
-            assert _plain_is_safe(value), f"fast path kept {value!r} plain but PyYAML quotes it"
-        assert yaml.safe_load(f"k: {_safe_yaml_scalar(value)}")["k"] == value
+
+    def _rand() -> str:
+        return "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 8)))
+
+    for _ in range(40):
+        chunk = [_rand() for _ in range(500)]
+        lines = []
+        for i, value in enumerate(chunk):
+            if _plain_is_fast_safe(value):
+                assert _plain_is_safe(value), f"fast path kept {value!r} plain but PyYAML quotes it"
+            lines.append(f"k{i}: {_safe_yaml_scalar(value)}")
+        parsed = yaml.safe_load("\n".join(lines))
+        for i, value in enumerate(chunk):
+            assert parsed[f"k{i}"] == value
 
 
 @pytest.mark.parametrize(

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -25,6 +25,8 @@ What we pin:
 
 from __future__ import annotations
 
+import random
+import string
 from typing import Any
 
 import pytest
@@ -47,6 +49,7 @@ from esphome_device_builder.helpers.yaml import (
     rewrite_yaml_scalar,
     upsert_yaml_leaf_under_top_block,
 )
+from esphome_device_builder.helpers.yaml.scalar import _plain_is_fast_safe, _plain_is_safe
 from esphome_device_builder.models.common import ConfigEntry, ConfigEntryType
 from esphome_device_builder.models.components import (
     ComponentCatalogEntry,
@@ -708,6 +711,25 @@ def test_safe_yaml_scalar(value: str, expected: str) -> None:
     assert _safe_yaml_scalar(value) == expected
 
 
+def test_plain_fast_path_is_strict_subset_and_round_trips() -> None:
+    """The identifier fast path never disagrees with PyYAML, and output round-trips.
+
+    Fuzzes a deterministic corpus over indicators, control chars,
+    digits, whitespace and unicode. ``_plain_is_fast_safe`` returning
+    True MUST imply ``_plain_is_safe`` (the PyYAML decision) is also
+    True — a violation would emit a value unquoted that the parser
+    rejects or rewrites. Every ``_safe_yaml_scalar`` result must also
+    survive a re-parse.
+    """
+    rng = random.Random(20260604)  # noqa: S311, fuzz corpus, not cryptographic
+    alphabet = string.ascii_letters + string.digits + "_-./ :#!%@&*,[]{}\"'~+\t\n\r\x00\x0b\x7fé好"
+    for _ in range(20000):
+        value = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 8)))
+        if _plain_is_fast_safe(value):
+            assert _plain_is_safe(value), f"fast path kept {value!r} plain but PyYAML quotes it"
+        assert yaml.safe_load(f"k: {_safe_yaml_scalar(value)}")["k"] == value
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
@@ -1180,13 +1202,13 @@ def test_generate_component_yaml_quotes_yaml_keyword_strings(keyword: str) -> No
 
 @pytest.mark.parametrize(
     "value",
-    ["foo:bar", "foo#bar", "!secret api_key", "%"],
+    ["foo:bar", "foo #bar", "!secret api_key", "%"],
     ids=["colon", "hash", "tag-prefix", "percent"],
 )
 def test_generate_component_yaml_quotes_strings_with_special_chars(value: str) -> None:
-    """Strings containing ``:`` / ``#`` or equal to a YAML reserved scalar get quoted.
+    """Strings PyYAML can't emit plain — ``:`` / `` #`` / leading ``!`` / ``%`` — get quoted.
 
-    ``:`` opens a mapping value, ``#`` opens a comment, ``!``
+    ``:`` opens a mapping value, `` #`` opens a comment, ``!``
     introduces a tag. ``%`` is the regression case from issue #675 —
     a humidity sensor's ``unit_of_measurement: "%"`` default was
     being emitted unquoted as ``unit_of_measurement: %`` and
@@ -1544,18 +1566,15 @@ def test_generate_component_yaml_quotes_case_variant_keyword_strings(variant: st
     assert f'  v: "{variant}"' in out
 
 
-def test_generate_component_yaml_quotes_unparseable_string_starting_with_digit() -> None:
-    r"""A digit-led string yaml can't parse (``"0\t"``) falls through unquoted.
+def test_generate_component_yaml_quotes_digit_led_control_char_string() -> None:
+    r"""A digit-led control-char value (``"0\t"``) is quoted and round-trips.
 
-    Exercises the ``yaml.YAMLError`` branch in
-    ``_yaml_reparses_as_non_string`` — the pre-filter lets the value
-    through, the parser raises, and the helper returns False so the
-    string emits without quotes.
+    Emitted bare it is invalid YAML; the renderer quotes and escapes
+    it so a re-parse recovers the exact value.
     """
     component = _component(component_id="myc", category=ComponentCategory.MISC)
     out = generate_component_yaml(component, {"v": "0\t"})
-    # The value rendered bare — no extra quotes from the reparse check.
-    assert '  v: "' not in out
+    assert yaml.safe_load(out)["myc"]["v"] == "0\t"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The plain-vs-quoted decision lived in two hand-rolled predicates that kept drifting from what the YAML parser actually accepts; `_safe_yaml_scalar` (the friendly_name / ssid rewrite path) and `_string_needs_quoting` (the component emit path) each carried their own indicator sets, reserved words, and substring checks, and each missed a different class of value. That drift is the root cause of the #1095 / #1186 family of quoting bugs.

This consolidates both onto PyYAML itself. `_plain_is_safe` asks the emitter's `analyze_scalar` whether a value is safe unquoted, then asks the resolver whether the unquoted form would re-parse as a non-string; the fallback `_quote` renders through PyYAML's double-quoted emitter so every control character is escaped correctly. The hand-rolled predicates and escape table are deleted.

It also closes the gaps #1186 left open; leading whitespace, and control characters beyond `\n` / `\r` / `\t`, now round trip instead of emitting invalid YAML or silently losing data.

The double-quote path uses libyaml's `CSafeDumper` when available, mirroring `FastestSafeLoader`, for byte-identical output at roughly half the wall-time; the decision path stays pure Python because libyaml does not expose scalar analysis.

**Related issue or feature (if applicable):**

- closes #1186

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
