### PR TITLE
Self-heal a stale git index.lock in version history

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -82,6 +83,10 @@ _SECRETS_FILENAME = "secrets.yaml"
 # Glob patterns for the YAML configs this feature versions.
 _YAML_GLOBS = ("*.yaml", "*.yml")
 
+# Min age before a leftover ``index.lock`` counts as stale and is cleared;
+# younger than this a live git may still hold it, so we leave it alone.
+_STALE_LOCK_SECONDS = 30.0
+
 # Written only when *we* create the repo and no ``.gitignore`` exists; a
 # pre-existing one is left untouched (the local exclude is what actually
 # protects the secrets above). ``secrets.yaml`` is ignored here — not in
@@ -133,6 +138,10 @@ class GitRepo:
     git_bin: str | None = None
     toplevel: Path | None = None
     enabled: bool = field(default=False)
+    # True only when *we* initialised the repo, never when adopting one.
+    # Gates stale-index.lock recovery so we never clear a lock in a user's
+    # own ``/config`` work tree.
+    created: bool = field(default=False)
 
     # ------------------------------------------------------------------
     # lifecycle
@@ -194,6 +203,7 @@ class GitRepo:
         self._run(["init", str(self.config_dir)], cwd=self.config_dir, check=True)
         self.toplevel = self.config_dir
         self.enabled = True
+        self.created = True
         self._ensure_local_excludes()
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
@@ -300,11 +310,11 @@ class GitRepo:
         if not self.enabled or not paths:
             return None
         spec = [str(p) for p in paths]
-        self._run(["add", "-A", "--", *spec], check=True)
+        self._run_write(["add", "-A", "--", *spec])
         staged = self._run(["diff", "--cached", "--quiet", "--", *spec], check=False)
         if staged.returncode == 0:
             return None  # nothing staged for these paths
-        self._run(self._commit_argv(message, tuple(spec)), check=True)
+        self._run_write(self._commit_argv(message, tuple(spec)))
         head = self._run(["rev-parse", "HEAD"], check=False)
         return head.stdout.strip() if head.returncode == 0 else None
 
@@ -410,6 +420,51 @@ class GitRepo:
     # internals
     # ------------------------------------------------------------------
 
+    def _run_write(self, args: list[str]) -> None:
+        """Run a checked git write, clearing a *stale* index.lock and retrying once."""
+        try:
+            self._run(args, check=True)
+        except subprocess.CalledProcessError as exc:
+            if not self._clear_stale_index_lock(exc):
+                raise
+            self._run(args, check=True)
+
+    def _clear_stale_index_lock(self, exc: subprocess.CalledProcessError) -> bool:
+        """Remove the index.lock blamed by *exc* iff it's stale; return whether removed.
+
+        Gated on ownership (only a repo we created, never an adopted
+        ``/config``) and age (:data:`_STALE_LOCK_SECONDS`), so a lock a
+        live git is actively holding is never deleted out from under it.
+        """
+        if not self.created or "index.lock" not in (exc.stderr or ""):
+            return False
+        lock = self._index_lock_path()
+        if lock is None or not lock.exists():
+            return False
+        try:
+            age = time.time() - lock.stat().st_mtime
+        except OSError:
+            return False
+        if age < _STALE_LOCK_SECONDS:
+            return False  # fresh — a live git may hold it; don't clobber
+        try:
+            lock.unlink()
+        except OSError as unlink_exc:
+            _LOGGER.warning("Could not remove stale git index.lock at %s: %s", lock, unlink_exc)
+            return False
+        _LOGGER.warning("Removed stale git index.lock at %s (age %.0fs)", lock, age)
+        return True
+
+    def _index_lock_path(self) -> Path | None:
+        """Resolve the work tree's ``index.lock`` path (handles split git dirs)."""
+        result = self._run(["rev-parse", "--git-path", "index.lock"], check=False)
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+        lock = Path(result.stdout.strip())
+        if not lock.is_absolute():
+            lock = (self.toplevel or self.config_dir) / lock
+        return lock
+
     def _rel_to_toplevel(self, path: Path) -> str:
         """Return *path* relative to the work-tree root (git's pathspec base)."""
         assert self.toplevel is not None
@@ -439,8 +494,11 @@ class GitRepo:
         # close_fds=True makes the child iterate the fd table before
         # exec, which is pure overhead on memory-pressured systems; our
         # spawns don't rely on inherited fds being closed at the boundary.
