### PR TITLE
Raise cold-connect queue_status wait to 10s for CI contention

### DIFF
--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -227,8 +227,13 @@ async def test_cold_connect_offloader_observes_initial_queue_status_then_picks_r
     # Wait for the offloader to observe the receiver's initial
     # ``queue_status`` push. Cold-connect contract:
     # the offloader's ``_peer_queue_status`` must populate from
-    # the wire without any local-side seeding.
-    await asyncio.wait_for(queue_status_landed.received.wait(), timeout=2.0)
+    # the wire without any local-side seeding. The push is a
+    # fire-and-forget background task scheduled at session
+    # registration, so under ``-n auto`` CI contention it can
+    # lag a couple event-loop turns behind session-open; a 2s
+    # ceiling tipped over on a loaded runner. The global
+    # ``--timeout=120`` still catches a truly broken push.
+    await asyncio.wait_for(queue_status_landed.received.wait(), timeout=10.0)
     payload = queue_status_landed[-1]
     assert payload["pin_sha256"] == paired_instances.pin_sha256
     assert payload["idle"] is True


### PR DESCRIPTION
# What does this implement/fix?

The cold-connect e2e timed out on the stable channel in CI; it waited 2s for the receiver's fire-and-forget initial queue_status push to reach the offloader. The e2e job runs under pytest-xdist -n auto, so on a 2-core runner the push can lag a few event-loop turns past session-open and tip over the 2s ceiling. This wait is a synchronization point, not a latency assertion, so I raised it to 10s; the job's global --timeout=120 still catches a genuinely broken push.

**Related issue or feature (if applicable):**

- Failing run: https://github.com/esphome/device-builder/actions/runs/27043235179/job/79823735522

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

