### PR TITLE
Mute esphome.loader INFO spam during catalog introspection sweep

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -760,6 +760,10 @@ _ADVANCED_IMPORTANT_KEYS: frozenset[str] = frozenset({"id"})
 def main() -> int:
     """Entry point — parse args, fetch schema, generate JSON."""
     logging.basicConfig(format="%(message)s", level=logging.INFO)
+    # The introspection sweep probes missing platform/stem combos via
+    # loader.get_platform; esphome.loader logs each expected miss at INFO.
+    # Mute that noise; genuine import failures still log at ERROR.
+    logging.getLogger("esphome.loader").setLevel(logging.WARNING)
 
     parser = argparse.ArgumentParser(
         description=(


### PR DESCRIPTION
# What does this implement/fix?

The catalog sync logs hundreds of `Unable to import component <stem>.<platform>` lines, one per missing platform/stem combo the introspection sweep probes through `loader.get_platform`. Those misses are expected and the sweep already skips them silently, but esphome's loader logs each one at INFO so they flood the CI job output. This mutes `esphome.loader` to WARNING during the sync; genuine import failures still log at ERROR, so nothing useful is lost.

**Related issue or feature (if applicable):**

- fixes log spam seen in https://github.com/esphome/device-builder/actions/runs/27085740292/job/79939733804

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
