### PR TITLE
Bound the unreachable-receiver peer-link tests to sub-second

### DIFF
--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -64,6 +64,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
     _DownloadArtifactsState,
     _extract_receiver_esphome_version,
     drive_initiator_round_trip,
+    one_shot,
     preview_pair,
     request_pair,
 )
@@ -117,6 +118,25 @@ def bound_unused_tcp_port() -> Iterator[int]:
     """Yield a 127.0.0.1 port held bound (no ``listen``) for the test — no TOCTOU race."""
     with closing(get_unused_port_socket("127.0.0.1")) as sock:
         yield sock.getsockname()[1]
+
+
+@pytest.fixture
+def fast_unreachable_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bound the one-shot connect so an unreachable receiver fails sub-second.
+
+    A bound-but-unlistened port refuses instantly on Linux (RST) but
+    BSD/macOS silently drops the SYN, so the connect otherwise hangs to
+    the 10s client budget. The timeout and the refusal both surface as
+    the same ``PeerLinkClientError("...failed...")`` / ``UNAVAILABLE``,
+    so shortening the driver budget keeps the assertions intact.
+    """
+    real = one_shot.drive_initiator_round_trip
+
+    async def _fast(**kwargs: Any) -> Any:
+        kwargs.setdefault("timeout_seconds", 0.5)
+        return await real(**kwargs)
+
+    monkeypatch.setattr(one_shot, "drive_initiator_round_trip", _fast)
 
 
 def _make_controller(*, config_dir: Path) -> RemoteBuildController:
@@ -214,6 +234,7 @@ async def test_preview_pair_does_not_persist_state_on_receiver(
 async def test_preview_pair_connection_refused_raises_client_error(
     tmp_path: Path,
     bound_unused_tcp_port: int,
+    fast_unreachable_connect: None,
 ) -> None:
     """Connecting to a closed port raises :class:`PeerLinkClientError`."""
     initiator_priv = secrets.token_bytes(32)
@@ -766,6 +787,7 @@ async def test_controller_preview_pair_returns_receiver_pin(
 async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
     bound_unused_tcp_port: int,
+    fast_unreachable_connect: None,
 ) -> None:
     """Receiver unreachable → CommandError(UNAVAILABLE)."""
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -863,6 +885,7 @@ async def test_controller_request_pair_closed_window_raises_no_pairing_window(
 async def test_controller_request_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
     bound_unused_tcp_port: int,
+    fast_unreachable_connect: None,
 ) -> None:
     """Receiver unreachable → CommandError(UNAVAILABLE)."""
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -231,10 +231,10 @@ async def test_preview_pair_does_not_persist_state_on_receiver(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("fast_unreachable_connect")
 async def test_preview_pair_connection_refused_raises_client_error(
     tmp_path: Path,
     bound_unused_tcp_port: int,
-    fast_unreachable_connect: None,
 ) -> None:
     """Connecting to a closed port raises :class:`PeerLinkClientError`."""
     initiator_priv = secrets.token_bytes(32)
@@ -784,10 +784,10 @@ async def test_controller_preview_pair_returns_receiver_pin(
     assert await _saved_pairings(offloader) == []
 
 
+@pytest.mark.usefixtures("fast_unreachable_connect")
 async def test_controller_preview_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
     bound_unused_tcp_port: int,
-    fast_unreachable_connect: None,
 ) -> None:
     """Receiver unreachable → CommandError(UNAVAILABLE)."""
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
@@ -882,10 +882,10 @@ async def test_controller_request_pair_closed_window_raises_no_pairing_window(
     assert exc.value.code == ErrorCode.NO_PAIRING_WINDOW
 
 
+@pytest.mark.usefixtures("fast_unreachable_connect")
 async def test_controller_request_pair_unavailable_on_unreachable_receiver(
     offloader_controller_dir: Path,
     bound_unused_tcp_port: int,
-    fast_unreachable_connect: None,
 ) -> None:
     """Receiver unreachable → CommandError(UNAVAILABLE)."""
     offloader = _make_offloader_controller(config_dir=offloader_controller_dir)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -122,14 +122,10 @@ def bound_unused_tcp_port() -> Iterator[int]:
 
 @pytest.fixture
 def fast_unreachable_connect(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bound the one-shot connect so an unreachable receiver fails sub-second.
-
-    A bound-but-unlistened port refuses instantly on Linux (RST) but
-    BSD/macOS silently drops the SYN, so the connect otherwise hangs to
-    the 10s client budget. The timeout and the refusal both surface as
-    the same ``PeerLinkClientError("...failed...")`` / ``UNAVAILABLE``,
-    so shortening the driver budget keeps the assertions intact.
-    """
+    """Shorten the one-shot connect budget so unreachable-receiver tests fail fast."""
+    # A bound-but-unlistened port RSTs instantly on Linux but BSD/macOS drops
+    # the SYN, so the connect hangs to the 10s budget; a timeout and a refusal
+    # both surface as PeerLinkClientError("...failed") / UNAVAILABLE.
     real = one_shot.drive_initiator_round_trip
 
     async def _fast(**kwargs: Any) -> Any:


### PR DESCRIPTION
# What does this implement/fix?

Three peer-link tests point at a 127.0.0.1 port held bound but not listening; the held socket is what keeps the port reserved with no TOCTOU race. Linux answers a connect to such a port with an instant RST, but BSD and macOS silently drop the SYN, so the connect hangs to the 10s one-shot client budget; that is ~10s per test on the macOS runner. This keeps the bound-socket reservation and injects a 0.5s driver timeout for just these tests via a fast_unreachable_connect fixture. A connect timeout and a refusal both surface as PeerLinkClientError("...failed") or CommandError(UNAVAILABLE), so the assertions are unchanged; the tests drop from ~10s to ~0.5s on macOS and stay instant on Linux.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
