### PR TITLE
Exit cleanly on a stop signal received during dashboard startup

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import os
 import signal
@@ -100,10 +101,31 @@ def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     activate_log_queue_handler()
 
 
-def _exit_cleanly_on_signal(signum: int, _frame: object) -> None:
-    """Exit 0 on a stop signal the event loop isn't trapping itself."""
-    logging.getLogger(_LOGGER_NAME).info("Received stop signal %s; shutting down cleanly", signum)
-    raise SystemExit(0)
+def _exit_cleanly_on_signal(_signum: int, _frame: object) -> None:
+    """Exit 0 on a stop signal the event loop isn't trapping itself.
+
+    Runs in signal context (between bytecodes on the main thread, possibly
+    mid-logging-write), so it must do no logging and no real work — that
+    would re-enter the stream/queue and deadlock or raise (a stop landing
+    while the startup banner is being emitted hit
+    ``RuntimeError: reentrant call inside <_io.BufferedWriter>``). With no
+    running loop (pre-serving cold start) raise ``SystemExit(0)``;
+    otherwise hand off to the loop, which runs ``_raise_graceful_exit`` at
+    a safe point so ``run_app`` drains ``on_cleanup``.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        raise SystemExit(0) from None
+    loop.call_soon_threadsafe(_raise_graceful_exit)
+
+
+def _raise_graceful_exit() -> None:
+    """Loop-context callback: log the stop and raise ``GracefulExit`` so ``run_app`` drains."""
+    from aiohttp.web import GracefulExit  # noqa: PLC0415
+
+    logging.getLogger(_LOGGER_NAME).info("Received stop signal; shutting down cleanly")
+    raise GracefulExit
 
 
 def main() -> None:

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -8,6 +8,7 @@ that lands while serving drains ``on_cleanup`` (``stop()``) before exiting.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import signal
 import socket
@@ -17,6 +18,7 @@ import time
 from typing import TYPE_CHECKING
 
 import pytest
+from aiohttp.web import GracefulExit
 
 from esphome_device_builder import __main__ as main_module
 
@@ -32,11 +34,28 @@ windows_only = pytest.mark.skipif(sys.platform != "win32", reason="Windows CTRL_
 _DRAIN_MARKER = "Shutting down ESPHome Device Builder"
 
 
-def test_exit_cleanly_on_signal_raises_zero() -> None:
-    """The handler raises ``SystemExit(0)`` so the interpreter exits cleanly."""
+def test_exit_cleanly_on_signal_without_loop_raises_zero() -> None:
+    """With no running loop the handler raises ``SystemExit(0)``."""
     with pytest.raises(SystemExit) as excinfo:
         main_module._exit_cleanly_on_signal(signal.SIGTERM, None)
     assert excinfo.value.code == 0
+
+
+async def test_exit_cleanly_on_signal_with_loop_defers_graceful_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With a running loop the handler defers ``GracefulExit`` instead of raising inline."""
+    scheduled: list[object] = []
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "call_soon_threadsafe", lambda cb, *a: scheduled.append(cb))
+    main_module._exit_cleanly_on_signal(signal.SIGTERM, None)
+    assert scheduled == [main_module._raise_graceful_exit]
+
+
+def test_raise_graceful_exit_raises_graceful_exit() -> None:
+    """The deferred callback raises aiohttp's ``GracefulExit``."""
+    with pytest.raises(GracefulExit):
+        main_module._raise_graceful_exit()
 
 
 def test_main_installs_stop_signal_handlers_before_parsing(
@@ -59,7 +78,7 @@ def test_main_installs_stop_signal_handlers_before_parsing(
 
 
 def _spawn_dashboard(
-    config_dir: Path, *, creationflags: int = 0
+    config_dir: Path, *, creationflags: int = 0, env: dict[str, str] | None = None
 ) -> tuple[subprocess.Popen[str], int]:
     """Launch the dashboard on an ephemeral port; return ``(proc, port)``."""
     with socket.socket() as probe:
@@ -80,22 +99,69 @@ def _spawn_dashboard(
         stderr=subprocess.STDOUT,
         text=True,
         creationflags=creationflags,
+        env=env,
     )
     return proc, port
 
 
-def _wait_for_startup_window(proc: subprocess.Popen[str]) -> None:
+# Holds the loop running but with our pre-serving SIGTERM trap still the active
+# handler — the exact "startup crack" window before aiohttp's AppRunner.setup
+# arms its own handler. Writing it via PYTHONPATH/sitecustomize makes the
+# otherwise timing-dependent race deterministic so CI exercises it every run.
+_CRACK_SITECUSTOMIZE = """
+import asyncio, time as _t
+_orig = asyncio.unix_events._UnixSelectorEventLoop.add_signal_handler
+def _slow(self, sig, callback, *args):
+    print("CRACK_OPEN", flush=True)
+    _t.sleep(2.0)
+    return _orig(self, sig, callback, *args)
+asyncio.unix_events._UnixSelectorEventLoop.add_signal_handler = _slow
+"""
+
+
+def _crack_env(tmp_path: Path) -> dict[str, str]:
+    """Build an env whose sitecustomize widens the startup crack."""
+    shim = tmp_path / "crack_shim"
+    shim.mkdir(exist_ok=True)
+    (shim / "sitecustomize.py").write_text(_CRACK_SITECUSTOMIZE)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(shim), env.get("PYTHONPATH", "")])
+    return env
+
+
+def _wait_for_startup_window(proc: subprocess.Popen[str]) -> list[str]:
     """Block until the first log line, marking the pre-serving startup window.
 
     Logging is configured *below* the stop-signal trap in ``main``, so any
     output proves the trap is armed; the server binds ~1s later, so a signal
     sent now deterministically lands pre-serving on slow and fast runners.
+    Returns the lines consumed so the caller can fold them into a full
+    transcript for failure diagnostics.
     """
     assert proc.stdout is not None
