### PR TITLE
Funnel secrets.yaml writes through one locked helper

### DIFF
--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -17,6 +17,7 @@ from ...helpers.secrets_state import (
     is_valid_secret_key,
     read_secrets_yaml,
     write_secret,
+    write_secrets_locked,
 )
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, UserPreferences
@@ -142,18 +143,16 @@ class ConfigController:
             raise CommandError(ErrorCode.INVALID_ARGS, "value must be a string")
         if not isinstance(overwrite, bool):
             raise CommandError(ErrorCode.INVALID_ARGS, "overwrite must be a boolean")
-        loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
-        async with self._db.secrets_write_lock:
-            try:
-                created = await loop.run_in_executor(
-                    None,
-                    partial(write_secret, config_dir, key, value, overwrite=overwrite),
-                )
-            except SecretsContentError as err:
-                raise CommandError(
-                    ErrorCode.INVALID_ARGS, f"refusing to save invalid secrets.yaml: {err}"
-                ) from err
+        try:
+            created = await write_secrets_locked(
+                self._db.secrets_write_lock,
+                partial(write_secret, config_dir, key, value, overwrite=overwrite),
+            )
+        except SecretsContentError as err:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS, f"refusing to save invalid secrets.yaml: {err}"
+            ) from err
         return {"created": created}
 
     @api_command("config/get_info")

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -9,7 +9,6 @@ which to replace, then re-submits with ``overwrite`` set.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import binascii
 import logging
@@ -24,7 +23,7 @@ from esphome.helpers import write_file as atomic_write_file
 from ...constants import SECRETS_FILENAME
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem, parse_platform_from_yaml
-from ...helpers.secrets_state import merge_secrets_file
+from ...helpers.secrets_state import merge_secrets_file, write_secrets_locked
 from ...helpers.yaml import read_yaml_scalar
 from ...models import ErrorCode, ImportBundleResponse
 from .helpers import _validate_archive_configuration
@@ -66,13 +65,11 @@ async def import_bundle(
         raise CommandError(ErrorCode.INVALID_ARGS, "overwrite must be a list of strings")
 
     config_dir = controller._db.settings.config_dir
-    loop = asyncio.get_running_loop()
-    # Staging merges secrets.yaml; hold the shared lock so that merge can't
-    # interleave with a concurrent config/set_secret and lose a key.
-    async with controller._db.secrets_write_lock:
-        outcome = await loop.run_in_executor(
-            None, _stage_bundle, file_content_b64, config_dir, overwrite
-        )
+    # Staging merges secrets.yaml; route it through the shared lock so that
+    # merge can't interleave with a concurrent config/set_secret and lose a key.
+    outcome = await write_secrets_locked(
+        controller._db.secrets_write_lock, _stage_bundle, file_content_b64, config_dir, overwrite
+    )
     if outcome.conflicts is not None:
         return ImportBundleResponse(
             status="conflicts",

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -27,6 +27,7 @@ from ..helpers.api import CommandError, api_command
 from ..helpers.secrets_state import (
     is_wifi_unconfigured,
     read_secrets_yaml,
+    write_secrets_locked,
     write_wifi_secrets,
 )
 from ..models import (
@@ -147,12 +148,10 @@ class OnboardingController:
                     f"{label} can't contain control characters.",
                 )
 
-        loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
-        # Shared lock so this write can't interleave with a concurrent
-        # config/set_secret and lose one side's update.
-        async with self._db.secrets_write_lock:
-            await loop.run_in_executor(None, write_wifi_secrets, config_dir, ssid, password)
+        await write_secrets_locked(
+            self._db.secrets_write_lock, write_wifi_secrets, config_dir, ssid, password
+        )
         return await self.get_state()
 
     @api_command("onboarding/mark_acknowledged")

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -41,10 +41,7 @@ async def write_secrets_locked[T](lock: asyncio.Lock, fn: Callable[..., T], *arg
     """
     Run a blocking ``secrets.yaml`` mutator under *lock*, off the event loop.
 
-    The single funnel for the executor-based secrets.yaml writers so the
-    shared-lock-plus-``run_in_executor`` invariant lives in one place — a
-    new writer that takes neither is the exact lost-update regression this
-    guards against. Pre-bind keyword args with ``functools.partial``.
+    Pre-bind keyword args with ``functools.partial``.
     """
     loop = asyncio.get_running_loop()
     async with lock:

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -18,10 +18,13 @@ existing values on conflict (ruamel round-trip).
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import re
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from esphome import yaml_util
 from esphome.core import EsphomeError
@@ -32,6 +35,21 @@ from ..constants import SECRETS_FILENAME
 from .yaml import load_yaml_fast_then_esphome
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def write_secrets_locked[T](lock: asyncio.Lock, fn: Callable[..., T], *args: Any) -> T:
+    """
+    Run a blocking ``secrets.yaml`` mutator under *lock*, off the event loop.
+
+    The single funnel for the executor-based secrets.yaml writers so the
+    shared-lock-plus-``run_in_executor`` invariant lives in one place — a
+    new writer that takes neither is the exact lost-update regression this
+    guards against. Pre-bind keyword args with ``functools.partial``.
+    """
+    loop = asyncio.get_running_loop()
+    async with lock:
+        return await loop.run_in_executor(None, fn, *args)
+
 
 # Bootstrap placeholder strings. Upstream now exports these from
 # ``esphome.const``; fall back to local literals on older releases

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -8,6 +8,7 @@ a non-string typo.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from esphome_device_builder.helpers.secrets_state import (
     read_secrets_yaml,
     validate_secrets_content,
     write_secret,
+    write_secrets_locked,
 )
 
 
@@ -334,6 +336,17 @@ def test_write_secret_round_trips_a_multiline_value_without_folding(tmp_path: Pa
 
 def test_quote_yaml_string_escapes_named_and_hex_control_chars() -> None:
     assert _quote_yaml_string("a\nb\tc\x07d") == '"a\\nb\\tc\\x07d"'
+
+
+async def test_write_secrets_locked_runs_under_the_lock_and_returns() -> None:
+    """The funnel holds the lock (blocking a held one) and returns the fn's result."""
+    lock = asyncio.Lock()
+    await lock.acquire()
+    task = asyncio.create_task(write_secrets_locked(lock, lambda: "done"))
+    await asyncio.sleep(0)
+    assert not task.done()  # blocked on the held lock
+    lock.release()
+    assert await task == "done"
 
 
 @pytest.mark.parametrize("key", ["wifi_ssid", "_x", "ABC123", "a"])


### PR DESCRIPTION
# What does this implement/fix?

Follow-up DRY pass on the #1334 secrets-write locking. After that change, four code paths write `secrets.yaml`, and three of them (config/set_secret, onboarding's wifi write, bundle import) had copy-pasted the same `loop = get_running_loop()` + `async with secrets_write_lock:` + `run_in_executor(...)` dance. The bundle-import writer had originally shipped without the lock at all; review caught it. That repetition is exactly where the next secrets writer can silently forget the lock and reintroduce the lost-update race.

This extracts one funnel, `write_secrets_locked(lock, fn, *args)` in `helpers/secrets_state.py`, and routes the three executor-based writers through it, so the lock-and-offload invariant lives in one place and the locked path is the path of least resistance. Behaviour is unchanged; the whole-file `/secrets` editor save keeps its own `async with` since it awaits an async persist rather than a blocking writer. Adds a focused test pinning that the funnel holds the lock and returns the writer's result.

**Related issue or feature (if applicable):**

- n/a (refactor of the just-merged #1334 work)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
