### PR TITLE
Read through retry helper in storage tests to ride out Windows replace race

### DIFF
--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from esphome_device_builder.helpers.atomic_io import read_bytes_with_retry
 from esphome_device_builder.helpers.storage import ShutdownCallback, Store
 
 
@@ -85,7 +86,7 @@ async def test_async_delay_save_writes_after_delay(store_path: Path, store: Stor
     # longer than 1s for the executor hop + atomic rename after the 50ms
     # timer fires.
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert store_path.read_bytes() == b"delayed"
+    assert read_bytes_with_retry(store_path) == b"delayed"
 
 
 async def test_async_delay_save_collapses_within_window(
@@ -110,7 +111,7 @@ async def test_async_delay_save_collapses_within_window(
     store.async_delay_save(_capture, delay=0.1)
 
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert store_path.read_bytes() == b"final"
+    assert read_bytes_with_retry(store_path) == b"final"
 
 
 async def test_async_delay_save_extends_deadline_on_later_call(
@@ -132,7 +133,7 @@ async def test_async_delay_save_extends_deadline_on_later_call(
     await _drain_loop_until(store_path.exists, timeout=2.0)
     elapsed = loop.time() - started
     assert elapsed >= 0.18, f"wrote too early: {elapsed:.3f}s"
-    assert store_path.read_bytes() == b"late"
+    assert read_bytes_with_retry(store_path) == b"late"
 
 
 async def test_async_delay_save_earlier_call_replaces_handle(
@@ -156,7 +157,7 @@ async def test_async_delay_save_earlier_call_replaces_handle(
     await _drain_loop_until(store_path.exists, timeout=4.0)
     elapsed = loop.time() - started
     assert elapsed < 1.5, f"earlier handle did not replace later: {elapsed:.3f}s"
-    assert store_path.read_bytes() == b"earlier"
+    assert read_bytes_with_retry(store_path) == b"earlier"
 
 
 async def test_async_save_now_flushes_pending_save(store_path: Path, store: Store[bytes]) -> None:
@@ -164,7 +165,7 @@ async def test_async_save_now_flushes_pending_save(store_path: Path, store: Stor
     store.async_delay_save(lambda: b"pending", delay=10.0)
     assert not store_path.exists()
     await store.async_save_now()
-    assert store_path.read_bytes() == b"pending"
+    assert read_bytes_with_retry(store_path) == b"pending"
 
 
 async def test_async_save_now_is_noop_when_empty(store_path: Path, store: Store[bytes]) -> None:
@@ -215,7 +216,7 @@ async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
 
     assert seen == [b"first", b"second"]
     # Final disk content reflects the *last* write.
-    assert store_path.read_bytes() == b"second"
+    assert read_bytes_with_retry(store_path) == b"second"
 
 
 async def test_write_failure_logged_and_swallowed(
@@ -281,7 +282,7 @@ async def test_data_func_called_at_flush_not_scheduling(
     # longer than 1s for the executor hop + atomic rename after the 50ms
     # timer fires.
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert store_path.read_bytes() == b"after-mutation"
+    assert read_bytes_with_retry(store_path) == b"after-mutation"
 
 
 async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
@@ -298,7 +299,7 @@ async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
     # the parent-directory mkdir on top of the atomic write can tip
     # this past 1s on loaded Windows runners.
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert store_path.read_bytes() == b"nested"
+    assert read_bytes_with_retry(store_path) == b"nested"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
@@ -387,7 +388,7 @@ async def test_constructor_registers_shutdown_callback(
     assert len(recorder.shutdown_callbacks) == 1
     store.async_delay_save(lambda: b"via-shutdown", delay=10.0)
     await recorder.shutdown_callbacks[0]()
-    assert store_path.read_bytes() == b"via-shutdown"
+    assert read_bytes_with_retry(store_path) == b"via-shutdown"
 
 
 async def test_lifecycle_walk_flushes_pending_saves_across_stores(
@@ -427,8 +428,8 @@ async def test_lifecycle_walk_flushes_pending_saves_across_stores(
     for cb in callbacks:
         await cb()
 
-    assert pairings_path.read_bytes() == b"pairings-final"
-    assert peers_path.read_bytes() == b"peers-final"
+    assert read_bytes_with_retry(pairings_path) == b"pairings-final"
+    assert read_bytes_with_retry(peers_path) == b"peers-final"
 
 
 async def test_save_now_skips_when_no_pending_data_after_drain(
@@ -439,7 +440,7 @@ async def test_save_now_skips_when_no_pending_data_after_drain(
     await _drain_loop_until(store_path.exists, timeout=1.0)
     await store.async_save_now()
     # Disk content unchanged — the second flush had nothing to do.
-    assert store_path.read_bytes() == b"v"
+    assert read_bytes_with_retry(store_path) == b"v"
 
 
 async def test_extend_then_save_now_picks_up_latest(store_path: Path, store: Store[bytes]) -> None:
@@ -448,7 +449,7 @@ async def test_extend_then_save_now_picks_up_latest(store_path: Path, store: Sto
     store.async_delay_save(lambda: b"b", delay=10.0)
     store.async_delay_save(lambda: b"c", delay=10.0)
     await store.async_save_now()
-    assert store_path.read_bytes() == b"c"
+    assert read_bytes_with_retry(store_path) == b"c"
 
 
 async def test_handle_write_returns_early_when_data_func_already_drained(

--- a/tests/test_helpers_storage.py
+++ b/tests/test_helpers_storage.py
@@ -86,7 +86,7 @@ async def test_async_delay_save_writes_after_delay(store_path: Path, store: Stor
     # longer than 1s for the executor hop + atomic rename after the 50ms
     # timer fires.
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert read_bytes_with_retry(store_path) == b"delayed"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"delayed"
 
 
 async def test_async_delay_save_collapses_within_window(
@@ -111,7 +111,7 @@ async def test_async_delay_save_collapses_within_window(
     store.async_delay_save(_capture, delay=0.1)
 
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert read_bytes_with_retry(store_path) == b"final"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"final"
 
 
 async def test_async_delay_save_extends_deadline_on_later_call(
@@ -133,7 +133,7 @@ async def test_async_delay_save_extends_deadline_on_later_call(
     await _drain_loop_until(store_path.exists, timeout=2.0)
     elapsed = loop.time() - started
     assert elapsed >= 0.18, f"wrote too early: {elapsed:.3f}s"
-    assert read_bytes_with_retry(store_path) == b"late"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"late"
 
 
 async def test_async_delay_save_earlier_call_replaces_handle(
@@ -157,7 +157,7 @@ async def test_async_delay_save_earlier_call_replaces_handle(
     await _drain_loop_until(store_path.exists, timeout=4.0)
     elapsed = loop.time() - started
     assert elapsed < 1.5, f"earlier handle did not replace later: {elapsed:.3f}s"
-    assert read_bytes_with_retry(store_path) == b"earlier"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"earlier"
 
 
 async def test_async_save_now_flushes_pending_save(store_path: Path, store: Store[bytes]) -> None:
@@ -165,7 +165,7 @@ async def test_async_save_now_flushes_pending_save(store_path: Path, store: Stor
     store.async_delay_save(lambda: b"pending", delay=10.0)
     assert not store_path.exists()
     await store.async_save_now()
-    assert read_bytes_with_retry(store_path) == b"pending"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"pending"
 
 
 async def test_async_save_now_is_noop_when_empty(store_path: Path, store: Store[bytes]) -> None:
@@ -216,7 +216,7 @@ async def test_async_save_now_awaits_inflight_write(tmp_path: Path) -> None:
 
     assert seen == [b"first", b"second"]
     # Final disk content reflects the *last* write.
-    assert read_bytes_with_retry(store_path) == b"second"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"second"
 
 
 async def test_write_failure_logged_and_swallowed(
@@ -282,7 +282,7 @@ async def test_data_func_called_at_flush_not_scheduling(
     # longer than 1s for the executor hop + atomic rename after the 50ms
     # timer fires.
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert read_bytes_with_retry(store_path) == b"after-mutation"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"after-mutation"
 
 
 async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
@@ -299,7 +299,7 @@ async def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
     # the parent-directory mkdir on top of the atomic write can tip
     # this past 1s on loaded Windows runners.
     await _drain_loop_until(store_path.exists, timeout=2.0)
-    assert read_bytes_with_retry(store_path) == b"nested"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"nested"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
@@ -388,7 +388,7 @@ async def test_constructor_registers_shutdown_callback(
     assert len(recorder.shutdown_callbacks) == 1
     store.async_delay_save(lambda: b"via-shutdown", delay=10.0)
     await recorder.shutdown_callbacks[0]()
-    assert read_bytes_with_retry(store_path) == b"via-shutdown"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"via-shutdown"
 
 
 async def test_lifecycle_walk_flushes_pending_saves_across_stores(
@@ -428,8 +428,8 @@ async def test_lifecycle_walk_flushes_pending_saves_across_stores(
     for cb in callbacks:
         await cb()
 
-    assert read_bytes_with_retry(pairings_path) == b"pairings-final"
-    assert read_bytes_with_retry(peers_path) == b"peers-final"
+    assert await asyncio.to_thread(read_bytes_with_retry, pairings_path) == b"pairings-final"
+    assert await asyncio.to_thread(read_bytes_with_retry, peers_path) == b"peers-final"
 
 
 async def test_save_now_skips_when_no_pending_data_after_drain(
@@ -440,7 +440,7 @@ async def test_save_now_skips_when_no_pending_data_after_drain(
     await _drain_loop_until(store_path.exists, timeout=1.0)
     await store.async_save_now()
     # Disk content unchanged — the second flush had nothing to do.
-    assert read_bytes_with_retry(store_path) == b"v"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"v"
 
 
 async def test_extend_then_save_now_picks_up_latest(store_path: Path, store: Store[bytes]) -> None:
@@ -449,7 +449,7 @@ async def test_extend_then_save_now_picks_up_latest(store_path: Path, store: Sto
     store.async_delay_save(lambda: b"b", delay=10.0)
     store.async_delay_save(lambda: b"c", delay=10.0)
     await store.async_save_now()
-    assert read_bytes_with_retry(store_path) == b"c"
+    assert await asyncio.to_thread(read_bytes_with_retry, store_path) == b"c"
 
 
 async def test_handle_write_returns_early_when_data_func_already_drained(


### PR DESCRIPTION
# What does this implement/fix?

The release Windows pytest job flaked with a `PermissionError` reading `data.json`; the production code is fine, this is test only. On Windows, right after `atomic_write` replaces the file, Defender or the search indexer can briefly hold it open, so a bare `read_bytes()` immediately after hits a sharing violation. Production reads already ride this out via `read_bytes_with_retry` (`atomic_io.py`, used in `controllers/config/metadata.py`); the tests used a raw `read_bytes()`. This routes the post write assertions in `tests/test_helpers_storage.py` through `read_bytes_with_retry`. POSIX never retries, so non Windows behaviour is unchanged.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
