### PR TITLE
Ignore stray top-level YAML so a misplaced config can't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ htmlcov/
 !/README.md
 !/CLAUDE.md
 /*.png
+
+# Stray top-level YAML must never be committed: a misplaced device config
+# could leak secrets. Only the tooling configs below are tracked; nested
+# YAML (definitions/, .github/, board manifests) is unaffected.
+/*.yaml
+/*.yml
+!/.pre-commit-config.yaml
+!/codecov.yml


### PR DESCRIPTION
# What does this implement/fix?

Ignores stray top-level `*.yaml` / `*.yml` so a device config accidentally dropped in the repo root can't be committed (a misplaced config with secrets is a credential-leak risk). Mirrors the existing root-level `/*.md` and `/*.png` rules and their negation style; the tracked tooling configs (`.pre-commit-config.yaml`, `codecov.yml`) are negated back, and nested YAML (`definitions/`, `.github/`, board manifests) is untouched by the `/` anchor.

Verified with `git check-ignore`: a root `bktest.yaml` is now ignored, while `.pre-commit-config.yaml`, `codecov.yml`, `.github/workflows/*.yml`, and `definitions/boards/*/manifest.yaml` stay tracked.

## Types of changes

- [x] Maintenance (dependencies, CI, tooling) — `maintenance`

## Checklist

- [x] The code change is tested and works locally.
