### PR TITLE
Dispatch peer-link app frames via a table on the receiver side

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link/session.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/session.py
@@ -273,38 +273,63 @@ async def _receive_loop(session: PeerLinkSession, controller: ReceiverController
             # the WS will drain via the next ``CLOSE`` frame.
             session._closing = True
             return
-        if msg_type == AppMessageType.SUBMIT_JOB.value:
-            # The ``cast`` is the dispatch boundary's "wire said
-            # submit_job; treat as the matching TypedDict"
-            # hand-off; receiver validates the fields.
-            await controller.get_submit_job_receiver().handle_submit_job(
-                session, cast(SubmitJobFrameData, parsed)
-            )
-            continue
-        if msg_type == AppMessageType.SUBMIT_JOB_CHUNK.value:
-            await controller.get_submit_job_receiver().handle_submit_job_chunk(
-                session, cast(SubmitJobChunkFrameData, parsed)
-            )
-            continue
-        if msg_type == AppMessageType.CANCEL_JOB.value:
-            # Cooperative cancel; fire-and-forget. The resulting
-            # ``JOB_CANCELLED`` bus event fans out
-            # ``job_state_changed{cancelled}`` which the offloader
-            # already plumbs — no ack frame needed.
-            await controller.handle_cancel_job(session, parsed)
-            continue
-        if msg_type == AppMessageType.DOWNLOAD_ARTIFACTS.value:
-            # Streams the completed build's artifacts back via
-            # ``artifacts_start`` → chunks → ``artifacts_end``.
-            await controller.get_artifacts_download_sender().handle_download_artifacts(
-                session, parsed
-            )
+        handler = _APP_FRAME_DISPATCH.get(msg_type) if isinstance(msg_type, str) else None
+        if handler is not None:
+            await handler(controller, session, parsed)
             continue
         _LOGGER.debug(
             "peer-link unknown app frame type %r from %s; ignoring",
             msg_type,
             session.dashboard_id,
         )
+
+
+async def _dispatch_submit_job(
+    controller: ReceiverController, session: PeerLinkSession, parsed: dict[str, Any]
+) -> None:
+    # The cast is the dispatch boundary's "wire said submit_job; treat as the
+    # matching TypedDict" hand-off; the receiver validates the fields.
+    await controller.get_submit_job_receiver().handle_submit_job(
+        session, cast(SubmitJobFrameData, parsed)
+    )
+
+
+async def _dispatch_submit_job_chunk(
+    controller: ReceiverController, session: PeerLinkSession, parsed: dict[str, Any]
+) -> None:
+    await controller.get_submit_job_receiver().handle_submit_job_chunk(
+        session, cast(SubmitJobChunkFrameData, parsed)
+    )
+
+
+async def _dispatch_cancel_job(
+    controller: ReceiverController, session: PeerLinkSession, parsed: dict[str, Any]
+) -> None:
+    # Cooperative cancel; fire-and-forget. The resulting JOB_CANCELLED bus
+    # event fans out job_state_changed{cancelled} which the offloader already
+    # plumbs, so no ack frame is needed.
+    await controller.handle_cancel_job(session, parsed)
+
+
+async def _dispatch_download_artifacts(
+    controller: ReceiverController, session: PeerLinkSession, parsed: dict[str, Any]
+) -> None:
+    # Streams the completed build's artifacts back via artifacts_start,
+    # chunks, then artifacts_end.
+    await controller.get_artifacts_download_sender().handle_download_artifacts(session, parsed)
+
+
+# Inbound app-frame type → async handler. PING / PONG / TERMINATE branch in
+# the receive loop body; they touch session-local state or close the loop and
+# don't fit the shared handler shape. Malformed frames branch upstream.
+_APP_FRAME_DISPATCH: dict[
+    str, Callable[[ReceiverController, PeerLinkSession, dict[str, Any]], Awaitable[None]]
+] = {
+    AppMessageType.SUBMIT_JOB.value: _dispatch_submit_job,
+    AppMessageType.SUBMIT_JOB_CHUNK.value: _dispatch_submit_job_chunk,
+    AppMessageType.CANCEL_JOB.value: _dispatch_cancel_job,
+    AppMessageType.DOWNLOAD_ARTIFACTS.value: _dispatch_download_artifacts,
+}
 
 
 def _monotonic() -> float:


### PR DESCRIPTION
# What does this implement/fix?

The receiver-side peer-link receive loop (`peer_link/session.py:_receive_loop`) hand-branched four app-frame types (`submit_job`, `submit_job_chunk`, `cancel_job`, `download_artifacts`) in an if-chain. The client side already does this with a dispatch table (`peer_link_client/client.py:_build_sync_frame_dispatch`); this brings the receiver into parity.

Frame types are now keyed in a module-level `_APP_FRAME_DISPATCH` constant built once at import, so there is no per-session or per-frame allocation. PING / PONG / TERMINATE stay branched in the loop body since they touch session-local state or close the loop. The non-string and unknown `msg_type` paths behave as before; a non-string short-circuits the lookup and falls through to the debug-log branch.

Behaviour is unchanged; the submit/artifacts accessors still resolve per-frame inside the handlers, so the table build never touches state that only exists after `ReceiverController.start()`.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
