### PR TITLE
Reject binary uploads on devices/create instead of writing unparsable YAML

### DIFF
--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -51,6 +51,7 @@ __all__ = [
     "_apply_featured_presets",
     "_build_address_cache_args",
     "_drop_unconfigured_dependent_fields",
+    "_looks_binary",
     "_normalize_pin_value",
     "_redact_concealed_secrets",
     "_rewrite_required_yaml_leaf",
@@ -72,6 +73,12 @@ _LOGGER = logging.getLogger(__name__)
 # (``\n`` / ``\t`` / ``\r``) while emitting the rest (NUL, bell, …)
 # literally — a literal NUL alone makes the YAML unparsable.
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+# Same control set minus the three the YAML layer tolerates (tab, LF,
+# CR), plus U+FFFD. A text config never carries these; a .tar.gz read
+# as text does (gzip magic 0x1f at byte 0, then NULs and invalid-UTF-8
+# bytes the frontend's readAsText turns into U+FFFD).
+_BINARY_CONTENT_RE = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\ufffd]")
 
 # ESPHome's ``validate_hostname`` caps the device name at 31 chars (24
 # with name_add_mac_suffix, which the create wizard never sets). Keep
@@ -112,6 +119,11 @@ def clean_friendly_name(value: str) -> str:
     if len(encoded) > FRIENDLY_NAME_MAX_LEN:
         cleaned = encoded[:FRIENDLY_NAME_MAX_LEN].decode("utf-8", "ignore").rstrip()
     return cleaned
+
+
+def _looks_binary(content: str) -> bool:
+    """Return True when *content* holds control/replacement chars no text YAML carries."""
+    return _BINARY_CONTENT_RE.search(content) is not None
 
 
 def _rewrite_required_yaml_leaf(

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -74,11 +74,14 @@ _LOGGER = logging.getLogger(__name__)
 # literally — a literal NUL alone makes the YAML unparsable.
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
-# Same control set minus the three the YAML layer tolerates (tab, LF,
-# CR), plus U+FFFD. A text config never carries these; a .tar.gz read
-# as text does (gzip magic 0x1f at byte 0, then NULs and invalid-UTF-8
-# bytes the frontend's readAsText turns into U+FFFD).
-_BINARY_CONTENT_RE = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\ufffd]")
+# Any C0/C1 control or U+FFFD means non-text content; a text config
+# never carries these, but a .tar.gz read as text does (gzip magic 0x1f
+# at byte 0, then NULs and invalid-UTF-8 bytes readAsText turns into
+# U+FFFD). The YAML-safe whitespace (tab, LF, CR) is stripped by
+# ``_looks_binary`` before the match so the class can use the same
+# contiguous control range as ``_CONTROL_CHARS_RE``.
+_BINARY_CONTENT_RE = re.compile("[\x00-\x1f\x7f-\x9f\ufffd]")
+_YAML_SAFE_WHITESPACE = str.maketrans("", "", "\t\n\r")
 
 # ESPHome's ``validate_hostname`` caps the device name at 31 chars (24
 # with name_add_mac_suffix, which the create wizard never sets). Keep
@@ -123,7 +126,7 @@ def clean_friendly_name(value: str) -> str:
 
 def _looks_binary(content: str) -> bool:
     """Return True when *content* holds control/replacement chars no text YAML carries."""
