### PR TITLE
Document running the dashboard from the standard ESPHome container

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,21 @@ every few minutes.
 
 </details>
 
+### Standard ESPHome container image
+
+The standard `ghcr.io/esphome/esphome` container doesn't carry the
+preview toggle yet (only the Home Assistant add-on image does). To run
+the new dashboard from it, override the entrypoint to install the wheel
+and launch it against your config dir:
+
+```bash
+uv pip install esphome-device-builder && exec esphome-device-builder /config
+```
+
+The wheel ships the prebuilt frontend, so there's nothing to build by
+hand. Point it at wherever your YAMLs are mounted (`/config` matches the
+standard image's layout).
+
 ## Username / password authentication
 
 The three install paths each handle network reach and the auth gate


### PR DESCRIPTION
# What does this implement/fix?

Documents how to run the new Device Builder from the standard `ghcr.io/esphome/esphome` container by overriding the entrypoint, since that image doesn't carry the preview toggle yet. This question keeps coming up; having it in the README should cut down the repeats, and it notes the wheel already ships the prebuilt frontend so there's nothing to build by hand.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
