### PR TITLE
Preserve the !lambda tag when round-tripping automations

### DIFF
--- a/esphome_device_builder/controllers/automations/_decompose.py
+++ b/esphome_device_builder/controllers/automations/_decompose.py
@@ -231,18 +231,20 @@ def _render_value(value: Any) -> Any:
     """
     Convert a ruamel-parsed value to its JSON-wire shape.
 
-    Lambda block scalars (``|`` or ``!lambda`` tagged) become the
-    ``{"_lambda": "<source>"}`` sentinel; ruamel maps and lists
-    become plain dicts/lists, recursively. Tagged scalars from
-    ruamel are not JSON-serialisable on their own, so any
-    unrecognised tag falls back to its plain string value.
+    Lambda block scalars become the ``{"_lambda": "<source>"}``
+    sentinel; an ``!lambda``-tagged value additionally carries
+    ``"_tag": "!lambda"`` so the emitter re-emits the tag (dropping it
+    turns the C++ lambda into a plain string literal). ruamel maps and
+    lists become plain dicts/lists, recursively. Tagged scalars from
+    ruamel are not JSON-serialisable on their own, so any unrecognised
+    tag falls back to its plain string value.
     """
     if isinstance(value, LiteralScalarString):
         return {"_lambda": str(value)}
     if isinstance(value, TaggedScalar):
         tag = getattr(value.tag, "value", "") if value.tag is not None else ""
         if tag == "!lambda":
-            return {"_lambda": str(value)}
+            return {"_lambda": str(value), "_tag": "!lambda"}
         return str(value)
     if isinstance(value, dict):
         return {k: _render_value(v) for k, v in value.items()}

--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -27,8 +27,9 @@ from __future__ import annotations
 from io import StringIO
 from typing import Any
 
-from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.comments import CommentedMap, CommentedSeq, TaggedScalar
 from ruamel.yaml.scalarstring import LiteralScalarString
