### PR TITLE
Consolidate duplicated list-handler write-path scaffold

### DIFF
--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -62,12 +62,13 @@ from .writing_layout import (
     _locate_top_list_item,
 )
 from .writing_lists import (
-    apply_list_entry_upsert,
+    ListContainerStrategy,
     delete_light_effect,
     delete_list_entry,
-    drop_after_block_comment,
+    delete_list_entry_for,
     upsert_component_on_entry,
     upsert_light_effect,
+    upsert_list_entry,
     wrap_handler_list_block,
 )
 
@@ -164,6 +165,33 @@ def _upsert_device_on(
     return _upsert_under_top_key(yaml_text, "esphome", location.trigger, rendered)
 
 
+def _esphome_container(yaml_text: str, _error_code: ErrorCode) -> dict | None:
+    """Return the ``esphome:`` mapping, or ``None`` when absent (never raises)."""
+    data = make_yaml().load(yaml_text) or {}
+    esphome = data.get("esphome") if isinstance(data, dict) else None
+    return esphome if isinstance(esphome, dict) else None
+
+
+def _esphome_resplice(yaml_text: str, handler_key: str, entries: list) -> tuple[str, YamlDiff]:
+    """Re-emit a device handler list under ``esphome:``; remove the key when emptied."""
+    if entries:
+        rendered = wrap_handler_list_block(handler_key, dump(entries))
+        return _upsert_under_top_key(yaml_text, "esphome", handler_key, rendered)
+    return _delete_under_top_key(yaml_text, "esphome", handler_key)
+
+
+def _esphome_not_present_msg(key: str, index: int) -> str:
+    """Delete not-found message for a device-level list handler."""
+    return f"{key}[{index}] not present"
+
+
+_DEVICE_STRATEGY = ListContainerStrategy(
+    locate=_esphome_container,
+    resplice=_esphome_resplice,
+    not_present_msg=_esphome_not_present_msg,
+)
+
+
 def _upsert_device_on_entry(
     yaml_text: str,
     tree: AutomationTree,
@@ -172,22 +200,17 @@ def _upsert_device_on_entry(
 ) -> tuple[str, YamlDiff]:
     """Insert or replace one entry of a list-form device handler (``esphome.on_boot``).
 
-    ``index == len(entries)`` appends; an in-range index replaces. Refuses to
-    grow a single mapping into a list (the user picked that shape). No
-    ``supports_list`` gate here: every device-level trigger is list-capable, and
-    the wizard already withholds the affordance for any that are not.
+    Refuses to grow a single mapping into a list (the user picked that shape).
+    No ``supports_list`` gate here: every device-level trigger is list-capable,
+    and the wizard already withholds the affordance for any that are not.
     """
-    data = make_yaml().load(yaml_text) or {}
-    esphome = data.get("esphome") if isinstance(data, dict) else None
-    existing = esphome.get(trigger) if isinstance(esphome, dict) else None
-    if existing is not None and not isinstance(existing, list):
-        msg = f"{trigger}: is a single mapping, not a list; convert it to a list first"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    entries = existing if isinstance(existing, list) else []
-    drop_after_block_comment(entries)
-    apply_list_entry_upsert(entries, emit_trigger_list_item(tree), index, label=trigger)
-    rendered = wrap_handler_list_block(trigger, dump(entries))
-    return _upsert_under_top_key(yaml_text, "esphome", trigger, rendered)
+    return upsert_list_entry(
+        yaml_text,
+        key=trigger,
+        item=emit_trigger_list_item(tree),
+        index=index,
+        strategy=_DEVICE_STRATEGY,
+    )
 
 
 def _delete_device_on_entry(
@@ -196,18 +219,12 @@ def _delete_device_on_entry(
     index: int,
 ) -> tuple[str, YamlDiff]:
     """Drop one entry of a list-form device handler; remove the key when emptied."""
-    data = make_yaml().load(yaml_text) or {}
-    esphome = data.get("esphome") if isinstance(data, dict) else None
-    entries = esphome.get(trigger) if isinstance(esphome, dict) else None
-    if not isinstance(entries, list) or not 0 <= index < len(entries):
-        msg = f"{trigger}[{index}] not present"
-        raise CommandError(ErrorCode.NOT_FOUND, msg)
-    drop_after_block_comment(entries)
-    del entries[index]
-    if entries:
-        rendered = wrap_handler_list_block(trigger, dump(entries))
-        return _upsert_under_top_key(yaml_text, "esphome", trigger, rendered)
-    return _delete_under_top_key(yaml_text, "esphome", trigger)
+    return delete_list_entry_for(
+        yaml_text,
+        key=trigger,
+        index=index,
+        strategy=_DEVICE_STRATEGY,
+    )
 
 
 def _upsert_component_on(

--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -132,8 +132,11 @@ def apply_list_entry_upsert(entries: list, item: Any, index: int, *, label: str)
 class ListContainerStrategy:
     """How to find the dict holding a handler list and how to re-emit it.
 
-    ``locate`` returns the container dict or ``None``, or raises with the
-    passed ``error_code``; ``not_present_msg`` builds the delete error.
+    ``locate`` returns ``None`` only when an absent container should be
+    auto-created on resplice (device ``esphome:``); it raises with the
+    passed ``error_code`` when the container is a hard prerequisite
+    (a configured component instance). ``not_present_msg`` builds the
+    delete error.
     """
 
     locate: Callable[[str, ErrorCode], dict | None]

--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -11,6 +11,9 @@ the single-handler / top-level splice paths.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 from ...helpers.api import CommandError
@@ -70,11 +73,11 @@ def _strip_comments(node: Any) -> None:
 
 def _resplice_list_block(
     yaml_text: str,
+    handler_key: str,
+    entries: list,
     *,
     domain: str,
     component_id: str,
-    handler_key: str,
-    entries: list,
 ) -> tuple[str, YamlDiff]:
     """
     Re-emit a component's list handler from *entries* and return the diff.
@@ -125,6 +128,76 @@ def apply_list_entry_upsert(entries: list, item: Any, index: int, *, label: str)
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
 
+@dataclass(frozen=True)
+class ListContainerStrategy:
+    """How to find the dict holding a handler list and how to re-emit it.
+
+    ``locate`` returns the container dict or ``None``, or raises with the
+    passed ``error_code``; ``not_present_msg`` builds the delete error.
+    """
+
+    locate: Callable[[str, ErrorCode], dict | None]
+    resplice: Callable[[str, str, list], tuple[str, YamlDiff]]
+    not_present_msg: Callable[[str, int], str]
+
+
+def upsert_list_entry(
+    yaml_text: str,
+    *,
+    key: str,
+    item: Any,
+    index: int,
+    strategy: ListContainerStrategy,
+) -> tuple[str, YamlDiff]:
+    """
+    Insert or replace one entry of a list-shaped handler at *index*.
+
+    ``index == len(entries)`` appends; an in-range index replaces. Refuses
+    when the existing handler is a single mapping rather than a list — the
+    user picked that shape, so don't silently rewrite it.
+    """
+    container = strategy.locate(yaml_text, ErrorCode.INVALID_ARGS)
+    existing = container.get(key) if container is not None else None
+    if existing is not None and not isinstance(existing, list):
+        msg = f"{key}: is a single mapping, not a list; convert it to a list first"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    entries = existing if isinstance(existing, list) else []
+    drop_after_block_comment(entries)
+    apply_list_entry_upsert(entries, item, index, label=key)
+    return strategy.resplice(yaml_text, key, entries)
+
+
+def delete_list_entry_for(
+    yaml_text: str,
+    *,
+    key: str,
+    index: int,
+    strategy: ListContainerStrategy,
+) -> tuple[str, YamlDiff]:
+    """Drop entry *index* from a ``<key>:`` list and re-emit the block."""
+    container = strategy.locate(yaml_text, ErrorCode.NOT_FOUND)
+    entries = container.get(key) if container is not None else None
+    if not isinstance(entries, list) or not 0 <= index < len(entries):
+        raise CommandError(ErrorCode.NOT_FOUND, strategy.not_present_msg(key, index))
+    drop_after_block_comment(entries)
+    del entries[index]
+    return strategy.resplice(yaml_text, key, entries)
+
+
+def _component_not_present_msg(component_id: str, key: str, index: int) -> str:
+    """Delete not-found message for a component-nested list handler."""
+    return f"{key}[{index}] not present on component id={component_id!r}"
+
+
+def _component_strategy(domain: str, component_id: str) -> ListContainerStrategy:
+    """Strategy for a list handler nested under a configured component instance."""
+    return ListContainerStrategy(
+        locate=partial(_require_instance, domain=domain, component_id=component_id),
+        resplice=partial(_resplice_list_block, domain=domain, component_id=component_id),
+        not_present_msg=partial(_component_not_present_msg, component_id),
+    )
+
+
 def upsert_component_on_entry(
     yaml_text: str,
     *,
@@ -134,34 +207,18 @@ def upsert_component_on_entry(
     trigger_key: str,
     index: int,
 ) -> tuple[str, YamlDiff]:
-    """
-    Insert or replace one entry of a list-shaped trigger (``time.on_time``).
-
-    ``index == len(entries)`` appends; an in-range index replaces. Refuses
-    when the existing handler is a single mapping rather than a list — the
-    user picked that shape, so don't silently rewrite it.
-    """
-    instance = _require_instance(
-        yaml_text, domain=domain, component_id=component_id, error_code=ErrorCode.INVALID_ARGS
-    )
-    existing = instance.get(trigger_key)
-    if existing is not None and not isinstance(existing, list):
-        msg = f"{trigger_key}: is a single mapping, not a list; convert it to a list first"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    entries = existing if isinstance(existing, list) else []
-    drop_after_block_comment(entries)
-    apply_list_entry_upsert(entries, emit_trigger_list_item(tree), index, label=trigger_key)
-    return _resplice_list_block(
+    """Insert or replace one entry of a list-shaped trigger (``time.on_time``)."""
+    return upsert_list_entry(
         yaml_text,
-        domain=domain,
-        component_id=component_id,
-        handler_key=trigger_key,
-        entries=entries,
+        key=trigger_key,
+        item=emit_trigger_list_item(tree),
+        index=index,
+        strategy=_component_strategy(domain, component_id),
     )
 
 
 def _require_instance(
-    yaml_text: str, *, domain: str, component_id: str, error_code: ErrorCode
+    yaml_text: str, error_code: ErrorCode, *, domain: str, component_id: str
 ) -> dict:
     """
     Return the ``<domain>:`` list item whose ``id`` matches *component_id*.
@@ -190,21 +247,11 @@ def delete_list_entry(
     yaml_text: str, *, domain: str, component_id: str, handler_key: str, index: int
 ) -> tuple[str, YamlDiff]:
     """Drop entry *index* from a component's ``<handler_key>:`` list; re-splice."""
-    instance = _require_instance(
-        yaml_text, domain=domain, component_id=component_id, error_code=ErrorCode.NOT_FOUND
-    )
-    entries = instance.get(handler_key)
-    if not isinstance(entries, list) or not 0 <= index < len(entries):
-        msg = f"{handler_key}[{index}] not present on component id={component_id!r}"
-        raise CommandError(ErrorCode.NOT_FOUND, msg)
-    drop_after_block_comment(entries)
-    del entries[index]
-    return _resplice_list_block(
+    return delete_list_entry_for(
         yaml_text,
-        domain=domain,
-        component_id=component_id,
-        handler_key=handler_key,
-        entries=entries,
+        key=handler_key,
+        index=index,
+        strategy=_component_strategy(domain, component_id),
     )
 
 
@@ -229,26 +276,13 @@ def upsert_light_effect(
     if catalog_entry is None:
         msg = f"Unknown light effect id: {effect_id!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    instance = _require_instance(
-        yaml_text,
-        domain="light",
-        component_id=location.component_id,
-        error_code=ErrorCode.INVALID_ARGS,
-    )
     item = emit_effect_item(catalog_entry, str(effect_id), params or {})
-    existing = instance.get("effects")
-    if existing is not None and not isinstance(existing, list):
-        msg = "effects: is a single mapping, not a list; convert it to a list first"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    entries = existing if isinstance(existing, list) else []
-    drop_after_block_comment(entries)
-    apply_list_entry_upsert(entries, item, location.index, label="effects")
-    return _resplice_list_block(
+    return upsert_list_entry(
         yaml_text,
-        domain="light",
-        component_id=location.component_id,
-        handler_key="effects",
-        entries=entries,
+        key="effects",
+        item=item,
+        index=location.index,
+        strategy=_component_strategy("light", location.component_id),
     )
 
 

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -152,6 +152,23 @@ def test_upsert_device_on_boot_replaces_list_entry() -> None:
     assert parsed[0].automation.actions[0].params == {"format": "second"}
 
 
+def test_upsert_device_on_boot_replace_keeps_sibling_entries() -> None:
+    """Replacing one entry of a 2-entry on_boot leaves the sibling untouched."""
+    two = _LIST_ON_BOOT + "    - priority: 200\n      then:\n        - delay: 1s\n"
+    tree = AutomationTree(
+        trigger_id="on_boot",
+        trigger_params={"priority": -300},
+        actions=[ActionNode(action_id="logger.log", params={"format": "second"})],
+    )
+    new_text, _ = render_upsert(
+        two, tree=tree, location=DeviceOnLocation(trigger="on_boot", index=0)
+    )
+    parsed = parse_device_yaml(new_text)
+    assert [p.location.index for p in parsed] == [0, 1]
+    assert parsed[0].automation.actions[0].params == {"format": "second"}
+    assert parsed[1].automation.trigger_params == {"priority": 200}
+
+
 def test_delete_device_on_boot_list_entry() -> None:
     """Deleting one entry of a multi-handler on_boot keeps the rest as a list."""
     two = _LIST_ON_BOOT + "    - priority: 200\n      then:\n        - delay: 1s\n"


### PR DESCRIPTION
# What does this implement/fix?

The three list-shaped automation write-path pairs (component on_*, light effects, device on_*) each carried a copy of the same scaffold; load YAML, locate the list container, refuse a single mapping, drop block comments, mutate at index, then re-emit the block. The bodies had already started to drift.

This pulls the shared skeleton into two generic functions, `upsert_list_entry` and `delete_list_entry_for`, parameterized by a small `ListContainerStrategy` holding the two things that actually vary; how the container is located and how the block is re-spliced (plus the per-container not-present message). Component strategies bind their config with `functools.partial`; the device strategy is a module constant. No behaviour change; error messages, error codes, single-mapping refusal, and empty-list removal are all preserved.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1291

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
