### PR TITLE
Surface id-less component instances as automation targets

### DIFF
--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -379,15 +379,17 @@ def _scope_component_instances(
         catalog_id = parsing.catalog_id(domain, item.get("platform"))
         subs = list(parsing.iter_subentities(domain, item))
         comp_id = item.get("id")
-        if comp_id:
-            # Mark a container only when it actually surfaces ided sub-entities;
-            # a multi-entity platform whose readings carry no id keeps its plain
-            # instance (the frontend hides containers, and would otherwise leave
-            # the user nothing to target).
-            out.append(_component_instance(catalog_id, str(comp_id), item, is_container=bool(subs)))
-        parent_id = str(comp_id) if comp_id else f"{domain}_{idx}"
+        instance_id = str(comp_id) if comp_id else f"{domain}_{idx}"
+        # Surface the instance as a target unless it's an id-less container —
+        # an id-less leaf (a gpio binary_sensor, an uptime sensor) keys on the
+        # same f"{domain}_{idx}" synthetic id the parser and writer use, so it
+        # round-trips. Mark a container only when it surfaces ided sub-entities;
+        # the frontend hides containers and redirects to those sub-entities, so
+        # an id-less container has nothing to redirect to and is left out.
+        if comp_id or not subs:
+            out.append(_component_instance(catalog_id, instance_id, item, is_container=bool(subs)))
         for sub_domain, sub, sub_id, _sub_key in subs:
-            out.append(_component_instance(sub_domain, sub_id, sub, parent_id=parent_id))
+            out.append(_component_instance(sub_domain, sub_id, sub, parent_id=instance_id))
     return out
 
 

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -143,13 +143,13 @@ def test_scope_skips_non_dict_component_instances() -> None:
     assert [d.id for d in scoped.devices] == ["real"]
 
 
-def test_scope_skips_component_instance_without_id() -> None:
-    """A configured component without an ``id`` doesn't surface in the picker."""
+def test_scope_surfaces_idless_component_instance() -> None:
+    """An id-less leaf surfaces under its positional synthetic id beside ided ones."""
     scoped = _scope_from_yaml(
         "binary_sensor:\n  - platform: gpio\n    pin: GPIO0\n"
         "  - platform: gpio\n    id: real\n    pin: GPIO1\n",
     )
-    assert [d.id for d in scoped.devices] == ["real"]
+    assert [d.id for d in scoped.devices] == ["binary_sensor_0", "real"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -295,6 +295,48 @@ async def test_get_available_skips_idless_subentity(tmp_path: Path) -> None:
     assert "aht20_humidity" not in ids
 
 
+async def test_get_available_surfaces_idless_binary_sensor_leaf(tmp_path: Path) -> None:
+    """An id-less binary_sensor leaf is targetable via its positional synthetic id."""
+    config = tmp_path / "bs.yaml"
+    config.write_text(
+        "esphome:\n  name: d\n"
+        "binary_sensor:\n"
+        "  - platform: status\n    name: Status\n"
+        '  - platform: gpio\n    pin: GPIO9\n    name: "Button"\n'
+        "  - platform: gpio\n    pin: GPIO3\n    name: Pir Sensor\n    id: pir\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.get_available(configuration="bs.yaml")
+    devices = {(d["component_id"], d["id"]): d for d in result["devices"]}
+    button = devices[("binary_sensor.gpio", "binary_sensor_1")]
+    assert button["name"] == "Button"
+    assert button["is_entity_container"] is False
+    assert ("binary_sensor.status", "binary_sensor_0") in devices
+    assert ("binary_sensor.gpio", "pir") in devices
+    trigger_ids = {t["id"] for t in result["triggers"]}
+    assert {"binary_sensor.on_press", "binary_sensor.on_multi_click"} <= trigger_ids
+
+
+async def test_get_available_surfaces_idless_sensor_leaves(tmp_path: Path) -> None:
+    """Named id-less sensor leaves (uptime / template) become positional targets."""
+    config = tmp_path / "sensor.yaml"
+    config.write_text(
+        "esphome:\n  name: d\n"
+        "sensor:\n"
+        "  - platform: uptime\n    name: Uptime\n"
+        "  - platform: template\n    name: Free Memory\n"
+        "    lambda: return 0;\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.get_available(configuration="sensor.yaml")
+    devices = {(d["component_id"], d["id"]): d for d in result["devices"]}
+    assert devices[("sensor.uptime", "sensor_0")]["name"] == "Uptime"
+    assert devices[("sensor.template", "sensor_1")]["name"] == "Free Memory"
+    assert "sensor.on_value" in {t["id"] for t in result["triggers"]}
+
+
 async def test_get_available_ignores_non_platform_nested_blocks(tmp_path: Path) -> None:
     """Nested groups without a ``platform_type`` (``availability:``) aren't sub-entities."""
     config = tmp_path / "aht.yaml"


### PR DESCRIPTION
# What does this implement/fix?

Adding an automation to a component that has no `id:` failed with "No triggers available for this target"; a named gpio binary_sensor or an uptime/template sensor could not be targeted at all. The trigger catalog already had the triggers, and the parser and writer already handled id-less components via a synthetic `<domain>_<idx>` id, but the target-surfacing step `_scope_component_instances` never emitted those instances, so the wizard had nothing to point at.

This surfaces an id-less leaf the same way, keyed on that same synthetic id, so it round-trips through parse, upsert, and delete. An id-less container (a multi-entity platform with no id of its own) stays out, since its sub-entities are the targets; that is a separate pre-existing gap. The frontend already computes the same synthetic id and looks it up in the returned devices list, so no frontend change is needed.

**Related issue or feature (if applicable):**

- No filed issue; reported in conversation against the live dashboard.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
