### PR TITLE
Exit cleanly on SIGTERM received during startup

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import signal
 import sys
 import threading
 from contextlib import suppress
@@ -99,8 +100,22 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     activate_log_queue_handler()
 
 
+def _exit_on_startup_sigterm(_signum: int, _frame: object) -> None:
+    """Exit cleanly (0) on a SIGTERM received before the run loop is up."""
+    raise SystemExit(0)
+
+
 def main() -> None:
     """Run the ESPHome Device Builder."""
+    # Trap SIGTERM for the whole startup phase. aiohttp installs the
+    # run-loop's handler only once the server is up; a SIGTERM landing in
+    # the seconds before that (slow esphome import, catalog load, mDNS
+    # bring-up) would otherwise hit the OS default disposition and exit
+    # 143, which a supervisor reports as "did not handle SIGTERM".
+    # ``web.run_app`` replaces this with its own graceful handler once
+    # serving begins.
+    signal.signal(signal.SIGTERM, _exit_on_startup_sigterm)
+
     parser = argparse.ArgumentParser(
         description="ESPHome Device Builder",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -1,0 +1,92 @@
+"""SIGTERM during the startup window exits 0, not 143.
+
+``main`` traps SIGTERM before serving begins, where aiohttp's handler
+isn't up yet, so a stop mid cold-start exits cleanly.
+"""
+
+from __future__ import annotations
+
+import signal
+import socket
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from esphome_device_builder import __main__ as main_module
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+posix_only = pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGTERM disposition")
+
+
+def test_exit_on_startup_sigterm_raises_zero() -> None:
+    """The handler raises ``SystemExit(0)`` so the interpreter exits cleanly."""
+    with pytest.raises(SystemExit) as excinfo:
+        main_module._exit_on_startup_sigterm(signal.SIGTERM, None)
+    assert excinfo.value.code == 0
+
+
+def test_main_installs_sigterm_handler_before_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SIGTERM trap is installed before argparse runs."""
+    original = signal.getsignal(signal.SIGTERM)
+    try:
+        monkeypatch.setattr(sys, "argv", ["esphome-device-builder", "--version"])
+        with pytest.raises(SystemExit):
+            main_module.main()
+        assert signal.getsignal(signal.SIGTERM) is main_module._exit_on_startup_sigterm
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+@posix_only
+@pytest.mark.timeout(60)
+def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
+    """A real SIGTERM landing mid-startup (pre-serving) exits 0, not 143."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    proc = subprocess.Popen(  # noqa: S603 — args are fully test-controlled
+        [
+            sys.executable,
+            "-m",
+            "esphome_device_builder",
+            str(tmp_path),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert proc.stdout is not None
+    try:
+        # Signal on the first log line rather than after a fixed sleep:
+        # logging is configured *below* the SIGTERM trap in ``main``, so any
+        # output proves the trap is armed, and the server binds ~1s later, so
+        # the signal deterministically lands in the startup window on slow and
+        # fast runners alike.
+        deadline = time.monotonic() + 15
+        while not proc.stdout.readline().strip():
+            assert proc.poll() is None, "process exited during startup"
+            assert time.monotonic() < deadline, "no startup output before deadline"
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            pytest.fail("dashboard did not exit within 30s of SIGTERM")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+    # A negative code is death by signal: -SIGTERM (== shell 143) is the
+    # regression this test guards.
+    assert proc.returncode == 0, f"expected clean exit 0, got {proc.returncode}"


### PR DESCRIPTION
# What does this implement/fix?

A SIGTERM that arrives while the dashboard is still starting up was hitting the OS default disposition and exiting 143; the HA Supervisor reports that as "App ESPHome Device Builder did not handle SIGTERM and was terminated by the default signal handler (exit code 143)". aiohttp only installs its SIGTERM handler once the server is actually serving, so a stop landing during the multi-second cold start (esphome import, catalog load, mDNS bring-up, the firmware CLI sanity subprocess) was unguarded. This traps SIGTERM at the very top of `main`, before any of that work, so a startup-window stop exits 0 cleanly; once serving begins, `web.run_app` swaps in its own graceful handler as before.

A steady-state SIGTERM already exited 0 on both old and new code, so this is purely the startup window. Verified empirically on macOS: a SIGTERM sent 0.1 to 0.3s after launch goes from 143 before the change to 0 after.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
