### PR TITLE
Pre-roll cold-connect queue_status capture to fix lost-event flake

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -138,6 +138,11 @@ class PairedInstances:
     offloader_closed: _CapturedEvents
     receiver_opened: _CapturedEvents
     receiver_closed: _CapturedEvents
+    # The receiver's one-shot ``queue_status`` push lands on a
+    # background task right after the session opens, so it can
+    # fire before a test body attaches its own listener. Pre-roll
+    # it here for the same reason as the lifecycle events above.
+    offloader_queue_status: _CapturedEvents
 
     @property
     def offloader(self) -> OffloaderController:
@@ -241,6 +246,7 @@ async def _paired_instances_ctx(
     offloader_closed = capture_events(offloader_bus, EventType.OFFLOADER_PEER_LINK_CLOSED)
     receiver_opened = capture_events(receiver_bus, EventType.RECEIVER_PEER_LINK_SESSION_OPENED)
     receiver_closed = capture_events(receiver_bus, EventType.RECEIVER_PEER_LINK_SESSION_CLOSED)
+    offloader_queue_status = capture_events(offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED)
 
     # Stand up the receiver's peer-link WS endpoint on a real
     # TCP port. ``TestServer`` picks an ephemeral port; the
@@ -316,6 +322,7 @@ async def _paired_instances_ctx(
         offloader_closed=offloader_closed,
         receiver_opened=receiver_opened,
         receiver_closed=receiver_closed,
+        offloader_queue_status=offloader_queue_status,
     )
     try:
         yield instances

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -220,19 +220,15 @@ async def test_cold_connect_offloader_observes_initial_queue_status_then_picks_r
     :func:`build_scheduler_snapshot` + :func:`pick_build_path`
     resolve to ``BuildPath.REMOTE`` against the same pin.
     """
-    queue_status_landed = capture_events(
-        paired_instances.offloader_bus, EventType.OFFLOADER_QUEUE_STATUS_CHANGED
-    )
+    # The capture is pre-rolled in the fixture, before the session
+    # opens. The receiver's one-shot ``queue_status`` push lands on
+    # a background task right after registration, so a listener
+    # attached in the test body could miss it entirely — the source
+    # of an earlier lost-event flake. Cold-connect contract: the
+    # offloader's ``_peer_queue_status`` populates from the wire
+    # with no local-side seeding.
+    queue_status_landed = paired_instances.offloader_queue_status
     await paired_instances.wait_until_session_opened()
-    # Wait for the offloader to observe the receiver's initial
-    # ``queue_status`` push. Cold-connect contract:
-    # the offloader's ``_peer_queue_status`` must populate from
-    # the wire without any local-side seeding. The push is a
-    # fire-and-forget background task scheduled at session
-    # registration, so under ``-n auto`` CI contention it can
-    # lag a couple event-loop turns behind session-open; a 2s
-    # ceiling tipped over on a loaded runner. The global
-    # ``--timeout=120`` still catches a truly broken push.
     await asyncio.wait_for(queue_status_landed.received.wait(), timeout=10.0)
     payload = queue_status_landed[-1]
     assert payload["pin_sha256"] == paired_instances.pin_sha256


### PR DESCRIPTION
# What does this implement/fix?

The cold-connect `queue_status` e2e test attached its `OFFLOADER_QUEUE_STATUS_CHANGED` listener inside the test body, after the `paired_instances` fixture had already yielded. The receiver's one-shot `queue_status` push runs on a background task right after the session opens, so it could fire before the listener was attached; the event was then lost and the test waited the full timeout. Bumping the wait to 10s in #1240 did not help, since nothing was ever going to arrive.

This pre-rolls the capture in the fixture, before either controller starts, the same way the session-lifecycle captures are already pre-rolled, and has the test read it off the fixture instead of subscribing late.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
