### PR TITLE
Own the stop signal across startup so a mid-startup quit exits 0

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -27,6 +27,7 @@ from .helpers.logging import activate_log_queue_handler
 
 if TYPE_CHECKING:
     from .controllers.config import DashboardSettings
+    from .device_builder import DeviceBuilder
 
 _FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -345,19 +346,24 @@ def main() -> None:
     ):
         if lock.exit_code is not None:
             sys.exit(lock.exit_code)
-        device_builder = DeviceBuilder(settings)
-        try:
-            device_builder.run()
-        except Exception:
-            # A stop signal landing mid-``on_startup`` cancels aiohttp's
-            # main task while it's still in ``runner.setup()`` — outside
-            # ``run_app``'s cleanup try/finally — so a half-started
-            # controller's teardown can surface a non-``CancelledError``
-            # that escapes ``run_app``. If the user asked us to stop, that's
-            # a clean exit; only a crash with no stop pending propagates.
-            if not _stop_requested:
-                raise
-            logging.getLogger(_LOGGER_NAME).info("Stop signal interrupted startup; exiting cleanly")
+        _serve_until_stop(DeviceBuilder(settings))
+
+
+def _serve_until_stop(device_builder: DeviceBuilder) -> None:
+    """Run the dashboard; swallow a teardown error caused by a pending stop.
+
+    A stop signal landing mid-``on_startup`` cancels aiohttp's main task
+    while it's still in ``runner.setup()`` — outside ``run_app``'s cleanup
+    try/finally — so a half-started controller's teardown can surface a
+    non-``CancelledError`` that escapes ``run_app``. With a stop pending
+    that's a clean exit; a crash with no stop pending propagates.
+    """
+    try:
+        device_builder.run()
+    except Exception:
+        if not _stop_requested:
+            raise
+        logging.getLogger(_LOGGER_NAME).info("Stop signal interrupted startup; exiting cleanly")
 
 
 def _log_uncaught_exception(

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -48,6 +48,10 @@ _LOG_COLORS = {
     "CRITICAL": "red",
 }
 
+# Set by the stop-signal trap so ``main`` can tell a user-requested
+# shutdown apart from a genuine startup crash when ``run_app`` propagates.
+_stop_requested = False
+
 
 def _setup_logging(log_level: str, log_file: str | None = None) -> None:
     """Set up logging with a coloured console handler and an optional rotating file."""
@@ -113,6 +117,8 @@ def _exit_cleanly_on_signal(_signum: int, _frame: object) -> None:
     otherwise hand off to the loop, which runs ``_raise_graceful_exit`` at
     a safe point so ``run_app`` drains ``on_cleanup``.
     """
+    global _stop_requested  # noqa: PLW0603 — process-wide stop latch
+    _stop_requested = True
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -132,13 +138,16 @@ def main() -> None:
     """Run the ESPHome Device Builder."""
     # Trap the platform's stop signal so a quit exits cleanly instead of
     # the OS default disposition. POSIX: a startup-window SIGTERM exits
-    # 143 ("did not handle SIGTERM") before aiohttp arms its run-loop
-    # handler; once serving, ``web.run_app`` replaces this with its own.
-    # Windows: aiohttp installs no handler at all, and the desktop quits
-    # the backend with CTRL_BREAK_EVENT (→ SIGBREAK; SIGTERM is
-    # uncatchable there), so without this the break default-terminates
-    # abruptly instead of draining. The Proactor loop's wakeup fd makes
-    # the break land promptly while serving.
+    # 143 ("did not handle SIGTERM") before aiohttp would arm its own
+    # handler. We run ``web.run_app(handle_signals=False)`` so this trap
+    # stays the sole handler for the whole lifecycle — otherwise aiohttp's
+    # ``add_signal_handler`` (armed in ``runner.setup`` before ``on_startup``)
+    # would replace it, and a stop landing mid-startup would skip the
+    # clean-exit bookkeeping below. Windows: aiohttp installs no handler at
+    # all, and the desktop quits the backend with CTRL_BREAK_EVENT
+    # (→ SIGBREAK; SIGTERM is uncatchable there), so without this the break
+    # default-terminates abruptly instead of draining. The Proactor loop's
+    # wakeup fd makes the break land promptly while serving.
     signal.signal(signal.SIGTERM, _exit_cleanly_on_signal)
     if sys.platform == "win32":
         signal.signal(signal.SIGBREAK, _exit_cleanly_on_signal)
@@ -337,7 +346,18 @@ def main() -> None:
         if lock.exit_code is not None:
             sys.exit(lock.exit_code)
         device_builder = DeviceBuilder(settings)
-        device_builder.run()
+        try:
+            device_builder.run()
+        except Exception:
+            # A stop signal landing mid-``on_startup`` cancels aiohttp's
+            # main task while it's still in ``runner.setup()`` — outside
+            # ``run_app``'s cleanup try/finally — so a half-started
+            # controller's teardown can surface a non-``CancelledError``
+            # that escapes ``run_app``. If the user asked us to stop, that's
+            # a clean exit; only a crash with no stop pending propagates.
+            if not _stop_requested:
+                raise
+            logging.getLogger(_LOGGER_NAME).info("Stop signal interrupted startup; exiting cleanly")
 
 
 def _log_uncaught_exception(

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -837,16 +837,26 @@ class DeviceBuilder:
                 host=hosts,
                 port=settings.ingress_port,
                 shutdown_timeout=_SHUTDOWN_TIMEOUT_SECONDS,
+                handle_signals=False,
             )
             return
         app = self.create_app()
         hosts = resolve_bind_host(settings.host)
         ensure_single_host_for_ephemeral_port(hosts, settings.port, "--port")
+        # ``handle_signals=False``: keep our ``__main__`` SIGTERM/SIGBREAK trap
+        # as the sole handler for the whole lifecycle. aiohttp's own
+        # ``add_signal_handler`` is armed inside ``runner.setup()`` *before*
+        # ``on_startup`` runs and would otherwise replace our trap, so a stop
+        # landing mid-startup would take aiohttp's path and bypass the
+        # clean-exit bookkeeping in ``main``. Our trap defers ``GracefulExit``
+        # to the loop just the same, so ``run_app`` still drains ``on_cleanup``
+        # while serving.
         web.run_app(
             app,
             host=hosts,
             port=settings.port,
             shutdown_timeout=_SHUTDOWN_TIMEOUT_SECONDS,
+            handle_signals=False,
         )
 
     @staticmethod

--- a/tests/test_ha_addon_failsafe.py
+++ b/tests/test_ha_addon_failsafe.py
@@ -73,10 +73,13 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: list[str], port: int, **_: object) -> None:
+    def fake_run_app(
+        app, *, host: list[str], port: int, handle_signals: bool = True, **_: object
+    ) -> None:
         captured["host"] = host
         captured["port"] = port
         captured["trusted"] = bool(app.get("trusted_site"))
+        captured["handle_signals"] = handle_signals
 
     with (
         caplog.at_level("WARNING", logger="esphome_device_builder.device_builder"),
@@ -92,6 +95,7 @@ def test_ha_addon_no_password_with_ingress_runs_ingress_only(
     # uniformly when the operator passes an interface name.
     assert captured["host"] == ["0.0.0.0"]  # ingress_host fallback
     assert captured["trusted"] is True  # trusted=True (auth bypass)
+    assert captured["handle_signals"] is False  # we own the stop signal end-to-end
 
     # The single create_app call was for the trusted ingress, with
     # the ingress-site hook disabled (the app IS the ingress).
@@ -181,9 +185,12 @@ def test_non_ha_addon_binds_public_site_normally(make_settings: MakeSettingsFact
 
     captured: dict[str, object] = {}
 
-    def fake_run_app(app, *, host: list[str], port: int, **_: object) -> None:
+    def fake_run_app(
+        app, *, host: list[str], port: int, handle_signals: bool = True, **_: object
+    ) -> None:
         captured["host"] = host
         captured["port"] = port
+        captured["handle_signals"] = handle_signals
 
     with patch("esphome_device_builder.device_builder.web.run_app", fake_run_app):
         db.run()
@@ -192,6 +199,9 @@ def test_non_ha_addon_binds_public_site_normally(make_settings: MakeSettingsFact
     # default of "no auth required, user opts in via PASSWORD".
     assert captured["port"] == 6052
     assert captured["host"] == ["0.0.0.0"]
+    # We own the stop signal end-to-end (see DeviceBuilder.run); aiohttp
+    # must not install its own handler.
+    assert captured["handle_signals"] is False
 
 
 def test_public_run_refuses_port_zero_with_multi_host(

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -15,6 +15,7 @@ import socket
 import subprocess
 import sys
 import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -56,6 +57,46 @@ def test_raise_graceful_exit_raises_graceful_exit() -> None:
     """The deferred callback raises aiohttp's ``GracefulExit``."""
     with pytest.raises(GracefulExit):
         main_module._raise_graceful_exit()
+
+
+def test_exit_cleanly_on_signal_sets_stop_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The trap latches ``_stop_requested`` so ``main`` can recognise the stop."""
+    monkeypatch.setattr(main_module, "_stop_requested", False)
+    with pytest.raises(SystemExit):
+        main_module._exit_cleanly_on_signal(signal.SIGTERM, None)
+    assert main_module._stop_requested is True
+
+
+def test_serve_until_stop_returns_on_clean_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A normally-returning ``run`` propagates nothing."""
+    monkeypatch.setattr(main_module, "_stop_requested", False)
+    builder = SimpleNamespace(run=lambda: None)
+    main_module._serve_until_stop(builder)  # type: ignore[arg-type]
+
+
+def test_serve_until_stop_swallows_error_when_stop_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A teardown error during a pending stop is a clean exit, not a crash."""
+    monkeypatch.setattr(main_module, "_stop_requested", True)
+
+    def _boom() -> None:
+        raise RuntimeError("half-started teardown failure")
+
+    main_module._serve_until_stop(SimpleNamespace(run=_boom))  # type: ignore[arg-type]
+
+
+def test_serve_until_stop_reraises_without_pending_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuine startup crash with no stop pending still propagates."""
+    monkeypatch.setattr(main_module, "_stop_requested", False)
+
+    def _boom() -> None:
+        raise RuntimeError("real startup failure")
+
+    with pytest.raises(RuntimeError, match="real startup failure"):
+        main_module._serve_until_stop(SimpleNamespace(run=_boom))  # type: ignore[arg-type]
 
 
 def test_main_installs_stop_signal_handlers_before_parsing(

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -104,18 +104,19 @@ def _spawn_dashboard(
     return proc, port
 
 
-# Holds the loop running but with our pre-serving SIGTERM trap still the active
-# handler — the exact "startup crack" window before aiohttp's AppRunner.setup
-# arms its own handler. Writing it via PYTHONPATH/sitecustomize makes the
-# otherwise timing-dependent race deterministic so CI exercises it every run.
+# Holds the loop running mid-``AppRunner.setup`` with our SIGTERM trap active —
+# the pre-serving startup window. We run ``run_app(handle_signals=False)`` so the
+# trap is our handler the whole way; the blocking sleep inside ``setup`` makes a
+# signal land here deterministically so CI exercises the window every run.
 _CRACK_SITECUSTOMIZE = """
-import asyncio, time as _t
-_orig = asyncio.unix_events._UnixSelectorEventLoop.add_signal_handler
-def _slow(self, sig, callback, *args):
+import time as _t
+from aiohttp import web_runner as _wr
+_orig = _wr.AppRunner.setup
+async def _slow(self):
     print("CRACK_OPEN", flush=True)
     _t.sleep(2.0)
-    return _orig(self, sig, callback, *args)
-asyncio.unix_events._UnixSelectorEventLoop.add_signal_handler = _slow
+    return await _orig(self)
+_wr.AppRunner.setup = _slow
 """
 
 
@@ -124,6 +125,34 @@ def _crack_env(tmp_path: Path) -> dict[str, str]:
     shim = tmp_path / "crack_shim"
     shim.mkdir(exist_ok=True)
     (shim / "sitecustomize.py").write_text(_CRACK_SITECUSTOMIZE)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(shim), env.get("PYTHONPATH", "")])
+    return env
+
+
+# Holds the process inside ``on_startup`` (catalogs loaded, devices not yet)
+# and makes the half-started controller's teardown raise a non-CancelledError
+# when the stop-driven cancellation lands — the shape that escaped ``run_app``
+# and exited 1 instead of 0. Deterministic stand-in for whichever real
+# controller's cancel-time teardown raised on the CI runner.
+_TEARDOWN_FAIL_SITECUSTOMIZE = """
+import asyncio
+import esphome_device_builder.controllers.devices.controller as _c
+async def _start(self):
+    print("STARTUP_HELD", flush=True)
+    try:
+        await asyncio.sleep(30)
+    except asyncio.CancelledError:
+        raise RuntimeError("simulated half-started teardown failure") from None
+_c.DevicesController.start = _start
+"""
+
+
+def _teardown_fail_env(tmp_path: Path) -> dict[str, str]:
+    """Build an env whose sitecustomize fails a controller's cancel teardown."""
+    shim = tmp_path / "teardown_fail_shim"
+    shim.mkdir(exist_ok=True)
+    (shim / "sitecustomize.py").write_text(_TEARDOWN_FAIL_SITECUSTOMIZE)
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join([str(shim), env.get("PYTHONPATH", "")])
     return env
@@ -211,10 +240,10 @@ def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
 @posix_only
 @pytest.mark.timeout(120)
 def test_sigterm_in_startup_crack_exits_zero(tmp_path: Path) -> None:
-    """A SIGTERM landing in the loop-startup crack exits 0, not hang or 143."""
-    # The crack (loop running, our trap still active before aiohttp arms its
-    # own handler) is timing-dependent in the wild; the shim widens it so CI
-    # hits it deterministically. The transcript surfaces the child traceback
+    """A SIGTERM landing while the loop is mid-startup exits 0, not hang or 143."""
+    # The window (loop running, our trap active, pre-serving) is timing-
+    # dependent in the wild; the shim's blocking sleep inside setup widens it so
+    # CI hits it deterministically. The transcript surfaces the child traceback
     # on failure. Looped a few times to also shake out the signal-context
     # reentrancy that only bites when the stop lands mid-log-write.
     env = _crack_env(tmp_path)
@@ -248,6 +277,47 @@ def test_sigterm_in_startup_crack_exits_zero(tmp_path: Path) -> None:
             f"iteration {i}: expected clean exit 0, got {returncode}\n"
             f"--- child transcript ---\n{transcript}"
         )
