### PR TITLE
Preserve the !lambda tag when emitting component fields

### DIFF
--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -38,6 +38,7 @@ from ...models.automations import (
     AutomationTree,
     ConditionNode,
     LightEffect,
+    is_lambda_sentinel,
 )
 from . import catalog
 from .parsing import DEFAULT_SHORTHAND_KEY, make_yaml
@@ -217,11 +218,7 @@ def encode_value(value: Any) -> Any:
     tag (dropping it would turn the C++ lambda into a string literal,
     silently breaking the firmware). Nested dicts and lists recurse.
     """
-    if (
-        isinstance(value, dict)
-        and value.keys() <= {"_lambda", "_tag"}
-        and isinstance(value.get("_lambda"), str)
-    ):
+    if is_lambda_sentinel(value):
         return _encode_lambda(value["_lambda"], value.get("_tag"))
     if isinstance(value, dict):
         out = CommentedMap()

--- a/esphome_device_builder/controllers/automations/emitter.py
+++ b/esphome_device_builder/controllers/automations/emitter.py
@@ -31,6 +31,7 @@ from ruamel.yaml.comments import CommentedMap, CommentedSeq, TaggedScalar
 from ruamel.yaml.scalarstring import LiteralScalarString
 from ruamel.yaml.tag import Tag
 
+from ...helpers.yaml.scalar import is_lambda_sentinel
 from ...models.automations import (
     ActionNode,
     AutomationAction,
@@ -38,7 +39,6 @@ from ...models.automations import (
     AutomationTree,
     ConditionNode,
     LightEffect,
-    is_lambda_sentinel,
 )
 from . import catalog
 from .parsing import DEFAULT_SHORTHAND_KEY, make_yaml

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
-from ...models.automations import is_lambda_sentinel
 from ...models.common import ConfigEntryType
-from .scalar import ESPHOME_YAML_INDENT, _quote, _safe_yaml_scalar, block_body_is_list
+from .scalar import (
+    ESPHOME_YAML_INDENT,
+    _quote,
+    _safe_yaml_scalar,
+    block_body_is_list,
+    is_lambda_sentinel,
+)
 
 if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from ...models.automations import is_lambda_sentinel
 from ...models.common import ConfigEntryType
 from .scalar import ESPHOME_YAML_INDENT, _quote, _safe_yaml_scalar, block_body_is_list
 
@@ -382,6 +383,19 @@ def _format_flow_yaml_value(value: Any) -> str:
     return formatted
 
 
+def _emit_lambda_lines(header_prefix: str, body_indent: str, value: dict[str, Any]) -> list[str]:
+    """
+    Emit a ``{_lambda, _tag}`` sentinel as a ``!lambda |-`` block scalar.
+
+    ``_tag: "!lambda"`` re-emits the tag so the body compiles as a
+    lambda; an untagged sentinel emits a bare ``|-``.
+    """
+    header = "!lambda |-" if value.get("_tag") == "!lambda" else "|-"
+    lines = [f"{header_prefix}{header}"]
+    lines.extend(f"{body_indent}{line}" if line else "" for line in value["_lambda"].split("\n"))
+    return lines
+
+
 def _emit_field(key: str, value: Any, indent: str) -> list[str]:
     """
     Emit a single ``key: value`` pair as one or more YAML lines.
@@ -390,8 +404,11 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
     ConfigEntry with type=NESTED renders as a YAML mapping under its
     parent. Lists of dicts render as ``- mapping`` entries; lists of
     scalars render as ``[a, b, c]`` flow-style for compactness.