-    return _BINARY_CONTENT_RE.search(content) is not None
+    return _BINARY_CONTENT_RE.search(content.translate(_YAML_SAFE_WHITESPACE)) is not None
 
 
 def _rewrite_required_yaml_leaf(

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -11,7 +11,7 @@ from ...helpers.api import CommandError
 from ...helpers.device_yaml import parse_platform_from_yaml
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, WizardResponse
-from .helpers import clean_friendly_name, slugify_hostname
+from .helpers import _looks_binary, clean_friendly_name, slugify_hostname
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -93,7 +93,19 @@ async def create_device(  # noqa: C901
     # on disk. User uploads are deliberately skipped: the upload
     # flow exists so users can bring an existing (often older)
     # config into the builder and repair it in the editor.
-    if source != "user":
+    if source == "user":
+        # Schema validation stays off (an older-but-valid config must
+        # still land for repair), but a binary blob is a different
+        # failure: a .tar.gz read as text can't be opened in the editor
+        # at all, so refuse it instead of writing an unparsable .yaml.
+        if _looks_binary(yaml_content):
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "This doesn't look like a text YAML configuration; it "
+                "contains binary data, for example a .tar.gz archive. "
+                "Upload a plain-text .yaml file.",
+            )
+    else:
         await controller._validate_rewritten_yaml_or_raise(
             filename,
             yaml_content,

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -435,15 +435,7 @@ async def test_create_device_accepts_old_esphome_version_yaml(
 async def test_create_device_rejects_binary_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """A .tar.gz uploaded as ``file_content`` is refused, not written.
-
-    The wizard reads the picked file as text, so a gzip bundle
-    arrives as control bytes (magic 0x1f, NULs, U+FFFD from the
-    invalid-UTF-8 bytes). That can't open in the editor at all, so
-    it must fail with ``INVALID_ARGS`` rather than land an unparsable
-    .yaml. This is the binary-vs-text guard; it must not turn into
-    schema validation of legacy-but-textual configs.
-    """
+    """A .tar.gz read as text is refused with ``INVALID_ARGS``, not written."""
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     # Mirror the frontend's readAsText of a gzip archive.
     bundle_bytes = gzip.compress(b"esphome:\n  name: kitchen\n")

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -11,6 +11,7 @@ exception.
 from __future__ import annotations
 
 import asyncio
+import gzip
 import io
 import warnings
 from pathlib import Path
@@ -429,6 +430,47 @@ async def test_create_device_accepts_old_esphome_version_yaml(
     written = (tmp_path / "old-device.yaml").read_text("utf-8")
     assert written == legacy_yaml
     assert ctrl._scanner.calls == [("scan",)]
+
+
+async def test_create_device_rejects_binary_file_content(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A .tar.gz uploaded as ``file_content`` is refused, not written.
+
+    The wizard reads the picked file as text, so a gzip bundle
+    arrives as control bytes (magic 0x1f, NULs, U+FFFD from the
+    invalid-UTF-8 bytes). That can't open in the editor at all, so
+    it must fail with ``INVALID_ARGS`` rather than land an unparsable
+    .yaml. This is the binary-vs-text guard; it must not turn into
+    schema validation of legacy-but-textual configs.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    # Mirror the frontend's readAsText of a gzip archive.
+    bundle_bytes = gzip.compress(b"esphome:\n  name: kitchen\n")
+    file_content = bundle_bytes.decode("utf-8", "replace")
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", file_content=file_content)
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "binary" in excinfo.value.message
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
+
+
+async def test_create_device_rejects_file_content_with_nul(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A lone NUL in otherwise-texty content is still refused (unparsable YAML)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    content = "esphome:\n  name: kitchen\x00\n"
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", file_content=content)
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")


### PR DESCRIPTION
# What does this implement/fix?

Uploading a `.tar.gz` bundle through the import wizard wrote the raw gzip
bytes verbatim into a `.yaml`, so the editor failed to open it with
`unacceptable character #x001f`. The upload path reads the picked file as
text, so a bundle arrives as control bytes (gzip magic `0x1f`, NULs, and
U+FFFD from the invalid-UTF-8 bytes).

This adds a binary-vs-text guard on the user-upload branch of
`devices/create`: content carrying control or replacement characters no
text YAML holds is refused with `INVALID_ARGS` instead of landing an
unparsable file. Schema validation stays off for uploads, so an
older-but-valid config still lands for in-editor repair; the guard only
rejects genuinely binary content.

fixes #1243

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
