### PR TITLE
De-duplicate block-scan loop and _indent_block in the automation writer

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from ...helpers.api import CommandError
 from ...helpers.yaml import (
+    _block_end,
+    _indent_block,
     _splice_into_domain_block,
     remove_inline_handler,
     remove_subentity_handler,
@@ -53,7 +55,6 @@ from .parsing import (
 )
 from .writing_layout import (
     _build_diff_for_append,
-    _indent_block,
     _indent_for_top_list,
     _locate_singleton_block,
     _locate_top_list_item,
@@ -400,16 +401,7 @@ def _upsert_under_top_key(
         text = lines[idx].rstrip("\n\r")
         if text == handler_re_prefix or text.startswith(handler_re_prefix + " "):
             handler_start = idx
-            for jdx in range(idx + 1, end):
-                content = lines[jdx].rstrip("\n\r")
-                if not content:
-                    continue
-                leading = len(content) - len(content.lstrip(" "))
-                if leading <= len(indent):
-                    handler_end = jdx
-                    break
-            if handler_end is None:
-                handler_end = end
+            handler_end = _block_end(lines, idx, end, indent)
             break
     rendered_text = "\n".join(_indent_block(rendered_yaml, indent)) + "\n"
     if handler_start is not None and handler_end is not None:
@@ -517,15 +509,7 @@ def _delete_under_top_key(
     for idx in range(start + 1, end):
         text = lines[idx].rstrip("\n\r")
         if text == handler_prefix or text.startswith(handler_prefix + " "):
-            handler_end = end
-            for jdx in range(idx + 1, end):
-                content = lines[jdx].rstrip("\n\r")
-                if not content:
-                    continue
-                leading = len(content) - len(content.lstrip(" "))
-                if leading <= len(indent):
-                    handler_end = jdx
-                    break
+            handler_end = _block_end(lines, idx, end, indent)
             new_lines = [*lines[:idx], *lines[handler_end:]]
             return "".join(new_lines), YamlDiff(
                 fromLine=idx + 1,

--- a/esphome_device_builder/controllers/automations/writing_layout.py
+++ b/esphome_device_builder/controllers/automations/writing_layout.py
@@ -7,17 +7,6 @@ from ...models.api import ErrorCode
 from ...models.automations import YamlDiff
 
 
-def _indent_block(block_text: str, indent: str) -> list[str]:
-    """Prefix every non-empty line of *block_text* with *indent*."""
-    out: list[str] = []
-    for line in block_text.splitlines():
-        if not line:
-            out.append("")
-            continue
-        out.append(indent + line)
-    return out
-
-
 def _indent_for_top_list(rendered_item: str) -> str:
     """Indent *rendered_item* (one ``- ...`` block) for top-level list use."""
     # ``dump([item])`` already produces the dashed list form; we

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -47,6 +47,7 @@ from .component import _splice_into_domain_block as _splice_into_domain_block
 from .component import _splice_into_multi_conf_block as _splice_into_multi_conf_block
 from .component import generate_component_yaml as generate_component_yaml
 from .component import merge_component_yaml as merge_component_yaml
+from .inline import _block_end as _block_end
 from .inline import _indent_block as _indent_block
 from .inline import remove_inline_handler as remove_inline_handler
 from .inline import remove_subentity_handler as remove_subentity_handler

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -47,9 +47,6 @@ from esphome_device_builder.controllers.automations.parsing import (
     parse_device_yaml,
 )
 from esphome_device_builder.controllers.automations.writing import (
-    _indent_block as _writer_indent_block,
-)
-from esphome_device_builder.controllers.automations.writing import (
     _indent_for_top_list,
     _locate_top_list_item,
     render_delete,
@@ -1164,11 +1161,6 @@ def test_delete_under_top_key_walk_skips_blank_lines() -> None:
 def test_indent_for_top_list_adds_trailing_newline() -> None:
     """The helper appends a trailing newline when the rendered item lacks one."""
     assert _indent_for_top_list("- foo: bar").endswith("\n")
-
-
-def test_indent_block_preserves_blank_lines() -> None:
-    """Blank lines in the rendered text pass through unchanged."""
-    assert _writer_indent_block("a\n\nb", "  ") == ["  a", "", "  b"]
 
 
 def test_locate_top_list_item_missing_domain_raises_not_found() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Removes two pre-existing duplications in the automation YAML writer,
tracked separately after the #1263 DRY review left them out of scope.
No behaviour change.

- **Block-extent scan loop.** `_upsert_under_top_key` and
  `_delete_under_top_key` in `controllers/automations/writing.py` each
  carried a byte-identical copy of the "walk forward to the first
  sibling-or-shallower line, default to block end" loop. Both now call
  the existing `helpers/yaml/inline.py:_block_end` (extracted for the
  inline / sub-entity paths in #1267), re-exported through
  `helpers.yaml`.
- **`_indent_block` defined twice.** Identical definitions lived in
  `helpers/yaml/inline.py` (the canonical home, already re-exported) and
  `controllers/automations/writing_layout.py`. The writer-side copy is
  dropped; `writing.py` now imports it from `helpers.yaml`. The
  now-redundant `_writer_indent_block` test alias is folded into the
  single `helpers.yaml` pin.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1268

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
