### PR TITLE
Skip storage regen for secrets.yaml; centralize the secrets-file check

### DIFF
--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 
 def _resolve_version() -> str:
@@ -24,6 +25,17 @@ __version__ = _resolve_version()
 
 DEFAULT_PORT = 6052
 DEFAULT_HOST = "0.0.0.0"
+
+# Shared credentials file in the config dir. It's not a buildable device
+# config (no build dir / build_info.json) and is kept out of version
+# history, so callers special-case it via ``is_secrets_file``.
+SECRETS_FILENAME = "secrets.yaml"
+
+
+def is_secrets_file(configuration: str | Path) -> bool:
+    """Return True when *configuration* names the shared secrets.yaml (by basename)."""
+    return Path(configuration).name == SECRETS_FILENAME
+
 
 # Trusted TCP site for HA Ingress. Bound only when ``--ha-addon`` is set,
 # on the supervisor's docker bridge network, and bypasses the password

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -18,6 +18,7 @@ from typing import Any
 import yaml
 from esphome.core import EsphomeError
 
+from ..constants import SECRETS_FILENAME
 from ..helpers.device_yaml import load_device_yaml
 from ..helpers.yaml import FastestSafeLoader, load_yaml_fast_then_esphome
 from ..models import Device
@@ -107,7 +108,7 @@ class DeviceMqttCoordinator:
 
     def _collect_brokers(self) -> list[MqttBrokerConfig]:
         secrets_map = _load_secrets(self._config_dir)
-        secrets_mtime = _safe_mtime(self._config_dir / "secrets.yaml")
+        secrets_mtime = _safe_mtime(self._config_dir / SECRETS_FILENAME)
         seen: dict[tuple[str, int], MqttBrokerConfig] = {}
         seen_devices: set[str] = set()
         for device in self._get_devices():
@@ -291,7 +292,7 @@ def _broker_from_block(mqtt: dict) -> MqttBrokerConfig | None:
 
 
 def _load_secrets(config_dir: Path) -> dict[str, Any]:
-    secrets_path = config_dir / "secrets.yaml"
+    secrets_path = config_dir / SECRETS_FILENAME
     if not secrets_path.exists():
         return {}
     try:

--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -13,7 +13,7 @@ from esphome.core import CORE
 from esphome.helpers import get_bool_env
 from esphome.helpers import write_file as atomic_write_file
 
-from ...constants import DEFAULT_INGRESS_PORT, DEFAULT_REMOTE_BUILD_PORT
+from ...constants import DEFAULT_INGRESS_PORT, DEFAULT_REMOTE_BUILD_PORT, SECRETS_FILENAME
 from ...helpers.api import CommandError
 from ...helpers.auth import hash_password
 from ...helpers.secrets_state import PLACEHOLDER_WIFI_PASSWORD, PLACEHOLDER_WIFI_SSID
@@ -128,7 +128,7 @@ class DashboardSettings:
         # ``OnboardingController`` reads the same constants from
         # ``helpers.secrets_state`` to detect the unconfigured state
         # and surface the setup wizard.
-        secrets_path = self.config_dir / "secrets.yaml"
+        secrets_path = self.config_dir / SECRETS_FILENAME
         if not secrets_path.exists():
             atomic_write_file(
                 secrets_path,

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -18,6 +18,7 @@ from esphome.core import CORE
 from esphome.helpers import write_file as atomic_write_file
 from esphome.zeroconf import AsyncEsphomeZeroconf
 
+from ...constants import is_secrets_file
 from ...helpers.api import CommandError, api_command
 from ...helpers.build_size import BuildSizeRefreshResult
 from ...helpers.device_yaml import (
@@ -646,7 +647,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
                 f"refusing to write empty content to {configuration!r} to prevent "
                 "accidental data loss; use the delete action to remove a file",
             )
-        if Path(configuration).name == "secrets.yaml":
+        if is_secrets_file(configuration):
             try:
                 validate_secrets_content(content, self._db.settings.rel_path(configuration))
             except SecretsContentError as err:

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from esphome.core import EsphomeError
 from esphome.helpers import write_file as atomic_write_file
 
+from ...constants import SECRETS_FILENAME
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem, parse_platform_from_yaml
 from ...helpers.secrets_state import merge_secrets_file
@@ -34,7 +35,6 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-_SECRETS_FILENAME = "secrets.yaml"
 # Compressed-upload cap. The 500 MB decompressed cap is enforced inside
 # esphome.bundle.extract_bundle; this guards the base64 payload itself.
 _MAX_BUNDLE_UPLOAD_BYTES = 64 * 1024 * 1024
@@ -175,7 +175,7 @@ def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] 
             if src.is_file() and (rel := src.relative_to(staging).as_posix()) != MANIFEST_FILENAME
         ]
         conflicts = sorted(
-            rel for rel, _ in placements if rel != _SECRETS_FILENAME and (config_dir / rel).exists()
+            rel for rel, _ in placements if rel != SECRETS_FILENAME and (config_dir / rel).exists()
         )
         if conflicts and overwrite is None:
             return _Outcome(
@@ -190,7 +190,7 @@ def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] 
         kept: list[str] = []
         for rel, src in placements:
             dest = config_dir / rel
-            if rel == _SECRETS_FILENAME:
+            if rel == SECRETS_FILENAME:
                 merge_secrets_file(src, dest)
                 continue
             # A conflicting file the user didn't pick is left as-is; record

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from ...constants import is_secrets_file
 from ...helpers.config_hash import read_build_info_hash
 from ...helpers.subprocess import create_subprocess_exec
 
