### PR TITLE
Extend flaky storage-flush test timeout to 2s on loaded runners

### DIFF
--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -277,7 +277,10 @@ async def test_data_func_called_at_flush_not_scheduling(
 
     store.async_delay_save(_read, delay=0.05)
     state[:] = b"after-mutation"
-    await _drain_loop_until(store_path.exists, timeout=1.0)
+    # 2s rather than the 1s default; busy Windows xdist workers can take
+    # longer than 1s for the executor hop + atomic rename after the 50ms
+    # timer fires.
+    await _drain_loop_until(store_path.exists, timeout=2.0)
     assert store_path.read_bytes() == b"after-mutation"
 
 


### PR DESCRIPTION
# What does this implement/fix?

`test_data_func_called_at_flush_not_scheduling` flakes on Windows CI; it waited only 1s for the flush to land, but on a busy xdist worker the executor hop plus atomic rename after the 50ms timer can take longer than that. Bumped the wait to 2s and added the same explanatory comment its sibling tests already carry.

**Related issue or feature (if applicable):**

- fixes flaky test in https://github.com/esphome/device-builder/actions/runs/27085000631/job/79937619863

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
