### PR TITLE
Recover scalar value type for templatable filters from the registry

### DIFF
--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -121,6 +121,8 @@ class LightEffect(DataClassORJSONMixin):
     config_entries: list[ConfigEntry] = field(default_factory=list)
     applies_to: list[str] = field(default_factory=list)
     value_type: str | None = None
+    # ``templatable`` scalar value accepts a lambda; renderer offers the toggle.
+    templatable: bool = False
 
 
 @dataclass
@@ -133,7 +135,8 @@ class Filter(DataClassORJSONMixin):
     the REGISTRY_LIST renderer uses it to scope the per-row picker.
     ``value_type`` flags scalar-valued entries (``throttle``,
     ``delayed_on``) so the renderer mounts an inline scalar input
-    instead of an empty sub-form.
+    instead of an empty sub-form; ``templatable`` adds a lambda toggle
+    on that scalar (``multiply: !lambda``).
     """
 
     id: str
@@ -141,6 +144,7 @@ class Filter(DataClassORJSONMixin):
     config_entries: list[ConfigEntry] = field(default_factory=list)
     applies_to: list[str] = field(default_factory=list)
     value_type: str | None = None
+    templatable: bool = False
 
 
 @dataclass
@@ -212,6 +216,7 @@ class LightEffectIndex(DataClassORJSONMixin):
     name: str
     applies_to: list[str] = field(default_factory=list)
     value_type: str | None = None
+    templatable: bool = False
 
 
 @dataclass
@@ -222,6 +227,7 @@ class FilterIndex(DataClassORJSONMixin):
     name: str
     applies_to: list[str] = field(default_factory=list)
     value_type: str | None = None
+    templatable: bool = False
 
 
 @dataclass

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -5703,6 +5703,60 @@ def _scalar_value_type_for_schema(name: str, schema: dict | None) -> str | None:
     return types[0]
 
 
+# ``vol.Coerce`` target type -> the ``value_type`` string; the whole
+# vocabulary, no per-validator allowlist. Keyed on ``object`` since
+# ``Coerce.type`` may be a callable (which just misses the lookup).
+_PY_TYPE_TO_VALUE_TYPE: dict[object, str] = {float: "float", int: "integer", str: "string"}
+
+
+def _classify_scalar_validator(validator: Any, _depth: int = 0) -> str | None:
+    """
+    Derive the scalar value type a (possibly wrapped) validator accepts, or None.
+
+    Reads the ``vol.Coerce`` target (``cv.float_`` is ``Coerce(float)``), peeling
+    ``Schema`` / ``templatable`` / ``All`` wrappers. ``vol.Any`` is left alone so
+    a scalar-or-list filter stays unclassified; depth guard stops cycles.
+    """
+    if validator is None or _depth > 8:
+        return None
+    if isinstance(validator, vol.Coerce):
+        return _PY_TYPE_TO_VALUE_TYPE.get(validator.type)
+    inner = getattr(validator, "schema", None)
+    if inner is not None and inner is not validator:
+        return _classify_scalar_validator(inner, _depth + 1)
+    # Recurse into a templatable closure's captured inner or an All refinement
+    # chain. Any is deliberately skipped (a scalar-or-list filter stays None).
+    children: tuple[Any, ...] = ()
+    if "templatable" in (getattr(validator, "__qualname__", "") or ""):
+        children = tuple(c.cell_contents for c in getattr(validator, "__closure__", None) or ())
+    elif isinstance(validator, vol.All):
+        children = tuple(validator.validators)
+    for child in children:
+        found = _classify_scalar_validator(child, _depth + 1)
+        if found:
+            return found
+    return None
+
+
+@cache
+def _filter_value_type_live(domain: str, name: str) -> str | None:
+    """
+    Recover a filter's scalar value type from the live ``FILTER_REGISTRY``.
+
+    The bundle dumps templatable scalar filters (``multiply`` / ``offset``)
+    type-less, so introspect the registered validator. None if not a scalar.
+    """
+    try:
+        module = importlib.import_module(f"esphome.components.{domain}")
+        registry = getattr(module, "FILTER_REGISTRY", None)
+        if registry is None or name not in registry:
+            return None
+        schema = getattr(registry[name], "schema", None)
+    except Exception:
+        return None
+    return _classify_scalar_validator(schema)
+
+
 # Per-filter field overrides for shapes the upstream schema bundle
 # can't surface because the validator is a custom callable (e.g.
 # ``ntc_process_calibration``) instead of a structural cv.*
@@ -5735,13 +5789,21 @@ def _convert_registry_entry(
     label_domain: str,
     applies_to: list[str],
     schema_dir: Path,
+    live_value_type: str | None = None,
 ) -> dict | None:
-    """Build a registry catalog dict (id, name, config_entries, applies_to, value_type)."""
+    """
+    Build a registry catalog dict (id, name, config_entries, applies_to, value_type).
+
+    ``live_value_type`` is a fallback the caller recovered by live
+    introspection for scalar entries the schema bundle dumps type-less
+    (templatable ``multiply`` / ``offset``); used only when the bundle
+    schema yields no ``value_type``.
+    """
     if not isinstance(body, dict):
         return None
     docs = clean_docs(body.get("docs"))
     schema = body.get("schema") if isinstance(body.get("schema"), dict) else None
-    value_type = _scalar_value_type_for_schema(name, schema)
+    value_type = _scalar_value_type_for_schema(name, schema) or live_value_type
     has_config_vars = bool(schema and schema.get("config_vars"))
     if value_type is not None and not has_config_vars:
         # Pure scalar shorthand (``delayed_on: 50ms``).
@@ -5758,13 +5820,18 @@ def _convert_registry_entry(
             extract_schema = {k: v for k, v in schema.items() if k != "extends"}
         config_entries, _alist, _hcg = _extract_automation_param_schema(extract_schema, schema_dir)
         config_entries = _apply_field_overrides(name, config_entries)
-    return {
+    entry = {
         "id": name,
         "name": _automation_label(label_domain, name, docs.name),
         "config_entries": [_strip_entry_defaults(e) for e in config_entries],
         "applies_to": applies_to,
         "value_type": value_type,
     }
+    # Surface the bundle's templatable flag so the frontend offers a lambda
+    # toggle on the scalar value (``multiply: !lambda``). Omitted when false.
+    if body.get("templatable"):
+        entry["templatable"] = True
+    return entry
 
 
 # Shared by `_automation_label` (producer) and `_dedupe_filters`
@@ -5786,6 +5853,7 @@ def _convert_filter(
         label_domain=domain,
         applies_to=[domain],
         schema_dir=schema_dir,
+        live_value_type=_filter_value_type_live(domain, name),
     )
 
 

--- a/tests/test_sync_components_filters.py
+++ b/tests/test_sync_components_filters.py
@@ -13,11 +13,16 @@ import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import voluptuous as vol
+
 from esphome_device_builder.controllers.components import ComponentCatalog
 from script.sync_components import (  # type: ignore[import-not-found]
+    _classify_scalar_validator,
     _convert_field,
+    _convert_filter,
     _convert_registry_entry,
     _dedupe_filters,
+    _filter_value_type_live,
     _is_scalar_extends_schema,
 )
 
@@ -394,3 +399,77 @@ def test_to_ntc_temperature_calibration_promoted_to_multi_value() -> None:
     assert entry is not None
     cal = next(c for c in entry["config_entries"] if c["key"] == "calibration")
     assert cal["multi_value"] is True
+
+
+# ---------------------------------------------------------------------------
+# Scalar value-type recovery for templatable filters (#1304)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_scalar_validator_reads_coerce_target() -> None:
+    """The value type is derived from the Coerce target, not a name list."""
+    import esphome.config_validation as cv  # noqa: PLC0415
+
+    assert _classify_scalar_validator(cv.float_) == "float"
+    assert _classify_scalar_validator(vol.Coerce(int)) == "integer"
+    assert _classify_scalar_validator(vol.Coerce(str)) == "string"
+    # All(Coerce, Range) refinement chains unwrap to the inner Coerce. Built
+    # here rather than off ``cv.positive_float`` whose internal shape varies
+    # across esphome versions.
+    assert _classify_scalar_validator(vol.All(vol.Coerce(float), vol.Range(min=0))) == "float"
+
+
+def test_classify_scalar_validator_skips_polymorphic_any() -> None:
+    """vol.Any (scalar-or-list) is not forced to a bare scalar."""
+    assert _classify_scalar_validator(vol.Any(vol.Coerce(float), [vol.Coerce(float)])) is None
+    assert _classify_scalar_validator(lambda v: v) is None
+
+
+def test_filter_value_type_live_recovers_multiply_offset() -> None:
+    """Multiply / offset are templatable floats the bundle dumps type-less."""
+    assert _filter_value_type_live("sensor", "multiply") == "float"
+    assert _filter_value_type_live("sensor", "offset") == "float"
+    # filter_out is scalar-or-list; must not collapse to a bare scalar.
+    assert _filter_value_type_live("sensor", "filter_out") is None
+    assert _filter_value_type_live("sensor", "does_not_exist") is None
+
+
+def test_convert_filter_recovers_scalar_value_type_and_templatable() -> None:
+    """A bundle entry with only {templatable, docs} gains value_type + templatable."""
+    entry = _convert_filter(
+        name="multiply",
+        body={"templatable": True, "docs": "Multiplies each value by a templatable value."},
+        domain="sensor",
+        schema_dir=_UNUSED_SCHEMA_DIR,
+    )
+    assert entry is not None
+    assert entry["value_type"] == "float"
+    assert entry["config_entries"] == []
+    assert entry["templatable"] is True
+
+
+def test_convert_filter_omits_templatable_when_absent() -> None:
+    """A non-templatable filter carries no templatable key."""
+    entry = _convert_filter(
+        name="lambda",
+        body={"docs": "..."},
+        domain="sensor",
+        schema_dir=_UNUSED_SCHEMA_DIR,
+    )
+    assert entry is not None
+    assert entry["value_type"] == "lambda"
+    assert "templatable" not in entry
+
+
+def test_bundle_value_type_wins_over_live_fallback() -> None:
+    """A schema-typed filter keeps its bundle value_type; live is only a fallback."""
+    entry = _convert_registry_entry(
+        name="multiply",
+        body={"schema": {"extends": ["core.positive_time_period_milliseconds"]}, "type": "schema"},
+        label_domain="sensor",
+        applies_to=["sensor"],
+        schema_dir=_UNUSED_SCHEMA_DIR,
+        live_value_type="float",
+    )
+    assert entry is not None
+    assert entry["value_type"] == "time_period"


### PR DESCRIPTION
# What does this implement/fix?

A sensor `filters:` entry (e.g. `multiply`) showed its type dropdown but no field to set the value (`multiply: 0.01`) or a lambda. ESPHome's schema bundle dumps templatable scalar filters (`multiply`/`offset`) as bare `{templatable, docs}` with no schema, so the catalog emitted `value_type: null` and the editor rendered nothing.

This recovers the type by introspecting the live `FILTER_REGISTRY`: it reads the `vol.Coerce` target the primitive is built from (`cv.float_` is `Coerce(float)`), peeling `templatable` / `Schema` / `All` wrappers and leaving `vol.Any` alone so a scalar-or-list filter (`filter_out`) isn't forced to a bare scalar. The only constant is the inherent `{float, int, str}` to value-type map; there is no per-validator name list to keep in sync with ESPHome. It also surfaces the bundle's `templatable` flag on the catalog entry so the editor can offer a literal/lambda toggle on the value (`multiply: !lambda`); the companion frontend change renders that toggle.

This PR changes only the generator and tests. The catalog JSON is regenerated by the nightly `sync-component-catalog` workflow against the canonical environment.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1304

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: pairs with the registry-list lambda-toggle change (linked once opened)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