@@ -33,6 +34,10 @@ def schedule(controller: DevicesController, configuration: str) -> None:
     (cross-restart, TTL-gated), and ``_regenerate_lock``
     serialising the subprocess itself.
     """
+    if is_secrets_file(configuration):
+        # Shared credentials, not a buildable config: no build dir to
+        # --only-generate, so a regen would only warn about a missing hash.
+        return
     if not controller.state.esphome_cmd:
         return  # ``start()`` hasn't run yet.
     if configuration in controller.state.regenerate_pending:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -33,6 +33,7 @@ from itertools import batched
 from pathlib import Path
 
 import esphome_device_builder
+from esphome_device_builder.constants import is_secrets_file
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,10 +77,10 @@ _EXCLUDE_MARKER = "# >>> ESPHome Device Builder (managed) >>>"
 _EXCLUDE_END = "# <<< ESPHome Device Builder (managed) <<<"
 
 # The seed must never capture the user's secrets file (credentials don't
-# belong in a repo that may be pushed to a remote). The CORE sentinel
-# (``controllers/config/settings.py``) is a virtual ``CORE.config_path``
-# value, never written to disk, so it can't be globbed and needs no filter.
-_SECRETS_FILENAME = "secrets.yaml"
+# belong in a repo that may be pushed to a remote); ``is_secrets_file``
+# filters it out. The CORE sentinel (``controllers/config/settings.py``) is
+# a virtual ``CORE.config_path`` value, never written to disk, so it can't
+# be globbed and needs no filter.
 
 # Fields ``git check-ignore -v -z`` emits per input path: source, linenum,
 # pattern, pathname. A non-empty pattern marks that path ignored.
@@ -239,7 +240,7 @@ class GitRepo:
             names += [
                 path.name
                 for path in sorted(self.config_dir.glob(pattern))
-                if path.name != _SECRETS_FILENAME
+                if not is_secrets_file(path)
             ]
         return [name for name in names if (self.config_dir / name).exists()]
 

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -28,6 +28,7 @@ from esphome.core import EsphomeError
 from esphome.helpers import write_file as atomic_write_file
 from ruamel.yaml import YAML
 
+from ..constants import SECRETS_FILENAME
 from .yaml import load_yaml_fast_then_esphome
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,7 +67,7 @@ def read_secrets_yaml(config_dir: Path) -> dict | None:
     at type-check time instead of as an ``AttributeError`` slipping
     past the narrow ``EsphomeError`` catch below.
     """
-    secrets_path = config_dir / "secrets.yaml"
+    secrets_path = config_dir / SECRETS_FILENAME
     if not secrets_path.exists():
         return None
     try:
@@ -194,7 +195,7 @@ def write_wifi_secrets(config_dir: Path, ssid: str, password: str) -> None:
     it on startup, but a user who deleted it shouldn't be stuck
     here).
     """
-    secrets_path = config_dir / "secrets.yaml"
+    secrets_path = config_dir / SECRETS_FILENAME
     original = secrets_path.read_text(encoding="utf-8") if secrets_path.exists() else ""
 
     updated = _replace_or_append_secret(

--- a/tests/controllers/devices/test_storage_regenerate_e2e.py
+++ b/tests/controllers/devices/test_storage_regenerate_e2e.py
@@ -169,6 +169,22 @@ def test_regenerate_skips_when_esphome_cmd_unset(
     assert controller.state.regenerate_pending == set()
 
 
+def test_regenerate_skips_secrets_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """secrets.yaml is shared credentials, not a buildable config; regen is a no-op.
+
+    Even with esphome_cmd set (so a real config would schedule), secrets.yaml
+    has no build dir to --only-generate, so nothing is spawned.
+    """
+    controller = make_controller(tmp_path, with_regenerate_state=True, esphome_cmd=["esphome"])
+
+    controller._schedule_storage_regenerate("secrets.yaml")
+
+    assert controller._spawned_tasks == []  # type: ignore[attr-defined]
+    assert controller.state.regenerate_pending == set()
+
+
 def test_regenerate_skips_duplicate_schedule(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,16 @@
+"""Tests for shared constants helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from esphome_device_builder.constants import SECRETS_FILENAME, is_secrets_file
+
+
+def test_is_secrets_file_matches_by_basename() -> None:
+    """is_secrets_file is True only for the secrets.yaml basename, str or Path."""
+    assert is_secrets_file(SECRETS_FILENAME)
+    assert is_secrets_file("secrets.yaml")
+    assert is_secrets_file(Path("/config/esphome/secrets.yaml"))
+    assert not is_secrets_file("kitchen.yaml")
+    assert not is_secrets_file(Path("/config/secrets.yml"))


### PR DESCRIPTION
# What does this implement/fix?

Saving secrets.yaml kicked off a storage regen the same way a device config does, but secrets.yaml has no build dir, so storage_regen logged a stale config hash warning on every secrets write. It now skips secrets.yaml at the regen entry point, so the warning is gone.

While here I pulled the secrets.yaml special case into one place, `constants.is_secrets_file` and `constants.SECRETS_FILENAME`; the literal was duplicated across the version history seed, the bundle import, the config writer, the mqtt coordinator, and the config-save path, so now only constants.py holds it. It lives in constants.py rather than secrets_state.py so lightweight modules can import it without pulling in ruamel.

**Related issue or feature (if applicable):**

- N/A; caught in the logs of a running dashboard

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
