### PR TITLE
Drain cleanly on Windows CTRL_BREAK (SIGBREAK)

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -100,21 +100,25 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     activate_log_queue_handler()
 
 
-def _exit_on_startup_sigterm(_signum: int, _frame: object) -> None:
-    """Exit cleanly (0) on a SIGTERM received before the run loop is up."""
+def _exit_cleanly_on_signal(_signum: int, _frame: object) -> None:
+    """Exit 0 on a stop signal the event loop isn't trapping itself."""
     raise SystemExit(0)
 
 
 def main() -> None:
     """Run the ESPHome Device Builder."""
-    # Trap SIGTERM for the whole startup phase. aiohttp installs the
-    # run-loop's handler only once the server is up; a SIGTERM landing in
-    # the seconds before that (slow esphome import, catalog load, mDNS
-    # bring-up) would otherwise hit the OS default disposition and exit
-    # 143, which a supervisor reports as "did not handle SIGTERM".
-    # ``web.run_app`` replaces this with its own graceful handler once
-    # serving begins.
-    signal.signal(signal.SIGTERM, _exit_on_startup_sigterm)
+    # Trap the platform's stop signal so a quit exits cleanly instead of
+    # the OS default disposition. POSIX: a startup-window SIGTERM exits
+    # 143 ("did not handle SIGTERM") before aiohttp arms its run-loop
+    # handler; once serving, ``web.run_app`` replaces this with its own.
+    # Windows: aiohttp installs no handler at all, and the desktop quits
+    # the backend with CTRL_BREAK_EVENT (→ SIGBREAK; SIGTERM is
+    # uncatchable there), so without this the break default-terminates
+    # abruptly instead of draining. The Proactor loop's wakeup fd makes
+    # the break land promptly while serving.
+    signal.signal(signal.SIGTERM, _exit_cleanly_on_signal)
+    if sys.platform == "win32":
+        signal.signal(signal.SIGBREAK, _exit_cleanly_on_signal)
 
     parser = argparse.ArgumentParser(
         description="ESPHome Device Builder",

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -416,6 +416,7 @@ class DeviceBuilder:
 
     async def stop(self) -> None:  # noqa: C901
         """Shut down the application."""
+        _LOGGER.info("Shutting down ESPHome Device Builder")
         if self._bg_task:
             self._bg_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -1,11 +1,14 @@
-"""SIGTERM during the startup window exits 0, not 143.
+"""A stop signal exits the dashboard cleanly, not via the OS default.
 
-``main`` traps SIGTERM before serving begins, where aiohttp's handler
-isn't up yet, so a stop mid cold-start exits cleanly.
+``main`` traps SIGTERM (the POSIX startup window, before aiohttp arms its
+run-loop handler) and, on Windows, SIGBREAK (the desktop quits the backend
+with CTRL_BREAK_EVENT; aiohttp installs no handler there at all). A signal
+that lands while serving drains ``on_cleanup`` (``stop()``) before exiting.
 """
 
 from __future__ import annotations
 
+import os
 import signal
 import socket
 import subprocess
@@ -21,43 +24,53 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 posix_only = pytest.mark.skipif(sys.platform == "win32", reason="POSIX SIGTERM disposition")
+windows_only = pytest.mark.skipif(sys.platform != "win32", reason="Windows CTRL_BREAK path")
+
+# Logged at the top of ``DeviceBuilder.stop()``; present in a process's
+# output only if the graceful ``on_cleanup`` drain ran, so its absence
+# distinguishes a clean shutdown from an abrupt OS default-terminate.
+_DRAIN_MARKER = "Shutting down ESPHome Device Builder"
 
 
-def test_exit_on_startup_sigterm_raises_zero() -> None:
+def test_exit_cleanly_on_signal_raises_zero() -> None:
     """The handler raises ``SystemExit(0)`` so the interpreter exits cleanly."""
     with pytest.raises(SystemExit) as excinfo:
-        main_module._exit_on_startup_sigterm(signal.SIGTERM, None)
+        main_module._exit_cleanly_on_signal(signal.SIGTERM, None)
     assert excinfo.value.code == 0
 
 
-def test_main_installs_sigterm_handler_before_parsing(
+def test_main_installs_stop_signal_handlers_before_parsing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The SIGTERM trap is installed before argparse runs."""
-    original = signal.getsignal(signal.SIGTERM)
+    """The stop-signal traps are installed before argparse runs."""
+    original_term = signal.getsignal(signal.SIGTERM)
+    original_break = signal.getsignal(signal.SIGBREAK) if sys.platform == "win32" else None
     try:
         monkeypatch.setattr(sys, "argv", ["esphome-device-builder", "--version"])
         with pytest.raises(SystemExit):
             main_module.main()
-        assert signal.getsignal(signal.SIGTERM) is main_module._exit_on_startup_sigterm
+        assert signal.getsignal(signal.SIGTERM) is main_module._exit_cleanly_on_signal
+        if sys.platform == "win32":
+            assert signal.getsignal(signal.SIGBREAK) is main_module._exit_cleanly_on_signal
     finally:
-        signal.signal(signal.SIGTERM, original)
+        signal.signal(signal.SIGTERM, original_term)
+        if original_break is not None:
+            signal.signal(signal.SIGBREAK, original_break)
 
 
-@posix_only
-@pytest.mark.timeout(60)
-def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
-    """A real SIGTERM landing mid-startup (pre-serving) exits 0, not 143."""
+def _spawn_dashboard(
+    config_dir: Path, *, creationflags: int = 0
+) -> tuple[subprocess.Popen[str], int]:
+    """Launch the dashboard on an ephemeral port; return ``(proc, port)``."""
     with socket.socket() as probe:
         probe.bind(("127.0.0.1", 0))
         port = probe.getsockname()[1]
-
     proc = subprocess.Popen(  # noqa: S603 — args are fully test-controlled
         [
             sys.executable,
             "-m",
             "esphome_device_builder",
-            str(tmp_path),
+            str(config_dir),
             "--host",
             "127.0.0.1",
             "--port",
@@ -66,18 +79,45 @@ def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        creationflags=creationflags,
     )
+    return proc, port
+
+
+def _wait_for_startup_window(proc: subprocess.Popen[str]) -> None:
+    """Block until the first log line, marking the pre-serving startup window.
+
+    Logging is configured *below* the stop-signal trap in ``main``, so any
+    output proves the trap is armed; the server binds ~1s later, so a signal
+    sent now deterministically lands pre-serving on slow and fast runners.
+    """
     assert proc.stdout is not None
+    deadline = time.monotonic() + 15
+    while not proc.stdout.readline().strip():
+        assert proc.poll() is None, "process exited during startup"
+        assert time.monotonic() < deadline, "no startup output before deadline"
+
+
+def _wait_until_serving(proc: subprocess.Popen[str], port: int) -> None:
+    """Block until the dashboard accepts a TCP connection on *port*."""
+    deadline = time.monotonic() + 20
+    while True:
+        assert proc.poll() is None, "process exited before it began serving"
+        with socket.socket() as probe:
+            probe.settimeout(0.2)
+            if probe.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        assert time.monotonic() < deadline, "server did not start before deadline"
+        time.sleep(0.1)
+
+
+@posix_only
+@pytest.mark.timeout(60)
+def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
+    """A real SIGTERM landing mid-startup (pre-serving) exits 0, not 143."""
+    proc, _ = _spawn_dashboard(tmp_path)
     try:
-        # Signal on the first log line rather than after a fixed sleep:
-        # logging is configured *below* the SIGTERM trap in ``main``, so any
-        # output proves the trap is armed, and the server binds ~1s later, so
-        # the signal deterministically lands in the startup window on slow and
-        # fast runners alike.
-        deadline = time.monotonic() + 15
-        while not proc.stdout.readline().strip():
-            assert proc.poll() is None, "process exited during startup"
-            assert time.monotonic() < deadline, "no startup output before deadline"
+        _wait_for_startup_window(proc)
         proc.send_signal(signal.SIGTERM)
         try:
             proc.communicate(timeout=30)
@@ -90,3 +130,45 @@ def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
     # A negative code is death by signal: -SIGTERM (== shell 143) is the
     # regression this test guards.
     assert proc.returncode == 0, f"expected clean exit 0, got {proc.returncode}"
+
+
+@posix_only
+@pytest.mark.timeout(60)
+def test_sigterm_while_serving_drains_cleanly(tmp_path: Path) -> None:
+    """A SIGTERM while serving runs the on_cleanup drain and exits 0."""
+    proc, port = _spawn_dashboard(tmp_path)
+    out = ""
+    try:
+        _wait_until_serving(proc, port)
+        proc.send_signal(signal.SIGTERM)
+        try:
+            out, _ = proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            pytest.fail("dashboard did not exit within 30s of SIGTERM")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+    assert proc.returncode == 0, f"expected clean exit 0, got {proc.returncode}"
+    assert _DRAIN_MARKER in out, "graceful drain (stop()) did not run"
+
+
+@windows_only
+@pytest.mark.timeout(60)
+def test_ctrl_break_while_serving_drains_cleanly(tmp_path: Path) -> None:
+    """CTRL_BREAK_EVENT while serving runs the on_cleanup drain and exits 0."""
+    proc, port = _spawn_dashboard(tmp_path, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+    out = ""
+    try:
+        _wait_until_serving(proc, port)
+        os.kill(proc.pid, signal.CTRL_BREAK_EVENT)
+        try:
+            out, _ = proc.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            pytest.fail("dashboard did not exit within 30s of CTRL_BREAK")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+    assert proc.returncode == 0, f"expected clean exit 0, got {proc.returncode}"
+    assert _DRAIN_MARKER in out, "graceful drain (stop()) did not run"


### PR DESCRIPTION
# What does this implement/fix?

The Windows counterpart to the recent macOS/startup SIGTERM fix. On Windows aiohttp installs no run-loop signal handler at all (`add_signal_handler` raises `NotImplementedError` on the Proactor loop), and SIGTERM there is uncatchable, so the desktop quits the backend with `CTRL_BREAK_EVENT`. Without a handler that break hits the OS default console handler and abruptly terminates the dashboard; controllers, mDNS, and the firmware queue never drain. This adds a `SIGBREAK` trap (the same `_exit_cleanly_on_signal` the startup SIGTERM uses) so the break runs `on_cleanup` and exits 0. It lands promptly while serving because the Proactor loop wires its self-pipe to the signal wakeup fd, so the break wakes the loop, the handler raises `SystemExit(0)`, and `run_app`'s `finally` still drives `runner.cleanup()`.

Pairs with esphome/esphome-desktop#125, which starts the child in its own process group and sends `CTRL_BREAK_EVENT` on quit.

Proving the clean drain, not just exit 0: `stop()` now logs a one-line shutdown marker that only appears when the graceful `on_cleanup` path runs; an abrupt default-terminate never reaches it. The Windows test sends a real `CTRL_BREAK_EVENT` to a serving instance and asserts both exit 0 and that marker. The identical drain assertion runs locally on POSIX via a steady-state SIGTERM, so the only Windows-specific unknown the CI test pins is whether the break reaches the handler.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
