### PR TITLE
Don't adopt the Device Builder source repo for version history

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -32,6 +32,12 @@ from pathlib import Path
 
 _LOGGER = logging.getLogger(__name__)
 
+# The installed Device Builder package dir. Only ever sits inside a source
+# checkout's git work tree, never under a user's /config — so it identifies the
+# one repo we must never adopt as a history store: a config dir kept inside the
+# clone (``--dev configs``) would otherwise commit user YAML into the project.
+_OWN_SOURCE_ROOT = Path(__file__).resolve().parents[2]
+
 # Errors a commit attempt raises for genuine git / environment reasons
 # (a failed ``git`` invocation, the binary vanishing) as opposed to a
 # programming bug. Callers swallow these as best-effort and let anything
@@ -127,12 +133,19 @@ class GitRepo:
             return
         try:
             toplevel = self._discover_toplevel()
-            if toplevel is not None:
+            if toplevel is not None and not _encloses_own_source(toplevel):
                 self.toplevel = toplevel
                 self.enabled = True
                 self._ensure_local_excludes()
                 _LOGGER.debug("Adopted existing git work tree at %s", toplevel)
                 return
+            if toplevel is not None:
+                _LOGGER.info(
+                    "Config dir %s is inside the Device Builder source checkout (%s); "
+                    "creating a config-local history repo instead of committing into it",
+                    self.config_dir,
+                    toplevel,
+                )
             self._init_repo()
         except OSError as exc:
             _LOGGER.warning("Could not set up version-history git repo: %s", exc)
@@ -410,3 +423,12 @@ class GitRepo:
             check=check,
             close_fds=False,
         )
+
+
+def _encloses_own_source(toplevel: Path) -> bool:
+    """Whether *toplevel* is the Device Builder's own source checkout."""
+    try:
+        _OWN_SOURCE_ROOT.relative_to(toplevel.resolve())
+    except ValueError:
+        return False
+    return True

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -30,13 +30,16 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import esphome_device_builder
+
 _LOGGER = logging.getLogger(__name__)
 
 # The installed Device Builder package dir. Only ever sits inside a source
 # checkout's git work tree, never under a user's /config — so it identifies the
 # one repo we must never adopt as a history store: a config dir kept inside the
 # clone (``--dev configs``) would otherwise commit user YAML into the project.
-_OWN_SOURCE_ROOT = Path(__file__).resolve().parents[2]
+# Resolved from the package itself so it survives this module being moved.
+_OWN_SOURCE_ROOT = Path(esphome_device_builder.__file__).resolve().parent
 
 # Errors a commit attempt raises for genuine git / environment reasons
 # (a failed ``git`` invocation, the binary vanishing) as opposed to a

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -89,6 +89,27 @@ def test_adopts_repo_when_config_dir_is_subdir(tmp_path: Path) -> None:
     assert repo.toplevel == tmp_path
 
 
+def test_adopts_enclosing_repo_that_lacks_our_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An enclosing repo without our package source is still adopted (the ``/config`` case)."""
+    _make_repo(tmp_path)
+    sub = tmp_path / "esphome"
+    sub.mkdir()
+    # A normal pip / site-packages install: our package lives outside the
+    # user's repo, so the enclosing repo is the genuine adoption target.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo._OWN_SOURCE_ROOT",
+        Path("/opt/site-packages/esphome_device_builder"),
+    )
+
+    repo = GitRepo(config_dir=sub)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert repo.toplevel == tmp_path  # adopted the outer repo, not a nested one
+
+
 def test_declines_to_adopt_own_source_checkout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -89,6 +89,28 @@ def test_adopts_repo_when_config_dir_is_subdir(tmp_path: Path) -> None:
     assert repo.toplevel == tmp_path
 
 
+def test_declines_to_adopt_own_source_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Config dir inside the Device Builder source repo gets its own nested repo."""
+    _make_repo(tmp_path)  # stands in for the device-builder source checkout
+    pkg = tmp_path / "esphome_device_builder"
+    pkg.mkdir()
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo._OWN_SOURCE_ROOT",
+        pkg,
+    )
+    configs = tmp_path / "configs"
+    configs.mkdir()
+
+    repo = GitRepo(config_dir=configs)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert repo.toplevel == configs  # nested repo, not the enclosing source repo
+    assert (configs / ".git").is_dir()
+
+
 def test_init_keeps_a_preexisting_gitignore(tmp_path: Path) -> None:
     """A .gitignore already sitting in a non-repo dir is committed, not overwritten."""
     (tmp_path / ".gitignore").write_text("user-rules/\n", encoding="utf-8")


### PR DESCRIPTION
# What does this implement/fix?

The git-backed version-history feature locates its work tree with
`git rev-parse --show-toplevel` from the config dir, which walks *up* the
tree. When the config dir lives inside the Device Builder source checkout
(a `--dev configs` run, with no nested `.git` of its own yet), discovery
returns the **project's own repo** and `discover_or_init` adopts it — so
creating a device commits user YAML straight into the clone's branch
(#1214).

This declines to adopt an enclosing work tree that contains our installed
package source (`_OWN_SOURCE_ROOT`, the `esphome_device_builder` package
dir — only ever inside a source checkout, never under a user's `/config`).
In that case it initialises a config-local repo inside the config dir
instead, so history still works but lands in a nested repo the clone
already gitignores.

Intentional production adoption — `/config/esphome` sitting inside a
`/config` git repo — is unchanged, since that enclosing repo does not
contain our package source.

Verified against the real checkout: with the config dir inside this repo
and no nested `.git`, the new path creates a nested repo, the device
commit lands there, and the Device Builder repo HEAD stays untouched.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1214

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
