### PR TITLE
Log when a stop signal triggers shutdown

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -100,8 +100,11 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     activate_log_queue_handler()
 
 
-def _exit_cleanly_on_signal(_signum: int, _frame: object) -> None:
+def _exit_cleanly_on_signal(signum: int, _frame: object) -> None:
     """Exit 0 on a stop signal the event loop isn't trapping itself."""
+    logging.getLogger(_LOGGER_NAME).info(
+        "Received stop signal %s; shutting down cleanly", signum
+    )
     raise SystemExit(0)
 
 

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -102,9 +102,7 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
 
 def _exit_cleanly_on_signal(signum: int, _frame: object) -> None:
     """Exit 0 on a stop signal the event loop isn't trapping itself."""
-    logging.getLogger(_LOGGER_NAME).info(
-        "Received stop signal %s; shutting down cleanly", signum
-    )
+    logging.getLogger(_LOGGER_NAME).info("Received stop signal %s; shutting down cleanly", signum)
     raise SystemExit(0)
 
 


### PR DESCRIPTION
# What does this implement/fix?

The signal handler (`_exit_cleanly_on_signal`) raised `SystemExit(0)` without
logging, so a clean shutdown left no trace in the log. On Windows the desktop
stops the backend with `CTRL_BREAK_EVENT` (SIGBREAK), and there was no way to
tell from `dashboard.log` whether the backend drained cleanly or was killed.

This logs the signal at INFO before exiting, so the clean path is visible:

```
INFO [esphome_device_builder] Received stop signal 21; shutting down cleanly
INFO [esphome_device_builder.device_builder] Shutting down ESPHome Device Builder
```

On a clean `SystemExit(0)` the line flushes during normal teardown: atexit runs
`logging.shutdown()`, which closes the `LoggingQueueHandler` and stops its
listener, draining queued records before the console and file handlers close. A
killed process skips all of that, which is exactly the case we want to be able
to spot in the log.

Tested on Windows by sending `CTRL_BREAK_EVENT` to the running backend several
times; every run exited 0, freed the port, and wrote the new line to
`dashboard.log` right before the existing shutdown message.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally. (manually verified on Windows via `CTRL_BREAK_EVENT`)
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable. (signal-handler log line; verified manually rather than in the suite)
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`. (no architecture change)