+
+
+@posix_only
+@pytest.mark.timeout(60)
+def test_sigterm_during_startup_with_failing_teardown_exits_zero(tmp_path: Path) -> None:
+    """A stop interrupting on_startup exits 0 even if a half-started teardown raises."""
+    # aiohttp runs on_startup outside its cleanup try/finally, so a stop-driven
+    # cancellation mid-startup can surface a non-CancelledError that escapes
+    # run_app. ``main`` treats that as a clean exit because a stop was pending.
+    proc, _ = _spawn_dashboard(tmp_path, env=_teardown_fail_env(tmp_path))
+    assert proc.stdout is not None
+    captured: list[str] = []
+    deadline = time.monotonic() + 20
+    while True:
+        line = proc.stdout.readline()
+        captured.append(line)
+        if "STARTUP_HELD" in line:
+            break
+        assert line or proc.poll() is None, "process exited before startup hold"
+        assert time.monotonic() < deadline, "no STARTUP_HELD before deadline"
+    try:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            out, _ = proc.communicate(timeout=30)
+            captured.append(out)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            out, _ = proc.communicate()
+            captured.append(out)
+            pytest.fail(
+                "dashboard did not exit within 30s of SIGTERM\n"
+                f"--- child transcript ---\n{''.join(captured)}"
+            )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+    assert proc.returncode == 0, (
+        f"expected clean exit 0, got {proc.returncode}\n"
+        f"--- child transcript ---\n{''.join(captured)}"
+    )
 
 
 @posix_only


