### PR TITLE
Add list-form triggers under flat singleton components

### DIFF
--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -32,6 +32,9 @@ from . import catalog
 from .emitter import dump, emit_effect_item, emit_trigger_list_item
 from .parsing import make_yaml
 
+# The YAML field naming a component instance's id.
+_ID_KEY = "id"
+
 
 def wrap_handler_list_block(handler_key: str, rendered_list: str) -> str:
     """Prefix a rendered dashed list with its ``<handler_key>:`` header."""
@@ -233,15 +236,26 @@ def _require_instance(
     section = data.get(domain) if isinstance(data, dict) else None
     if isinstance(section, list):
         for instance in section:
-            if isinstance(instance, dict) and str(instance.get("id", "")) == component_id:
+            if isinstance(instance, dict) and str(instance.get(_ID_KEY, "")) == component_id:
                 return instance
         # Fall back to the parser's positional ``<domain>_<idx>`` label for
         # an id-less instance (only when that instance is genuinely id-less).
         idx = synthetic_instance_index(domain, component_id)
         if idx is not None and idx < len(section):
             candidate = section[idx]
-            if isinstance(candidate, dict) and "id" not in candidate:
+            if isinstance(candidate, dict) and _ID_KEY not in candidate:
                 return candidate
+    elif isinstance(section, dict):
+        # Flat singleton block (``logger:`` / ``mqtt:`` / ``sun:``): the block
+        # is the instance. Match its declared ``id``, else the domain name when
+        # the ``id`` key is absent (key presence, not value, so ``id: null``
+        # isn't treated as id-less; mirrors the list branch and the text-layer
+        # ``_locate_singleton_instance``).
+        if _ID_KEY in section:
+            if str(section[_ID_KEY]) == component_id:
+                return section
+        elif component_id == domain:
+            return section
     msg = f"Component instance id={component_id!r} not found under {domain!r}"
     raise CommandError(error_code, msg)
 

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -455,6 +455,117 @@ def test_upsert_flat_singleton_unknown_id_raises() -> None:
     assert err.value.code == ErrorCode.INVALID_ARGS
 
 
+def test_upsert_list_form_trigger_on_idd_singleton() -> None:
+    """A list-form trigger (carries an index) adds under a flat singleton with an id (#1297)."""
+    text = "logger:\n  level: DEBUG\n  id: logger_id\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="logger.on_message",
+            actions=[ActionNode(action_id="logger.log", params={"format": "hi"})],
+        ),
+        location=ComponentOnLocation(component_id="logger_id", trigger="on_message", index=0),
+    )
+    assert "level: DEBUG" in new_text
+    assert "id: logger_id" in new_text
+    parsed = parse_device_yaml(new_text)
+    assert len(parsed) == 1
+    loc = parsed[0].location
+    assert (loc.component_id, loc.trigger, loc.index) == ("logger_id", "on_message", 0)
+
+
+def test_upsert_list_form_trigger_on_idless_singleton() -> None:
+    """A list-form trigger adds under an id-less singleton (``component_id == domain``)."""
+    text = "logger:\n  level: DEBUG\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="logger.on_message",
+            actions=[ActionNode(action_id="logger.log", params={"format": "hi"})],
+        ),
+        location=ComponentOnLocation(component_id="logger", trigger="on_message", index=0),
+    )
+    assert "level: DEBUG" in new_text
+    parsed = parse_device_yaml(new_text)
+    assert len(parsed) == 1
+    assert parsed[0].location.component_id == "logger"
+    assert parsed[0].location.index == 0
+
+
+def test_upsert_list_form_trigger_appends_second_entry_on_singleton() -> None:
+    """Upserting at the list length appends a second entry under the singleton."""
+    text = (
+        "logger:\n"
+        "  level: DEBUG\n"
+        "  id: logger_id\n"
+        "  on_message:\n"
+        "    - then:\n"
+        "        - logger.log: first\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="logger.on_message",
+            actions=[ActionNode(action_id="logger.log", params={"format": "second"})],
+        ),
+        location=ComponentOnLocation(component_id="logger_id", trigger="on_message", index=1),
+    )
+    assert "first" in new_text
+    assert "second" in new_text
+    assert [p.location.index for p in parse_device_yaml(new_text)] == [0, 1]
+
+
+def test_upsert_list_form_trigger_on_null_id_singleton_raises() -> None:
+    """An explicit ``id: null`` is not treated as id-less; domain-name match is refused."""
+    text = "logger:\n  level: DEBUG\n  id: null\n"
+    with pytest.raises(CommandError) as err:
+        render_upsert(
+            text,
+            tree=AutomationTree(trigger_id="logger.on_message", actions=[]),
+            location=ComponentOnLocation(component_id="logger", trigger="on_message", index=0),
+        )
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
+def test_upsert_list_form_trigger_on_ambiguous_key_singleton() -> None:
+    """A list-form trigger with an ambiguous key resolves to its singleton (mqtt)."""
+    text = "mqtt:\n  broker: 192.168.1.10\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(
+            trigger_id="mqtt.on_message",
+            actions=[ActionNode(action_id="logger.log", params={"format": "hi"})],
+        ),
+        location=ComponentOnLocation(component_id="mqtt", trigger="on_message", index=0),
+    )
+    assert "broker: 192.168.1.10" in new_text
+    parsed = parse_device_yaml(new_text)
+    assert [(p.location.component_id, p.location.trigger, p.location.index) for p in parsed] == [
+        ("mqtt", "on_message", 0),
+    ]
+
+
+def test_delete_list_form_trigger_entry_on_singleton() -> None:
+    """Deleting the only list-form entry drops the handler key but keeps config."""
+    text = (
+        "logger:\n"
+        "  level: DEBUG\n"
+        "  id: logger_id\n"
+        "  on_message:\n"
+        "    - then:\n"
+        "        - logger.log: only\n"
+    )
+    new_text, diff = render_delete(
+        text,
+        location=ComponentOnLocation(component_id="logger_id", trigger="on_message", index=0),
+    )
+    assert "on_message:" not in new_text
+    assert "level: DEBUG" in new_text
+    assert "id: logger_id" in new_text
+    assert parse_device_yaml(new_text) == []
+    assert diff.replacement == ""
+
+
 def test_stale_positional_id_on_idd_instance_is_refused() -> None:
     """A ``<domain>_<idx>`` id pointing at an instance with a real id is refused."""
     text = "esphome:\n  name: x\nbinary_sensor:\n  - platform: gpio\n    id: real\n    pin: GPIO0\n"


### PR DESCRIPTION
# What does this implement/fix?

Adding a list-form trigger (one the catalog marks `supports_list: true`, e.g. `logger.on_message`) from the Visual Editor failed on flat singleton components with `invalid_args: Component instance id='logger_id' not found under 'logger'`. The list-form write path resolved the target through `_require_instance`, which only matched list-shaped `<domain>:` sections; a singleton like `logger:`/`mqtt:`/`sun:` is a mapping, so the lookup fell through and the add (and delete) failed. It now matches the singleton block by its declared `id`, or by the domain name when id-less, mirroring `_locate_singleton_instance`; the resplice path already handled singletons. Affects every flat-singleton component, logger is just the reported case.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1297

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
