### PR TITLE
Validate secrets.yaml parses before saving

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -648,7 +648,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             )
         if Path(configuration).name == "secrets.yaml":
             try:
-                validate_secrets_content(content)
+                validate_secrets_content(content, self._db.settings.rel_path(configuration))
             except SecretsContentError as err:
                 raise CommandError(
                     ErrorCode.INVALID_ARGS,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -24,6 +24,7 @@ from ...helpers.device_yaml import (
     configuration_stem,
 )
 from ...helpers.event_bus import Event
+from ...helpers.secrets_state import SecretsContentError, validate_secrets_content
 from ...helpers.storage import ShutdownCallback
 from ...models import (
     AddComponentResponse,
@@ -645,6 +646,14 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
                 f"refusing to write empty content to {configuration!r} to prevent "
                 "accidental data loss; use the delete action to remove a file",
             )
+        if Path(configuration).name == "secrets.yaml":
+            try:
+                validate_secrets_content(content)
+            except SecretsContentError as err:
+                raise CommandError(
+                    ErrorCode.INVALID_ARGS,
+                    f"refusing to save invalid secrets.yaml: {err}",
+                ) from err
         await self._persist_yaml_mutation(configuration, content, message=f"Edit {configuration}")
 
     async def apply_restored_yaml(

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -23,13 +23,12 @@ import logging
 import re
 from pathlib import Path
 
-import yaml
 from esphome import yaml_util
 from esphome.core import EsphomeError
 from esphome.helpers import write_file as atomic_write_file
 from ruamel.yaml import YAML
 
-from .yaml import FastestSafeLoader, load_yaml_fast_then_esphome
+from .yaml import load_yaml_fast_then_esphome
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,24 +84,17 @@ def validate_secrets_content(content: str) -> None:
     """
     Raise ``SecretsContentError`` unless *content* is a valid ``secrets.yaml``.
 
-    A comment-only file (parses to ``None``) is accepted; every other
-    non-mapping top level is rejected, matching the dict-shape ``!secret``
-    lookups require. The message carries the parser's 1-indexed line/column.
+    Parsed through ESPHome's own loader so validation matches how secrets
+    actually resolve at compile time, rejecting duplicate keys the plain
+    ``SafeLoader`` would silently accept. A non-mapping top level (list /
+    scalar) is rejected; the raised message carries the line/column.
     """
     try:
-        data = yaml.load(content, Loader=FastestSafeLoader)  # noqa: S506
-    except yaml.YAMLError as err:
-        raise SecretsContentError(_format_yaml_error(err)) from err
+        data = yaml_util.parse_yaml(Path(yaml_util.SECRET_YAML), io.StringIO(content))
+    except EsphomeError as err:
+        raise SecretsContentError(str(err)) from err
     if data is not None and not isinstance(data, dict):
         raise SecretsContentError("secrets.yaml must be a top-level mapping of name: value entries")
-
-
-def _format_yaml_error(err: yaml.YAMLError) -> str:
-    problem = getattr(err, "problem", None) or "could not parse YAML"
-    mark = getattr(err, "problem_mark", None)
-    if mark is None:
-        return problem
-    return f"{problem} at line {mark.line + 1}, column {mark.column + 1}"
 
 
 def is_wifi_unconfigured(secrets: dict | None) -> bool:

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -80,19 +80,25 @@ class SecretsContentError(ValueError):
     """``secrets.yaml`` content failed to parse or isn't a top-level mapping."""
 
 
-def validate_secrets_content(content: str) -> None:
+def validate_secrets_content(content: str, path: Path) -> None:
     """
     Raise ``SecretsContentError`` unless *content* is a valid ``secrets.yaml``.
 
-    Parsed through ESPHome's own loader so validation matches how secrets
-    actually resolve at compile time, rejecting duplicate keys the plain
-    ``SafeLoader`` would silently accept. A non-mapping top level (list /
-    scalar) is rejected; the raised message carries the line/column.
+    Parsed through ESPHome's own loader, keyed on the real on-disk *path*,
+    so ``!include`` / ``!secret`` / merge keys resolve against the config
+    dir exactly as the saved file would be read, and duplicate keys the
+    plain ``SafeLoader`` silently accepts are rejected. A non-mapping top
+    level (list / scalar) is rejected. Any loader failure is surfaced as a
+    rejection rather than a 500; the message carries the line/column.
     """
     try:
-        data = yaml_util.parse_yaml(Path(yaml_util.SECRET_YAML), io.StringIO(content))
+        data = yaml_util.parse_yaml(path, io.StringIO(content))
     except EsphomeError as err:
         raise SecretsContentError(str(err)) from err
+    except Exception as err:
+        # A self-referential ``!secret`` inside secrets.yaml recurses in the
+        # loader (it crashes the real reader too); reject instead of 500ing.
+        raise SecretsContentError(f"secrets.yaml could not be parsed: {err}") from err
     if data is not None and not isinstance(data, dict):
         raise SecretsContentError("secrets.yaml must be a top-level mapping of name: value entries")
 

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -23,12 +23,13 @@ import logging
 import re
 from pathlib import Path
 
+import yaml
 from esphome import yaml_util
 from esphome.core import EsphomeError
 from esphome.helpers import write_file as atomic_write_file
 from ruamel.yaml import YAML
 
-from .yaml import load_yaml_fast_then_esphome
+from .yaml import FastestSafeLoader, load_yaml_fast_then_esphome
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +75,34 @@ def read_secrets_yaml(config_dir: Path) -> dict | None:
     except EsphomeError:
         return None
     return data if isinstance(data, dict) else None
+
+
+class SecretsContentError(ValueError):
+    """``secrets.yaml`` content failed to parse or isn't a top-level mapping."""
+
+
+def validate_secrets_content(content: str) -> None:
+    """
+    Raise ``SecretsContentError`` unless *content* is a valid ``secrets.yaml``.
+
+    A comment-only file (parses to ``None``) is accepted; every other
+    non-mapping top level is rejected, matching the dict-shape ``!secret``
+    lookups require. The message carries the parser's 1-indexed line/column.
+    """
+    try:
+        data = yaml.load(content, Loader=FastestSafeLoader)  # noqa: S506
+    except yaml.YAMLError as err:
+        raise SecretsContentError(_format_yaml_error(err)) from err
+    if data is not None and not isinstance(data, dict):
+        raise SecretsContentError("secrets.yaml must be a top-level mapping of name: value entries")
+
+
+def _format_yaml_error(err: yaml.YAMLError) -> str:
+    problem = getattr(err, "problem", None) or "could not parse YAML"
+    mark = getattr(err, "problem_mark", None)
+    if mark is None:
+        return problem
+    return f"{problem} at line {mark.line + 1}, column {mark.column + 1}"
 
 
 def is_wifi_unconfigured(secrets: dict | None) -> bool:

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -295,6 +295,90 @@ async def test_update_config_refuses_whitespace_only_content(
     assert controller._scanner.calls == []
 
 
+async def test_update_config_rejects_invalid_secrets_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A malformed ``secrets.yaml`` is rejected and the prior good file survives."""
+    controller = make_controller(tmp_path)
+    regenerated = _stub_regenerate(controller)
+    target = tmp_path / "secrets.yaml"
+    original = "wifi_ssid: home\nwifi_password: hunter2\n"
+    target.write_text(original, encoding="utf-8")
+    bad = 'wifi_ssid: "myssid"\nwifi_password: "mypassword"\nxx:xxx\na:a\n'
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.update_config(configuration="secrets.yaml", content=bad)
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "line" in excinfo.value.message
+    assert target.read_text(encoding="utf-8") == original
+    assert regenerated == []
+    assert controller._scanner.calls == []
+
+
+async def test_update_config_rejects_non_mapping_secrets_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A ``secrets.yaml`` whose top level is a list/scalar is rejected."""
+    controller = make_controller(tmp_path)
+    regenerated = _stub_regenerate(controller)
+    target = tmp_path / "secrets.yaml"
+    original = "wifi_ssid: home\n"
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.update_config(configuration="secrets.yaml", content="- a\n- b\n")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "mapping" in excinfo.value.message
+    assert target.read_text(encoding="utf-8") == original
+    assert regenerated == []
+
+
+async def test_update_config_accepts_valid_secrets_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A well-formed ``secrets.yaml`` mapping writes through unchanged."""
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    content = "wifi_ssid: home\nwifi_password: hunter2\n"
+
+    await controller.update_config(configuration="secrets.yaml", content=content)
+
+    assert (tmp_path / "secrets.yaml").read_text(encoding="utf-8") == content
+
+
+async def test_update_config_accepts_comment_only_secrets_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A comment-only ``secrets.yaml`` (parses to ``None``) is a legitimate file."""
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    content = "# add your secrets below\n"
+
+    await controller.update_config(configuration="secrets.yaml", content=content)
+
+    assert (tmp_path / "secrets.yaml").read_text(encoding="utf-8") == content
+
+
+async def test_update_config_does_not_validate_device_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Device YAML with ``!secret`` tags (not plain-safe-loadable) still writes.
+
+    The parse guard is scoped to ``secrets.yaml``; device configs carry
+    ESPHome tags a safe loader rejects and must land so the user can
+    repair them in the editor.
+    """
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    content = "wifi:\n  ssid: !secret wifi_ssid\n  password: !secret wifi_password\n"
+
+    await controller.update_config(configuration="kitchen.yaml", content=content)
+
+    assert (tmp_path / "kitchen.yaml").read_text(encoding="utf-8") == content
+
+
 async def test_round_trip_update_then_get_returns_written_content(
     tmp_path: Path,
     make_controller: MakeControllerFactory,

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 from esphome.core import EsphomeError
 
 from esphome_device_builder.helpers.secrets_state import (
     PLACEHOLDER_WIFI_PASSWORD,
     PLACEHOLDER_WIFI_SSID,
     SecretsContentError,
+    _format_yaml_error,
     is_wifi_unconfigured,
     merge_secrets_file,
     read_secrets_yaml,
@@ -143,6 +145,11 @@ def test_validate_secrets_content_accepts_valid_mapping() -> None:
 def test_validate_secrets_content_accepts_comment_only_file() -> None:
     """A comment-only file parses to ``None`` and is a legitimate secrets.yaml."""
     validate_secrets_content("# nothing here yet\n")
+
+
+def test_format_yaml_error_without_mark_falls_back_to_plain_message() -> None:
+    """A YAMLError carrying no ``problem_mark`` yields the bare message, no line/col."""
+    assert _format_yaml_error(yaml.YAMLError()) == "could not parse YAML"
 
 
 def test_placeholder_password_constant_is_exported() -> None:

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from esphome import yaml_util
 from esphome.core import EsphomeError
 
 from esphome_device_builder.helpers.secrets_state import (
@@ -120,35 +121,68 @@ def test_read_secrets_yaml_returns_dict_for_valid_file(tmp_path: Path) -> None:
     assert data["api_key"] == "ABC"
 
 
-def test_validate_secrets_content_rejects_malformed_yaml() -> None:
+def test_validate_secrets_content_rejects_malformed_yaml(tmp_path: Path) -> None:
     """The issue's no-space-after-colon example raises with line info."""
     bad = 'wifi_ssid: "myssid"\nwifi_password: "mypassword"\nxx:xxx\na:a\n'
     with pytest.raises(SecretsContentError) as excinfo:
-        validate_secrets_content(bad)
+        validate_secrets_content(bad, tmp_path / "secrets.yaml")
     assert "line 4" in str(excinfo.value)
 
 
-def test_validate_secrets_content_rejects_duplicate_keys() -> None:
+def test_validate_secrets_content_rejects_duplicate_keys(tmp_path: Path) -> None:
     """ESPHome's loader rejects duplicate keys the plain SafeLoader would accept."""
     with pytest.raises(SecretsContentError, match="Duplicate key"):
-        validate_secrets_content("wifi_ssid: a\nwifi_ssid: b\n")
+        validate_secrets_content("wifi_ssid: a\nwifi_ssid: b\n", tmp_path / "secrets.yaml")
 
 
-def test_validate_secrets_content_rejects_non_mapping_top_level() -> None:
+def test_validate_secrets_content_rejects_non_mapping_top_level(tmp_path: Path) -> None:
     """A list or scalar top level isn't the dict ``!secret`` lookups expect."""
+    secrets = tmp_path / "secrets.yaml"
     with pytest.raises(SecretsContentError, match="mapping"):
-        validate_secrets_content("- a\n- b\n")
+        validate_secrets_content("- a\n- b\n", secrets)
     with pytest.raises(SecretsContentError, match="mapping"):
-        validate_secrets_content("just a scalar\n")
+        validate_secrets_content("just a scalar\n", secrets)
 
 
-def test_validate_secrets_content_accepts_valid_mapping() -> None:
-    validate_secrets_content("wifi_ssid: home\nwifi_password: secret\n")
+def test_validate_secrets_content_accepts_valid_mapping(tmp_path: Path) -> None:
+    validate_secrets_content("wifi_ssid: home\nwifi_password: secret\n", tmp_path / "secrets.yaml")
 
 
-def test_validate_secrets_content_accepts_comment_only_file() -> None:
+def test_validate_secrets_content_accepts_include_and_merge_keys(tmp_path: Path) -> None:
+    """HA-style secrets with ``!include`` and a merge key resolve, not rejected.
+
+    Includes resolve against the file's own dir, so a present sibling
+    passes; this guards the regression a plain SafeLoader would cause by
+    rejecting every tagged secrets file.
+    """
+    (tmp_path / "shared.yaml").write_text("shared_pw: abc\n", encoding="utf-8")
+    content = "<<: !include shared.yaml\nwifi_ssid: home\nca_cert: !include ca.pem\n"
+    validate_secrets_content(content, tmp_path / "secrets.yaml")
+
+
+def test_validate_secrets_content_rejects_missing_include_target(tmp_path: Path) -> None:
+    """A merge-key include of an absent file fails just like the real read would."""
+    secrets = tmp_path / "secrets.yaml"
+    with pytest.raises(SecretsContentError):
+        validate_secrets_content("<<: !include gone.yaml\nwifi_ssid: home\n", secrets)
+
+
+def test_validate_secrets_content_wraps_unexpected_loader_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-EsphomeError from the loader (self-referential !secret recurses) rejects, not 500s."""
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(yaml_util, "parse_yaml", _boom)
+    with pytest.raises(SecretsContentError, match="could not be parsed"):
+        validate_secrets_content("wifi_ssid: home\n", tmp_path / "secrets.yaml")
+
+
+def test_validate_secrets_content_accepts_comment_only_file(tmp_path: Path) -> None:
     """A comment-only file (empty mapping) is a legitimate secrets.yaml."""
-    validate_secrets_content("# nothing here yet\n")
+    validate_secrets_content("# nothing here yet\n", tmp_path / "secrets.yaml")
 
 
 def test_placeholder_password_constant_is_exported() -> None:

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -11,14 +11,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
 from esphome.core import EsphomeError
 
 from esphome_device_builder.helpers.secrets_state import (
     PLACEHOLDER_WIFI_PASSWORD,
     PLACEHOLDER_WIFI_SSID,
     SecretsContentError,
-    _format_yaml_error,
     is_wifi_unconfigured,
     merge_secrets_file,
     read_secrets_yaml,
@@ -130,6 +128,12 @@ def test_validate_secrets_content_rejects_malformed_yaml() -> None:
     assert "line 4" in str(excinfo.value)
 
 
+def test_validate_secrets_content_rejects_duplicate_keys() -> None:
+    """ESPHome's loader rejects duplicate keys the plain SafeLoader would accept."""
+    with pytest.raises(SecretsContentError, match="Duplicate key"):
+        validate_secrets_content("wifi_ssid: a\nwifi_ssid: b\n")
+
+
 def test_validate_secrets_content_rejects_non_mapping_top_level() -> None:
     """A list or scalar top level isn't the dict ``!secret`` lookups expect."""
     with pytest.raises(SecretsContentError, match="mapping"):
@@ -143,13 +147,8 @@ def test_validate_secrets_content_accepts_valid_mapping() -> None:
 
 
 def test_validate_secrets_content_accepts_comment_only_file() -> None:
-    """A comment-only file parses to ``None`` and is a legitimate secrets.yaml."""
+    """A comment-only file (empty mapping) is a legitimate secrets.yaml."""
     validate_secrets_content("# nothing here yet\n")
-
-
-def test_format_yaml_error_without_mark_falls_back_to_plain_message() -> None:
-    """A YAMLError carrying no ``problem_mark`` yields the bare message, no line/col."""
-    assert _format_yaml_error(yaml.YAMLError()) == "could not parse YAML"
 
 
 def test_placeholder_password_constant_is_exported() -> None:

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -16,9 +16,11 @@ from esphome.core import EsphomeError
 from esphome_device_builder.helpers.secrets_state import (
     PLACEHOLDER_WIFI_PASSWORD,
     PLACEHOLDER_WIFI_SSID,
+    SecretsContentError,
     is_wifi_unconfigured,
     merge_secrets_file,
     read_secrets_yaml,
+    validate_secrets_content,
 )
 
 
@@ -116,6 +118,31 @@ def test_read_secrets_yaml_returns_dict_for_valid_file(tmp_path: Path) -> None:
     assert data is not None
     assert data["wifi_ssid"] == "home"
     assert data["api_key"] == "ABC"
+
+
+def test_validate_secrets_content_rejects_malformed_yaml() -> None:
+    """The issue's no-space-after-colon example raises with line info."""
+    bad = 'wifi_ssid: "myssid"\nwifi_password: "mypassword"\nxx:xxx\na:a\n'
+    with pytest.raises(SecretsContentError) as excinfo:
+        validate_secrets_content(bad)
+    assert "line 4" in str(excinfo.value)
+
+
+def test_validate_secrets_content_rejects_non_mapping_top_level() -> None:
+    """A list or scalar top level isn't the dict ``!secret`` lookups expect."""
+    with pytest.raises(SecretsContentError, match="mapping"):
+        validate_secrets_content("- a\n- b\n")
+    with pytest.raises(SecretsContentError, match="mapping"):
+        validate_secrets_content("just a scalar\n")
+
+
+def test_validate_secrets_content_accepts_valid_mapping() -> None:
+    validate_secrets_content("wifi_ssid: home\nwifi_password: secret\n")
+
+
+def test_validate_secrets_content_accepts_comment_only_file() -> None:
+    """A comment-only file parses to ``None`` and is a legitimate secrets.yaml."""
+    validate_secrets_content("# nothing here yet\n")
 
 
 def test_placeholder_password_constant_is_exported() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`devices/update_config` only checked that the submitted content was non-empty before writing it to disk; it never parsed the YAML. Since every device resolves `!secret` against the single `secrets.yaml`, one malformed save silently broke secret resolution for every device at once, with no feedback at save time and the previous good file overwritten.

This validates `secrets.yaml` before persisting: the content must parse, and the top level must be a mapping (the shape `!secret` lookups expect). On failure the save is rejected with `INVALID_ARGS` and a message carrying the parser's line and column. A comment-only file (parses to `None`) is still accepted. The guard is scoped to `secrets.yaml`; device YAMLs carry `!secret` / `!include` tags a safe loader can't load, and per the editor-repair principle they must still land so the user can fix them in place, so their behaviour is unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1252

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#663

A companion frontend change surfaces the returned line and column in the Secrets editor toast: esphome/device-builder-frontend#663. This backend guard stands on its own and protects every write path regardless.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

