### PR TITLE
Decode automation locations via a dispatch table

### DIFF
--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -436,8 +436,7 @@ def _decode_location(raw: dict) -> AutomationLocation:
         msg = f"location must carry a 'kind' discriminator; got {raw!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     kind = raw["kind"]
-    decoder = _LOCATION_DECODERS.get(kind)
-    if decoder is None:
+    if (decoder := _LOCATION_DECODERS.get(kind)) is None:
         msg = f"Unknown location kind: {kind!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return decoder(raw)

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from ruamel.yaml import YAMLError
@@ -416,28 +417,27 @@ def _component_instance(
     )
 
 
-def _decode_location(raw: dict) -> AutomationLocation:  # noqa: PLR0911 — one return per kind
+# Each value's covariant return (a concrete subclass) keeps the dict
+# typed as ``AutomationLocation`` without widening to ``Any``.
+_LOCATION_DECODERS: dict[str, Callable[[dict], AutomationLocation]] = {
+    "script": ScriptLocation.from_dict,
+    "interval": IntervalLocation.from_dict,
+    "component_on": ComponentOnLocation.from_dict,
+    "component_action": ComponentActionFieldLocation.from_dict,
+    "device_on": DeviceOnLocation.from_dict,
+    "light_effect": LightEffectLocation.from_dict,
+    "api_action": ApiActionLocation.from_dict,
+}
+
+
+def _decode_location(raw: dict) -> AutomationLocation:
     """Convert a wire-shape ``{kind: ...}`` dict into a typed location."""
     if not isinstance(raw, dict) or "kind" not in raw:
         msg = f"location must carry a 'kind' discriminator; got {raw!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    kind = raw.get("kind")
-    # The discriminator narrowing is by-string so mypy can pin the
-    # concrete type per branch — a single dict mapping would widen
-    # the return to ``Any`` (every value is a different subclass).
-    if kind == "script":
-        return ScriptLocation.from_dict(raw)
-    if kind == "interval":
-        return IntervalLocation.from_dict(raw)
-    if kind == "component_on":
-        return ComponentOnLocation.from_dict(raw)
-    if kind == "component_action":
-        return ComponentActionFieldLocation.from_dict(raw)
-    if kind == "device_on":
-        return DeviceOnLocation.from_dict(raw)
-    if kind == "light_effect":
-        return LightEffectLocation.from_dict(raw)
-    if kind == "api_action":
-        return ApiActionLocation.from_dict(raw)
-    msg = f"Unknown location kind: {kind!r}"
-    raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    kind = raw["kind"]
+    decoder = _LOCATION_DECODERS.get(kind)
+    if decoder is None:
+        msg = f"Unknown location kind: {kind!r}"
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+    return decoder(raw)

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -436,7 +436,7 @@ def _decode_location(raw: dict) -> AutomationLocation:
         msg = f"location must carry a 'kind' discriminator; got {raw!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     kind = raw["kind"]
-    if (decoder := _LOCATION_DECODERS.get(kind)) is None:
+    if not isinstance(kind, str) or (decoder := _LOCATION_DECODERS.get(kind)) is None:
         msg = f"Unknown location kind: {kind!r}"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     return decoder(raw)

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -230,6 +230,13 @@ def test_decode_location_unknown_kind_raises_invalid_args() -> None:
     assert err.value.code == ErrorCode.INVALID_ARGS
 
 
+def test_decode_location_unhashable_kind_raises_invalid_args() -> None:
+    """A non-string ``kind`` raises INVALID_ARGS, not TypeError."""
+    with pytest.raises(CommandError) as err:
+        _decode_location({"kind": []})
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
 # ---------------------------------------------------------------------------
 # parsing.py
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The `_decode_location` `{kind: ...}` decoder was a seven-branch if-chain (one `return` per kind, carrying a `# noqa: PLR0911`). Replace it with a module-level `dict[str, Callable[[dict], AutomationLocation]]` mapping each kind to the matching `from_dict`; the covariant return keeps the table typed as `AutomationLocation` without widening to `Any`, so the old narrowing comment and the noqa both go away.

Behaviour is unchanged; the missing-`kind` and unknown-`kind` paths still raise the same `CommandError`.

I looked at the other three `PLR0911` sites and left them: `render_upsert` dispatches by `isinstance` and a type-keyed table would need `Any` for the location param (function-arg contravariance), losing per-branch mypy narrowing; `_drive_peer_link_session` and `auth_middleware` are sequential guard cascades, not dispatch.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
