### PR TITLE
Surface git stderr on a failed version-history commit

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -98,6 +98,22 @@ _DEFAULT_GITIGNORE = "".join(
 )
 
 
+class GitCommandError(subprocess.CalledProcessError):
+    """``CalledProcessError`` whose ``str`` carries git's stderr.
+
+    Plain ``CalledProcessError`` renders only the exit status, so a
+    logged ``exc_info`` drops the ``fatal:`` line that says *why* — the
+    one fact needed to triage a failed commit (stale ``index.lock``,
+    dubious ownership, disk full).
+    """
+
+    def __str__(self) -> str:
+        """Exit-status line followed by git's trimmed stderr, when present."""
+        detail = (self.stderr or "").strip()
+        base = super().__str__()
+        return f"{base}: {detail}" if detail else base
+
+
 @dataclass(slots=True)
 class CommitInfo:
     """One commit touching a file, as surfaced to the history UI."""
@@ -409,7 +425,12 @@ class GitRepo:
         check: bool,
         cwd: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        """Run ``git`` with *args* in the work tree; capture text output."""
+        """Run ``git`` with *args* in the work tree; capture text output.
+
+        Checks the exit status here (rather than via ``check=True``) so a
+        failure raises :class:`GitCommandError`, whose ``str`` carries the
+        ``fatal:`` stderr line a bare ``CalledProcessError`` would drop.
+        """
         assert self.git_bin is not None
         # git_bin is a resolved absolute path from shutil.which and the
         # args are a fixed argv (never shell-interpreted), so the only
@@ -418,14 +439,19 @@ class GitRepo:
         # close_fds=True makes the child iterate the fd table before
         # exec, which is pure overhead on memory-pressured systems; our
         # spawns don't rely on inherited fds being closed at the boundary.
-        return subprocess.run(  # noqa: S603
+        result = subprocess.run(  # noqa: S603
             [self.git_bin, *args],
             cwd=str(cwd or self.toplevel or self.config_dir),
             capture_output=True,
             text=True,
-            check=check,
+            check=False,
             close_fds=False,
         )
+        if check and result.returncode != 0:
+            raise GitCommandError(
+                result.returncode, result.args, output=result.stdout, stderr=result.stderr
+            )
+        return result
 
 
 def _encloses_own_source(toplevel: Path) -> bool:

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -377,6 +377,25 @@ def test_commit_paths_raises_on_git_error(tmp_path: Path, monkeypatch: pytest.Mo
         repo.commit_paths([yaml], "Create kitchen.yaml")
 
 
+def test_run_surfaces_git_stderr_on_failure(tmp_path: Path) -> None:
+    """A checked git failure raises with the ``fatal:`` stderr line in ``str``.
+
+    Pins the triage path: a stale ``index.lock`` (or any fatal) must show
+    *why* in the log, not a bare ``exit status 128``.
+    """
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    # Simulate the killed-mid-commit leftover that breaks every add.
+    (tmp_path / ".git" / "index.lock").write_text("", encoding="utf-8")
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        repo.commit_paths([yaml], "Create kitchen.yaml")
+
+    assert "index.lock" in str(exc_info.value)
+
+
 def test_file_at_returns_none_for_unknown_commit(tmp_path: Path) -> None:
     """Asking for a path at a commit that doesn't have it yields None, not a crash."""
     repo = GitRepo(config_dir=tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

A failed version-history `git add` / `commit` logged a dead end. The
catch-all warning in `VersionHistoryController._flush_pending` re-raises
the `CalledProcessError` with `exc_info=True`, but a plain
`CalledProcessError`'s string is only `returned non-zero exit status 128`.
The `GitRepo` wrapper already captured git's stderr (`capture_output=True`)
and then threw it away, so the one line that explains a git 128 — the
`fatal: ...` on stderr — never reached the log. In production this showed
up as a repeating, undiagnosable:

```
WARNING ... Version-history catch-all failed for athom-tem-hum-sensor-605c88.yaml
...
subprocess.CalledProcessError: Command '['/usr/bin/git', 'add', '-A', '--',
'/config/esphome/athom-tem-hum-sensor-605c88.yaml']' returned non-zero exit status 128.
```

with no way to tell whether it was a stale `index.lock`, dubious
ownership, a full disk, or something else.

This adds `GitCommandError(subprocess.CalledProcessError)` whose `__str__`
appends git's trimmed stderr, and changes `GitRepo._run` to check the exit
status itself and raise that instead of relying on `check=True`. It stays
a `CalledProcessError` subclass, so `GIT_COMMIT_ERRORS` and every existing
`except subprocess.CalledProcessError` clause keep catching it unchanged.

After this, the same failure logs the actionable cause, e.g.
`... returned non-zero exit status 128: fatal: Unable to create
'/config/esphome/.git/index.lock': File exists.`

This is a diagnosability fix, not a behaviour change — the feature still
self-disables and the catch-all still swallows git errors as best-effort.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
