### PR TITLE
Skip the version-history commit for a gone, untracked path

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -317,7 +317,14 @@ class GitRepo:
         """
         if not self.enabled or not paths:
             return None
-        spec = [str(p) for p in paths]
+        # A path that's gone from disk and untracked has nothing to commit:
+        # the dashboard delete already recorded the removal, or an atomic-save
+        # editor briefly removed it. Drop those. A gone-but-tracked path stays
+        # so its deletion is staged (git add -A picks up the removal); exists()
+        # short-circuits the git call for the common create / edit case.
+        spec = [str(p) for p in paths if p.exists() or self._is_tracked(p)]
+        if not spec:
+            return None
         self._run_write(["add", "-A", "--", *spec])
         staged = self._run(["diff", "--cached", "--quiet", "--", *spec], check=False)
         if staged.returncode == 0:
@@ -524,6 +531,11 @@ class GitRepo:
         if not lock.is_absolute():
             lock = (self.toplevel or self.config_dir) / lock
         return lock
+
+    def _is_tracked(self, path: Path) -> bool:
+        """Whether *path* is in git's index (tracked), vs untracked / never committed."""
+        result = self._run(["ls-files", "--error-unmatch", "--", str(path)], check=False)
+        return result.returncode == 0
 
     def _rel_to_toplevel(self, path: Path) -> str:
         """Return *path* relative to the work-tree root (git's pathspec base)."""

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -322,8 +322,13 @@ class GitRepo:
         # editor briefly removed it. Drop those. A gone-but-tracked path stays
         # so its deletion is staged (git add -A picks up the removal). The
         # common create / edit case has no gone paths, so it skips git here.
-        spec = [str(p) for p in paths if p.exists()]
-        gone = [p for p in paths if not p.exists()]
+        spec: list[str] = []
+        gone: list[Path] = []
+        for p in paths:
+            if p.exists():
+                spec.append(str(p))
+            else:
+                gone.append(p)
         if gone:
             spec += [str(p) for p in self._tracked_subset(gone)]
         if not spec:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -541,12 +541,15 @@ class GitRepo:
         return lock
 
     def _tracked_subset(self, paths: list[Path]) -> list[Path]:
-        """Return the subset of *paths* git tracks in the index (one ls-files call)."""
+        """Return the subset of *paths* git tracks in the index (one ls-files call).
+
+        Runs with ``check=True``: ``ls-files`` exits 0 (empty output) for an
+        untracked pathspec, so a non-zero exit is a genuine git failure and
+        must propagate rather than masquerade as "nothing tracked".
+        """
         result = self._run(
-            ["ls-files", "-z", "--full-name", "--", *(str(p) for p in paths)], check=False
+            ["ls-files", "-z", "--full-name", "--", *(str(p) for p in paths)], check=True
         )
-        if result.returncode != 0 or not result.stdout:
-            return []
         tracked = {rel for rel in result.stdout.split("\0") if rel}
         return [p for p in paths if self._rel_to_toplevel(p) in tracked]
 

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -320,9 +320,12 @@ class GitRepo:
         # A path that's gone from disk and untracked has nothing to commit:
         # the dashboard delete already recorded the removal, or an atomic-save
         # editor briefly removed it. Drop those. A gone-but-tracked path stays
-        # so its deletion is staged (git add -A picks up the removal); exists()
-        # short-circuits the git call for the common create / edit case.
-        spec = [str(p) for p in paths if p.exists() or self._is_tracked(p)]
+        # so its deletion is staged (git add -A picks up the removal). The
+        # common create / edit case has no gone paths, so it skips git here.
+        spec = [str(p) for p in paths if p.exists()]
+        gone = [p for p in paths if not p.exists()]
+        if gone:
+            spec += [str(p) for p in self._tracked_subset(gone)]
         if not spec:
             return None
         self._run_write(["add", "-A", "--", *spec])
@@ -532,10 +535,15 @@ class GitRepo:
             lock = (self.toplevel or self.config_dir) / lock
         return lock
 