+    consumed: list[str] = []
     deadline = time.monotonic() + 15
-    while not proc.stdout.readline().strip():
+    while True:
+        line = proc.stdout.readline()
+        consumed.append(line)
+        if line.strip():
+            return consumed
         assert proc.poll() is None, "process exited during startup"
         assert time.monotonic() < deadline, "no startup output before deadline"
+
+
+def _wait_for_crack(proc: subprocess.Popen[str]) -> list[str]:
+    """Block until the child prints CRACK_OPEN; return the lines consumed."""
+    assert proc.stdout is not None
+    consumed: list[str] = []
+    deadline = time.monotonic() + 20
+    while True:
+        line = proc.stdout.readline()
+        consumed.append(line)
+        if "CRACK_OPEN" in line:
+            return consumed
+        assert line or proc.poll() is None, "process exited before the crack"
+        assert time.monotonic() < deadline, "no CRACK_OPEN before deadline"
 
 
 def _wait_until_serving(proc: subprocess.Popen[str], port: int) -> None:
@@ -116,20 +182,72 @@ def _wait_until_serving(proc: subprocess.Popen[str], port: int) -> None:
 def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
     """A real SIGTERM landing mid-startup (pre-serving) exits 0, not 143."""
     proc, _ = _spawn_dashboard(tmp_path)
+    captured = _wait_for_startup_window(proc)
     try:
-        _wait_for_startup_window(proc)
         proc.send_signal(signal.SIGTERM)
         try:
-            proc.communicate(timeout=30)
+            out, _ = proc.communicate(timeout=30)
+            captured.append(out)
         except subprocess.TimeoutExpired:
-            pytest.fail("dashboard did not exit within 30s of SIGTERM")
+            proc.kill()
+            out, _ = proc.communicate()
+            captured.append(out)
+            pytest.fail(
+                "dashboard did not exit within 30s of SIGTERM\n"
+                f"--- child transcript ---\n{''.join(captured)}"
+            )
     finally:
         if proc.poll() is None:
             proc.kill()
             proc.communicate()
     # A negative code is death by signal: -SIGTERM (== shell 143) is the
     # regression this test guards.
