### PR TITLE
Skip gitignored paths in version-history commits

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -322,13 +322,15 @@ class GitRepo:
         # editor briefly removed it. Drop those. A gone-but-tracked path stays
         # so its deletion is staged (git add -A picks up the removal). The
         # common create / edit case has no gone paths, so it skips git here.
-        spec: list[str] = []
+        present: list[Path] = []
         gone: list[Path] = []
         for p in paths:
-            if p.exists():
-                spec.append(str(p))
-            else:
-                gone.append(p)
+            (present if p.exists() else gone).append(p)
+        # Explicitly listing an untracked, gitignored path (e.g. secrets.yaml,
+        # which we deliberately keep out of history) makes ``git add`` fail, so
+        # drop those; a commit of only such paths is a clean no-op.
+        ignored = set(self._ignored_subset(present))
+        spec: list[str] = [str(p) for p in present if p not in ignored]
         if gone:
             spec += [str(p) for p in self._tracked_subset(gone)]
         if not spec:
@@ -552,6 +554,27 @@ class GitRepo:
         )
         tracked = {rel for rel in result.stdout.split("\0") if rel}
         return [p for p in paths if self._rel_to_toplevel(p) in tracked]
+
+    def _ignored_subset(self, paths: list[Path]) -> list[Path]:
+        """Return the subset of *paths* git would refuse to ``add`` as ignored.
+
+        ``check-ignore`` honours the index, so a tracked path is never
+        reported even if it matches a rule; the result is exactly the set
+        ``git add`` rejects with "paths are ignored". A non-0/1 exit (a
+        genuine failure) is treated as "nothing ignored" so a checkable
+        path is never silently dropped.
+        """
+        if not paths:
+            return []
+        # ``check-ignore`` echoes each matching path verbatim, one per line;
+        # ``-z`` is rejected here (it's --stdin-only), and top-level config
+        # paths never contain newlines. Exit 0 = some ignored, 1 = none, and
+        # anything else is a genuine failure we treat as "nothing ignored".
+        result = self._run(["check-ignore", "--", *(str(p) for p in paths)], check=False)
+        if result.returncode not in (0, 1):
+            return []
+        ignored = {echoed for echoed in result.stdout.splitlines() if echoed}
+        return [p for p in paths if str(p) in ignored]
 
     def _rel_to_toplevel(self, path: Path) -> str:
         """Return *path* relative to the work-tree root (git's pathspec base)."""

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -325,15 +325,15 @@ class GitRepo:
         # A path that's gone from disk and untracked has nothing to commit:
         # the dashboard delete already recorded the removal, or an atomic-save
         # editor briefly removed it. Drop those. A gone-but-tracked path stays
-        # so its deletion is staged (git add -A picks up the removal). The
-        # common create / edit case has no gone paths, so it skips git here.
+        # so its deletion is staged (git add -A picks up the removal).
         present: list[Path] = []
         gone: list[Path] = []
         for p in paths:
             (present if p.exists() else gone).append(p)
-        # Explicitly listing an untracked, gitignored path (e.g. secrets.yaml,
-        # which we deliberately keep out of history) makes ``git add`` fail, so
-        # drop those; a commit of only such paths is a clean no-op.
+        # Drop present paths git would refuse as ignored (e.g. secrets.yaml,
+        # deliberately kept out of history); explicitly listing one makes
+        # ``git add`` fail, and a commit of only such paths is a clean no-op.
+        # Costs one ``check-ignore`` per save, ahead of the add/diff/commit.
         ignored = set(self._ignored_subset(present))
         spec: list[str] = [str(p) for p in present if p not in ignored]
         if gone:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -29,6 +29,7 @@ import shutil
 import subprocess
 import time
 from dataclasses import dataclass, field
+from itertools import batched
 from pathlib import Path
 
 import esphome_device_builder
@@ -79,6 +80,10 @@ _EXCLUDE_END = "# <<< ESPHome Device Builder (managed) <<<"
 # (``controllers/config/settings.py``) is a virtual ``CORE.config_path``
 # value, never written to disk, so it can't be globbed and needs no filter.
 _SECRETS_FILENAME = "secrets.yaml"
