### PR TITLE
Cover the off-lane CancelledError and pool-retry server-loss raise

### DIFF
--- a/tests/controllers/firmware/test_remote_dispatch.py
+++ b/tests/controllers/firmware/test_remote_dispatch.py
@@ -373,6 +373,36 @@ async def test_drive_remote_finalizes_failed_on_unexpected_exception(
     assert pool.busy_pins() == frozenset()
 
 
+async def test_drive_remote_reraises_cancelled_error_and_frees_slot(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CancelledError out of run_remote_job propagates (shutdown), freeing the pool slot."""
+    controller = firmware_controller_factory(with_queue=True, with_real_bus=True)
+
+    async def _cancelled(_ctrl: object, _job: FirmwareJob, **_kw: object) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(remote_dispatch, "run_remote_job", _cancelled)
+    job = FirmwareJob(
+        job_id="c1",
+        configuration="dev.yaml",
+        job_type=JobType.COMPILE,
+        source=JobSource.REMOTE,
+        source_pin_sha256=_PIN_A,
+    )
+    controller.state.jobs["c1"] = job
+    pool = controller.state.remote_dispatch
+    pool.in_flight["c1"] = MagicMock()
+    pool.job_peer["c1"] = _PIN_A
+
+    with pytest.raises(asyncio.CancelledError):
+        await remote_dispatch._drive_remote(controller, job)
+
+    assert "c1" not in pool.in_flight  # finally still freed the slot
+    assert pool.busy_pins() == frozenset()
+
+
 async def test_drive_remote_skips_build_when_already_terminal(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1009,11 +1009,7 @@ async def test_remote_compile_session_lost_raises_for_pool_retry(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,
 ) -> None:
-    """With ``retry_on_server_loss=True`` a mid-build session loss raises rather than failing.
-
-    The dispatch pool catches ``RemoteServerLostError`` to re-route the compile
-    to another worker, so this path must not finalise the job locally.
-    """
+    """A mid-build session loss raises for pool retry instead of finalising locally."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     client = _make_client()

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -1005,6 +1005,37 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     ), output_lines
 
 
+async def test_remote_compile_session_lost_raises_for_pool_retry(
+    firmware_controller_factory: FirmwareControllerFactory,
+    patch_bundle: AsyncMock,
+) -> None:
+    """With ``retry_on_server_loss=True`` a mid-build session loss raises rather than failing.
+
+    The dispatch pool catches ``RemoteServerLostError`` to re-route the compile
+    to another worker, so this path must not finalise the job locally.
+    """
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client()
+    _wire_remote_build(controller, client=client)
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(
+        remote_runner.run_remote_job(controller, job, retry_on_server_loss=True)
+    )
+    await _wait_until_dispatched(client)
+    _fire_session_closed(
+        controller, reason="transport_error", error_detail="Connection reset by peer"
+    )
+
+    with pytest.raises(remote_runner.RemoteServerLostError, match="transport_error"):
+        await asyncio.wait_for(runner, timeout=2.0)
+
+    # The pool driver owns the re-route; the runner must not have failed it.
+    assert job.status != JobStatus.FAILED
+    assert captured[EventType.JOB_FAILED] == []
+
+
 async def test_remote_compile_session_lost_synthetic_line_skips_leading_newline(
     firmware_controller_factory: FirmwareControllerFactory,
     patch_bundle: AsyncMock,


### PR DESCRIPTION
# What does this implement/fix?

Adds the two lines of test coverage Codecov flagged on #1229 after it merged. Both are real branches the higher-level pool tests bypassed by mocking `run_remote_job`, so the internal raise/re-raise never executed:

* `remote_dispatch._drive_remote`'s `except asyncio.CancelledError: raise` — a test now raises `CancelledError` out of `run_remote_job` and asserts it propagates (shutdown-cancel) while the `finally` still frees the pool slot.
* `remote_runner._await_terminal`'s `raise RemoteServerLostError` — a mid-build session loss with `retry_on_server_loss=True` now drives the real `run_remote_job` (not a mock), asserting it raises rather than finalising the job locally, so the dispatch pool can re-route it.

Tests only; no production change.

**Related issue or feature (if applicable):**

- follows up https://github.com/esphome/device-builder/pull/1229

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