+from ruamel.yaml.tag import Tag
 
 from ...models.automations import (
     ActionNode,
@@ -209,25 +210,17 @@ def encode_value(value: Any) -> Any:
     """
     Encode a JSON-wire value back into a ruamel-native scalar.
 
-    The lambda sentinel (``{"_lambda": "..."}``) becomes a
-    :class:`LiteralScalarString` (``|`` block scalar); nested
-    dicts and lists recurse.
+    The lambda sentinel (``{"_lambda": "..."}``) becomes a ruamel
+    scalar; an ``"_tag": "!lambda"`` marker re-emits the ``!lambda``
+    tag (dropping it would turn the C++ lambda into a string literal,
+    silently breaking the firmware). Nested dicts and lists recurse.
     """
-    # ESPHome treats unquoted ``|`` block scalars on templatable
-    # fields as lambdas without needing an explicit ``!lambda``
-    # tag — matching that shape on fresh writes so a freshly-emitted
-    # YAML doesn't gain a tag the user wouldn't have typed. The
-    # parser still detects both bare-block and ``!lambda``-tagged
-    # forms, so a hand-tagged input round-trips intact.
     if (
         isinstance(value, dict)
-        and set(value.keys()) == {"_lambda"}
-        and isinstance(value["_lambda"], str)
+        and value.keys() <= {"_lambda", "_tag"}
+        and isinstance(value.get("_lambda"), str)
     ):
-        body = value["_lambda"]
-        if not body.endswith("\n"):
-            body += "\n"
-        return LiteralScalarString(body)
+        return _encode_lambda(value["_lambda"], value.get("_tag"))
     if isinstance(value, dict):
         out = CommentedMap()
         for k, v in value.items():
@@ -247,3 +240,24 @@ def dump(value: Any) -> str:
     buf = StringIO()
     yaml.dump(value, buf)
     return buf.getvalue()
+
+
+def _encode_lambda(body: str, tag: str | None) -> Any:
+    """
+    Build a ruamel scalar for a lambda sentinel body.
+
+    ``tag == "!lambda"`` re-emits the explicit tag — multi-line bodies
+    as a ``|`` block, single-line bodies plain (``!lambda return 0;``).
+    Untagged bodies stay bare ``|`` block scalars, the shape ESPHome
+    auto-detects as a lambda on ``lambda:``-keyed fields.
+    """
+    if tag != "!lambda":
+        if not body.endswith("\n"):
+            body += "\n"
+        return LiteralScalarString(body)
+    if "\n" in body.rstrip("\n"):
+        scalar = TaggedScalar(value=body if body.endswith("\n") else body + "\n", style="|")
+    else:
+        scalar = TaggedScalar(value=body.rstrip("\n"), style=None)
+    scalar.yaml_set_ctag(Tag(suffix="!lambda"))
+    return scalar

--- a/esphome_device_builder/controllers/automations/writing.py
+++ b/esphome_device_builder/controllers/automations/writing.py
@@ -9,8 +9,9 @@ left untouched. Delete is the inverse splice.
 
 Trigger handlers always emit the explicit ``then:`` form — the
 parser accepts both shortcut forms but emitting one shape keeps
-round-trips deterministic. Lambdas render as ruamel
-:class:`LiteralScalarString` block scalars.
+round-trips deterministic. Untagged lambdas render as ruamel
+:class:`LiteralScalarString` block scalars; an ``!lambda``-tagged
+value re-emits its tag (see :func:`emitter.encode_value`).
 """
 
 from __future__ import annotations

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
+from ruamel.yaml.comments import TaggedScalar
 from ruamel.yaml.scalarstring import LiteralScalarString
 
 from esphome_device_builder.controllers.automations import catalog
@@ -476,10 +477,10 @@ def test_render_value_passes_lists_through_recursively() -> None:
 
 
 def test_render_value_handles_tagged_lambda_scalar() -> None:
-    """A ruamel ``!lambda``-tagged plain scalar surfaces as the lambda sentinel."""
+    """A ruamel ``!lambda``-tagged plain scalar surfaces with the ``_tag`` marker."""
     yaml = make_yaml()
     data = yaml.load('a: !lambda ESP_LOGI("x");\n')
-    assert _render_value(data["a"]) == {"_lambda": 'ESP_LOGI("x");'}
+    assert _render_value(data["a"]) == {"_lambda": 'ESP_LOGI("x");', "_tag": "!lambda"}
 
 
 def test_render_value_falls_back_to_str_for_unknown_tagged_scalar() -> None:
@@ -643,6 +644,24 @@ def test_encode_value_lambda_with_trailing_newline_preserved() -> None:
     out = encode_value({"_lambda": 'ESP_LOGI("x");\n'})
     assert isinstance(out, LiteralScalarString)
     assert str(out) == 'ESP_LOGI("x");\n'
+
+
+def test_encode_value_tagged_lambda_single_line_emits_plain() -> None:
+    """A tagged single-line sentinel becomes a plain ``!lambda`` scalar."""
+    out = encode_value({"_lambda": "return 0;", "_tag": "!lambda"})
+    assert isinstance(out, TaggedScalar)
+    assert str(out.tag) == "!lambda"
+    assert out.style is None
+    assert str(out) == "return 0;"
+
+
+def test_encode_value_tagged_lambda_multiline_emits_block() -> None:
+    """A tagged multi-line sentinel becomes a ``!lambda |`` block scalar."""
+    out = encode_value({"_lambda": "uint8_t a = 1;\nreturn {a};", "_tag": "!lambda"})
+    assert isinstance(out, TaggedScalar)
+    assert str(out.tag) == "!lambda"
+    assert out.style == "|"
+    assert str(out) == "uint8_t a = 1;\nreturn {a};\n"
 
 
 def test_encode_value_recursive_list() -> None:

--- a/tests/test_automations_parse.py
+++ b/tests/test_automations_parse.py
@@ -486,6 +486,9 @@ def test_parse_lambda_action_surfaces_lambda_sentinel() -> None:
     assert isinstance(body, dict)
     assert "_lambda" in body
     assert "ESP_LOGI" in body["_lambda"]
+    # A bare ``|`` block is untagged — no ``_tag`` marker, so it
+    # re-emits bare (not ``!lambda``) and the common idiom is a no-op.
+    assert "_tag" not in body
 
 
 def test_parse_tagged_lambda_scalars_render_as_sentinel() -> None:
@@ -493,16 +496,19 @@ def test_parse_tagged_lambda_scalars_render_as_sentinel() -> None:
     parsed = parse_device_yaml(_load("lambda_tagged_scalars.yaml"))
     by_kind = {p.location.kind: p for p in parsed}
 
-    # Script: ``- delay: !lambda return 0;`` → params={"id": {"_lambda": "return 0;"}}.
+    # Script: ``- delay: !lambda return 0;`` → the sentinel carries the
+    # ``!lambda`` tag so the emitter re-emits it (dropping it turns the
+    # lambda into a plain string literal — issue #1306).
     script_actions = by_kind["script"].automation.actions
     assert [a.action_id for a in script_actions] == ["delay"]
-    assert script_actions[0].params == {"id": {"_lambda": "return 0;"}}
+    assert script_actions[0].params == {"id": {"_lambda": "return 0;", "_tag": "!lambda"}}
 
-    # Interval: ``- lambda: !lambda |`` block → params={"lambda": {"_lambda": "<body>"}}.
+    # Interval: ``- lambda: !lambda |`` block → params={"lambda": {"_lambda": "<body>", ...}}.
     interval_actions = by_kind["interval"].automation.actions
     assert [a.action_id for a in interval_actions] == ["lambda"]
     interval_body = interval_actions[0].params["lambda"]
     assert isinstance(interval_body, dict)
+    assert interval_body.get("_tag") == "!lambda"
     assert interval_body.get("_lambda", "").strip().endswith("return;")
 
     # The whole response round-trips through orjson — TaggedScalar

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -2085,3 +2085,70 @@ def test_subentity_context_rejects_incomplete_target() -> None:
     """A sub-entity target missing its parent context raises rather than leaking None."""
     with pytest.raises(CommandError):
         _subentity_context(ComponentTarget(domain="sensor", is_sub_entity=True))
+
+
+# ---------------------------------------------------------------------------
+# !lambda tag preservation (issue #1306)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_component_action_lambda_keeps_tag() -> None:
+    """A ``!lambda`` action value re-emits its tag, not a bare ``|`` string.
+
+    Dropping ``!lambda`` would compile the body as a plain string
+    literal instead of a C++ lambda, silently breaking the firmware.
+    """
+    text = (
+        "esphome:\n  name: x\n\n"
+        "number:\n"
+        "  - platform: template\n"
+        "    name: Blockade Time\n"
+        "    id: Blockade_Time\n"
+        "    optimistic: true\n"
+        "    set_action:\n"
+        "      - uart.write: !lambda\n"
+        '          std::string b = "x";\n'
+        "          return std::vector<uint8_t>(b.begin(), b.end());\n"
+    )
+    parsed = parse_device_yaml(text)[0]
+    new_text, diff = render_upsert(text, tree=parsed.automation, location=parsed.location)
+    assert "!lambda" in diff.replacement
+    # Re-parsing yields the same tagged sentinel — a stable round-trip.
+    reparsed = parse_device_yaml(new_text)[0]
+    field = reparsed.automation.actions[0].params["data"]
+    assert field["_tag"] == "!lambda"
+
+
+def test_round_trip_block_tagged_lambda_keeps_newlines() -> None:
+    """A ``!lambda |`` block keeps its tag and its line breaks."""
+    text = (
+        "esphome:\n  name: x\n\n"
+        "interval:\n"
+        "  - interval: 5s\n"
+        "    then:\n"
+        "      - uart.write: !lambda |-\n"
+        "          uint8_t a = 1;\n"
+        "          uint8_t b = 2;\n"
+        "          return {a, b};\n"
+    )
+    parsed = parse_device_yaml(text)[0]
+    _new_text, diff = render_upsert(text, tree=parsed.automation, location=parsed.location)
+    assert "!lambda |" in diff.replacement
+    assert "uint8_t a = 1;\n" in diff.replacement
+    assert "uint8_t b = 2;\n" in diff.replacement
+
+
+def test_round_trip_delay_lambda_stays_plain_lambda() -> None:
+    """``delay: !lambda return 0;`` round-trips as a plain ``!lambda`` (not a ``|`` string)."""
+    text = _load("lambda_tagged_scalars.yaml")
+    script = next(p for p in parse_device_yaml(text) if p.location.kind == "script")
+    _new_text, diff = render_upsert(text, tree=script.automation, location=script.location)
+    assert "delay: !lambda return 0;" in diff.replacement
+
+
+def test_round_trip_untagged_lambda_stays_bare() -> None:
+    """An untagged ``lambda: |`` block doesn't gain a ``!lambda`` tag on write."""
+    text = _load("lambda_action.yaml")
+    parsed = parse_device_yaml(text)[0]
+    _new_text, diff = render_upsert(text, tree=parsed.automation, location=parsed.location)
+    assert "!lambda" not in diff.replacement


### PR DESCRIPTION
# What does this implement/fix?

Editing an automation that contains a `!lambda` value dropped the `!lambda` tag on save, and re-emitted a bare `|` block; that turned the C++ lambda into a plain string literal and silently broke the firmware (the source was sent as raw bytes instead of being executed). It also rewrote `delay: !lambda return 0;` into an invalid `delay: |` string.

The fix carries the tag through the parse to upsert wire sentinel as an optional `_tag` key, so the emitter re-emits `!lambda`; block style `!lambda |-` bodies keep their line breaks. Untagged bare `|` lambdas are left unchanged, so the common `lambda: |-` idiom still round trips as a no-op.

A plain (non block) multiline `!lambda` has its newlines folded to spaces by YAML at parse time; that fold is not recoverable from the parsed tree, so it re-emits as a single line `!lambda`, which compiles identically.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1306

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#696

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