+        # --no-optional-locks stops reads from grabbing index.lock for an
+        # optional refresh, so an unlocked read can't contend with a commit;
+        # the required lock add/commit take is unaffected.
         result = subprocess.run(  # noqa: S603
-            [self.git_bin, *args],
+            [self.git_bin, "--no-optional-locks", *args],
             cwd=str(cwd or self.toplevel or self.config_dir),
             capture_output=True,
             text=True,

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -464,7 +464,8 @@ class GitRepo:
         return True
 
     def _adopt_ownership(self) -> bool:
-        """Resolve whether an adopted repo is one we own, stamping the marker once.
+        """
+        Resolve whether an adopted repo is one we own, stamping the marker once.
 
         New repos carry :data:`_MANAGED_CONFIG_KEY`. Repos we created before
         that marker existed are recognised by their self-authored root
@@ -479,7 +480,13 @@ class GitRepo:
 
     def _mark_managed(self) -> None:
         """Stamp the repo-local flag marking this as a repo we own."""
-        self._run(["config", "--local", _MANAGED_CONFIG_KEY, "true"], check=False)
+        result = self._run(["config", "--local", _MANAGED_CONFIG_KEY, "true"], check=False)
+        if result.returncode != 0:
+            # Not fatal — ownership is re-derived from the seed root next
+            # start — but a dropped stamp should be observable.
+            _LOGGER.warning(
+                "Could not stamp managed flag on %s: %s", self.toplevel, result.stderr.strip()
+            )
 
     def _read_managed_flag(self) -> bool:
         """Whether a prior run stamped this (now adopted) repo as one we created."""
@@ -487,7 +494,8 @@ class GitRepo:
         return result.returncode == 0 and result.stdout.strip() == "true"
 
     def _looks_self_initialised(self) -> bool:
-        """Whether a root commit was authored by our seed — backfill for pre-marker repos.
+        """
+        Whether a root commit was authored by our seed — backfill for pre-marker repos.
 
         The ``Initialize version history`` seed is authored by our identity,
         which an adopted user repo's root commit never is; git filters on

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -87,9 +87,10 @@ _YAML_GLOBS = ("*.yaml", "*.yml")
 # younger than this a live git may still hold it, so we leave it alone.
 _STALE_LOCK_SECONDS = 30.0
 
-# Repo-local git-config flag stamped only when *we* initialise a repo. Read
-# back on the adopt path so ownership survives a restart (we own the repo
-# but re-discover it as "adopted"); an adopted user repo never carries it.
+# Repo-local git-config verdict (``true``/``false``) for whether we own a
+# repo. Written at init and cached on the first adopt so ownership survives a
+# restart and the seed-root backfill scan runs at most once per repo. Unset
+# means "not yet resolved"; an adopted user repo ends up cached ``false``.
 _MANAGED_CONFIG_KEY = "device-builder.managed"
 
 # Written only when *we* create the repo and no ``.gitignore`` exists; a
@@ -210,7 +211,7 @@ class GitRepo:
         self.toplevel = self.config_dir
         self.enabled = True
         self.managed = True
-        self._mark_managed()
+        self._mark_managed(managed=True)
         self._ensure_local_excludes()
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
@@ -465,47 +466,54 @@ class GitRepo:
 
     def _adopt_ownership(self) -> bool:
         """
-        Resolve whether an adopted repo is one we own, stamping the marker once.
+        Resolve whether an adopted repo is one we own, caching the verdict once.
 
-        New repos carry :data:`_MANAGED_CONFIG_KEY`. Repos we created before
-        that marker existed are recognised by their self-authored root
-        commit and stamped here, so the heal works after an upgrade too.
+        A prior run's cached :data:`_MANAGED_CONFIG_KEY` short-circuits.
+        Otherwise the seed-root backfill identifies repos we created before
+        the marker existed; the verdict (ours or not) is stamped so the scan
+        runs at most once. A scan that couldn't run is left uncached.
         """
-        if self._read_managed_flag():
-            return True
-        if self._looks_self_initialised():
-            self._mark_managed()
-            return True
-        return False
+        cached = self._read_managed_flag()
+        if cached is not None:
+            return cached
+        owned = self._looks_self_initialised()
+        if owned is None:
+            return False  # couldn't determine; re-resolve next start
+        self._mark_managed(managed=owned)
+        return owned
 
-    def _mark_managed(self) -> None:
-        """Stamp the repo-local flag marking this as a repo we own."""
-        result = self._run(["config", "--local", _MANAGED_CONFIG_KEY, "true"], check=False)
+    def _mark_managed(self, *, managed: bool) -> None:
+        """Persist the ownership verdict so the next start skips re-deriving it."""
+        value = "true" if managed else "false"
+        result = self._run(["config", "--local", _MANAGED_CONFIG_KEY, value], check=False)
         if result.returncode != 0:
-            # Not fatal — ownership is re-derived from the seed root next
-            # start — but a dropped stamp should be observable.
             _LOGGER.warning(
                 "Could not stamp managed flag on %s: %s", self.toplevel, result.stderr.strip()
             )
 
-    def _read_managed_flag(self) -> bool:
-        """Whether a prior run stamped this (now adopted) repo as one we created."""
+    def _read_managed_flag(self) -> bool | None:
+        """Return the cached ownership verdict from a prior run, or ``None`` if unresolved."""
         result = self._run(["config", "--local", "--get", _MANAGED_CONFIG_KEY], check=False)
-        return result.returncode == 0 and result.stdout.strip() == "true"
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() == "true"
 
-    def _looks_self_initialised(self) -> bool:
+    def _looks_self_initialised(self) -> bool | None:
         """
         Whether a root commit was authored by our seed — backfill for pre-marker repos.
 
         The ``Initialize version history`` seed is authored by our identity,
         which an adopted user repo's root commit never is; git filters on
-        the author so we only ask whether such a root exists.
+        the author so we only ask whether such a root exists. ``None`` when
+        the query couldn't run (e.g. a repo with no commits yet).
         """
         result = self._run(
             ["log", "--max-parents=0", f"--author={_COMMIT_EMAIL}", "--format=%H"],
             check=False,
         )
-        return result.returncode == 0 and bool(result.stdout.strip())
+        if result.returncode != 0:
+            return None
+        return bool(result.stdout.strip())
 
     def _index_lock_path(self) -> Path | None:
         """Resolve the work tree's ``index.lock`` path (handles split git dirs)."""

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -87,6 +87,11 @@ _YAML_GLOBS = ("*.yaml", "*.yml")
 # younger than this a live git may still hold it, so we leave it alone.
 _STALE_LOCK_SECONDS = 30.0
 
+# Repo-local git-config flag stamped only when *we* initialise a repo. Read
+# back on the adopt path so ownership survives a restart (we own the repo
+# but re-discover it as "adopted"); an adopted user repo never carries it.
+_MANAGED_CONFIG_KEY = "device-builder.managed"
+
 # Written only when *we* create the repo and no ``.gitignore`` exists; a
 # pre-existing one is left untouched (the local exclude is what actually
 # protects the secrets above). ``secrets.yaml`` is ignored here — not in
@@ -138,10 +143,10 @@ class GitRepo:
     git_bin: str | None = None
     toplevel: Path | None = None
     enabled: bool = field(default=False)
-    # True only when *we* initialised the repo, never when adopting one.
-    # Gates stale-index.lock recovery so we never clear a lock in a user's
-    # own ``/config`` work tree.
-    created: bool = field(default=False)
+    # True for a repo *we* initialised, set from the persisted
+    # _MANAGED_CONFIG_KEY so it survives a restart's adopt path. Gates
+    # stale-index.lock recovery; an adopted user repo is never ours.
+    managed: bool = field(default=False)
 
     # ------------------------------------------------------------------
     # lifecycle
@@ -164,6 +169,7 @@ class GitRepo:
             if toplevel is not None and not _encloses_own_source(toplevel):
                 self.toplevel = toplevel
                 self.enabled = True
+                self.managed = self._adopt_ownership()
                 self._ensure_local_excludes()
                 _LOGGER.debug("Adopted existing git work tree at %s", toplevel)
                 return
@@ -203,7 +209,8 @@ class GitRepo:
         self._run(["init", str(self.config_dir)], cwd=self.config_dir, check=True)
         self.toplevel = self.config_dir
         self.enabled = True
-        self.created = True
+        self.managed = True
+        self._mark_managed()
         self._ensure_local_excludes()
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
@@ -430,13 +437,14 @@ class GitRepo:
             self._run(args, check=True)
 
     def _clear_stale_index_lock(self, exc: subprocess.CalledProcessError) -> bool:
-        """Remove the index.lock blamed by *exc* iff it's stale; return whether removed.
+        """
+        Remove the index.lock blamed by *exc* iff it's stale; return whether removed.
 
-        Gated on ownership (only a repo we created, never an adopted
+        Gated on ownership (only a repo we manage, never an adopted
         ``/config``) and age (:data:`_STALE_LOCK_SECONDS`), so a lock a
         live git is actively holding is never deleted out from under it.
         """
-        if not self.created or "index.lock" not in (exc.stderr or ""):
+        if not self.managed or "index.lock" not in (exc.stderr or ""):
             return False
         lock = self._index_lock_path()
         if lock is None or not lock.exists():
@@ -454,6 +462,42 @@ class GitRepo:
             return False
         _LOGGER.warning("Removed stale git index.lock at %s (age %.0fs)", lock, age)
         return True
+
+    def _adopt_ownership(self) -> bool:
+        """Resolve whether an adopted repo is one we own, stamping the marker once.
+
+        New repos carry :data:`_MANAGED_CONFIG_KEY`. Repos we created before
+        that marker existed are recognised by their self-authored root
+        commit and stamped here, so the heal works after an upgrade too.
+        """
+        if self._read_managed_flag():
+            return True
+        if self._looks_self_initialised():
+            self._mark_managed()
+            return True
+        return False
+
+    def _mark_managed(self) -> None:
+        """Stamp the repo-local flag marking this as a repo we own."""
+        self._run(["config", "--local", _MANAGED_CONFIG_KEY, "true"], check=False)
+
+    def _read_managed_flag(self) -> bool:
+        """Whether a prior run stamped this (now adopted) repo as one we created."""
+        result = self._run(["config", "--local", "--get", _MANAGED_CONFIG_KEY], check=False)
+        return result.returncode == 0 and result.stdout.strip() == "true"
+
+    def _looks_self_initialised(self) -> bool:
+        """Whether a root commit was authored by our seed — backfill for pre-marker repos.
+
+        The ``Initialize version history`` seed is authored by our identity,
+        which an adopted user repo's root commit never is; git filters on
+        the author so we only ask whether such a root exists.
+        """
+        result = self._run(
+            ["log", "--max-parents=0", f"--author={_COMMIT_EMAIL}", "--format=%H"],
+            check=False,
+        )
+        return result.returncode == 0 and bool(result.stdout.strip())
 
     def _index_lock_path(self) -> Path | None:
         """Resolve the work tree's ``index.lock`` path (handles split git dirs)."""

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shutil
 import subprocess
+import time
 from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
@@ -90,6 +92,49 @@ async def test_external_edit_committed_via_scanner_catch_all(
 
     versions = await controller.list_versions(configuration="kitchen.yaml")
     assert [v["message"] for v in versions] == ["Edit kitchen.yaml"]
+
+
+async def test_external_edit_self_heals_stale_index_lock_after_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: addon killed mid-commit, restart, next external edit clears the lock.
+
+    Boots once to create the repo, simulates a restart (a fresh controller
+    adopting the same dir as managed), drops an aged ``index.lock`` like a
+    SIGTERM'd git would, then drives the scanner catch-all and asserts the
+    commit lands through the full stack and the stale lock is gone.
+    """
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
+        0.0,
+    )
+    # First boot initialises the repo (and stamps the managed marker).
+    first = _make_controller(tmp_path)
+    await first.start()
+    await first.stop()
+
+    # Restart: a fresh controller re-discovers the existing repo as managed.
+    controller = _make_controller(tmp_path)
+    await controller.start()
+    assert controller._repo.managed
+
+    # A git killed mid-commit left this behind; it blocks every future add.
+    lock = tmp_path / ".git" / "index.lock"
+    lock.write_text("", encoding="utf-8")
+    stale = time.time() - 3600
+    os.utime(lock, (stale, stale))
+
+    (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
+    device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
+    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    assert controller._flush_task is not None
+    await controller._flush_task
+
+    # The stale lock was cleared and the edit committed via the catch-all.
+    assert not lock.exists()
+    versions = await controller.list_versions(configuration="kitchen.yaml")
+    assert [v["message"] for v in versions] == ["Edit kitchen.yaml"]
+    await controller.stop()
 
 
 async def test_dashboard_commit_makes_catch_all_a_noop(

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -97,13 +97,7 @@ async def test_external_edit_committed_via_scanner_catch_all(
 async def test_external_edit_self_heals_stale_index_lock_after_restart(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """End to end: addon killed mid-commit, restart, next external edit clears the lock.
-
-    Boots once to create the repo, simulates a restart (a fresh controller
-    adopting the same dir as managed), drops an aged ``index.lock`` like a
-    SIGTERM'd git would, then drives the scanner catch-all and asserts the
-    commit lands through the full stack and the stale lock is gone.
-    """
+    """Catch-all commit clears a stale index.lock after a restart re-adopts the repo."""
     monkeypatch.setattr(
         "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
         0.0,

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -10,8 +10,10 @@ The load-bearing guarantees these pin:
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -19,6 +21,15 @@ import pytest
 from esphome_device_builder.controllers.version_history.git_repo import GitRepo
 
 _GIT = shutil.which("git") or "git"
+
+
+def _index_lock(repo_root: Path, *, age_seconds: float) -> Path:
+    """Write a ``.git/index.lock`` aged *age_seconds* in the past."""
+    lock = repo_root / ".git" / "index.lock"
+    lock.write_text("", encoding="utf-8")
+    stamp = time.time() - age_seconds
+    os.utime(lock, (stamp, stamp))
+    return lock
 
 
 def _git(cwd: Path, *args: str) -> str:
@@ -375,6 +386,69 @@ def test_commit_paths_raises_on_git_error(tmp_path: Path, monkeypatch: pytest.Mo
     )
     with pytest.raises(subprocess.CalledProcessError):
         repo.commit_paths([yaml], "Create kitchen.yaml")
+
+
+def test_commit_clears_stale_index_lock_and_retries(tmp_path: Path) -> None:
+    """A repo we created self-heals a stale ``index.lock`` left by a killed git."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    assert repo.created
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    lock = _index_lock(tmp_path, age_seconds=3600)
+
+    sha = repo.commit_paths([yaml], "Create kitchen.yaml")
+
+    assert sha
+    assert not lock.exists()
+
+
+def test_commit_keeps_fresh_index_lock(tmp_path: Path) -> None:
+    """A young ``index.lock`` (a live git may hold it) is left alone; the write raises."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    lock = _index_lock(tmp_path, age_seconds=0)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert lock.exists()
+
+
+def test_adopted_repo_never_clears_index_lock(tmp_path: Path) -> None:
+    """An adopted work tree (user's ``/config``) is never auto-unlocked, even when stale."""
+    _make_repo(tmp_path)
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    assert not repo.created
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    lock = _index_lock(tmp_path, age_seconds=3600)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert lock.exists()
+
+
+def test_reads_pass_no_optional_locks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every git invocation carries ``--no-optional-locks`` so reads can't grab index.lock."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _record(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _record
+    )
+    repo.log_file(tmp_path / "kitchen.yaml")
+
+    assert calls
+    assert all(cmd[1] == "--no-optional-locks" for cmd in calls)
 
 
 def test_run_surfaces_git_stderr_on_failure(tmp_path: Path) -> None:

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -422,6 +422,18 @@ def test_managed_flag_survives_restart_and_heals(tmp_path: Path) -> None:
     assert not lock.exists()
 
 
+def test_adopted_user_repo_caches_not_managed_verdict(tmp_path: Path) -> None:
+    """An adopted user repo records a ``false`` verdict so the seed-root scan runs once."""
+    _make_repo(tmp_path)  # root commit authored by someone other than us
+    GitRepo(config_dir=tmp_path).discover_or_init()
+    assert _git(tmp_path, "config", "--local", "--get", "device-builder.managed").strip() == "false"
+
+    # A restart reads the cached verdict rather than re-scanning history.
+    restarted = GitRepo(config_dir=tmp_path)
+    restarted.discover_or_init()
+    assert not restarted.managed
+
+
 def test_pre_marker_repo_is_backfilled_as_managed(tmp_path: Path) -> None:
     """A pre-marker repo we created is recognised by its seed root commit and re-stamped."""
     GitRepo(config_dir=tmp_path).discover_or_init()

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -392,7 +392,7 @@ def test_commit_clears_stale_index_lock_and_retries(tmp_path: Path) -> None:
     """A repo we created self-heals a stale ``index.lock`` left by a killed git."""
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
-    assert repo.created
+    assert repo.managed
     yaml = tmp_path / "kitchen.yaml"
     yaml.write_text("v1\n", encoding="utf-8")
     lock = _index_lock(tmp_path, age_seconds=3600)
@@ -401,6 +401,46 @@ def test_commit_clears_stale_index_lock_and_retries(tmp_path: Path) -> None:
 
     assert sha
     assert not lock.exists()
+
+
+def test_managed_flag_survives_restart_and_heals(tmp_path: Path) -> None:
+    """A repo we created is re-adopted as managed on restart, so the heal still fires.
+
+    The headline scenario: the addon is SIGTERM'd mid-commit (leaving the
+    lock), then a fresh process re-discovers the existing ``.git``.
+    """
+    GitRepo(config_dir=tmp_path).discover_or_init()  # first boot: initialises
+
+    restarted = GitRepo(config_dir=tmp_path)
+    restarted.discover_or_init()  # re-discovers the existing repo via adopt
+    assert restarted.managed
+
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    lock = _index_lock(tmp_path, age_seconds=3600)
+
+    sha = restarted.commit_paths([yaml], "Create kitchen.yaml")
+
+    assert sha
+    assert not lock.exists()
+
+
+def test_pre_marker_repo_is_backfilled_as_managed(tmp_path: Path) -> None:
+    """A repo we created before the marker existed is recognised by its seed commit.
+
+    Simulates an upgrade: drop the marker our init wrote, then re-discover —
+    the self-authored ``Initialize version history`` root identifies it as
+    ours and the marker is stamped back.
+    """
+    GitRepo(config_dir=tmp_path).discover_or_init()
+    _git(tmp_path, "config", "--local", "--unset", "device-builder.managed")
+
+    upgraded = GitRepo(config_dir=tmp_path)
+    upgraded.discover_or_init()
+
+    assert upgraded.managed
+    # The backfill re-stamped the marker, so the next restart is cheap.
+    assert _git(tmp_path, "config", "--local", "--get", "device-builder.managed").strip() == "true"
 
 
 def test_commit_keeps_fresh_index_lock(tmp_path: Path) -> None:
@@ -421,7 +461,7 @@ def test_adopted_repo_never_clears_index_lock(tmp_path: Path) -> None:
     _make_repo(tmp_path)
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
-    assert not repo.created
+    assert not repo.managed
     yaml = tmp_path / "kitchen.yaml"
     yaml.write_text("v1\n", encoding="utf-8")
     lock = _index_lock(tmp_path, age_seconds=3600)
@@ -429,6 +469,72 @@ def test_adopted_repo_never_clears_index_lock(tmp_path: Path) -> None:
     with pytest.raises(subprocess.CalledProcessError):
         repo.commit_paths([yaml], "Create kitchen.yaml")
     assert lock.exists()
+
+
+def test_commit_raises_when_stale_lock_cannot_be_removed(tmp_path: Path) -> None:
+    """If the stale lock can't be unlinked (e.g. it's a directory), the write still raises."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    # A directory at the lock path: aged-stale, but unlink() raises OSError.
+    lock_dir = tmp_path / ".git" / "index.lock"
+    lock_dir.mkdir()
+    stamp = time.time() - 3600
+    os.utime(lock_dir, (stamp, stamp))
+
+    with pytest.raises(subprocess.CalledProcessError):
+        repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert lock_dir.exists()
+
+
+def test_clear_stale_index_lock_noop_when_lock_already_gone(tmp_path: Path) -> None:
+    """A race where the lock vanished before we looked is a clean no-op, not a crash."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    exc = subprocess.CalledProcessError(128, ["git", "add"], stderr="fatal: ... index.lock")
+
+    assert repo._clear_stale_index_lock(exc) is False
+
+
+def test_clear_stale_index_lock_handles_stat_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stat() failure between the exists check and age read is swallowed, not raised."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    class _BadLock:
+        def exists(self) -> bool:
+            return True
+
+        def stat(self) -> object:
+            raise OSError("stat failed")
+
+    monkeypatch.setattr(GitRepo, "_index_lock_path", lambda _self: _BadLock())
+    exc = subprocess.CalledProcessError(128, ["git", "add"], stderr="fatal: ... index.lock")
+
+    assert repo._clear_stale_index_lock(exc) is False
+
+
+def test_index_lock_path_none_when_rev_parse_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing ``rev-parse --git-path`` yields no lock path rather than crashing."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    real_run = subprocess.run
+
+    def _fail_git_path(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "--git-path" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _fail_git_path
+    )
+
+    assert repo._index_lock_path() is None
 
 
 def test_reads_pass_no_optional_locks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -10,6 +10,7 @@ The load-bearing guarantees these pin:
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -404,11 +405,7 @@ def test_commit_clears_stale_index_lock_and_retries(tmp_path: Path) -> None:
 
 
 def test_managed_flag_survives_restart_and_heals(tmp_path: Path) -> None:
-    """A repo we created is re-adopted as managed on restart, so the heal still fires.
-
-    The headline scenario: the addon is SIGTERM'd mid-commit (leaving the
-    lock), then a fresh process re-discovers the existing ``.git``.
-    """
+    """A repo we created is re-adopted as managed on restart, so the stale-lock heal fires."""
     GitRepo(config_dir=tmp_path).discover_or_init()  # first boot: initialises
 
     restarted = GitRepo(config_dir=tmp_path)
@@ -426,12 +423,7 @@ def test_managed_flag_survives_restart_and_heals(tmp_path: Path) -> None:
 
 
 def test_pre_marker_repo_is_backfilled_as_managed(tmp_path: Path) -> None:
-    """A repo we created before the marker existed is recognised by its seed commit.
-
-    Simulates an upgrade: drop the marker our init wrote, then re-discover —
-    the self-authored ``Initialize version history`` root identifies it as
-    ours and the marker is stamped back.
-    """
+    """A pre-marker repo we created is recognised by its seed root commit and re-stamped."""
     GitRepo(config_dir=tmp_path).discover_or_init()
     _git(tmp_path, "config", "--local", "--unset", "device-builder.managed")
 
@@ -515,6 +507,26 @@ def test_clear_stale_index_lock_handles_stat_error(
     exc = subprocess.CalledProcessError(128, ["git", "add"], stderr="fatal: ... index.lock")
 
     assert repo._clear_stale_index_lock(exc) is False
+
+
+def test_mark_managed_warns_when_config_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed managed-flag stamp is logged, not silently dropped."""
+    real_run = subprocess.run
+
+    def _fail_mark(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "config" in cmd and "device-builder.managed" in cmd and "true" in cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "config write failed")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _fail_mark
+    )
+    with caplog.at_level(logging.WARNING):
+        GitRepo(config_dir=tmp_path).discover_or_init()
+
+    assert any("Could not stamp managed flag" in rec.message for rec in caplog.records)
 
 
 def test_index_lock_path_none_when_rev_parse_fails(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1241. With git's stderr now surfaced, the failure behind the
repeating `Version-history catch-all failed for ...` warnings is a
leftover `.git/index.lock`: a git process killed mid-commit (the addon
getting SIGTERM'd is the common trigger) leaves the lock on disk, and then
every subsequent `git add` fails with exit 128 (`fatal: Unable to create
'.../index.lock': File exists`) until it's removed by hand. It survives
restarts, so commits stay broken indefinitely. History *reads* keep
working, which is why the feature still looks enabled.

Two changes:

- **Self-heal a stale lock.** `GitRepo._run_write` clears the
  `index.lock` and retries the write once, but only when it's safe:
  gated on ownership (a new `created` flag — true only for a repo we
  initialised, never an adopted `/config` work tree) and on age
  (`_STALE_LOCK_SECONDS`). A young lock, or any lock in a repo the user
  owns, is left untouched so we never delete one a live git is actively
  holding.
- **Stop reads contending for the lock.** Reads run unlocked for
  responsiveness, and `diff_file` (`git diff <sha> -- <path>`) refreshes
  the stat-cache, which can grab `index.lock` and race a concurrent
  commit. All git invocations now pass `--no-optional-locks`, which
  suppresses that optional lock without touching the required lock
  `add`/`commit` take.

Writes were already serialized behind the controller's `asyncio.Lock`, so
two of our own commits never collided; this closes the remaining
read-vs-write window and recovers from a crash-leftover lock.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