-    assert proc.returncode == 0, f"expected clean exit 0, got {proc.returncode}"
+    assert proc.returncode == 0, (
+        f"expected clean exit 0, got {proc.returncode}\n"
+        f"--- child transcript ---\n{''.join(captured)}"
+    )
+
+
+@posix_only
+@pytest.mark.timeout(120)
+def test_sigterm_in_startup_crack_exits_zero(tmp_path: Path) -> None:
+    """A SIGTERM landing in the loop-startup crack exits 0, not hang or 143."""
+    # The crack (loop running, our trap still active before aiohttp arms its
+    # own handler) is timing-dependent in the wild; the shim widens it so CI
+    # hits it deterministically. The transcript surfaces the child traceback
+    # on failure. Looped a few times to also shake out the signal-context
+    # reentrancy that only bites when the stop lands mid-log-write.
+    env = _crack_env(tmp_path)
+    for i in range(3):
+        config_dir = tmp_path / f"crack{i}"
+        config_dir.mkdir()
+        proc, _ = _spawn_dashboard(config_dir, env=env)
+        captured = _wait_for_crack(proc)
+        time.sleep(0.3)  # land the signal mid the shim's 2s widening sleep
+        try:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                out, _ = proc.communicate(timeout=30)
+                captured.append(out)
+                returncode: int | None = proc.returncode
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                out, _ = proc.communicate()
+                captured.append(out)
+                returncode = None
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.communicate()
+        transcript = "".join(captured)
+        assert returncode is not None, (
+            f"iteration {i}: dashboard did not exit within 30s of SIGTERM\n"
+            f"--- child transcript ---\n{transcript}"
+        )
+        assert returncode == 0, (
+            f"iteration {i}: expected clean exit 0, got {returncode}\n"
+            f"--- child transcript ---\n{transcript}"
+        )
 
 
 @posix_only


### PR DESCRIPTION
# What does this implement/fix?

**Production bug: the dashboard could hang or exit non-zero when it received a stop signal during startup.** A SIGTERM from the supervisor (systemd, Docker, the Home Assistant add-on) arriving while the dashboard is still cold-starting could leave the process wedged or make it exit unclean instead of shutting down. The flaky `test_sigterm_during_startup_exits_zero` was the symptom that surfaced it.

Two faults in the startup signal trap (`_exit_cleanly_on_signal`):

**1. Hang.** It raised `SystemExit` inline. When the signal landed in the window after aiohttp's event loop starts but before `AppRunner.setup` arms its own SIGTERM handler, that `SystemExit` was raised inside the live loop; `run_app` does not catch `SystemExit`, so it fell into its `finally`, re-entered the loop to clean up, and blocked in `select` forever. The supervisor then waits out its grace period and SIGKILLs (exit 137). The trap now raises `SystemExit(0)` only when no loop is running (the genuine pre-loop cold start), and otherwise defers aiohttp's own `GracefulExit` through `loop.call_soon_threadsafe`, so `run_app` catches it and drains `on_cleanup` exactly as a stop received while serving does.

**2. Unclean exit.** It also called `logging.info()`. A signal handler runs between bytecodes on the main thread, frequently while the no-auth startup banner is mid write, so logging from there re-enters the stream or queue. Under synchronous logging that is a hard `RuntimeError: reentrant call inside <_io.BufferedWriter>`; under the production async queue handler it corrupts or raises and the traceback is lost because the process exits before the listener thread flushes, surfacing as a bare non-zero exit. The handler now does no logging and minimal work; the stop is logged from `_raise_graceful_exit`, which runs in safe loop context.

## History

Several iterations. The first cut hard-exited via `os._exit`, which was blunt and needed a platform branch; the second deferred `GracefulExit` and fixed the hang, after which a rare non-zero exit surfaced on Linux 3.14. That second fault was sub 0.1 percent and would not reproduce until the tests captured the child transcript and drove many in-loop signals under contention; a diagnostic run that disabled the async log queue finally exposed the reentrant logging error and pinned the cause.

## Testing

- `_exit_cleanly_on_signal` and `_raise_graceful_exit` have unit tests for the no-loop, with-loop, and raise paths.
- Subprocess tests drive a real dashboard: SIGTERM pre-serving exits 0 (transcript captured on failure), SIGTERM while serving drains `on_cleanup` (drain marker asserted), and CTRL_BREAK on Windows drains.
- A deterministic crack test widens the loop-start window via a sitecustomize shim so CI exercises the exact race every run, exiting 0 instead of hanging.
- During the hunt, the bug was reproduced on CI under contention, root caused via a synchronous-logging diagnostic that exposed the reentrant logging error, and the verification run (the same diagnostic harness that reliably hung before) is now green on all five platforms. The heavy diagnostic harnesses were removed; the lean regression set above remains.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1270

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
