### PR TITLE
Ignore local config/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv/
 Thumbs.db
 
 # Configs (user data, not shipped)
+config/
 configs/
 secrets.yaml
 


### PR DESCRIPTION
# What does this implement/fix?

Adds `config/` to `.gitignore` so a local `config/` working directory (alongside the already-ignored `configs/`) isn't accidentally committed.

All ESPHome documentation refers to `config` as the directory so it makes sense to add this here too

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.