+    Lambda sentinels (``{_lambda, _tag}``) emit a ``!lambda |-`` block.
     """
     safe_key = _safe_yaml_scalar(key)
+    if is_lambda_sentinel(value):
+        return _emit_lambda_lines(f"{indent}{safe_key}: ", indent + ESPHOME_YAML_INDENT, value)
     if isinstance(value, dict):
         lines = [f"{indent}{safe_key}:"]
         for sub_key, sub_value in value.items():
@@ -399,6 +416,9 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
         return lines
     if isinstance(value, list) and value and all(isinstance(item, dict) for item in value):
         lines = [f"{indent}{safe_key}:"]
+        # Block-scalar lambda bodies under a list item indent three
+        # steps past the field key (matches the frontend serializer).
+        body_indent = indent + ESPHOME_YAML_INDENT * 3
         for item in value:
             first = True
             for sub_key, sub_value in item.items():
@@ -407,8 +427,13 @@ def _emit_field(key: str, value: Any, indent: str) -> list[str]:
                     if first
                     else f"{indent}{ESPHOME_YAML_INDENT * 2}"
                 )
-                rendered = _format_yaml_value(sub_value)
-                lines.append(f"{prefix}{_safe_yaml_scalar(sub_key)}: {rendered}")
+                safe_sub = _safe_yaml_scalar(sub_key)
+                if is_lambda_sentinel(sub_value):
+                    lines.extend(
+                        _emit_lambda_lines(f"{prefix}{safe_sub}: ", body_indent, sub_value)
+                    )
+                else:
+                    lines.append(f"{prefix}{safe_sub}: {_format_yaml_value(sub_value)}")
                 first = False
         return lines
     if isinstance(value, list):

--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from yaml.emitter import Emitter
@@ -12,6 +12,15 @@ from yaml.resolver import Resolver
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+
+
+def is_lambda_sentinel(value: Any) -> bool:
+    """Return True for the frontend's ``{_lambda, _tag}`` lambda wire-sentinel."""
+    return (
+        isinstance(value, dict)
+        and value.keys() <= {"_lambda", "_tag"}
+        and isinstance(value.get("_lambda"), str)
+    )
 
 
 # Canonical ESPHome YAML indent: two spaces per level. Mirrors the

--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -25,6 +25,16 @@ from mashumaro.types import Discriminator
 
 from .common import ConfigEntry
 
