### PR TITLE
Decouple flaky startup-teardown sigterm test from its idle sleep

### DIFF
--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -182,7 +182,9 @@ import esphome_device_builder.controllers.devices.controller as _c
 async def _start(self):
     print("STARTUP_HELD", flush=True)
     try:
-        await asyncio.sleep(30)
+        # 5s only bounds the worst-case lost-wakeup fallback under the test's
+        # 30s communicate timeout; a prompt SIGTERM cancels this far sooner.
+        await asyncio.sleep(5)
     except asyncio.CancelledError:
         raise RuntimeError("simulated half-started teardown failure") from None
 _c.DevicesController.start = _start


### PR DESCRIPTION
# What does this implement/fix?

`test_sigterm_during_startup_with_failing_teardown_exits_zero` flakes on the macOS / Python 3.14 runner, timing out at 30s. It is a test timing race, not a correctness bug; the prior sigterm PRs already got the exit-0 behaviour right.

The shim parked startup in a bare `asyncio.sleep(30)`, so the loop sat idle with no other pending timer. When the SIGTERM `call_soon_threadsafe` wakeup was occasionally not serviced promptly, the loop stayed blocked until that 30s sleep expired, then the queued `GracefulExit` fired and the process still exited 0, just at ~30s, racing the test's `communicate(timeout=30)`.

Fix shortens the shim sleep to 5s, decoupling the worst-case fallback from the 30s timeout while keeping plenty of margin for the signal to land mid-sleep. No production change; the eventual exit-0 guarantee already held.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
