### PR TITLE
Add a fallback hotspot and captive portal to the create-device wizard

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import secrets
+import string
 from typing import TYPE_CHECKING, Any
 
 from ..yaml import _safe_yaml_scalar, merge_component_yaml
@@ -49,6 +50,20 @@ except ImportError:
 
 _FALLBACK_WIFI_FIRST_PLATFORMS: frozenset[str] = frozenset(
     {"esp8266", "bk72xx", "rtl87xx", "ln882x", "libretiny"}
+)
+
+# Fallback-hotspot psk alphabet + length, mirroring esphome's wizard.
+_AP_PSK_ALPHABET = string.ascii_letters + string.digits
+_AP_PSK_LENGTH = 12
+
+# ESPHome's ``cv.ssid`` caps an AP ssid at 32 bytes.
+_AP_SSID_MAX_LEN = 32
+
+# Platforms supporting ``captive_portal:`` (esphome's ``cv.only_on``
+# allowlist). The fallback is emitted only here; a bare ``ap:`` without
+# a portal can't recover credentials, so other platforms get neither.
+_CAPTIVE_PORTAL_PLATFORMS: frozenset[str] = frozenset(
+    {"esp8266", "esp32", "bk72xx", "ln882x", "rp2040", "rtl87xx"}
 )
 
 # TODO comment block emitted by ``generate_device_yaml`` for
