### PR TITLE
Add FirmwareJob.is_terminal / is_active and drop _raise_if_cancelled

### DIFF
--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -7,7 +7,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 
 from ...models import FirmwareJob, JobSource, JobStatus, JobType
-from .constants import _ACTIVE_JOB_STATUSES
 
 
 @dataclass
@@ -168,7 +167,7 @@ class FirmwareState:
 
     def active_jobs(self) -> Iterator[FirmwareJob]:
         """Yield the queued or running jobs (skips terminal history)."""
-        return (j for j in self.jobs.values() if j.status in _ACTIVE_JOB_STATUSES)
+        return (j for j in self.jobs.values() if j.is_active)
 
     def dependency_satisfied(self, job: FirmwareJob) -> bool:
         """Return whether *job* has no prerequisite, or its prerequisite has completed."""

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -14,6 +14,7 @@ from esphome.storage_json import StorageJSON
 from ...helpers.remote_build_layout import parse_from_configuration as parse_remote_build_path
 from ...helpers.storage_path import resolve_storage_path
 from ...models import FirmwareJob, JobType
+from . import lifecycle
 from .constants import _OTA_ADDRESS_CACHE_JOB_TYPES, ESPHOME_SUBPROCESS_ENV
 from .helpers import _find_esptool_cmd
 
