### PR TITLE
Wrap shorthand action-list handlers before appending another

### DIFF
--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -622,17 +622,17 @@ def _is_list_form_trigger(body: Any, trigger: AutomationTrigger) -> bool:
     A bare action list (``on_press: [{light.turn_on: id}, ...]``) is *not*
     list-form: every item there is a known action id. List-form requires a
     non-empty list whose every item is trigger-shaped (see
-    :func:`_is_trigger_entry`), so the conservative default keeps the
+    :func:`is_trigger_entry`), so the conservative default keeps the
     existing bare-action-list behaviour intact.
     """
     return (
         isinstance(body, list)
         and bool(body)
-        and all(_is_trigger_entry(item, trigger) for item in body)
+        and all(is_trigger_entry(item, trigger) for item in body)
     )
 
 
-def _is_trigger_entry(item: Any, trigger: AutomationTrigger) -> bool:
+def is_trigger_entry(item: Any, trigger: AutomationTrigger) -> bool:
     """
     Report whether *item* looks like one entry of a list-shaped trigger.
 

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -210,6 +210,7 @@ def _upsert_device_on_entry(
         item=emit_trigger_list_item(tree),
         index=index,
         strategy=_DEVICE_STRATEGY,
+        trigger=catalog.trigger_by_id(trigger),
     )
 
 
@@ -245,6 +246,7 @@ def _upsert_component_on(
             domain=instance_domain,
             component_id=location.component_id,
             trigger_key=location.trigger,
+            trigger=trigger,
             index=location.index,
         )
     domain = trigger.applies_to[0] if trigger.applies_to else ""

--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
+from ruamel.yaml.comments import CommentedMap
+
 from ...helpers.api import CommandError
 from ...helpers.yaml import (
     remove_inline_handler,
@@ -25,12 +27,13 @@ from ...helpers.yaml import (
 from ...models.api import ErrorCode
 from ...models.automations import (
     AutomationTree,
+    AutomationTrigger,
     LightEffectLocation,
     YamlDiff,
 )
 from . import catalog
 from .emitter import dump, emit_effect_item, emit_trigger_list_item
-from .parsing import make_yaml
+from .parsing import _is_trigger_entry, make_yaml
 
 # The YAML field naming a component instance's id.
 _ID_KEY = "id"
@@ -154,6 +157,7 @@ def upsert_list_entry(
     item: Any,
     index: int,
     strategy: ListContainerStrategy,
+    trigger: AutomationTrigger | None = None,
 ) -> tuple[str, YamlDiff]:
     """
     Insert or replace one entry of a list-shaped handler at *index*.
@@ -161,6 +165,11 @@ def upsert_list_entry(
     ``index == len(entries)`` appends; an in-range index replaces. Refuses
     when the existing handler is a single mapping rather than a list — the
     user picked that shape, so don't silently rewrite it.
+
+    When *trigger* is given and the existing list body is the bare
+    action-list shorthand (one handler whose items aren't trigger
+    entries), wrap it as a single ``then:`` entry before applying, so a
+    new handler appends instead of overwriting an action (#1305).
     """
     container = strategy.locate(yaml_text, ErrorCode.INVALID_ARGS)
     existing = container.get(key) if container is not None else None
@@ -169,6 +178,10 @@ def upsert_list_entry(
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     entries = existing if isinstance(existing, list) else []
     drop_after_block_comment(entries)
+    if entries and trigger is not None and not all(_is_trigger_entry(e, trigger) for e in entries):
+        wrapped = CommentedMap()
+        wrapped["then"] = entries
+        entries = [wrapped]
     apply_list_entry_upsert(entries, item, index, label=key)
     return strategy.resplice(yaml_text, key, entries)
 
@@ -211,6 +224,7 @@ def upsert_component_on_entry(
     domain: str,
     component_id: str,
     trigger_key: str,
+    trigger: AutomationTrigger,
     index: int,
 ) -> tuple[str, YamlDiff]:
     """Insert or replace one entry of a list-shaped trigger (``time.on_time``)."""
@@ -220,6 +234,7 @@ def upsert_component_on_entry(
         item=emit_trigger_list_item(tree),
         index=index,
         strategy=_component_strategy(domain, component_id),
+        trigger=trigger,
     )
 
 

--- a/esphome_device_builder/controllers/automations/writing_lists.py
+++ b/esphome_device_builder/controllers/automations/writing_lists.py
@@ -33,7 +33,7 @@ from ...models.automations import (
 )
 from . import catalog
 from .emitter import dump, emit_effect_item, emit_trigger_list_item
-from .parsing import _is_trigger_entry, make_yaml
+from .parsing import is_trigger_entry, make_yaml
 
 # The YAML field naming a component instance's id.
 _ID_KEY = "id"
@@ -178,7 +178,7 @@ def upsert_list_entry(
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
     entries = existing if isinstance(existing, list) else []
     drop_after_block_comment(entries)
-    if entries and trigger is not None and not all(_is_trigger_entry(e, trigger) for e in entries):
+    if entries and trigger is not None and not all(is_trigger_entry(e, trigger) for e in entries):
         wrapped = CommentedMap()
         wrapped["then"] = entries
         entries = [wrapped]

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -200,6 +200,20 @@ def test_upsert_device_on_boot_index_out_of_range_raises() -> None:
         )
 
 
+def test_indexed_upsert_wraps_device_shorthand_action_list() -> None:
+    """A 2nd on_boot handler wraps the bare action-list body, preserving actions (#1305)."""
+    text = "esphome:\n  name: x\n  on_boot:\n    - delay: 1s\n    - delay: 2s\n"
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id="on_boot", trigger_params={}, actions=[]),
+        location=DeviceOnLocation(trigger="on_boot", index=1),
+    )
+    parsed = parse_device_yaml(new_text)
+    assert len(parsed) == 2
+    assert [a.action_id for a in parsed[0].automation.actions] == ["delay", "delay"]
+    assert parsed[1].automation.actions == []
+
+
 def test_upsert_device_on_boot_indexed_refuses_single_mapping() -> None:
     """An indexed upsert against a single-mapping on_boot refuses rather than rewriting it."""
     text = _load("device_on_boot.yaml")  # single-mapping form

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -230,6 +230,57 @@ def test_round_trip_inline_on_press_preserves_actions() -> None:
     ]
 
 
