### PR TITLE
Share one build_catalog() across board-pin tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,6 @@ from esphome_device_builder.models import (
     EventType,
     QueueStatus,
 )
-from script.sync_boards import build_catalog
 
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
@@ -496,6 +495,11 @@ def generated_board_catalog() -> BoardCatalogResponse:
     ``xdist_group("board_sync")`` so this runs a single time per suite.
     Tests read the result only — do not mutate it.
     """
+    # Imported lazily: ``script.sync_boards`` mutates ``sys.path`` at import
+    # time, so a top-level import would force that side effect on the whole
+    # suite during collection even when no test wants this fixture.
+    from script.sync_boards import build_catalog  # noqa: PLC0415
+
     return build_catalog()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,11 +52,13 @@ from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.peer_link_identity import PeerLinkIdentityStore
 from esphome_device_builder.models import (
     AdoptableDevice,
+    BoardCatalogResponse,
     Device,
     DeviceState,
     EventType,
     QueueStatus,
 )
+from script.sync_boards import build_catalog
 
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
@@ -483,6 +485,18 @@ def session_board_catalog() -> BoardCatalog:
     cat = BoardCatalog()
     cat.load()
     return cat
+
+
+@pytest.fixture(scope="session")
+def generated_board_catalog() -> BoardCatalogResponse:
+    """``script.sync_boards.build_catalog()`` run once per xdist worker.
+
+    Generation imports ESPHome's per-platform board modules and walks ~80
+    manifests; the board-pin test modules pin to one worker via
+    ``xdist_group("board_sync")`` so this runs a single time per suite.
+    Tests read the result only — do not mutate it.
+    """
+    return build_catalog()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_esp32_board_pins.py
+++ b/tests/test_esp32_board_pins.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import importlib
 
-from esphome_device_builder.models import Esp32Variant, PinFeature
-from script.sync_boards import (
-    _ESP32_BOARDS_ATTR,
-    _ESP32_BOARDS_MODULE,
-    build_catalog,
-)
+import pytest
+
+from esphome_device_builder.models import BoardCatalogResponse, Esp32Variant, PinFeature
+from script.sync_boards import _ESP32_BOARDS_ATTR, _ESP32_BOARDS_MODULE
+
+pytestmark = pytest.mark.xdist_group("board_sync")
 
 
 def test_every_esphome_variant_maps_to_enum() -> None:
@@ -21,8 +21,10 @@ def test_every_esphome_variant_maps_to_enum() -> None:
         assert Esp32Variant(variant.lower())
 
 
-def test_catalog_generates_board_with_derived_pins() -> None:
-    boards = {b.id: b for b in build_catalog().boards}
+def test_catalog_generates_board_with_derived_pins(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.id: b for b in generated_board_catalog.boards}
     # adafruit_feather_esp32_v2 has no manifest but is in ESP32_BOARD_PINS;
     # it exposes SDA/SCL/TX/RX so derives I2C + UART features.
     assert "adafruit_feather_esp32_v2" in boards
@@ -33,8 +35,10 @@ def test_catalog_generates_board_with_derived_pins() -> None:
     assert {PinFeature.I2C_SDA, PinFeature.I2C_SCL, PinFeature.UART_TX} <= feats
 
 
-def test_catalog_falls_back_to_generic_variant_pins() -> None:
-    boards = {b.id: b for b in build_catalog().boards}
+def test_catalog_falls_back_to_generic_variant_pins(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.id: b for b in generated_board_catalog.boards}
     # adafruit_camera_esp32s3 has no manifest and no ESP32_BOARD_PINS entry,
     # so it inherits the generic-esp32s3 pinout.
     assert "adafruit_camera_esp32s3" in boards
@@ -45,6 +49,8 @@ def test_catalog_falls_back_to_generic_variant_pins() -> None:
     assert [p.to_dict() for p in board.pins] == [p.to_dict() for p in generic.pins]
 
 
-def test_generated_boards_dedup_on_id() -> None:
-    ids = [b.id for b in build_catalog().boards]
+def test_generated_boards_dedup_on_id(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    ids = [b.id for b in generated_board_catalog.boards]
     assert len(ids) == len(set(ids)), "every catalog board id must be unique"

--- a/tests/test_esp8266_board_pins.py
+++ b/tests/test_esp8266_board_pins.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from esphome_device_builder.models import PinFeature
-from script.sync_boards import _derive_pins_from_aliases, build_catalog
+import pytest
+
+from esphome_device_builder.models import BoardCatalogResponse, PinFeature
+from script.sync_boards import _derive_pins_from_aliases
+
+pytestmark = pytest.mark.xdist_group("board_sync")
 
 
 def test_derive_tags_esp8266_base_pins() -> None:
@@ -25,8 +29,10 @@ def test_derive_tags_esp8266_base_pins() -> None:
     assert pins[1].notes == "UART TX"
 
 
-def test_catalog_generates_unmanifested_esp8266_board() -> None:
-    boards = {b.id: b for b in build_catalog().boards}
+def test_catalog_generates_unmanifested_esp8266_board(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.id: b for b in generated_board_catalog.boards}
     # huzzah has no device-builder manifest but is in ESPHome's esp8266 BOARDS.
     assert "huzzah" in boards, "huzzah should be auto-generated from ESPHome board data"
     huzzah = boards["huzzah"]
@@ -35,24 +41,30 @@ def test_catalog_generates_unmanifested_esp8266_board() -> None:
     assert PinFeature.UART_TX in feats and PinFeature.I2C_SDA in feats
 
 
-def test_catalog_does_not_duplicate_manifested_esp8266_board() -> None:
+def test_catalog_does_not_duplicate_manifested_esp8266_board(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
     # The curated d1_mini manifest uses the ESPHome board name as its id, so
     # id-dedup suppresses generating a second d1_mini entry.
-    ids = [b.id for b in build_catalog().boards if b.esphome.board == "d1_mini"]
+    ids = [b.id for b in generated_board_catalog.boards if b.esphome.board == "d1_mini"]
     assert ids.count("d1_mini") == 1
 
 
-def test_catalog_generates_canonical_board_only_referenced_by_products() -> None:
+def test_catalog_generates_canonical_board_only_referenced_by_products(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
     # esp01_1m has no canonical manifest, only product manifests run on it
     # (board: esp01_1m). It must still get a canonical entry so find_by_pio_board
     # has a non-arbitrary target (issue #395).
-    boards = {b.id: b for b in build_catalog().boards}
+    boards = {b.id: b for b in generated_board_catalog.boards}
     assert "esp01_1m" in boards
     assert boards["esp01_1m"].esphome.board == "esp01_1m"
 
 
-def test_catalog_fills_empty_esp8266_product_manifest() -> None:
-    boards = {b.id: b for b in build_catalog().boards}
+def test_catalog_fills_empty_esp8266_product_manifest(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.id: b for b in generated_board_catalog.boards}
     # mirabella_door_window_sensor (board: esp01_1m) ships ``pins: []``; the base
     # pinout is filled in so the visual editor offers real pins.
     pins = boards["mirabella_door_window_sensor"].pins

--- a/tests/test_libretiny_board_pins.py
+++ b/tests/test_libretiny_board_pins.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from esphome_device_builder.models import PinFeature
-from script.sync_boards import (
-    _alias_capability,
-    _derive_pins_from_aliases,
-    build_catalog,
-)
+import pytest
+
+from esphome_device_builder.models import BoardCatalogResponse, PinFeature
+from script.sync_boards import _alias_capability, _derive_pins_from_aliases
+
+pytestmark = pytest.mark.xdist_group("board_sync")
 
 
 def test_alias_capability_maps_fixed_functions() -> None:
@@ -42,8 +42,10 @@ def test_derive_unions_features_and_skips_flexible_mux() -> None:
     assert by_gpio[3].features == [PinFeature.ADC]
 
 
-def test_catalog_generates_unmanifested_libretiny_board() -> None:
-    boards = {b.esphome.board: b for b in build_catalog().boards}
+def test_catalog_generates_unmanifested_libretiny_board(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.esphome.board: b for b in generated_board_catalog.boards}
     # bw15 has no device-builder manifest but is in RTL87XX_BOARD_PINS.
     assert "bw15" in boards, "bw15 should be auto-generated from ESPHome board data"
     bw15 = boards["bw15"]

--- a/tests/test_nrf52_board_pins.py
+++ b/tests/test_nrf52_board_pins.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import logging
 
-from esphome_device_builder.models import PinFeature
+import pytest
+
+from esphome_device_builder.models import BoardCatalogResponse, PinFeature
 from script.sync_boards import _derive_nrf52_pins, build_catalog
+
+pytestmark = pytest.mark.xdist_group("board_sync")
 
 
 def test_derive_nrf52_pins_tags_adc_and_labels_port_pin() -> None:
@@ -23,8 +27,10 @@ def test_derive_nrf52_pins_tags_adc_and_labels_port_pin() -> None:
     assert by_gpio[48].label == "P1.16"
 
 
-def test_catalog_generates_nrf52_boards() -> None:
-    boards = {b.esphome.board: b for b in build_catalog().boards}
+def test_catalog_generates_nrf52_boards(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.esphome.board: b for b in generated_board_catalog.boards}
     assert "xiao_ble" in boards, "xiao_ble should be auto-generated from ESPHome board data"
     xiao = boards["xiao_ble"]
     assert xiao.esphome.platform.value == "nrf52"
@@ -34,12 +40,14 @@ def test_catalog_generates_nrf52_boards() -> None:
     assert adc_pins, "ADC-capable pins should be tagged"
 
 
-def test_nrf52_does_not_steal_rp2040_itsybitsy() -> None:
+def test_nrf52_does_not_steal_rp2040_itsybitsy(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
     # `adafruit_itsybitsy` is a board id on both rp2040 and nRF52 (the nRF52 one
     # is the legacy alias of adafruit_itsybitsy_nrf52840). An id-keyed catalog
     # can't serve both, so the clash leaves rp2040's entry in place rather than
     # shadowing it onto nRF52 pins.
-    by_id = {b.id: b for b in build_catalog().boards}
+    by_id = {b.id: b for b in generated_board_catalog.boards}
     assert by_id["adafruit_itsybitsy"].esphome.platform.value == "rp2040"
     assert by_id["adafruit_itsybitsy_nrf52840"].esphome.platform.value == "nrf52"
 

--- a/tests/test_rp2040_board_pins.py
+++ b/tests/test_rp2040_board_pins.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from esphome_device_builder.models import PinFeature
-from script.sync_boards import _derive_rp2040_pins, build_catalog
+import pytest
+
+from esphome_device_builder.models import BoardCatalogResponse, PinFeature
+from script.sync_boards import _derive_rp2040_pins
+
+pytestmark = pytest.mark.xdist_group("board_sync")
 
 
 def test_derive_enumerates_full_gpio_matrix_with_pwm() -> None:
@@ -39,8 +43,10 @@ def test_led_becomes_occupied_and_virtual_pin_dropped() -> None:
     assert all(p.gpio <= 29 for p in pins)
 
 
-def test_catalog_generates_unmanifested_rp2040_board() -> None:
-    boards = {b.id: b for b in build_catalog().boards}
+def test_catalog_generates_unmanifested_rp2040_board(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.id: b for b in generated_board_catalog.boards}
     # 0xcb_helios is in ESPHome's BOARDS but has no device-builder manifest.
     assert "0xcb_helios" in boards
     board = boards["0xcb_helios"]
@@ -48,7 +54,9 @@ def test_catalog_generates_unmanifested_rp2040_board() -> None:
     assert [p.gpio for p in board.pins] == list(range(30))
 
 
-def test_dedup_keeps_hand_curated_manifest() -> None:
-    boards = {b.id: b for b in build_catalog().boards}
+def test_dedup_keeps_hand_curated_manifest(
+    generated_board_catalog: BoardCatalogResponse,
+) -> None:
+    boards = {b.id: b for b in generated_board_catalog.boards}
     # rpipico stays the hand-curated entry — its built-in LED note survives.
     assert any(p.occupied_by == "Built-in LED" for p in boards["rpipico"].pins)


### PR DESCRIPTION
# What does this implement/fix?

The board-pin test modules each rebuilt the generated catalog on every test, so build_catalog() ran a dozen times per suite; under xdist contention each call stretched to roughly 4s. This shares one build_catalog() through a session-scoped generated_board_catalog fixture and pins the modules to a single worker with xdist_group, so the generation runs once. The nRF52 id-clash log test still calls build_catalog() directly since it asserts on the warning emitted during that call.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
