### PR TITLE
Fix remote-build firmware download on Windows offloaders

### DIFF
--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -184,12 +184,11 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             )
         if idedata_bytes is None:
             raise MaterialiseError(f"tarball missing required {IDEDATA_MEMBER_NAME!r} member")
-    elif new_storage.firmware_bin_path is None or not new_storage.firmware_bin_path.is_file():
-        # Native ESP-IDF has no platformio.ini / idedata to validate against,
-        # so confirm its firmware binary actually landed -- a truncated
-        # tarball that kept storage.json but lost the build/ tree would
-        # otherwise materialise empty and surface only as a 404 download later.
-        raise MaterialiseError("native ESP-IDF tarball missing its firmware binary")
+    # The bin must have landed (PIO and native-IDF alike); a build tree that
+    # didn't extract otherwise materialises empty and surfaces only as an empty
+    # download list later (#1340), with the job still reporting success.
+    if new_storage.firmware_bin_path is None or not new_storage.firmware_bin_path.is_file():
+        raise MaterialiseError("tarball missing its firmware binary")
     return _ExtractedTarball(
         storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -133,6 +133,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             receiver_storage = _parse_storage_json(storage_bytes)
             device_name = _device_name_from_storage(receiver_storage)
             receiver_build_path = _receiver_build_path_from_storage(receiver_storage)
+            receiver_firmware_bin = receiver_storage.get("firmware_bin_path")
 
             build_path = resolve_data_dir(configuration) / "build" / device_name
             # Stage the rewritten sidecar before deciding the wipe so
@@ -145,6 +146,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
             new_storage = _stage_offloader_storage(
                 configuration=configuration,
                 receiver_storage_bytes=storage_bytes,
+                receiver_firmware_bin_path=receiver_firmware_bin,
                 receiver_build_path=receiver_build_path,
                 offloader_build_path=build_path,
             )
@@ -188,7 +190,9 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
     # didn't extract otherwise materialises empty and surfaces only as an empty
     # download list later (#1340), with the job still reporting success.
     if new_storage.firmware_bin_path is None or not new_storage.firmware_bin_path.is_file():
-        raise MaterialiseError("tarball missing its firmware binary")
+        raise MaterialiseError(
+            f"tarball missing its firmware binary: {new_storage.firmware_bin_path}"
+        )
     return _ExtractedTarball(
         storage_bytes=storage_bytes,
         idedata_bytes=idedata_bytes,
@@ -326,6 +330,7 @@ def _stage_offloader_storage(
     *,
     configuration: str,
     receiver_storage_bytes: bytes,
+    receiver_firmware_bin_path: str | None,
     receiver_build_path: PurePath,
     offloader_build_path: Path,
 ) -> StorageJSON:
@@ -338,12 +343,14 @@ def _stage_offloader_storage(
         raise MaterialiseError(
             f"StorageJSON.load returned None for the staged sidecar at {storage_path}"
         )
-    if storage.firmware_bin_path is not None:
-        # ``str()`` round-trips the receiver-flavour string back out
-        # of the (possibly broken-on-this-OS) ``Path`` so
-        # ``_remap_to_offloader`` re-parses it with the right flavour.
+    if receiver_firmware_bin_path is not None:
+        # Remap from the raw receiver string, NOT str(storage.firmware_bin_path):
+        # StorageJSON.load parsed it into an offloader-OS Path, and on a Windows
+        # offloader str() of a POSIX receiver path swaps / for \, defeating
+        # _remap_to_offloader's receiver-flavour reparse and stranding the path
+        # unremapped (#1340).
         storage.firmware_bin_path = _remap_to_offloader(
-            str(storage.firmware_bin_path),
+            receiver_firmware_bin_path,
             receiver_build_path,
             offloader_build_path,
         )

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -119,6 +119,21 @@ def _synthetic_tarball(
     return buf.getvalue()
 
 
+def _synthetic_tarball_with_bin(**kwargs: Any) -> bytes:
+    """Synthetic tarball carrying a firmware bin, so it clears the landed check."""
+    storage = {
+        "storage_version": 1,
+        "name": "kitchen",
+        "build_path": _FAKE_BUILD_PATH,
+        "firmware_bin_path": f"{_FAKE_BUILD_PATH}/.pioenvs/kitchen/firmware.bin",
+    }
+    return _synthetic_tarball(
+        storage=storage,
+        extra_members=[(".pioenvs/kitchen/firmware.bin", b"FW")],
+        **kwargs,
+    )
+
+
 @pytest.fixture
 def paired_roots(tmp_path: Path) -> tuple[Path, Path]:
     """Return ``(receiver_root, offloader_root)`` directories under tmp_path."""
@@ -675,6 +690,19 @@ def test_materialise_rejects_native_idf_tarball_missing_firmware(tmp_path: Path)
         _materialise_in_tmp(tarball, tmp_path)
 
 
+def test_materialise_rejects_pio_tarball_missing_firmware(tmp_path: Path) -> None:
+    """A PlatformIO tarball with metadata but no firmware binary raises (#1340)."""
+    storage = {
+        "storage_version": 1,
+        "name": "kitchen",
+        "build_path": _FAKE_BUILD_PATH,
+        "firmware_bin_path": f"{_FAKE_BUILD_PATH}/.pioenvs/kitchen/firmware.bin",
+    }
+    tarball = _synthetic_tarball(storage=storage)
+    with pytest.raises(MaterialiseError, match="missing its firmware binary"):
+        _materialise_in_tmp(tarball, tmp_path)
+
+
 @pytest.mark.skipif(
     not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
 )
@@ -738,14 +766,14 @@ def test_materialise_rejects_non_dict_storage(tmp_path: Path) -> None:
 
 def test_materialise_rejects_non_json_idedata(tmp_path: Path) -> None:
     """idedata.json that isn't parseable JSON raises."""
-    tarball = _synthetic_tarball(idedata=b"{not-json")
+    tarball = _synthetic_tarball_with_bin(idedata=b"{not-json")
     with pytest.raises(MaterialiseError, match=r"idedata.*not valid JSON"):
         _materialise_in_tmp(tarball, tmp_path)
 
 
 def test_materialise_rejects_non_dict_idedata(tmp_path: Path) -> None:
     """idedata.json that parses to a non-dict raises MaterialiseError."""
-    tarball = _synthetic_tarball(idedata=b"null")
+    tarball = _synthetic_tarball_with_bin(idedata=b"null")
     with pytest.raises(MaterialiseError, match=r"is not a JSON object"):
         _materialise_in_tmp(tarball, tmp_path)
 

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -26,6 +26,7 @@ from unittest.mock import patch
 
 import pytest
 from esphome.core import CORE
+from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.controllers.remote_build.artifacts_tarball import (
     BUILD_INFO_MEMBER_NAME,
@@ -701,6 +702,31 @@ def test_materialise_rejects_pio_tarball_missing_firmware(tmp_path: Path) -> Non
     tarball = _synthetic_tarball(storage=storage)
     with pytest.raises(MaterialiseError, match="missing its firmware binary"):
         _materialise_in_tmp(tarball, tmp_path)
+
+
+def test_materialise_remaps_posix_receiver_on_separator_mangling_offloader(
+    paired_roots: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """firmware_bin_path remaps from the raw string on a separator-mangling offloader (#1340)."""
+    receiver_root, offloader_root = paired_roots
+    tarball = _pack_in_tmp(receiver_root)  # POSIX receiver, firmware.bin present
+
+    real_load = StorageJSON.load
+
+    def _mangling_load(path: Path) -> StorageJSON | None:
+        # Simulate a Windows offloader: Path(posix_str) is a WindowsPath whose
+        # str() swaps / for \. The remap must not depend on that round-trip.
+        storage = real_load(path)
+        if storage is not None and storage.firmware_bin_path is not None:
+            storage.firmware_bin_path = PureWindowsPath(
+                str(storage.firmware_bin_path).replace("/", "\\")
+            )
+        return storage
+
+    monkeypatch.setattr(StorageJSON, "load", _mangling_load)
+    build_path = _materialise_in_tmp(tarball, offloader_root)
+    assert (build_path / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# What does this implement/fix?

Remote-build firmware download failed on a Windows offloader (standalone install) with "No binaries were produced", even though the remote compile succeeded (#1340).

Root cause: when the offloader is Windows and the build server is POSIX (a Linux build server, the common case), `StorageJSON.load` parses the receiver's POSIX `firmware_bin_path` into a `WindowsPath`, and `str()` of that swaps `/` for `\`. The materialiser then fed that backslash string to `_remap_to_offloader`, which reparses with the receiver's POSIX flavour; `relative_to` fails, so the path is returned unremapped and points nowhere on the offloader. The binary is never found and the download list comes back empty. Windows->Windows and Windows-receiver->POSIX-offloader both happen to round-trip fine, which is why this only bites POSIX-receiver -> Windows-offloader and the existing cross-OS tests (run on POSIX hosts) never caught it.

Two changes:
- Remap `firmware_bin_path` from the raw receiver string (preserving its separators), the same way `build_path` already does, instead of round-tripping through the offloader-parsed `Path`.
- Apply the "firmware binary actually landed" check to PlatformIO builds too, not just native ESP-IDF, and include the path in the error. Any future case where the bin doesn't land now fails loudly with a diagnostic path instead of materialising empty and surfacing later as an empty download.

A regression test simulates a separator-mangling (Windows) offloader on any host by monkeypatching the load to swap separators; it fails on the old code and passes on the fix. The new PlatformIO landed-check is the mechanism that surfaced this on the Windows CI matrix.

**Related issue or feature (if applicable):**

- fixes #1340
- fixes #1343

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

