### PR TITLE
Invalidate editor validate cache on config-dir writes

### DIFF
--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -17,7 +17,6 @@ from ...helpers.secrets_state import (
     is_valid_secret_key,
     read_secrets_yaml,
     write_secret,
-    write_secrets_locked,
 )
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, UserPreferences
@@ -145,8 +144,9 @@ class ConfigController:
             raise CommandError(ErrorCode.INVALID_ARGS, "overwrite must be a boolean")
         config_dir = self._db.settings.config_dir
         try:
-            created = await write_secrets_locked(
-                self._db.secrets_write_lock,
+            # Funnel through DeviceBuilder so the editor's now-stale !secret
+            # lint is dropped along with the write (see write_secrets_locked).
+            created = await self._db.write_secrets_locked(
                 partial(write_secret, config_dir, key, value, overwrite=overwrite),
             )
         except SecretsContentError as err:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -867,6 +867,10 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         async with self._yaml_write_lock(configuration):
             await self._write_yaml_atomic_async(self._db.settings.rel_path(configuration), content)
             await self._commit_history(configuration, message or f"Update {configuration}")
+        # A write here (device YAML, or the whole-file secrets.yaml editor)
+        # can change what any open editor's lint resolves; clear the caches
+        # so the next validate re-reads disk instead of the stale result.
+        self._db.invalidate_editor_cache()
         self._scanner.request(configuration)
         # Mirrors the upstream dashboard's
         # ``async_schedule_storage_json_update``; without it

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -23,7 +23,7 @@ from esphome.helpers import write_file as atomic_write_file
 from ...constants import SECRETS_FILENAME
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem, parse_platform_from_yaml
-from ...helpers.secrets_state import merge_secrets_file, write_secrets_locked
+from ...helpers.secrets_state import merge_secrets_file
 from ...helpers.yaml import read_yaml_scalar
 from ...models import ErrorCode, ImportBundleResponse
 from .helpers import _validate_archive_configuration
@@ -65,10 +65,11 @@ async def import_bundle(
         raise CommandError(ErrorCode.INVALID_ARGS, "overwrite must be a list of strings")
 
     config_dir = controller._db.settings.config_dir
-    # Staging merges secrets.yaml; route it through the shared lock so that
-    # merge can't interleave with a concurrent config/set_secret and lose a key.
-    outcome = await write_secrets_locked(
-        controller._db.secrets_write_lock, _stage_bundle, file_content_b64, config_dir, overwrite
+    # Staging writes the bundle's files (secrets, !include fragments, packages,
+    # external_components). Funnel through the shared lock + editor-cache drop so
+    # any of those overwrites refreshes an open editor's lint, not just secrets.
+    outcome = await controller._db.write_secrets_locked(
+        _stage_bundle, file_content_b64, config_dir, overwrite
     )
     if outcome.conflicts is not None:
         return ImportBundleResponse(

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -91,6 +91,20 @@ class EditorController:
         for session in sessions:
             await self._terminate_subprocess(session)
 
+    def invalidate_cache(self) -> None:
+        """
+        Drop every session's cached validation after a config-dir write.
+
+        Cleared for all sessions, not just the written file: a referenced
+        file (secrets, ``!include``, ``packages``) the content-hash key
+        can't see affects any open device's validation.
+        """
+        # Snapshot the values: this is await-free so the dict can't change
+        # under us today, but the copy keeps it safe if a future caller adds
+        # a suspension point mid-clear.
+        for session in tuple(self._sessions.values()):
+            session.cached = None
+
     # ------------------------------------------------------------------
     # Subprocess management
     # ------------------------------------------------------------------

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -27,7 +27,6 @@ from ..helpers.api import CommandError, api_command
 from ..helpers.secrets_state import (
     is_wifi_unconfigured,
     read_secrets_yaml,
-    write_secrets_locked,
     write_wifi_secrets,
 )
 from ..models import (
@@ -149,9 +148,7 @@ class OnboardingController:
                 )
 
         config_dir = self._db.settings.config_dir
-        await write_secrets_locked(
-            self._db.secrets_write_lock, write_wifi_secrets, config_dir, ssid, password
-        )
+        await self._db.write_secrets_locked(write_wifi_secrets, config_dir, ssid, password)
         return await self.get_state()
 
     @api_command("onboarding/mark_acknowledged")

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -12,6 +12,7 @@ import contextlib
 import html
 import logging
 import re
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from pathlib import Path
@@ -49,6 +50,7 @@ from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
 from .helpers.json import cors_middleware
 from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
 from .helpers.peer_link_identity import PeerLinkIdentityStore
+from .helpers.secrets_state import write_secrets_locked
 from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
 
@@ -271,6 +273,23 @@ class DeviceBuilder:
     async def reload_remote_build_identity(self) -> bool:
         """Rebuild the peer-link listener after an X25519 identity rotation."""
         return await self._remote_build_lifecycle.reload_identity()
+
+    def invalidate_editor_cache(self) -> None:
+        """Drop the editor's validate cache after a config-dir write; no-op pre-start."""
+        if self.editor is not None:
+            self.editor.invalidate_cache()
+
+    async def write_secrets_locked[T](self, fn: Callable[..., T], *args: Any) -> T:
+        """
+        Run a ``secrets.yaml`` mutator under the shared lock, then drop the editor cache.
+
+        The single funnel for secrets writes: routing every writer through here
+        couples the cache invalidation to the write, so a new secrets path can't
+        forget that an open editor's ``!secret`` lint just went stale.
+        """
+        result = await write_secrets_locked(self.secrets_write_lock, fn, *args)
+        self.invalidate_editor_cache()
+        return result
 
     def _install_default_executor(self) -> None:
         """Register the dashboard's executor as the loop's default.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ from esphome_device_builder.controllers.remote_build import (
 )
 from esphome_device_builder.helpers.event_bus import Event, EventBus
 from esphome_device_builder.helpers.peer_link_identity import PeerLinkIdentityStore
+from esphome_device_builder.helpers.secrets_state import write_secrets_locked
 from esphome_device_builder.models import (
     AdoptableDevice,
     BoardCatalogResponse,
@@ -955,3 +956,18 @@ def record_scheduled_coros(coros: list[object]) -> Callable[[object], object]:
         return close_scheduled_coro(coro)
 
     return _impl
+
+
+def wire_secrets_writer(db_mock: Any) -> None:
+    """Make a mocked ``DeviceBuilder.write_secrets_locked`` run the real funnel.
+
+    Controllers now route secrets writes through
+    ``self._db.write_secrets_locked``; tests that mock ``_db`` need it to
+    actually run the write under the mock's ``secrets_write_lock`` (the
+    editor-cache drop the real wrapper also does is a no-op on the mock).
+    """
+
+    async def _run(fn: Callable[..., Any], *args: Any) -> Any:
+        return await write_secrets_locked(db_mock.secrets_write_lock, fn, *args)
+
+    db_mock.write_secrets_locked = _run

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -36,7 +36,7 @@ from esphome_device_builder.helpers.hostname import normalize_hostname
 from esphome_device_builder.models import AdoptableDevice, Device, DeviceState, EventType
 from tests._recording_scanner import RecordingScanner
 from tests._storage_fixtures import write_storage_json
-from tests.conftest import make_device
+from tests.conftest import make_device, wire_secrets_writer
 
 
 class RecordingStateMonitor:
@@ -456,6 +456,7 @@ def make_controller() -> MakeControllerFactory:
         controller.state = DevicesState()
         controller._yaml_write_locks = {}
         controller._db.secrets_write_lock = asyncio.Lock()
+        wire_secrets_writer(controller._db)
         controller._db.settings.config_dir = config_dir
         controller._db.settings.rel_path = lambda configuration: config_dir / configuration
         # Version history off by default — a MagicMock's

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -92,7 +92,7 @@ from esphome_device_builder.models.preferences import (
 )
 
 from ._storage_fixtures import write_storage_json
-from .conftest import MakeSettingsFactory
+from .conftest import MakeSettingsFactory, wire_secrets_writer
 
 
 def _make_controller(config_dir: Path) -> ConfigController:
@@ -103,6 +103,7 @@ def _make_controller(config_dir: Path) -> ConfigController:
     controller._db.settings.absolute_config_dir = config_dir.resolve()
     controller._db.settings.rel_path = config_dir.joinpath
     controller._db.secrets_write_lock = asyncio.Lock()
+    wire_secrets_writer(controller._db)
     return controller
 
 

--- a/tests/test_device_builder_lifecycle.py
+++ b/tests/test_device_builder_lifecycle.py
@@ -55,6 +55,54 @@ def test_init_leaves_controllers_unset(make_settings: MakeSettingsFactory) -> No
     assert db._executor is not None
 
 
+def test_invalidate_editor_cache_noop_before_start(
+    make_settings: MakeSettingsFactory,
+) -> None:
+    """The helper is a no-op while ``editor`` is unset (pre-start)."""
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    assert db.editor is None
+    db.invalidate_editor_cache()  # must not raise
+
+
+def test_invalidate_editor_cache_delegates_to_editor(
+    make_settings: MakeSettingsFactory,
+) -> None:
+    """Once ``editor`` exists, the helper clears its cache."""
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    calls = 0
+
+    class _Editor:
+        def invalidate_cache(self) -> None:
+            nonlocal calls
+            calls += 1
+
+    db.editor = _Editor()  # type: ignore[assignment]
+    db.invalidate_editor_cache()
+    assert calls == 1
+
+
+async def test_write_secrets_locked_runs_fn_then_invalidates(
+    make_settings: MakeSettingsFactory,
+) -> None:
+    """The wrapper runs the mutator under the lock, returns it, and drops the cache."""
+    db = DeviceBuilder(make_settings(with_core_path=True))
+    invalidations = 0
+
+    class _Editor:
+        def invalidate_cache(self) -> None:
+            nonlocal invalidations
+            invalidations += 1
+
+    db.editor = _Editor()  # type: ignore[assignment]
+
+    def _mutator(a: int, b: int) -> int:
+        return a + b
+
+    result = await db.write_secrets_locked(_mutator, 2, 3)
+    assert result == 5
+    assert invalidations == 1
+
+
 # ---------------------------------------------------------------------------
 # start()
 # ---------------------------------------------------------------------------

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -916,3 +916,42 @@ async def test_validate_yaml_inner_lock_recheck_coalesces_concurrent_calls(
 
     assert calls == 1
     assert results[0] == results[1] == {"yaml_errors": [], "validation_errors": []}
+
+
+async def test_invalidate_cache_drops_cached_result(tmp_path: Path) -> None:
+    """After invalidate, the next call re-runs ``_validate_locked``."""
+    controller = _make_controller(tmp_path)
+    calls: list[str] = []
+
+    async def _record(session: Any, configuration: str, content: str) -> dict:
+        calls.append(content)
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _record  # type: ignore[method-assign]
+    content = "esphome:\n  name: kitchen\n"
+
+    await controller.validate_yaml(configuration="kitchen.yaml", content=content)
+    controller.invalidate_cache()
+    await controller.validate_yaml(configuration="kitchen.yaml", content=content)
+
+    assert calls == [content, content]
+
+
+async def test_invalidate_cache_clears_every_session(tmp_path: Path) -> None:
+    """A secrets write must clear the *device* session's cache, not just its own."""
+    controller = _make_controller(tmp_path)
+    calls: list[str] = []
+
+    async def _record(session: Any, configuration: str, content: str) -> dict:
+        calls.append(configuration)
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _record  # type: ignore[method-assign]
+    await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+    await controller.validate_yaml(configuration="bedroom.yaml", content="esphome:\n")
+
+    controller.invalidate_cache()
+    await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
+    await controller.validate_yaml(configuration="bedroom.yaml", content="esphome:\n")
+
+    assert calls == ["kitchen.yaml", "bedroom.yaml", "kitchen.yaml", "bedroom.yaml"]

--- a/tests/test_onboarding_controller.py
+++ b/tests/test_onboarding_controller.py
@@ -36,6 +36,8 @@ from esphome_device_builder.models.onboarding import (
 )
 from esphome_device_builder.models.preferences import Theme, UserPreferences
 
+from .conftest import wire_secrets_writer
+
 
 def _make_controller(config_dir: Path) -> OnboardingController:
     controller = OnboardingController.__new__(OnboardingController)
@@ -43,6 +45,7 @@ def _make_controller(config_dir: Path) -> OnboardingController:
     controller._db.settings.config_dir = config_dir
     controller._db.settings.absolute_config_dir = config_dir.resolve()
     controller._db.secrets_write_lock = asyncio.Lock()
+    wire_secrets_writer(controller._db)
     return controller
 
 


### PR DESCRIPTION
# What does this implement/fix?

The editor's `validate_yaml` result is cached per session keyed only on the device YAML content hash (60s TTL). Writing `secrets.yaml` (via `config/set_secret`, the whole-file secrets editor, onboarding, or a bundle import) or any `!include`d file doesn't change the device YAML, so the device session's hash is unchanged and the stale `Secret '<name>' not defined` result was served for up to 60s. This adds `EditorController.invalidate_cache()` and calls it from every config-dir write path. It clears all sessions, not just the written file, since the stale result lives on the device session, not on `secrets.yaml`; a referenced file can affect any open device's validation. Validations are cheap to recompute, so clearing coarsely is the right trade.

Pairs with the frontend change that forces the open editor to re-lint promptly.

**Related issue or feature (if applicable):**

- fixes #1332

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#724

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
