### PR TITLE
Emit if condition before then/else

### DIFF
--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -139,12 +139,14 @@ def _shorthand_key(entry: AutomationAction | AutomationCondition | None) -> str 
 def emit_action_node(node: ActionNode) -> CommentedMap:
     """Build one ``{<action_id>: <body>}`` mapping for an action node."""
     body = CommentedMap()
+    # Condition gate leads the body: ``if`` / ``while`` want it before
+    # ``then`` / ``else``, ``wait_until`` before its ``timeout:`` param.
+    if node.conditions:
+        body["condition"] = emit_condition_seq(node.conditions)
     for key, value in node.params.items():
         body[key] = encode_value(value)
     for child_key in sorted(node.children.keys(), key=lambda k: (k != "then", k)):
         body[child_key] = emit_action_seq(node.children[child_key])
-    if node.conditions:
-        body["condition"] = emit_condition_seq(node.conditions)
     out = CommentedMap()
     shorthand = _shorthand_key(catalog.action_by_id(node.action_id))
     if (

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from esphome_device_builder.controllers.automations import writing
+from esphome_device_builder.controllers.automations.emitter import dump, emit_action_node
 from esphome_device_builder.controllers.automations.parsing import (
     ComponentTarget,
     ParsedAutomation,
@@ -38,6 +39,7 @@ from esphome_device_builder.models.automations import (
     AutomationTree,
     ComponentActionFieldLocation,
     ComponentOnLocation,
+    ConditionNode,
     DeviceOnLocation,
     IntervalLocation,
     LightEffectLocation,
@@ -786,6 +788,41 @@ def test_round_trip_if_then_else_preserves_recursive_actions() -> None:
     assert [c.condition_id for c in if_second.conditions] == [
         c.condition_id for c in if_first.conditions
     ]
+
+
+def test_if_emits_condition_before_then_else() -> None:
+    """``if`` re-renders ``condition:`` ahead of ``then:`` / ``else:``."""
+    text = _load("if_then_else.yaml")
+    parsed = parse_device_yaml(text)[0]
+    new_text, _diff = render_upsert(
+        text,
+        tree=parsed.automation,
+        location=parsed.location,
+    )
+    body = new_text[new_text.index("if:") :]
+    assert body.index("condition:") < body.index("then:") < body.index("else:")
+
+
+def test_while_emits_condition_before_then() -> None:
+    """``while`` emits ``condition:`` ahead of its ``then:`` branch."""
+    node = ActionNode(
+        action_id="while",
+        children={"then": [ActionNode(action_id="logger.log", params={"format": "x"})]},
+        conditions=[ConditionNode(condition_id="switch.is_on", params={"id": "relay1"})],
+    )
+    text = dump(emit_action_node(node))
+    assert text.index("condition:") < text.index("then:")
+
+
+def test_wait_until_emits_condition_before_timeout() -> None:
+    """``wait_until`` emits ``condition:`` ahead of its ``timeout:`` param."""
+    node = ActionNode(
+        action_id="wait_until",
+        params={"timeout": "8s"},
+        conditions=[ConditionNode(condition_id="binary_sensor.is_on", params={"id": "occ"})],
+    )
+    text = dump(emit_action_node(node))
+    assert text.index("condition:") < text.index("timeout:")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The visual editor serialized an `if` action's keys as `then`, `else`, then `condition`; saving a hand written `if` would shuffle `condition` to the bottom on every edit. The emitter now writes `condition` ahead of the `then`/`else` branches, matching the order in the ESPHome docs (`condition` is evaluated first, then `then` or `else`). `while` benefits the same way; `wait_until` is unaffected since the condition is its only key.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1119

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
