### PR TITLE
Extract automation writer layout utilities into writing_layout.py

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -43,6 +43,21 @@ from .emitter import (
     render_trigger_handler,
 )
 from .parsing import make_yaml, resolve_component_domain
+from .writing_layout import (
+    build_diff_for_append as _build_diff_for_append,
+)
+from .writing_layout import (
+    indent_block as _indent_block,
+)
+from .writing_layout import (
+    indent_for_top_list as _indent_for_top_list,
+)
+from .writing_layout import (
+    locate_singleton_block as _locate_singleton_block,
+)
+from .writing_layout import (
+    locate_top_list_item as _locate_top_list_item,
+)
 from .writing_lists import (
     delete_light_effect,
     delete_list_entry,
@@ -659,157 +674,3 @@ def _component_domain_from_yaml(
     if domain is not None:
         return domain
     return _component_domain(location)
-
-
-def _indent_block(block_text: str, indent: str) -> list[str]:
-    """Prefix every non-empty line of *block_text* with *indent*."""
-    out: list[str] = []
-    for line in block_text.splitlines():
-        if not line:
-            out.append("")
-            continue
-        out.append(indent + line)
-    return out
-
-
-def _indent_for_top_list(rendered_item: str) -> str:
-    """Indent *rendered_item* (one ``- ...`` block) for top-level list use."""
-    # ``dump([item])`` already produces the dashed list form; we
-    # use it as-is. The block is left at column-0 so it lands
-    # correctly under any top-level domain.
-    if not rendered_item.endswith("\n"):
-        rendered_item += "\n"
-    return rendered_item
-
-
-def _locate_top_list_item(  # noqa: C901
-    lines: list[str],
-    domain: str,
-    index: int,
-) -> tuple[int, int]:
-    """Return the line range of the *index*'th item under ``<domain>:``."""
-    domain_start: int | None = None
-    for idx, line in enumerate(lines):
-        stripped = line.rstrip("\n\r")
-        if stripped == f"{domain}:" or stripped.startswith(f"{domain}:"):
-            domain_start = idx
-            break
-    if domain_start is None:
-        msg = f"Block {domain!r} not present"
-        raise CommandError(ErrorCode.NOT_FOUND, msg)
-    domain_end = len(lines)
-    for idx in range(domain_start + 1, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            domain_end = idx
-            break
-    # Only column-2 dashes count as top-level list items; deeper
-    # dashes belong to nested action lists inside the item body.
-    item_indent: str | None = None
-    item_starts: list[int] = []
-    for idx in range(domain_start + 1, domain_end):
-        raw = lines[idx].rstrip("\n\r")
-        stripped = raw.lstrip(" ")
-        if not stripped.startswith("- "):
-            continue
-        prefix = raw[: len(raw) - len(stripped)]
-        if item_indent is None:
-            item_indent = prefix
-        if prefix != item_indent:
-            continue
-        item_starts.append(idx)
-    if index < 0 or index >= len(item_starts):
-        msg = f"{domain}[{index}] out of range (have {len(item_starts)})"
-        raise CommandError(ErrorCode.NOT_FOUND, msg)
-    start = item_starts[index]
-    end = item_starts[index + 1] if index + 1 < len(item_starts) else domain_end
-    return start, end
-
-
-def _locate_singleton_block(
-    lines: list[str],
-    block_key: str,
-) -> tuple[int, int, str] | None:
-    """Return ``(start, end, child_indent)`` for a singleton mapping block."""
-    header = f"{block_key}:"
-    start: int | None = None
-    indent = "  "
-    for idx, line in enumerate(lines):
-        stripped = line.rstrip("\n\r")
-        if stripped == header or stripped.startswith(header + " "):
-            start = idx
-            break
-    if start is None:
-        return None
-    end = len(lines)
-    captured = False
-    for idx in range(start + 1, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        if not stripped:
-            continue
-        if not stripped.startswith(" "):
-            if stripped[0].isalpha():
-                end = idx
-                break
-            # Column-0 comment ends the block only when the next
-            # non-blank line is also column-0 (a section banner
-            # between two top-level blocks). A comment sitting
-            # between a parent key and an indented child below is
-            # a no-op — keep scanning.
-            if _next_non_blank_at_col_zero(lines, idx + 1):
-                end = idx
-                break
-            continue
-        if not captured:
-            indent = " " * (len(stripped) - len(stripped.lstrip(" ")))
-            captured = True
-    return start, end, indent
-
-
-def _next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
-    """Return True iff the next non-blank line at *start* or later sits at column 0."""
-    for idx in range(start, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        if not stripped:
-            continue
-        return not stripped.startswith(" ")
-    return False
-
-
-def _build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:
-    """
-    Build a diff describing the lines changed by an append-style write.
-
-    Bounds the change to the region between the common leading and
-    trailing lines, so a splice into a block that isn't the last in
-    the file replaces only the changed span — without the suffix
-    match the unchanged tail would be re-emitted and duplicated.
-    """
-    old_lines = old_yaml.splitlines()
-    new_lines = new_yaml.splitlines()
-    prefix = 0
-    while (
-        prefix < len(old_lines)
-        and prefix < len(new_lines)
-        and old_lines[prefix] == new_lines[prefix]
-    ):
-        prefix += 1
-    suffix = 0
-    while (
-        suffix < len(old_lines) - prefix
-        and suffix < len(new_lines) - prefix
-        and old_lines[len(old_lines) - 1 - suffix] == new_lines[len(new_lines) - 1 - suffix]
-    ):
-        suffix += 1
-    from_line = prefix + 1
-    to_line = len(old_lines) - suffix  # == from_line - 1 ⇒ pure insert
-    replacement = "\n".join(new_lines[prefix : len(new_lines) - suffix])
-    if replacement and not replacement.endswith("\n"):
-        replacement += "\n"
-    return YamlDiff(fromLine=from_line, toLine=to_line, replacement=replacement)
-
-
-def _extract_replacement(yaml_text: str, from_line: int, to_line: int) -> str:
-    """Return the post-splice text spanned by the :class:`YamlDiff` range."""
-    lines = yaml_text.splitlines(keepends=True)
-    return "".join(lines[from_line - 1 : to_line])

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -44,19 +44,11 @@ from .emitter import (
 )
 from .parsing import make_yaml, resolve_component_domain
 from .writing_layout import (
-    build_diff_for_append as _build_diff_for_append,
-)
-from .writing_layout import (
-    indent_block as _indent_block,
-)
-from .writing_layout import (
-    indent_for_top_list as _indent_for_top_list,
-)
-from .writing_layout import (
-    locate_singleton_block as _locate_singleton_block,
-)
-from .writing_layout import (
-    locate_top_list_item as _locate_top_list_item,
+    _build_diff_for_append,
+    _indent_block,
+    _indent_for_top_list,
+    _locate_singleton_block,
+    _locate_top_list_item,
 )
 from .writing_lists import (
     delete_light_effect,

--- a/esphome_device_builder/controllers/automations/writing_layout.py
+++ b/esphome_device_builder/controllers/automations/writing_layout.py
@@ -1,11 +1,4 @@
-"""
-Pure line/diff layout utilities for the automation writer.
-
-Locate top-level list items and singleton blocks, indent rendered
-blocks, and turn an append-style rewrite into a bounded
-:class:`YamlDiff`. No catalog or parsing dependencies — just text
-geometry — so the writer's splice paths share one home for them.
-"""
+"""Pure line/diff layout utilities for the automation writer."""
 
 from __future__ import annotations
 
@@ -14,7 +7,7 @@ from ...models.api import ErrorCode
 from ...models.automations import YamlDiff
 
 
-def indent_block(block_text: str, indent: str) -> list[str]:
+def _indent_block(block_text: str, indent: str) -> list[str]:
     """Prefix every non-empty line of *block_text* with *indent*."""
     out: list[str] = []
     for line in block_text.splitlines():
@@ -25,7 +18,7 @@ def indent_block(block_text: str, indent: str) -> list[str]:
     return out
 
 
-def indent_for_top_list(rendered_item: str) -> str:
+def _indent_for_top_list(rendered_item: str) -> str:
     """Indent *rendered_item* (one ``- ...`` block) for top-level list use."""
     # ``dump([item])`` already produces the dashed list form; we
     # use it as-is. The block is left at column-0 so it lands
@@ -35,7 +28,7 @@ def indent_for_top_list(rendered_item: str) -> str:
     return rendered_item
 
 
-def locate_top_list_item(  # noqa: C901
+def _locate_top_list_item(  # noqa: C901
     lines: list[str],
     domain: str,
     index: int,
@@ -79,7 +72,7 @@ def locate_top_list_item(  # noqa: C901
     return start, end
 
 
-def locate_singleton_block(
+def _locate_singleton_block(
     lines: list[str],
     block_key: str,
 ) -> tuple[int, int, str] | None:
@@ -109,7 +102,7 @@ def locate_singleton_block(
             # between two top-level blocks). A comment sitting
             # between a parent key and an indented child below is
             # a no-op — keep scanning.
-            if next_non_blank_at_col_zero(lines, idx + 1):
+            if _next_non_blank_at_col_zero(lines, idx + 1):
                 end = idx
                 break
             continue
@@ -119,7 +112,7 @@ def locate_singleton_block(
     return start, end, indent
 
 
-def next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
+def _next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
     """Return True iff the next non-blank line at *start* or later sits at column 0."""
     for idx in range(start, len(lines)):
         stripped = lines[idx].rstrip("\n\r")
@@ -129,7 +122,7 @@ def next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
     return False
 
 
-def build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:
+def _build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:
     """
     Build a diff describing the lines changed by an append-style write.
 

--- a/esphome_device_builder/controllers/automations/writing_layout.py
+++ b/esphome_device_builder/controllers/automations/writing_layout.py
@@ -1,0 +1,162 @@
+"""
+Pure line/diff layout utilities for the automation writer.
+
+Locate top-level list items and singleton blocks, indent rendered
+blocks, and turn an append-style rewrite into a bounded
+:class:`YamlDiff`. No catalog or parsing dependencies — just text
+geometry — so the writer's splice paths share one home for them.
+"""
+
+from __future__ import annotations
+
+from ...helpers.api import CommandError
+from ...models.api import ErrorCode
+from ...models.automations import YamlDiff
+
+
+def indent_block(block_text: str, indent: str) -> list[str]:
+    """Prefix every non-empty line of *block_text* with *indent*."""
+    out: list[str] = []
+    for line in block_text.splitlines():
+        if not line:
+            out.append("")
+            continue
+        out.append(indent + line)
+    return out
+
+
+def indent_for_top_list(rendered_item: str) -> str:
+    """Indent *rendered_item* (one ``- ...`` block) for top-level list use."""
+    # ``dump([item])`` already produces the dashed list form; we
+    # use it as-is. The block is left at column-0 so it lands
+    # correctly under any top-level domain.
+    if not rendered_item.endswith("\n"):
+        rendered_item += "\n"
+    return rendered_item
+
+
+def locate_top_list_item(  # noqa: C901
+    lines: list[str],
+    domain: str,
+    index: int,
+) -> tuple[int, int]:
+    """Return the line range of the *index*'th item under ``<domain>:``."""
+    domain_start: int | None = None
+    for idx, line in enumerate(lines):
+        stripped = line.rstrip("\n\r")
+        if stripped == f"{domain}:" or stripped.startswith(f"{domain}:"):
+            domain_start = idx
+            break
+    if domain_start is None:
+        msg = f"Block {domain!r} not present"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    domain_end = len(lines)
+    for idx in range(domain_start + 1, len(lines)):
+        stripped = lines[idx].rstrip("\n\r")
+        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
+            domain_end = idx
+            break
+    # Only column-2 dashes count as top-level list items; deeper
+    # dashes belong to nested action lists inside the item body.
+    item_indent: str | None = None
+    item_starts: list[int] = []
+    for idx in range(domain_start + 1, domain_end):
+        raw = lines[idx].rstrip("\n\r")
+        stripped = raw.lstrip(" ")
+        if not stripped.startswith("- "):
+            continue
+        prefix = raw[: len(raw) - len(stripped)]
+        if item_indent is None:
+            item_indent = prefix
+        if prefix != item_indent:
+            continue
+        item_starts.append(idx)
+    if index < 0 or index >= len(item_starts):
+        msg = f"{domain}[{index}] out of range (have {len(item_starts)})"
+        raise CommandError(ErrorCode.NOT_FOUND, msg)
+    start = item_starts[index]
+    end = item_starts[index + 1] if index + 1 < len(item_starts) else domain_end
+    return start, end
+
+
+def locate_singleton_block(
+    lines: list[str],
+    block_key: str,
+) -> tuple[int, int, str] | None:
+    """Return ``(start, end, child_indent)`` for a singleton mapping block."""
+    header = f"{block_key}:"
+    start: int | None = None
+    indent = "  "
+    for idx, line in enumerate(lines):
+        stripped = line.rstrip("\n\r")
+        if stripped == header or stripped.startswith(header + " "):
+            start = idx
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    captured = False
+    for idx in range(start + 1, len(lines)):
+        stripped = lines[idx].rstrip("\n\r")
+        if not stripped:
+            continue
+        if not stripped.startswith(" "):
+            if stripped[0].isalpha():
+                end = idx
+                break
+            # Column-0 comment ends the block only when the next
+            # non-blank line is also column-0 (a section banner
+            # between two top-level blocks). A comment sitting
+            # between a parent key and an indented child below is
+            # a no-op — keep scanning.
+            if next_non_blank_at_col_zero(lines, idx + 1):
+                end = idx
+                break
+            continue
+        if not captured:
+            indent = " " * (len(stripped) - len(stripped.lstrip(" ")))
+            captured = True
+    return start, end, indent
+
+
+def next_non_blank_at_col_zero(lines: list[str], start: int) -> bool:
+    """Return True iff the next non-blank line at *start* or later sits at column 0."""
+    for idx in range(start, len(lines)):
+        stripped = lines[idx].rstrip("\n\r")
+        if not stripped:
+            continue
+        return not stripped.startswith(" ")
+    return False
+
+
+def build_diff_for_append(old_yaml: str, new_yaml: str) -> YamlDiff:
+    """
+    Build a diff describing the lines changed by an append-style write.
+
+    Bounds the change to the region between the common leading and
+    trailing lines, so a splice into a block that isn't the last in
+    the file replaces only the changed span — without the suffix
+    match the unchanged tail would be re-emitted and duplicated.
+    """
+    old_lines = old_yaml.splitlines()
+    new_lines = new_yaml.splitlines()
+    prefix = 0
+    while (
+        prefix < len(old_lines)
+        and prefix < len(new_lines)
+        and old_lines[prefix] == new_lines[prefix]
+    ):
+        prefix += 1
+    suffix = 0
+    while (
+        suffix < len(old_lines) - prefix
+        and suffix < len(new_lines) - prefix
+        and old_lines[len(old_lines) - 1 - suffix] == new_lines[len(new_lines) - 1 - suffix]
+    ):
+        suffix += 1
+    from_line = prefix + 1
+    to_line = len(old_lines) - suffix  # == from_line - 1 ⇒ pure insert
+    replacement = "\n".join(new_lines[prefix : len(new_lines) - suffix])
+    if replacement and not replacement.endswith("\n"):
+        replacement += "\n"
+    return YamlDiff(fromLine=from_line, toLine=to_line, replacement=replacement)


### PR DESCRIPTION
# What does this implement/fix?

Behavior-free split of the automation writer. `writing.py` was 815 lines, over the repo's 800-line soft cap, so the upcoming sub-entity automation work (issue #1263) has to split it first. This moves the pure line/diff layout helpers (indent, top-level-list and singleton-block locators, the append-diff builder) into a new `writing_layout.py` and imports them back under their existing private names; it also drops the dead `_extract_replacement`. No behavior change; `writing.py` drops to 676 lines and the automation test suite stays green.

**Related issue or feature (if applicable):**

- groundwork for #1263

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
