### PR TITLE
Mark _FIELD_OVERRIDES as legacy and discourage extending it

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -430,11 +430,26 @@ _UART_DEBUG_OVERRIDE: dict[str, Any] = {
 }
 
 
-# Per-(component, field) entry overrides for cases where the prebuilt
-# schema doesn't correctly capture the field's structure. Each value
-# is a partial ConfigEntry dict that overrides the schema-derived one.
-# Keep this list small and targeted — every entry is a workaround for
-# an upstream schema generator gap.
+# LEGACY — DO NOT EXTEND unless there is genuinely no other option.
+#
+# Per-(component, field) overrides that hand-author the ConfigEntry the
+# prebuilt schema fails to model: a custom ESPHome validator erases the
+# inner schema upstream, so the bundle emits a bare string / opaque dict
+# and we patch the real shape back in here. Each value is a partial
+# ConfigEntry dict merged over the schema-derived one.
+#
+# Why this is a code smell: the data is hand-maintained and frozen, so
+# it drifts from the live schema as ESPHome evolves — the override keeps
+# winning even after upstream learns to emit the field correctly, and
+# nobody notices until the rendered form is wrong. Every entry is a
+# standing maintenance liability, not a feature.
+#
+# Before adding an entry, exhaust the alternatives: fix the upstream
+# schema generator, recover the type in ``_convert_config_vars`` /
+# ``_convert_field``, or backfill via ``_backfill_descriptions_from_mdx``.
+# Only when none of those can express the field does a new override
+# belong here — and then document the exact upstream gap that forces it,
+# as the existing entries do.
 _FIELD_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
     # ``api.encryption`` is validated by a custom function in ESPHome
     # so the schema generator emits only ``{key: Optional, docs: ...}``


### PR DESCRIPTION
# What does this implement/fix?

`_FIELD_OVERRIDES` in `script/sync_components.py` hand-authors catalog entries that the prebuilt schema can't model; it's a code smell because the data is frozen and drifts from the live schema as ESPHome evolves, and the override keeps winning even after upstream starts emitting the field correctly. This relabels it as legacy and spells out that it should not be extended unless there is genuinely no other option, pointing at the alternatives to try first (fix the upstream schema generator, recover the type in `_convert_config_vars` / `_convert_field`, or backfill via `_backfill_descriptions_from_mdx`). Comment only, no behaviour change.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
