### PR TITLE
Add atomic config/set_secret to stop per-key secret writes racing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -282,6 +282,7 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 | `config/get_preferences` | — | `UserPreferences` | Get user preferences |
 | `config/set_preferences` | `{theme?, dashboard_view?, ...}` | `UserPreferences` | Update preferences (partial) |
 | `config/get_secrets` | — | `[string]` | List secret key names |
+| `config/set_secret` | `{key, value, overwrite?}` | `{created}` | Atomically set one secret in secrets.yaml under a write lock; `overwrite=false` is create-if-absent |
 
 ### Onboarding
 

--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from esphome.const import __version__ as esphome_version
@@ -11,7 +12,11 @@ from esphome.util import get_serial_ports
 
 from ...constants import __version__ as server_version
 from ...helpers.api import CommandError, api_command
-from ...helpers.secrets_state import read_secrets_yaml
+from ...helpers.secrets_state import (
+    is_valid_secret_key,
+    read_secrets_yaml,
+    write_secret,
+)
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, UserPreferences
 from .chip_detect import (
@@ -31,6 +36,11 @@ class ConfigController:
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
+        # Serialises the read-modify-write of the single shared secrets.yaml so
+        # two concurrent ``config/set_secret`` calls can't lose each other's
+        # key (issue #1334). The backend runs one event loop, so the lock plus
+        # an atomic write makes the whole update atomic.
+        self._secrets_write_lock = asyncio.Lock()
 
     @api_command("config/version")
     async def get_version(self, **kwargs: Any) -> dict:
@@ -118,6 +128,30 @@ class ConfigController:
         # to string keys before sorting — non-string keys aren't
         # usable in ``!secret`` references anyway.
         return sorted(k for k in data if isinstance(k, str))
+
+    @api_command("config/set_secret")
+    async def set_secret(
+        self, *, key: str, value: str, overwrite: bool = True, **kwargs: Any
+    ) -> dict:
+        """
+        Atomically set one key in ``secrets.yaml``; return ``{created}``.
+
+        The read-modify-write runs under a per-controller lock so concurrent
+        single-key writes don't clobber each other (issue #1334).
+        ``overwrite=False`` leaves an existing key untouched (create-if-absent).
+        """
+        if not is_valid_secret_key(key):
+            raise CommandError(ErrorCode.INVALID_ARGS, "invalid secret key")
+        if not isinstance(value, str):
+            raise CommandError(ErrorCode.INVALID_ARGS, "value must be a string")
+        loop = asyncio.get_running_loop()
+        config_dir = self._db.settings.config_dir
+        async with self._secrets_write_lock:
+            created = await loop.run_in_executor(
+                None,
+                partial(write_secret, config_dir, key, value, overwrite=bool(overwrite)),
+            )
+        return {"created": created}
 
     @api_command("config/get_info")
     async def get_info(self, *, configuration: str, **kwargs: Any) -> dict | None:

--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -13,6 +13,7 @@ from esphome.util import get_serial_ports
 from ...constants import __version__ as server_version
 from ...helpers.api import CommandError, api_command
 from ...helpers.secrets_state import (
+    SecretsContentError,
     is_valid_secret_key,
     read_secrets_yaml,
     write_secret,
@@ -36,11 +37,6 @@ class ConfigController:
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
-        # Serialises the read-modify-write of the single shared secrets.yaml so
-        # two concurrent ``config/set_secret`` calls can't lose each other's
-        # key (issue #1334). The backend runs one event loop, so the lock plus
-        # an atomic write makes the whole update atomic.
-        self._secrets_write_lock = asyncio.Lock()
 
     @api_command("config/version")
     async def get_version(self, **kwargs: Any) -> dict:
@@ -136,21 +132,28 @@ class ConfigController:
         """
         Atomically set one key in ``secrets.yaml``; return ``{created}``.
 
-        The read-modify-write runs under a per-controller lock so concurrent
-        single-key writes don't clobber each other (issue #1334).
+        The read-modify-write runs under the shared secrets write lock so
+        concurrent secrets.yaml mutations don't clobber each other.
         ``overwrite=False`` leaves an existing key untouched (create-if-absent).
         """
         if not is_valid_secret_key(key):
             raise CommandError(ErrorCode.INVALID_ARGS, "invalid secret key")
         if not isinstance(value, str):
             raise CommandError(ErrorCode.INVALID_ARGS, "value must be a string")
+        if not isinstance(overwrite, bool):
+            raise CommandError(ErrorCode.INVALID_ARGS, "overwrite must be a boolean")
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
-        async with self._secrets_write_lock:
-            created = await loop.run_in_executor(
-                None,
-                partial(write_secret, config_dir, key, value, overwrite=bool(overwrite)),
-            )
+        async with self._db.secrets_write_lock:
+            try:
+                created = await loop.run_in_executor(
+                    None,
+                    partial(write_secret, config_dir, key, value, overwrite=overwrite),
+                )
+            except SecretsContentError as err:
+                raise CommandError(
+                    ErrorCode.INVALID_ARGS, f"refusing to save invalid secrets.yaml: {err}"
+                ) from err
         return {"created": created}
 
     @api_command("config/get_info")

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -655,6 +655,14 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
                     ErrorCode.INVALID_ARGS,
                     f"refusing to save invalid secrets.yaml: {err}",
                 ) from err
+            # Hold the shared lock so a whole-file save can't interleave with a
+            # per-key config/set_secret. A full save still replaces the document
+            # (last-write-wins by design); the lock only prevents torn writes.
+            async with self._db.secrets_write_lock:
+                await self._persist_yaml_mutation(
+                    configuration, content, message=f"Edit {configuration}"
+                )
+            return
         await self._persist_yaml_mutation(configuration, content, message=f"Edit {configuration}")
 
     async def apply_restored_yaml(

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -67,9 +67,12 @@ async def import_bundle(
 
     config_dir = controller._db.settings.config_dir
     loop = asyncio.get_running_loop()
-    outcome = await loop.run_in_executor(
-        None, _stage_bundle, file_content_b64, config_dir, overwrite
-    )
+    # Staging merges secrets.yaml; hold the shared lock so that merge can't
+    # interleave with a concurrent config/set_secret and lose a key.
+    async with controller._db.secrets_write_lock:
+        outcome = await loop.run_in_executor(
+            None, _stage_bundle, file_content_b64, config_dir, overwrite
+        )
     if outcome.conflicts is not None:
         return ImportBundleResponse(
             status="conflicts",

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -149,7 +149,10 @@ class OnboardingController:
 
         loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
-        await loop.run_in_executor(None, write_wifi_secrets, config_dir, ssid, password)
+        # Shared lock so this write can't interleave with a concurrent
+        # config/set_secret and lose one side's update.
+        async with self._db.secrets_write_lock:
+            await loop.run_in_executor(None, write_wifi_secrets, config_dir, ssid, password)
         return await self.get_state()
 
     @api_command("onboarding/mark_acknowledged")

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -206,6 +206,9 @@ class DeviceBuilder:
         # pair so a quiet network with no observers generates no
         # ICMP traffic.
         self.subscriber_presence = SubscriberPresence()
+        # Serialises every secrets.yaml read-modify-write across
+        # controllers so concurrent per-key mutations can't lose updates.
+        self.secrets_write_lock = asyncio.Lock()
         self.loop: asyncio.AbstractEventLoop | None = None
         # Held so ``stop()`` can shut the pool down explicitly. Created
         # eagerly here (not in start()) so a test or caller that probes

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -184,6 +184,16 @@ def merge_secrets_file(src: Path, dest: Path) -> None:
 # to land before they re-run the wizard.
 _SECRET_LINE_RE = re.compile(r"^(\s*)([a-zA-Z_]\w*)\s*:[^#\n]*?(\s+#.*)?$")
 
+# A settable secret key. Anchored to the same shape ``_SECRET_LINE_RE``'s key
+# group matches, so "what we accept" tracks "what the line-based setter can
+# find and replace" — a key the setter could never locate must not be written.
+_SECRET_KEY_RE = re.compile(r"[a-zA-Z_]\w*\Z")
+
+
+def is_valid_secret_key(key: str) -> bool:
+    """Whether *key* is a writable ``!secret`` name (identifier-shaped)."""
+    return isinstance(key, str) and _SECRET_KEY_RE.match(key) is not None
+
 
 def write_wifi_secrets(config_dir: Path, ssid: str, password: str) -> None:
     """
@@ -204,6 +214,34 @@ def write_wifi_secrets(config_dir: Path, ssid: str, password: str) -> None:
         password,
     )
     atomic_write_file(secrets_path, updated)
+
+
+def write_secret(config_dir: Path, key: str, value: str, *, overwrite: bool = True) -> bool:
+    """
+    Set one *key* in ``secrets.yaml`` in place; return True when newly created.
+
+    With ``overwrite=False`` an existing key is left untouched (the
+    create-if-absent path). The read-modify-write is **not** locked here —
+    the caller must hold the write lock so concurrent single-key sets don't
+    lose each other's update (issue #1334).
+    """
+    secrets_path = config_dir / SECRETS_FILENAME
+    original = secrets_path.read_text(encoding="utf-8") if secrets_path.exists() else ""
+    existed = _has_secret_key(original, key)
+    if existed and not overwrite:
+        return False
+    updated = _replace_or_append_secret(original, key, value)
+    validate_secrets_content(updated, secrets_path)
+    atomic_write_file(secrets_path, updated)
+    return not existed
+
+
+def _has_secret_key(content: str, key: str) -> bool:
+    """Whether *content* already defines top-level *key* (setter's match rule)."""
+    return any(
+        (m := _SECRET_LINE_RE.match(line)) is not None and m.group(2) == key
+        for line in content.split("\n")
+    )
 
 
 def _replace_or_append_secret(content: str, key: str, value: str) -> str:

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -279,14 +279,31 @@ def _replace_or_append_secret(content: str, key: str, value: str) -> str:
     return f"{content}{key}: {encoded}\n"
 
 
+_YAML_DQ_ESCAPES: dict[str, str] = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\n": "\\n",
+    "\t": "\\t",
+    "\r": "\\r",
+}
+
+
 def _quote_yaml_string(value: str) -> str:
     r"""
-    Quote *value* as a YAML double-quoted scalar.
+    Quote *value* as a YAML double-quoted scalar that round-trips exactly.
 
-    Always uses double quotes so the round-trip stays predictable
-    regardless of what characters the user typed. Escapes the two
-    characters that have meaning inside double-quoted strings
-    (``\`` and ``"``) — everything else passes through verbatim.
+    Escapes ``\`` and ``"``, plus the control characters a literal would
+    otherwise fold or mangle on read — newline/tab/CR get their named
+    escapes and any other C0/DEL byte becomes ``\xHH``. Without this a
+    secret containing a real newline writes a multi-line scalar that
+    folds back to a space on read (silent round-trip corruption).
     """
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    out: list[str] = []
+    for ch in value:
+        if ch in _YAML_DQ_ESCAPES:
+            out.append(_YAML_DQ_ESCAPES[ch])
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append(f"\\x{ord(ch):02x}")
+        else:
+            out.append(ch)
+    return f'"{"".join(out)}"'

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -222,8 +222,8 @@ def write_secret(config_dir: Path, key: str, value: str, *, overwrite: bool = Tr
 
     With ``overwrite=False`` an existing key is left untouched (the
     create-if-absent path). The read-modify-write is **not** locked here —
-    the caller must hold the write lock so concurrent single-key sets don't
-    lose each other's update (issue #1334).
+    the caller must hold the shared secrets write lock so concurrent
+    single-key sets don't lose each other's update.
     """
     secrets_path = config_dir / SECRETS_FILENAME
     original = secrets_path.read_text(encoding="utf-8") if secrets_path.exists() else ""

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -455,6 +455,7 @@ def make_controller() -> MakeControllerFactory:
         controller._db = MagicMock()
         controller.state = DevicesState()
         controller._yaml_write_locks = {}
+        controller._db.secrets_write_lock = asyncio.Lock()
         controller._db.settings.config_dir = config_dir
         controller._db.settings.rel_path = lambda configuration: config_dir / configuration
         # Version history off by default — a MagicMock's

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -295,6 +295,20 @@ async def test_update_config_refuses_whitespace_only_content(
     assert controller._scanner.calls == []
 
 
+async def test_update_config_writes_valid_secrets_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A valid whole-file secrets.yaml save lands on disk (via the shared lock branch)."""
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    content = "wifi_ssid: home\nwifi_password: hunter2\n"
+
+    result = await controller.update_config(configuration="secrets.yaml", content=content)
+
+    assert result is None
+    assert (tmp_path / "secrets.yaml").read_text(encoding="utf-8") == content
+
+
 async def test_update_config_rejects_invalid_secrets_yaml(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -860,7 +860,7 @@ async def test_set_secret_creates_key(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     result = await controller.set_secret(key="api_key", value="ABC")
     assert result == {"created": True}
-    assert read_secrets_yaml(tmp_path) == {"api_key": "ABC"}
+    assert await asyncio.to_thread(read_secrets_yaml, tmp_path) == {"api_key": "ABC"}
 
 
 async def test_set_secret_overwrites_existing_key(tmp_path: Path) -> None:
@@ -868,7 +868,10 @@ async def test_set_secret_overwrites_existing_key(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     result = await controller.set_secret(key="api_key", value="NEW")
     assert result == {"created": False}
-    assert read_secrets_yaml(tmp_path) == {"api_key": "NEW", "wifi_ssid": "home"}
+    assert await asyncio.to_thread(read_secrets_yaml, tmp_path) == {
+        "api_key": "NEW",
+        "wifi_ssid": "home",
+    }
 
 
 async def test_set_secret_no_overwrite_leaves_existing(tmp_path: Path) -> None:
@@ -876,7 +879,7 @@ async def test_set_secret_no_overwrite_leaves_existing(tmp_path: Path) -> None:
     controller = _make_controller(tmp_path)
     result = await controller.set_secret(key="api_key", value="NEW", overwrite=False)
     assert result == {"created": False}
-    assert read_secrets_yaml(tmp_path) == {"api_key": "KEEP"}
+    assert await asyncio.to_thread(read_secrets_yaml, tmp_path) == {"api_key": "KEEP"}
 
 
 async def test_set_secret_rejects_invalid_key(tmp_path: Path) -> None:
@@ -900,7 +903,7 @@ async def test_set_secret_concurrent_writes_do_not_lose_updates(tmp_path: Path) 
         controller.set_secret(key="foo", value="1"),
         controller.set_secret(key="bar", value="2"),
     )
-    assert read_secrets_yaml(tmp_path) == {"foo": "1", "bar": "2"}
+    assert await asyncio.to_thread(read_secrets_yaml, tmp_path) == {"foo": "1", "bar": "2"}
 
 
 async def test_get_info_returns_storage_metadata_dict(

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -102,7 +102,7 @@ def _make_controller(config_dir: Path) -> ConfigController:
     controller._db.settings.config_dir = config_dir
     controller._db.settings.absolute_config_dir = config_dir.resolve()
     controller._db.settings.rel_path = config_dir.joinpath
-    controller._secrets_write_lock = asyncio.Lock()
+    controller._db.secrets_write_lock = asyncio.Lock()
     return controller
 
 
@@ -897,13 +897,25 @@ async def test_set_secret_rejects_non_string_value(tmp_path: Path) -> None:
 
 
 async def test_set_secret_concurrent_writes_do_not_lose_updates(tmp_path: Path) -> None:
-    """Two concurrent single-key writes both land — the #1334 lost-update."""
+    """Two concurrent single-key writes both land, no lost update."""
     controller = _make_controller(tmp_path)
     await asyncio.gather(
         controller.set_secret(key="foo", value="1"),
         controller.set_secret(key="bar", value="2"),
     )
     assert await asyncio.to_thread(read_secrets_yaml, tmp_path) == {"foo": "1", "bar": "2"}
+
+
+async def test_set_secret_waits_on_the_shared_lock(tmp_path: Path) -> None:
+    """The command serialises on ``db.secrets_write_lock`` (shared with onboarding)."""
+    controller = _make_controller(tmp_path)
+    lock = controller._db.secrets_write_lock
+    await lock.acquire()
+    task = asyncio.create_task(controller.set_secret(key="api_key", value="ABC"))
+    await asyncio.sleep(0)  # let the task reach the lock and block
+    assert not task.done()
+    lock.release()
+    assert await task == {"created": True}
 
 
 async def test_get_info_returns_storage_metadata_dict(

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -76,6 +76,7 @@ from esphome_device_builder.controllers.config import (
     update_preferences,
 )
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.secrets_state import read_secrets_yaml
 from esphome_device_builder.models import (
     DEFAULT_CLEANUP_TTL_SECONDS,
     MAX_CLEANUP_TTL_SECONDS,
@@ -101,6 +102,7 @@ def _make_controller(config_dir: Path) -> ConfigController:
     controller._db.settings.config_dir = config_dir
     controller._db.settings.absolute_config_dir = config_dir.resolve()
     controller._db.settings.rel_path = config_dir.joinpath
+    controller._secrets_write_lock = asyncio.Lock()
     return controller
 
 
@@ -852,6 +854,53 @@ async def test_get_secrets_returns_sorted_keys(tmp_path: Path) -> None:
 
     keys = await controller.get_secrets()
     assert keys == ["api_key", "wifi_password", "wifi_ssid"]
+
+
+async def test_set_secret_creates_key(tmp_path: Path) -> None:
+    controller = _make_controller(tmp_path)
+    result = await controller.set_secret(key="api_key", value="ABC")
+    assert result == {"created": True}
+    assert read_secrets_yaml(tmp_path) == {"api_key": "ABC"}
+
+
+async def test_set_secret_overwrites_existing_key(tmp_path: Path) -> None:
+    (tmp_path / "secrets.yaml").write_text("api_key: OLD\nwifi_ssid: home\n", "utf-8")
+    controller = _make_controller(tmp_path)
+    result = await controller.set_secret(key="api_key", value="NEW")
+    assert result == {"created": False}
+    assert read_secrets_yaml(tmp_path) == {"api_key": "NEW", "wifi_ssid": "home"}
+
+
+async def test_set_secret_no_overwrite_leaves_existing(tmp_path: Path) -> None:
+    (tmp_path / "secrets.yaml").write_text("api_key: KEEP\n", "utf-8")
+    controller = _make_controller(tmp_path)
+    result = await controller.set_secret(key="api_key", value="NEW", overwrite=False)
+    assert result == {"created": False}
+    assert read_secrets_yaml(tmp_path) == {"api_key": "KEEP"}
+
+
+async def test_set_secret_rejects_invalid_key(tmp_path: Path) -> None:
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as excinfo:
+        await controller.set_secret(key="has-dash", value="x")
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
+async def test_set_secret_rejects_non_string_value(tmp_path: Path) -> None:
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as excinfo:
+        await controller.set_secret(key="api_key", value=42)  # type: ignore[arg-type]
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
+async def test_set_secret_concurrent_writes_do_not_lose_updates(tmp_path: Path) -> None:
+    """Two concurrent single-key writes both land — the #1334 lost-update."""
+    controller = _make_controller(tmp_path)
+    await asyncio.gather(
+        controller.set_secret(key="foo", value="1"),
+        controller.set_secret(key="bar", value="2"),
+    )
+    assert read_secrets_yaml(tmp_path) == {"foo": "1", "bar": "2"}
 
 
 async def test_get_info_returns_storage_metadata_dict(

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -896,6 +896,22 @@ async def test_set_secret_rejects_non_string_value(tmp_path: Path) -> None:
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
 
 
+async def test_set_secret_rejects_non_bool_overwrite(tmp_path: Path) -> None:
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as excinfo:
+        await controller.set_secret(key="api_key", value="x", overwrite="yes")  # type: ignore[arg-type]
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
+async def test_set_secret_maps_corrupt_secrets_to_invalid_args(tmp_path: Path) -> None:
+    """A pre-corrupt secrets.yaml that won't re-validate surfaces as INVALID_ARGS."""
+    (tmp_path / "secrets.yaml").write_text("dup: 1\ndup: 2\n", "utf-8")  # duplicate keys
+    controller = _make_controller(tmp_path)
+    with pytest.raises(CommandError) as excinfo:
+        await controller.set_secret(key="api_key", value="x")
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
 async def test_set_secret_concurrent_writes_do_not_lose_updates(tmp_path: Path) -> None:
     """Two concurrent single-key writes both land, no lost update."""
     controller = _make_controller(tmp_path)

--- a/tests/test_onboarding_controller.py
+++ b/tests/test_onboarding_controller.py
@@ -42,6 +42,7 @@ def _make_controller(config_dir: Path) -> OnboardingController:
     controller._db = MagicMock()
     controller._db.settings.config_dir = config_dir
     controller._db.settings.absolute_config_dir = config_dir.resolve()
+    controller._db.secrets_write_lock = asyncio.Lock()
     return controller
 
 

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -18,6 +18,7 @@ from esphome_device_builder.helpers.secrets_state import (
     PLACEHOLDER_WIFI_PASSWORD,
     PLACEHOLDER_WIFI_SSID,
     SecretsContentError,
+    _quote_yaml_string,
     is_valid_secret_key,
     is_wifi_unconfigured,
     merge_secrets_file,
@@ -325,10 +326,14 @@ def test_write_secret_no_overwrite_creates_absent_key(tmp_path: Path) -> None:
 
 
 def test_write_secret_round_trips_a_multiline_value_without_folding(tmp_path: Path) -> None:
-    """A value with newlines/tabs reads back byte-for-byte, not folded to spaces."""
-    value = "-----BEGIN-----\nline2\twith-tab\r\n-----END-----"
+    """A value with newlines/tabs/control chars reads back byte-for-byte, not folded."""
+    value = "-----BEGIN-----\nline2\twith-tab\x07bell\r\n-----END-----"
     write_secret(tmp_path, "cert", value)
     assert read_secrets_yaml(tmp_path) == {"cert": value}
+
+
+def test_quote_yaml_string_escapes_named_and_hex_control_chars() -> None:
+    assert _quote_yaml_string("a\nb\tc\x07d") == '"a\\nb\\tc\\x07d"'
 
 
 @pytest.mark.parametrize("key", ["wifi_ssid", "_x", "ABC123", "a"])

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -18,10 +18,12 @@ from esphome_device_builder.helpers.secrets_state import (
     PLACEHOLDER_WIFI_PASSWORD,
     PLACEHOLDER_WIFI_SSID,
     SecretsContentError,
+    is_valid_secret_key,
     is_wifi_unconfigured,
     merge_secrets_file,
     read_secrets_yaml,
     validate_secrets_content,
+    write_secret,
 )
 
 
@@ -271,3 +273,62 @@ def test_merge_secrets_leaves_unreadable_untouched(
     merge_secrets_file(src, dest)
 
     assert dest.read_text("utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# write_secret — single-key setter (issue #1334)
+# ---------------------------------------------------------------------------
+
+
+def _secrets(tmp_path: Path) -> Path:
+    return tmp_path / "secrets.yaml"
+
+
+def test_write_secret_creates_file_and_key(tmp_path: Path) -> None:
+    created = write_secret(tmp_path, "api_key", "ABC")
+    assert created is True
+    assert read_secrets_yaml(tmp_path) == {"api_key": "ABC"}
+
+
+def test_write_secret_appends_to_existing_file(tmp_path: Path) -> None:
+    _secrets(tmp_path).write_text("wifi_ssid: home\n", "utf-8")
+    created = write_secret(tmp_path, "api_key", "ABC")
+    assert created is True
+    assert read_secrets_yaml(tmp_path) == {"wifi_ssid": "home", "api_key": "ABC"}
+
+
+def test_write_secret_overwrites_existing_key_and_returns_not_created(tmp_path: Path) -> None:
+    _secrets(tmp_path).write_text("wifi_ssid: home\napi_key: OLD\n", "utf-8")
+    created = write_secret(tmp_path, "api_key", "NEW")
+    assert created is False
+    assert read_secrets_yaml(tmp_path) == {"wifi_ssid": "home", "api_key": "NEW"}
+
+
+def test_write_secret_preserves_other_secrets_and_inline_comment(tmp_path: Path) -> None:
+    _secrets(tmp_path).write_text("wifi_ssid: home  # Apt 4B\napi_key: OLD\n", "utf-8")
+    write_secret(tmp_path, "wifi_ssid", "office")
+    assert _secrets(tmp_path).read_text("utf-8") == 'wifi_ssid: "office"  # Apt 4B\napi_key: OLD\n'
+
+
+def test_write_secret_no_overwrite_leaves_existing_value(tmp_path: Path) -> None:
+    _secrets(tmp_path).write_text("api_key: KEEP\n", "utf-8")
+    created = write_secret(tmp_path, "api_key", "NEW", overwrite=False)
+    assert created is False
+    assert read_secrets_yaml(tmp_path) == {"api_key": "KEEP"}
+
+
+def test_write_secret_no_overwrite_creates_absent_key(tmp_path: Path) -> None:
+    _secrets(tmp_path).write_text("api_key: KEEP\n", "utf-8")
+    created = write_secret(tmp_path, "mqtt_pw", "secret", overwrite=False)
+    assert created is True
+    assert read_secrets_yaml(tmp_path) == {"api_key": "KEEP", "mqtt_pw": "secret"}
+
+
+@pytest.mark.parametrize("key", ["wifi_ssid", "_x", "ABC123", "a"])
+def test_is_valid_secret_key_accepts_identifier_keys(key: str) -> None:
+    assert is_valid_secret_key(key) is True
+
+
+@pytest.mark.parametrize("key", ["", "1abc", "with-dash", "has space", "a:b", "x\n", "no#hash"])
+def test_is_valid_secret_key_rejects_non_identifier_keys(key: str) -> None:
+    assert is_valid_secret_key(key) is False

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -324,6 +324,13 @@ def test_write_secret_no_overwrite_creates_absent_key(tmp_path: Path) -> None:
     assert read_secrets_yaml(tmp_path) == {"api_key": "KEEP", "mqtt_pw": "secret"}
 
 
+def test_write_secret_round_trips_a_multiline_value_without_folding(tmp_path: Path) -> None:
+    """A value with newlines/tabs reads back byte-for-byte, not folded to spaces."""
+    value = "-----BEGIN-----\nline2\twith-tab\r\n-----END-----"
+    write_secret(tmp_path, "cert", value)
+    assert read_secrets_yaml(tmp_path) == {"cert": value}
+
+
 @pytest.mark.parametrize("key", ["wifi_ssid", "_x", "ABC123", "a"])
 def test_is_valid_secret_key_accepts_identifier_keys(key: str) -> None:
     assert is_valid_secret_key(key) is True

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -276,7 +276,7 @@ def test_merge_secrets_leaves_unreadable_untouched(
 
 
 # ---------------------------------------------------------------------------
-# write_secret — single-key setter (issue #1334)
+# write_secret — single-key setter
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
# What does this implement/fix?

Setting one secret from the dashboard was a whole-file read-modify-write of the shared `secrets.yaml` with no concurrency control: read the whole file, change one key in JS, write the whole file back. Two overlapping writers (two tabs, the device editor racing `/secrets`, two quick saves) each read the same base and wrote back their own full version, so the last write won and the other key was silently lost.

This adds a `config/set_secret(key, value, overwrite?)` WS command that performs the read-modify-write under a per-controller `asyncio.Lock`, reusing the existing line-based, comment-preserving setter and an atomic write. The backend runs one event loop, so the lock plus the atomic write makes the whole update atomic and the interleave can no longer drop a key. `overwrite=false` is create-if-absent (returns `{created}`), so the frontend's "ensure this secret exists, don't clobber" path stays race-free server-side instead of doing a check-then-set; the response keeps the created-vs-linked distinction. The whole-file `/secrets` editor still uses the generic config path; only per-key writes move.

Residual: two separate backend processes sharing one config tree would still race; an OS-level file lock could close that later if it matters. `config/delete_secret` can follow the same shape if needed.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1334

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#722

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