@@ -231,7 +246,7 @@ def generate_device_yaml(
         else:
             lines.append("  ssid: !secret wifi_ssid")
             lines.append("  password: !secret wifi_password")
-        lines.append("")
+        lines.extend(_fallback_recovery_lines(friendly_name or name, platform))
     else:
         # No native Wi-Fi → leave a TODO so the user knows what they
         # need to configure before adding ``api:`` / ``ota:``. Both
@@ -343,6 +358,7 @@ def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
     about to edit.
     """
     api_key = base64.b64encode(secrets.token_bytes(32)).decode()
+    recovery = "\n".join(_fallback_recovery_lines(friendly_name or name, "esp32"))
     return (
         f"esphome:\n  name: {name}\n"
         f"  friendly_name: {_safe_yaml_scalar(friendly_name)}\n\n"
@@ -355,4 +371,33 @@ def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
         "wifi:\n"
         "  ssid: !secret wifi_ssid\n"
         "  password: !secret wifi_password\n"
+        f"{recovery}"
     )
+
+
+def _fallback_recovery_lines(label: str, platform: str) -> list[str]:
+    """Fallback hotspot + ``captive_portal:`` recovery lines; bare separator where unsupported."""
+    if platform not in _CAPTIVE_PORTAL_PLATFORMS:
+        # No captive portal → no fallback, but keep the wifi block's
+        # trailing blank-line separator from the unconditional old path.
+        return [""]
+    psk = "".join(secrets.choice(_AP_PSK_ALPHABET) for _ in range(_AP_PSK_LENGTH))
+    return [
+        "  ap:",
+        f"    ssid: {_safe_yaml_scalar(_fallback_ap_ssid(label))}",
+        f'    password: "{psk}"',
+        "",
+        "captive_portal:",
+        "",
+    ]
+
+
+def _fallback_ap_ssid(label: str) -> str:
+    """AP ssid ``<label> Fallback Hotspot``; trims <label> so the marker survives the cap."""
+    base = label.strip() or "ESPHome"
+    suffix = " Fallback Hotspot"
+    # Trim the name, not the marker (esphome's wizard drops the whole
+    # marker here), so the recovery AP stays identifiable for long names.
+    if len(base) + len(suffix) > _AP_SSID_MAX_LEN:
+        base = base[: _AP_SSID_MAX_LEN - len(suffix)]
+    return f"{base}{suffix}"

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -107,6 +107,8 @@ def test_generate_minimal_stub_yaml_has_required_blocks() -> None:
     assert "Replace this with your actual platform" in out
     assert 'api:\n  encryption:\n    key: "' in out
     assert "ota:\n  - platform: esphome\n" in out
+    assert "  ap:\n    ssid: Kitchen Lamp Fallback Hotspot\n" in out
+    assert "\ncaptive_portal:\n" in out
 
 
 def test_generate_minimal_stub_yaml_emits_per_device_encryption_key() -> None:
@@ -993,6 +995,51 @@ def test_generate_device_yaml_quotes_wifi_credentials(ssid: str, psk: str) -> No
     assert parsed["wifi"]["password"] == psk
 
 
+def test_generate_device_yaml_emits_fallback_ap_and_captive_portal() -> None:
+    """ESP32 wizard YAML carries the fallback hotspot ssid + a captive_portal block."""
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    text = generate_device_yaml("kitchen", "Kitchen Lamp", board, ssid="Net", psk="pw")
+
+    parsed = yaml.safe_load(text)
+    assert parsed["wifi"]["ap"]["ssid"] == "Kitchen Lamp Fallback Hotspot"
+    assert parsed["wifi"]["ap"]["password"]
+    assert "captive_portal" in parsed
+
+
+def test_generate_device_yaml_fallback_ap_password_is_per_device() -> None:
+    """The fallback-hotspot psk is freshly generated each call."""
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    a = yaml.safe_load(generate_device_yaml("k", "K", board, ssid="N", psk="p"))
+    b = yaml.safe_load(generate_device_yaml("k", "K", board, ssid="N", psk="p"))
+    assert a["wifi"]["ap"]["password"] != b["wifi"]["ap"]["password"]
+
+
+@pytest.mark.parametrize(
+    ("friendly_name", "expected"),
+    [
+        pytest.param("Kitchen", "Kitchen Fallback Hotspot", id="short_keeps_full_name"),
+        pytest.param(
+            "Living Room Lamp", "Living Room Lam Fallback Hotspot", id="mid_trims_name_keeps_marker"
+        ),
+        pytest.param(
+            "Living Room Ceiling Light Controller",
+            "Living Room Cei Fallback Hotspot",
+            id="long_trims_name_keeps_marker",
+        ),
+    ],
+)
+def test_generate_device_yaml_fallback_ap_ssid_respects_32_char_cap(
+    friendly_name: str, expected: str
+) -> None:
+    """AP ssid keeps the " Fallback Hotspot" marker, trimming the name to stay within 32 chars."""
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    text = generate_device_yaml("dev", friendly_name, board, ssid="Net", psk="pw")
+    ap_ssid = yaml.safe_load(text)["wifi"]["ap"]["ssid"]
+    assert ap_ssid == expected
+    assert len(ap_ssid) <= 32
+    assert ap_ssid.endswith("Fallback Hotspot")
+
+
 # ---------------------------------------------------------------------------
 # generate_device_yaml — wifi-block inference for boards without an
 # explicit ``connectivity`` claim. Preempts the silent generation of
@@ -1028,6 +1075,39 @@ def _make_board(
         ),
         hardware=BoardHardware(connectivity=connectivity or []),
     )
+
+
+@pytest.mark.parametrize(
+    ("board", "expect_fallback"),
+    [
+        pytest.param(
+            _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32C3), True, id="esp32"
+        ),
+        pytest.param(
+            _make_board(platform=Platform.RP2040, pio_board="rpipicow"), True, id="rp2040_picow"
+        ),
+        pytest.param(
+            _make_board(platform=Platform.ESP32, variant=Esp32Variant.ESP32H2),
+            False,
+            id="esp32h2_no_wifi",
+        ),
+        # Wi-Fi claimed off the captive_portal allowlist: wifi block is
+        # emitted, fallback withheld (a bare ``ap:`` can't recover creds).
+        pytest.param(
+            _make_board(platform=Platform.NRF52, connectivity=[Connectivity.WIFI]),
+            False,
+            id="wifi_without_captive_portal_support",
+        ),
+    ],
+)
+def test_generate_device_yaml_fallback_recovery_by_platform(
+    board: BoardCatalogEntry, expect_fallback: bool
+) -> None:
+    """Fallback hotspot + ``captive_portal:`` emitted only where esphome supports captive_portal."""
+    text = generate_device_yaml("dev", "Dev Board", board, ssid="Net", psk="pw")
+    lines = text.splitlines()
+    assert ("  ap:" in lines) is expect_fallback
+    assert ("captive_portal:" in lines) is expect_fallback
 
 
 def test_generate_yaml_omits_wifi_for_esp32h2_without_explicit_connectivity() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The create-device wizard emitted a `wifi:` block with only `ssid` and `password`; if that network later went away (router swap, password change, moving the device) the firmware had no way back online short of a USB reflash. Both wizard generators now add a fallback hotspot plus `captive_portal:`, so a Wi-Fi outage drops the device into its own AP where the user re-enters credentials in a browser, no reflash needed.

The fallback is only emitted on platforms whose firmware supports `captive_portal:` (mirroring esphome's `cv.only_on` allowlist), since an `ap:` without a captive portal gives the user no way to enter new credentials. The hotspot gets a random per-device password, and its ssid is the friendly name plus "Fallback Hotspot", trimmed to the 32 character limit.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1318

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
