### PR TITLE
Force opaque mapping-or-list union fields to YAML-only

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -33,6 +33,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import ast
 import contextlib
 import copy
 import importlib
@@ -42,6 +43,7 @@ import logging
 import re
 import shutil
 import sys
+import textwrap
 import unicodedata
 import urllib.request
 import zipfile
@@ -4145,6 +4147,52 @@ def _extract_validator_units(validator: Any) -> list[str] | None:
     ]
 
 
+def _validator_branches_dict_and_list(src: str) -> bool:
+    """Report whether *src* tests both ``isinstance(_, dict)`` and ``isinstance(_, list)``."""
+    try:
+        tree = ast.parse(textwrap.dedent(src))
+    except (SyntaxError, ValueError):
+        return False
+    kinds: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "isinstance"
+            and len(node.args) >= 2
+        ):
+            target = node.args[1]
+            names = (
+                [target.id]
+                if isinstance(target, ast.Name)
+                else [e.id for e in getattr(target, "elts", []) if isinstance(e, ast.Name)]
+            )
+            kinds.update(k for k in ("dict", "list") if k in names)
+    return {"dict", "list"} <= kinds
+
+
+def _is_dict_list_union(validator: Any) -> bool:
+    """
+    Detect a component validator that accepts a mapping or a list.
+
+    ESPHome's ``cv.ensure_list`` tests the same types to reshape one item into
+    a list, so it is excluded by its ``esphome.config_validation`` module, as
+    are structural validators (Schema / All / Any) the peel above handles.
+    """
+    if not callable(validator) or isinstance(validator, vol.Schema):
+        return False
+    if getattr(validator, "validators", None):
+        return False
+    module = getattr(validator, "__module__", "") or ""
+    if module.startswith("voluptuous") or module == "esphome.config_validation":
+        return False
+    try:
+        src = inspect.getsource(validator)
+    except (OSError, TypeError):
+        return False
+    return _validator_branches_dict_and_list(src)
+
+
 def _collect_refined_types(  # noqa: C901
     manifest: Any,
 ) -> dict[tuple[str, ...], RefinedType]:
@@ -4236,6 +4284,8 @@ def _collect_refined_types(  # noqa: C901
         t = classify(val)
         if t is not None:
             out[path] = t
+        elif _is_dict_list_union(val):
+            out[path] = RefinedType("unknown")
 
     _walk_schema_keys(schema, visit)
     return out
@@ -4453,6 +4503,10 @@ def _apply_refined_types(
     technically the runtime type after coercion, but the YAML shape
     the user types is a string with a unit suffix; the
     ``float_with_unit`` type captures both halves.
+
+    An ``unknown`` refinement (a mapping-or-list union) is the other
+    exception: it overrides any guessed scalar (``float`` included) so
+    the field renders YAML-only, but never a structural entry.
     """
     if not refined:
         return
@@ -4466,6 +4520,11 @@ def _apply_refined_types(
             # the schema bundle can't represent.
             entry["type"] = new_type.type
             entry["unit_options"] = list(new_type.unit_options or [])
+        elif new_type.type == "unknown":
+            # Mapping-or-list union: force YAML-only, but not over a
+            # structural entry that already carries a real shape.
+            if not entry.get("config_entries"):
+                entry["type"] = "unknown"
         elif entry.get("type") == "string":
             entry["type"] = new_type.type
 

--- a/tests/test_sync_components_dict_list_union.py
+++ b/tests/test_sync_components_dict_list_union.py
@@ -1,0 +1,76 @@
+"""Mapping-or-list union detection (``_is_dict_list_union``) in the sync script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import voluptuous as vol
+
+_SCRIPT_DIR = Path(__file__).parent.parent / "script"
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+import esphome.config_validation as cv  # noqa: E402
+import sync_components  # noqa: E402
+from esphome.components.ntc.sensor import process_calibration  # noqa: E402
+from esphome.components.uart.event import validate_event_types  # noqa: E402
+
+
+def test_validator_branches_dict_and_list_needs_both() -> None:
+    assert sync_components._validator_branches_dict_and_list(
+        "def f(v):\n if isinstance(v, dict): pass\n if isinstance(v, list): pass\n"
+    )
+    assert not sync_components._validator_branches_dict_and_list(
+        "def f(v):\n if isinstance(v, list): pass\n"
+    )
+    assert not sync_components._validator_branches_dict_and_list("def f(v):\n return v\n")
+
+
+def test_validator_branches_dict_and_list_handles_tuple_isinstance() -> None:
+    assert sync_components._validator_branches_dict_and_list(
+        "def f(v):\n if isinstance(v, (dict, list)): pass\n"
+    )
+
+
+def test_is_dict_list_union_detects_real_unions() -> None:
+    assert sync_components._is_dict_list_union(process_calibration) is True
+    assert sync_components._is_dict_list_union(validate_event_types) is True
+
+
+def test_is_dict_list_union_excludes_ensure_list_reshaper() -> None:
+    """``cv.ensure_list``'s closure tests dict/list to reshape; excluded by module."""
+    assert sync_components._is_dict_list_union(cv.ensure_list(cv.string)) is False
+
+
+def test_is_dict_list_union_excludes_scalars_schemas_and_unions() -> None:
+    assert sync_components._is_dict_list_union(cv.string) is False
+    assert sync_components._is_dict_list_union(cv.Schema({})) is False
+    # vol.Any carries ``validators`` — the structural peel handles it, so the
+    # AST path never runs and would otherwise mis-flag a scalar-or-list union.
+    assert sync_components._is_dict_list_union(vol.Any(cv.string, [cv.string])) is False
+
+
+def test_collect_refined_types_flags_ntc_calibration_unknown() -> None:
+    loader = sync_components._get_esphome_loader()
+    manifest = loader.get_platform("sensor", "ntc")
+    refined = sync_components._collect_refined_types(manifest)
+    assert refined.get(("calibration",)) == sync_components.RefinedType("unknown")
+
+
+def test_apply_refined_types_forces_unknown_over_a_guessed_scalar() -> None:
+    entries = [
+        {"key": "calibration", "type": "float"},
+        {"key": "name", "type": "string"},
+    ]
+    refined = {("calibration",): sync_components.RefinedType("unknown")}
+    sync_components._apply_refined_types(entries, refined)
+    by_key = {e["key"]: e for e in entries}
+    assert by_key["calibration"]["type"] == "unknown"
+    assert by_key["name"]["type"] == "string"
+
+
+def test_apply_refined_types_unknown_skips_structural_nested() -> None:
+    entries = [{"key": "x", "type": "nested", "config_entries": [{"key": "a", "type": "string"}]}]
+    sync_components._apply_refined_types(entries, {("x",): sync_components.RefinedType("unknown")})
+    assert entries[0]["type"] == "nested"


### PR DESCRIPTION
# What does this implement/fix?

The ntc sensor's `calibration` is validated by a custom function that accepts a b-constant mapping or a steinhart-hart list; the schema bundle can only describe it as a bogus `float`, so the editor showed a broken required number input. This detects that mapping-or-list union shape from the validator's AST (branches on both `dict` and `list`) and emits `type: unknown` so the field falls back to the YAML pane. `cv.ensure_list` reshapers test the same types only to normalize a single item into a list, so they are excluded by module; the only two fields affected are `sensor.ntc.calibration` and `uart.event.event_types`, both genuine unions.

The catalog JSON is not regenerated here; it ships through the normal sync workflow so the docs descriptions stay intact.

**Related issue or feature (if applicable):**

- fixes #1328

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#720

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