-    def _is_tracked(self, path: Path) -> bool:
-        """Whether *path* is in git's index (tracked), vs untracked / never committed."""
-        result = self._run(["ls-files", "--error-unmatch", "--", str(path)], check=False)
-        return result.returncode == 0
+    def _tracked_subset(self, paths: list[Path]) -> list[Path]:
+        """Return the subset of *paths* git tracks in the index (one ls-files call)."""
+        result = self._run(
+            ["ls-files", "-z", "--full-name", "--", *(str(p) for p in paths)], check=False
+        )
+        if result.returncode != 0 or not result.stdout:
+            return []
+        tracked = {rel for rel in result.stdout.split("\0") if rel}
+        return [p for p in paths if self._rel_to_toplevel(p) in tracked]
 
     def _rel_to_toplevel(self, path: Path) -> str:
         """Return *path* relative to the work-tree root (git's pathspec base)."""

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -661,6 +661,30 @@ def test_commit_paths_no_change_returns_none(tmp_path: Path) -> None:
     assert repo.commit_paths([yaml], "Update kitchen.yaml") is None
 
 
+def test_commit_paths_untracked_and_deleted_returns_none(tmp_path: Path) -> None:
+    """Deleting a file the work tree/index never held is a no-op, not a git error."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    gone = tmp_path / "ghost.yaml"
+
+    assert repo.commit_paths([gone], "Delete ghost.yaml") is None
+
+
+def test_commit_paths_records_deletion_of_tracked_file(tmp_path: Path) -> None:
+    """A gone-but-tracked file still records its deletion (file already unlinked)."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Create kitchen.yaml")
+
+    yaml.unlink()
+    sha = repo.commit_paths([yaml], "Delete kitchen.yaml")
+
+    assert sha
+    assert repo.log_file(yaml)[0].message == "Delete kitchen.yaml"
+
+
 def test_commit_paths_does_not_sweep_unrelated_staged_edits(tmp_path: Path) -> None:
     """Pathspec scoping: our commit must not fold in the user's staged work.
 

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -685,6 +685,51 @@ def test_commit_paths_records_deletion_of_tracked_file(tmp_path: Path) -> None:
     assert repo.log_file(yaml)[0].message == "Delete kitchen.yaml"
 
 
+def test_latest_content_walks_back_past_a_deletion(tmp_path: Path) -> None:
+    """latest_content returns the newest commit where the file still had content."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Create kitchen.yaml")
+    yaml.write_text("v2\n", encoding="utf-8")
+    repo.commit_paths([yaml], "Update kitchen.yaml")
+    yaml.unlink()
+    repo.commit_paths([yaml], "Delete kitchen.yaml")
+
+    result = repo.latest_content(yaml)
+
+    assert result is not None
+    _, content = result
+    assert content == "v2\n"  # skipped the contentless deletion commit
+
+
+def test_latest_content_none_when_no_history(tmp_path: Path) -> None:
+    """latest_content is None for a path git has never recorded."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+
+    assert repo.latest_content(tmp_path / "ghost.yaml") is None
+
+
+def test_index_lock_path_absolute_returned_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An absolute ``--git-path index.lock`` (split git dir) is used as-is."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    abs_lock = tmp_path / ".git" / "index.lock"
+    monkeypatch.setattr(
+        GitRepo,
+        "_run",
+        lambda self, args, *, check, cwd=None: subprocess.CompletedProcess(
+            args, 0, stdout=f"{abs_lock}\n", stderr=""
+        ),
+    )
+
+    assert repo._index_lock_path() == abs_lock
+
+
 def test_commit_paths_does_not_sweep_unrelated_staged_edits(tmp_path: Path) -> None:
     """Pathspec scoping: our commit must not fold in the user's staged work.
 


### PR DESCRIPTION
# What does this implement/fix?

Deleting a device from the UI logs a scary git traceback even though the deletion is fine. The dashboard delete commits the removal and clears the pending catch-all, then the scanner notices the file is gone and re-queues a catch-all "Delete" right after; by the time that flush runs, the path is both absent from disk and already out of the index, so `git add -A` fails with a fatal pathspec error.

The fix drops paths that are gone and untracked before staging, so there is nothing to commit and it becomes a quiet no-op. A gone-but-tracked path stays in, so a genuine deletion (the dashboard delete, an external `rm`) is still recorded. `exists()` short-circuits the extra git check for the common create/edit case.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