+
+def is_lambda_sentinel(value: Any) -> bool:
+    """Return True for the frontend's ``{_lambda, _tag}`` lambda wire-sentinel."""
+    return (
+        isinstance(value, dict)
+        and value.keys() <= {"_lambda", "_tag"}
+        and isinstance(value.get("_lambda"), str)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Catalog
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/models/automations.py
+++ b/esphome_device_builder/models/automations.py
@@ -25,16 +25,6 @@ from mashumaro.types import Discriminator
 
 from .common import ConfigEntry
 
-
-def is_lambda_sentinel(value: Any) -> bool:
-    """Return True for the frontend's ``{_lambda, _tag}`` lambda wire-sentinel."""
-    return (
-        isinstance(value, dict)
-        and value.keys() <= {"_lambda", "_tag"}
-        and isinstance(value.get("_lambda"), str)
-    )
-
-
 # ---------------------------------------------------------------------------
 # Catalog
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -881,6 +881,32 @@ def test_generate_api_encryption_key_yields_distinct_base64_values() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_generate_component_yaml_preserves_lambda_filter_tag() -> None:
+    """A templatable filter lambda sentinel emits as a ``!lambda |-`` block.
+
+    The frontend sends a lambda-toggled filter value as the
+    ``{_lambda, _tag}`` sentinel; dropping the ``!lambda`` tag would
+    turn the C++ body into a string literal and break the firmware
+    (issue #1351).
+    """
+    component = _component(component_id="sensor.template", category=ComponentCategory.SENSOR)
+    fields: dict[str, Any] = {
+        "name": "Test Sensor",
+        "filters": [{"multiply": {"_lambda": "return 0.01;", "_tag": "!lambda"}}],
+    }
+
+    result = generate_component_yaml(component, fields)
+
+    assert "      - multiply: !lambda |-\n          return 0.01;" in result
+    # No sentinel leak as a nested mapping.
+    assert "_lambda" not in result
+    # The emitted block is valid YAML once the ``!lambda`` tag is known.
+    loader = type("_LambdaLoader", (yaml.SafeLoader,), {})
+    loader.add_constructor("!lambda", lambda ldr, node: ldr.construct_scalar(node))
+    loaded = yaml.load(result, Loader=loader)  # noqa: S506 - scoped test loader
+    assert loaded["sensor"][0]["filters"][0]["multiply"] == "return 0.01;"
+
+
 def test_merge_component_yaml_appends_first_platform_block() -> None:
     """First sensor in a YAML with no ``sensor:`` section gets appended.
 

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -882,13 +882,7 @@ def test_generate_api_encryption_key_yields_distinct_base64_values() -> None:
 
 
 def test_generate_component_yaml_preserves_lambda_filter_tag() -> None:
-    """A templatable filter lambda sentinel emits as a ``!lambda |-`` block.
-
-    The frontend sends a lambda-toggled filter value as the
-    ``{_lambda, _tag}`` sentinel; dropping the ``!lambda`` tag would
-    turn the C++ body into a string literal and break the firmware
-    (issue #1351).
-    """
+    """A templatable filter lambda sentinel emits as a ``!lambda |-`` block."""
     component = _component(component_id="sensor.template", category=ComponentCategory.SENSOR)
     fields: dict[str, Any] = {
         "name": "Test Sensor",
@@ -905,6 +899,20 @@ def test_generate_component_yaml_preserves_lambda_filter_tag() -> None:
     loader.add_constructor("!lambda", lambda ldr, node: ldr.construct_scalar(node))
     loaded = yaml.load(result, Loader=loader)  # noqa: S506 - scoped test loader
     assert loaded["sensor"][0]["filters"][0]["multiply"] == "return 0.01;"
+
+
+def test_generate_component_yaml_preserves_direct_lambda_field_tag() -> None:
+    """A scalar field holding a lambda sentinel emits a multi-line ``!lambda |-`` block."""
+    component = _component(component_id="sensor.template", category=ComponentCategory.SENSOR)
+    fields: dict[str, Any] = {
+        "name": "Test Sensor",
+        "lambda": {"_lambda": "auto x = id(t).state;\nreturn x + 1;", "_tag": "!lambda"},
+    }
+
+    result = generate_component_yaml(component, fields)
+
+    assert "    lambda: !lambda |-\n      auto x = id(t).state;\n      return x + 1;" in result
+    assert "_lambda" not in result
 
 
 def test_merge_component_yaml_appends_first_platform_block() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The catalog-driven `add_component` path renders YAML in Python via
`generate_component_yaml` -> `_emit_field`, which had no handling for
the frontend's `{_lambda, _tag}` lambda sentinel. A templatable filter
added with a lambda value (`multiply: !lambda |-`) either emitted a
broken nested mapping (`multiply:` then `_lambda:` / `_tag:`) or, for a
plain string, dropped the `!lambda` tag entirely, so the C++ body
compiled as a string literal instead of a lambda.

This is the backend half of the #1351 lambda-filter fix (the
user-visible Visual Editor parse bug is fixed in the companion frontend
PR).

**Changes**
- `_emit_field` now emits the `{_lambda, _tag}` sentinel as a
  `!lambda |-` block scalar in both the scalar position and the
  list-of-mappings (`filters:` / `effects:`) position, with body indent
  matching the frontend serializer.
- Hoist the sentinel-detection predicate that `_emit_field` and the
  automations `emitter.encode_value` now share into
  `models.automations.is_lambda_sentinel` (no behaviour change to
  automations).
- Test in `tests/test_yaml_helpers.py` pins that a lambda filter
  round-trips with the `!lambda` tag and reloads as valid YAML.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1351

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] Companion frontend PR: esphome/device-builder-frontend#735

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (not applicable).
