### PR TITLE
Document headless Chrome/CDP/puppeteer empirical testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,27 @@ site-packages dir the backend reads via `_get_frontend_dir`; no proxy,
 browse to `http://localhost:6052/`. Use dev-server for fast iteration,
 built path to verify the bundle the user actually receives.
 
+### Driving the browser headlessly (CDP + puppeteer)
+
+`npm i puppeteer` (downloads its own browser, no OS-specific path) and
+drive the dashboard with `headless:true`. The non-obvious bits:
+
+- Deep-link an editor at `/device/<configuration>.yaml`; drop repro
+  configs in `configs/` (gitignored).
+- The SPA is Lit + Web Awesome, so everything is in **shadow DOM** that
+  ordinary selectors miss: walk shadow roots to find nodes. Drive a
+  `wa-select` by setting `.value` to a `wa-option`'s `value` and
+  dispatching `change` + `input` (`{bubbles: true, composed: true}`); a
+  dependent select populates only after the one it depends on fires.
+- To prove a backend command without fighting the wizard DOM, open a
+  `WebSocket` to `/ws` in `page.evaluate` and send the frame the frontend
+  does (`{command, message_id, args}`, shape in the frontend repo's
+  `src/api/esphome-api.ts`); gate the send on the first server frame
+  (`server_version`); replies are `{result}` or `{error_code, details}`.
+- For a before/after, run the backend on pre-fix code without touching
+  your branch: `git show origin/main:<path> > <path>`, restart, then
+  `git checkout HEAD -- <path>`.
+
 ## Comparison with the legacy esphome dashboard
 
 The legacy Tornado dashboard (`esphome/dashboard/` upstream) is the


### PR DESCRIPTION
# What does this implement/fix?

Documents how an agent with no human at the keyboard runs the empirical browser tests: drive the dashboard with puppeteer-core against the cached Chrome-for-Testing, pierce the Lit/Web-Awesome shadow DOM, and use an in-page WebSocket to issue the exact controller command for a deterministic before/after (including the `git show origin/main` file swap to capture the pre-fix error). Extends the existing "Empirical browser testing" section; no code change.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