### PR DESCRIPTION
# What does this implement/fix?

`test_sigterm_during_startup_exits_zero` flaked on macOS/Windows CI with exit 1 instead of 0. The root cause is a real, if rare, shutdown bug: aiohttp arms its own SIGTERM handler inside `runner.setup()` before `on_startup` runs, and it runs `on_startup` outside its cleanup try/finally. So a stop signal landing mid-startup cancels aiohttp's main task while a controller is half-started; that controller's teardown can raise a non-`CancelledError` which escapes `run_app`, escapes `main`, and gets logged to the async log queue that is then lost on interpreter shutdown; the process exits 1 with no visible traceback, which is exactly what the CI transcript showed.

The fix runs `web.run_app(handle_signals=False)` so our `__main__` SIGTERM/SIGBREAK trap stays the sole handler for the whole lifecycle, instead of being replaced by aiohttp's mid-startup. The trap records that a stop was requested, and `main` treats a `run()` exception as a clean exit when a stop is pending; a genuine startup crash with no stop pending still propagates. The serving-time path is unchanged; our trap defers `GracefulExit` to the loop, so `run_app` still drains `on_cleanup`.

I reproduced the exit-1 under Python 3.14 with aiohttp 3.14, added a regression test that pins it (it fails on `main`, passes here), and reworked the existing startup-crack test since `handle_signals=False` closes the aiohttp handoff window its old shim relied on. Full suite is green (4628 passed).

**Related issue or feature (if applicable):**

- fixes flaky test in https://github.com/esphome/device-builder/actions/runs/27085856656/job/79940071051

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