+
+# Fields ``git check-ignore -v -z`` emits per input path: source, linenum,
+# pattern, pathname. A non-empty pattern marks that path ignored.
+_CHECK_IGNORE_FIELDS = 4
 
 # Glob patterns for the YAML configs this feature versions.
 _YAML_GLOBS = ("*.yaml", "*.yml")
@@ -556,7 +561,8 @@ class GitRepo:
         return [p for p in paths if self._rel_to_toplevel(p) in tracked]
 
     def _ignored_subset(self, paths: list[Path]) -> list[Path]:
-        """Return the subset of *paths* git would refuse to ``add`` as ignored.
+        """
+        Return the subset of *paths* git would refuse to ``add`` as ignored.
 
         ``check-ignore`` honours the index, so a tracked path is never
         reported even if it matches a rule; the result is exactly the set
@@ -566,15 +572,33 @@ class GitRepo:
         """
         if not paths:
             return []
-        # ``check-ignore`` echoes each matching path verbatim, one per line;
-        # ``-z`` is rejected here (it's --stdin-only), and top-level config
-        # paths never contain newlines. Exit 0 = some ignored, 1 = none, and
+        # ``--stdin -v --non-matching -z`` emits one record per input path, in
+        # order, as four NUL-separated fields (source, linenum, pattern,
+        # pathname). We correlate by position and read the pattern field
+        # rather than comparing path strings: git echoes forward slashes while
+        # ``str(p)`` uses backslashes on Windows, so a string match is
+        # unreliable there. Exit 0/1 are both normal (some/none ignored);
         # anything else is a genuine failure we treat as "nothing ignored".
-        result = self._run(["check-ignore", "--", *(str(p) for p in paths)], check=False)
+        result = self._run(
+            ["check-ignore", "-z", "-v", "--non-matching", "--stdin"],
+            check=False,
+            input_text="\0".join(str(p) for p in paths),
+        )
         if result.returncode not in (0, 1):
             return []
-        ignored = {echoed for echoed in result.stdout.splitlines() if echoed}
-        return [p for p in paths if str(p) in ignored]
+        # One record per input path, in order; correlate by position. The
+        # trailing element from the final NUL is a short record zip() drops.
+        records = batched(result.stdout.split("\0"), _CHECK_IGNORE_FIELDS)
+        ignored: list[Path] = []
+        # strict=False: the split's trailing element is a short final record
+        # zip() stops before, since there's exactly one record per path.
+        for path, record in zip(paths, records, strict=False):
+            if len(record) != _CHECK_IGNORE_FIELDS:
+                continue
+            _source, _linenum, pattern, _pathname = record
+            if pattern:
+                ignored.append(path)
+        return ignored
 
     def _rel_to_toplevel(self, path: Path) -> str:
         """Return *path* relative to the work-tree root (git's pathspec base)."""
@@ -590,12 +614,15 @@ class GitRepo:
         *,
         check: bool,
         cwd: Path | None = None,
+        input_text: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         """Run ``git`` with *args* in the work tree; capture text output.
 
         Checks the exit status here (rather than via ``check=True``) so a
         failure raises :class:`GitCommandError`, whose ``str`` carries the
         ``fatal:`` stderr line a bare ``CalledProcessError`` would drop.
+        *input_text*, when set, is fed to the child's stdin (e.g. for
+        ``--stdin`` pathspecs).
         """
         assert self.git_bin is not None
         # git_bin is a resolved absolute path from shutil.which and the
@@ -611,6 +638,7 @@ class GitRepo:
         result = subprocess.run(  # noqa: S603
             [self.git_bin, "--no-optional-locks", *args],
             cwd=str(cwd or self.toplevel or self.config_dir),
+            input=input_text,
             capture_output=True,
             text=True,
             check=False,

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -61,6 +61,19 @@ async def test_start_enables_and_commits(tmp_path: Path) -> None:
     assert controller._flush_task is None
 
 
+async def test_record_configuration_skips_gitignored_secrets(tmp_path: Path) -> None:
+    """A gitignored secrets.yaml records as a clean no-op through the full async path."""
+    controller = _make_controller(tmp_path)
+    await controller.start()  # seeds a .gitignore that ignores secrets.yaml
+
+    (tmp_path / "secrets.yaml").write_text("wifi_password: hunter2\n", encoding="utf-8")
+    sha = await controller.record_configuration("secrets.yaml", "Update secrets")
+
+    assert sha is None  # nothing committed; credentials stay out of history
+    assert await controller.list_versions(configuration="secrets.yaml") == []
+    await controller.stop()
+
+
 async def test_disabled_when_no_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """No git binary → controller disabled, commit is a quiet no-op."""
     monkeypatch.setattr(shutil, "which", lambda _name: None)

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -404,6 +404,34 @@ def test_commit_clears_stale_index_lock_and_retries(tmp_path: Path) -> None:
     assert not lock.exists()
 
 
+def test_commit_paths_skips_gitignored_secrets(tmp_path: Path) -> None:
+    """A commit for a gitignored secrets.yaml is a clean no-op, not a git error."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()  # seeds a .gitignore that ignores secrets.yaml
+    secrets = tmp_path / "secrets.yaml"
+    secrets.write_text("wifi_password: hunter2\n", encoding="utf-8")
+
+    assert repo.commit_paths([secrets], "Update secrets") is None
+    assert "secrets.yaml" not in _git(tmp_path, "ls-files").split()
+
+
+def test_commit_paths_commits_others_alongside_an_ignored_one(tmp_path: Path) -> None:
+    """A mixed batch commits the trackable file and drops the ignored one."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    kitchen = tmp_path / "kitchen.yaml"
+    kitchen.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    secrets = tmp_path / "secrets.yaml"
+    secrets.write_text("wifi_password: hunter2\n", encoding="utf-8")
+
+    sha = repo.commit_paths([kitchen, secrets], "Add kitchen + secrets")
+
+    assert sha
+    tracked = _git(tmp_path, "ls-files").split()
+    assert "kitchen.yaml" in tracked
+    assert "secrets.yaml" not in tracked
+
+
 def test_managed_flag_survives_restart_and_heals(tmp_path: Path) -> None:
     """A repo we created is re-adopted as managed on restart, so the stale-lock heal fires."""
     GitRepo(config_dir=tmp_path).discover_or_init()  # first boot: initialises

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -432,6 +432,36 @@ def test_commit_paths_commits_others_alongside_an_ignored_one(tmp_path: Path) ->
     assert "secrets.yaml" not in tracked
 
 
+def test_ignored_subset_treats_check_ignore_failure_as_nothing_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-0/1 check-ignore exit reports nothing ignored, never a crash."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()  # real _run; patch only the check-ignore call below
+    monkeypatch.setattr(
+        GitRepo,
+        "_run",
+        lambda self, *a, **k: subprocess.CompletedProcess(a, 128, stdout="", stderr="boom"),
+    )
+
+    assert repo._ignored_subset([tmp_path / "secrets.yaml"]) == []
+
+
+def test_ignored_subset_skips_a_truncated_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A short (malformed) check-ignore record is skipped, not unpacked into a crash."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()  # real _run; patch only the check-ignore call below
+    monkeypatch.setattr(
+        GitRepo,
+        "_run",
+        lambda self, *a, **k: subprocess.CompletedProcess(a, 0, stdout="src\0", stderr=""),
+    )
+
+    assert repo._ignored_subset([tmp_path / "x.yaml"]) == []
+
+
 def test_managed_flag_survives_restart_and_heals(tmp_path: Path) -> None:
     """A repo we created is re-adopted as managed on restart, so the stale-lock heal fires."""
     GitRepo(config_dir=tmp_path).discover_or_init()  # first boot: initialises


### PR DESCRIPTION
# What does this implement/fix?

The version history git repo ignores secrets.yaml on purpose, but `commit_paths` still handed it to `git add`, which refuses an explicitly listed ignored path; every time secrets.yaml changed the dashboard logged a failed version-history commit with a traceback. `commit_paths` now drops paths git would reject as ignored before staging, so a commit that only touches secrets.yaml is a clean no-op; other files batched in the same commit still go through.

**Related issue or feature (if applicable):**

- N/A; caught in the logs of a running dashboard

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