+_SHORTHAND_ON_PRESS = (
+    "esphome:\n  name: x\n"
+    "button:\n"
+    "  - platform: template\n"
+    "    name: B\n"
+    "    id: bid\n"
+    "    on_press:\n"
+    "      - switch.turn_off: relay\n"
+    '      - uart.write: "go\\r\\n"\n'
+    "      - delay: 1s\n"
+)
+
+
+def test_indexed_upsert_wraps_shorthand_action_list(tmp_path: Path) -> None:
+    """Adding a 2nd handler to a bare action list wraps it, preserving every action (#1305)."""
+    tree = AutomationTree(trigger_id="on_press", trigger_params={}, actions=[])
+    new_text, _diff = render_upsert(
+        _SHORTHAND_ON_PRESS,
+        tree=tree,
+        location=ComponentOnLocation(component_id="bid", trigger="on_press", index=1),
+    )
+    parsed = [p for p in parse_device_yaml(new_text) if p.location.component_id == "bid"]
+    assert len(parsed) == 2
+    # The original three actions land on the first handler; none clobbered.
+    assert [a.action_id for a in parsed[0].automation.actions] == [
+        "switch.turn_off",
+        "uart.write",
+        "delay",
+    ]
+    assert parsed[1].automation.actions == []
+    assert "then: []\n      - then:" not in new_text  # no then-in-then nesting
+
+
+def test_indexed_upsert_does_not_double_wrap_handler_list() -> None:
+    """An existing list of ``then:`` handlers appends without re-wrapping."""
+    text = (
+        "esphome:\n  name: x\n"
+        "button:\n"
+        "  - platform: template\n    name: B\n    id: bid\n"
+        "    on_press:\n      - then:\n          - delay: 1s\n"
+    )
+    new_text, _diff = render_upsert(
+        text,
+        tree=AutomationTree(trigger_id="on_press", trigger_params={}, actions=[]),
+        location=ComponentOnLocation(component_id="bid", trigger="on_press", index=1),
+    )
+    parsed = [p for p in parse_device_yaml(new_text) if p.location.component_id == "bid"]
+    assert len(parsed) == 2
+    assert [a.action_id for a in parsed[0].automation.actions] == ["delay"]
+
+
 def test_upsert_inline_on_press_leaves_sibling_components_untouched() -> None:
     """Adding ``on_press`` to one component doesn't mutate adjacent siblings."""
     text = (


### PR DESCRIPTION
# What does this implement/fix?

Adding a second `on_press` handler to a component whose existing `on_press:` is the common bare action-list shorthand corrupted the YAML; one existing action was overwritten with `- then: []`. The trigger advertises `supports_list: true`, so the wizard offers "add another" and sends an indexed list upsert; the writer then treated the bare action list as a list of handler entries and spliced the new handler into the action sequence.

The fix wraps the existing shorthand actions as a single `- then: [...]` handler before appending the new one, so every action is preserved and the new handler lands beside it. The wrap decision reuses the parser's existing `_is_trigger_entry` check, so parse and write share one definition of a handler entry; the same path covers device level handlers like `esphome.on_boot`. A single mapping body keeps its current refuse, unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1305

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
