### PR TITLE
Ignore the full editor swap & backup file range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ venv/
 # IDE
 .vscode/
 .idea/
-*.swp
-*.swo
+# Editor swap & backup files. Vim rotates .swp/.swo/.swn/.swm/... and a
+# swap such as .secrets.yaml.swp can hold unsaved buffer contents,
+# including secrets, so the whole range must be ignored.
+*.sw[a-p]
+*~
 
 # OS
 .DS_Store


### PR DESCRIPTION
# What does this implement/fix?

Editors like vim drop swap files (for example `.secrets.yaml.swp`) next to the file being edited, and those buffers can hold live secrets before they ever hit disk. We already ignored `*.swp`/`*.swo`, but vim rotates through `.swn`, `.swm` and the rest of the range once a swap already exists, and backup files (`*~`) were not covered at all. This widens the rules to `*.sw[a-p]` plus `*~` so no editor swap or backup file can be committed.

Nothing is being removed; no swap file was ever committed to this repo, this is purely preventive. Companion change in esphome/device-builder-frontend.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [ ] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