@@ -144,7 +145,7 @@ async def verify_chip(controller: FirmwareController, job: FirmwareJob, lane: La
     # in ``_execute_job`` would otherwise let the full install run
     # before reporting CANCELLED). Reusing the ``ValueError`` shape
     # keeps the error path identical to a chip mismatch.
-    controller._raise_if_cancelled(job, "chip verification")
+    lifecycle.raise_if_cancelled(controller, job, "chip verification")
 
     # Parse "Detecting chip type... ESP32-C3"
     detected = ""

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 
-from ...models import JobStatus, JobType
+from ...models import JobType
 
 # Metadata key under which the firmware queue persists itself in
 # ``.device-builder.json``.
@@ -119,11 +119,6 @@ _MAX_AUX_TERMINAL_JOBS = 5
 _PRIMARY_JOB_TYPES: frozenset[JobType] = frozenset(
     {JobType.COMPILE, JobType.UPLOAD, JobType.INSTALL}
 )
-
-# Statuses considered "active" — queued for execution or
-# currently running. Re-queued on dashboard restart by
-# ``persistence.load_jobs``; exempt from history pruning.
-_ACTIVE_JOB_STATUSES: frozenset[JobStatus] = frozenset({JobStatus.QUEUED, JobStatus.RUNNING})
 
 # Job types eligible for ``--mdns/--dns-address-cache`` forwarding.
 _OTA_ADDRESS_CACHE_JOB_TYPES: frozenset[JobType] = frozenset(

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -404,9 +404,6 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     def _finalize_cancelled(self, job: FirmwareJob) -> None:
         lifecycle.finalize_cancelled(self, job)
 
-    def _raise_if_cancelled(self, job: FirmwareJob, phase: str) -> None:
-        lifecycle.raise_if_cancelled(self, job, phase)
-
     async def _terminate_current_process(self, lane: Lane) -> None:
         await lifecycle.terminate_current_process(self, lane)
 

--- a/esphome_device_builder/controllers/firmware/follow.py
+++ b/esphome_device_builder/controllers/firmware/follow.py
@@ -10,7 +10,6 @@ from ...helpers.api import registered_stream
 from ...helpers.event_bus import StreamControls, stream_events
 from ...models import (
     TERMINAL_JOB_EVENTS,
-    TERMINAL_JOB_STATUSES,
     EventType,
     StreamEvent,
 )
@@ -143,7 +142,7 @@ async def _stream_job(
 ) -> None:
     """Replay history then tail live output for one job until it ends or is cancelled."""
     # Capture snapshot before ``stream_events`` attaches listeners.
-    is_terminal = job.status in TERMINAL_JOB_STATUSES
+    is_terminal = job.is_terminal
     snapshot = await _initial_snapshot(job, job_id)
     terminal_status = job.status.value if is_terminal else ""
     terminal_exit_code = job.exit_code
@@ -225,7 +224,7 @@ async def _initial_snapshot(job: Any, job_id: str) -> list[str]:
     output = job.output
     if output:
         return list(output)
-    if job.status in TERMINAL_JOB_STATUSES:
+    if job.is_terminal:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, read_job_output, job_id)
     return []

--- a/esphome_device_builder/controllers/firmware/jobs.py
+++ b/esphome_device_builder/controllers/firmware/jobs.py
@@ -15,7 +15,6 @@ from ...models import (
     JobStatus,
 )
 from . import lifecycle
-from .constants import _ACTIVE_JOB_STATUSES
 from .helpers import _fire_job_lifecycle
 
 if TYPE_CHECKING:
@@ -59,7 +58,7 @@ def active_remote_peer_jobs(controller: FirmwareController) -> Iterator[Firmware
     reach into ``state.jobs`` directly.
     """
     for job in controller.state.jobs.values():
-        if job.status not in _ACTIVE_JOB_STATUSES:
+        if not job.is_active:
             continue
         if not job.remote_peer:
             continue

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from ...helpers.process import terminate_subtree_with_grace
-from ...models import TERMINAL_JOB_STATUSES, EventType, FirmwareJob, JobStatus
+from ...models import EventType, FirmwareJob, JobStatus
 from .constants import _PREREQUISITE_FAILED_ERROR
 from .helpers import _fire_job_lifecycle, _trim_job_output
 
@@ -67,7 +67,7 @@ async def end_run(controller: FirmwareController, job: FirmwareJob) -> None:
     The trim/prune is a no-op while the job is still active. Caller releases its
     own slot (lane ``current_job`` / pool entry) first.
     """
-    if job.status in TERMINAL_JOB_STATUSES:
+    if job.is_terminal:
         _trim_job_output(job)
         controller._prune_history()
     await controller._persist_jobs()

--- a/esphome_device_builder/controllers/firmware/persistence.py
+++ b/esphome_device_builder/controllers/firmware/persistence.py
@@ -24,14 +24,12 @@ from esphome.core import CORE
 
 from ...helpers.atomic_io import atomic_write
 from ...models import (
-    TERMINAL_JOB_STATUSES,
     FirmwareJob,
     JobStatus,
     JobType,
 )
 from ..config import _load_metadata, metadata_transaction
 from .constants import (
-    _ACTIVE_JOB_STATUSES,
     _JOBS_KEY,
     _MAX_AUX_TERMINAL_JOBS,
     _MAX_PRIMARY_TERMINAL_JOBS,
@@ -68,13 +66,11 @@ def prune_history(controller: FirmwareController) -> None:
     :data:`_MAX_AUX_TERMINAL_JOBS`. Caller persists the result;
     sidecars of dropped jobs are reaped by ``persist_jobs``.
     """
-    terminal_states = TERMINAL_JOB_STATUSES
-
     active: list[FirmwareJob] = []
     primary: list[FirmwareJob] = []
     aux: list[FirmwareJob] = []
     for job in controller.state.jobs.values():
-        if job.status not in terminal_states:
+        if not job.is_terminal:
             active.append(job)
         elif job.job_type in _PRIMARY_JOB_TYPES:
             primary.append(job)
@@ -117,7 +113,7 @@ def _restore_job_entry(
     try:
         job = FirmwareJob.from_dict(job_data)  # type: ignore[arg-type]
         controller.state.jobs[job.job_id] = job
-        if job.status in _ACTIVE_JOB_STATUSES:
+        if job.is_active:
             job.restore_for_requeue()
             active.append(job)
         elif job.output:
@@ -148,7 +144,7 @@ def _restore_to_lane(controller: FirmwareController, job: FirmwareJob) -> None:
         controller.state.place_on_lane(job)
         return
     prereq = controller.state.jobs.get(job.depends_on)
-    if prereq is not None and prereq.status in _ACTIVE_JOB_STATUSES:
+    if prereq is not None and prereq.is_active:
         return
     # Prerequisite is gone (pruned from history) or terminal-but-not-completed:
     # the dependent can't run, so cancel it rather than hold it forever. Log so
@@ -227,7 +223,7 @@ async def _persist_jobs_locked(controller: FirmwareController) -> None:
         # drop it from RAM so idle memory holds metadata only. Runs
         # before ``to_dict`` so the persisted blob carries no output.
         for job in jobs:
-            if job.status in TERMINAL_JOB_STATUSES and job.output:
+            if job.is_terminal and job.output:
                 _write_job_sidecar(job.job_id, job.output)
                 job.output = []
         _reconcile_sidecars({job.job_id for job in jobs})
@@ -277,7 +273,7 @@ def _metadata_dict(job: FirmwareJob) -> dict:
     mid-build restart recovers the pre-crash log; there are no active
     jobs at idle, so this doesn't bloat the resting blob.
     """
-    if job.status in TERMINAL_JOB_STATUSES:
+    if job.is_terminal:
         return job_dict_without_output(job)
     return job.to_dict()
 

--- a/esphome_device_builder/controllers/firmware/remote_dispatch.py
+++ b/esphome_device_builder/controllers/firmware/remote_dispatch.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING
 from ...helpers.build_scheduler import DispatchOutcome, pick_dispatch_target
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
-    TERMINAL_JOB_STATUSES,
     EventType,
     FirmwareJob,
     JobBuildSource,
@@ -195,7 +194,7 @@ async def _drive_remote(controller: FirmwareController, job: FirmwareJob) -> Non
     terminal finalise and cancel.
     """
     pool = controller.state.remote_dispatch
-    if job.status in TERMINAL_JOB_STATUSES:
+    if job.is_terminal:
         # Cancelled / superseded in the window between dispatch and this task
         # running — don't start the build, just free the slot. (The eager
         # scheduler stamps RUNNING before the in-flight binding so this can't
@@ -216,7 +215,7 @@ async def _drive_remote(controller: FirmwareController, job: FirmwareJob) -> Non
         lifecycle.finalize_unexpected_error(controller, job, exc)
     finally:
         pool.release(job.job_id)
-        if job.status in TERMINAL_JOB_STATUSES:
+        if job.is_terminal:
             pool.forget_losses(job.job_id)
         await lifecycle.end_run(controller, job)
 

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -312,7 +312,7 @@ async def tracked_subprocess(
       handles the job-finalisation half and relies on this
       helper for the terminate.
 
-    Pairs with ``_raise_if_cancelled`` — wrap each spawn, then
+    Pairs with ``lifecycle.raise_if_cancelled`` — wrap each spawn, then
     call the helper after to short-circuit if the cancel landed
     between this subprocess and the next one.
     """

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -123,6 +123,9 @@ TERMINAL_JOB_STATUSES: frozenset[JobStatus] = frozenset(
     {JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED}
 )
 
+# Active job states — queued or running (the complement of terminal).
+_ACTIVE_JOB_STATUSES: frozenset[JobStatus] = frozenset({JobStatus.QUEUED, JobStatus.RUNNING})
+
 # Lifecycle events that match ``TERMINAL_JOB_STATUSES``. The runner
 # fires exactly one of these per job, matching the status set
 # above — kept as a separate constant because subscriptions key
@@ -267,6 +270,16 @@ class FirmwareJob(DataClassORJSONMixin):
     # pairing hadn't yet completed a peer-link session (the
     # pairing field populates on every session-open).
     source_esphome_version: str = ""
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the job has reached a terminal status (completed / failed / cancelled)."""
+        return self.status in TERMINAL_JOB_STATUSES
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the job is still queued or running (not yet terminal)."""
+        return self.status in _ACTIVE_JOB_STATUSES
 
     def reset(self) -> None:
         """

--- a/tests/models/test_firmware_job.py
+++ b/tests/models/test_firmware_job.py
@@ -199,6 +199,25 @@ def test_revert_to_pending_remote_clears_binding_and_run_state() -> None:
     assert job.progress is None
 
 
+@pytest.mark.parametrize(
+    ("status", "terminal", "active"),
+    [
+        (JobStatus.QUEUED, False, True),
+        (JobStatus.RUNNING, False, True),
+        (JobStatus.COMPLETED, True, False),
+        (JobStatus.FAILED, True, False),
+        (JobStatus.CANCELLED, True, False),
+    ],
+)
+def test_is_terminal_is_active_partition_the_statuses(
+    status: JobStatus, terminal: bool, active: bool
+) -> None:
+    """``is_terminal`` / ``is_active`` are exact complements across every status."""
+    job = _make_job(status=status)
+    assert job.is_terminal is terminal
+    assert job.is_active is active
+
+
 def test_mark_terminal_sets_status_and_completed_at() -> None:
     """``mark_terminal`` stamps a terminal status plus a parseable completion time."""
     job = _make_job(status=JobStatus.RUNNING, completed_at=None)


### PR DESCRIPTION
# What does this implement/fix?

Behaviour-free refactor following the build-server-pool work; encapsulates two job-state idioms the pool PR surfaced.

* `FirmwareJob.is_terminal` / `is_active` properties replace ~11 inline `status in TERMINAL_JOB_STATUSES` / `_ACTIVE_JOB_STATUSES` checks across persistence, remote_dispatch, lifecycle, follow, jobs, and _state. The active-status set moves onto the model beside `TERMINAL_JOB_STATUSES`, so the duplicate controller-side `_ACTIVE_JOB_STATUSES` constant and its imports go away and the two status sets live in one place.
* Drops the `controller._raise_if_cancelled` delegate; it had a single caller and, unlike `_finalize_terminal` / `_finalize_cancelled`, no test patches it, so it bought no interception seam. `cli.verify_chip` now calls `lifecycle.raise_if_cancelled` directly.

Stacked on `koan/remote-build-server-pool` (base set accordingly); rebase to main once that lands.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1236

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
