### PR TITLE
Install esphome extra in device-catalog sync

### DIFF
--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -46,12 +46,13 @@ jobs:
           python-version: "3.13"
           cache: pip
 
-      - name: Install package
+      - name: Install package (with esphome extra)
         run: |
           python -m pip install --upgrade pip
-          # The device sync only needs the base package (pyyaml +
-          # component catalog reader). No esphome introspection here.
-          pip install -e '.[test]'
+          # ``sync_boards.py`` introspects ESPHome's per-platform board
+          # modules to regenerate board pins, so the esphome extra is
+          # required; ``test`` carries jsonschema for validate_definitions.
+          pip install -e '.[esphome,test]'
 
       - name: Run sync_esphome_devices
         run: python script/sync_esphome_devices.py


### PR DESCRIPTION
# What does this implement/fix?

The nightly **Sync device catalog** workflow failed at the *Regenerate boards.json* step with `ModuleNotFoundError: No module named 'esphome'` ([run 27126057171](https://github.com/esphome/device-builder/actions/runs/27126057171/job/80054822763)).

That step runs `script/sync_boards.py`, whose `build_catalog()` calls `_augment_libretiny_boards` / `_augment_rp2040_boards` / `_augment_esp32_boards` / `_augment_esp8266_boards` / `_augment_nrf52_boards`, each doing `importlib.import_module("esphome.components.<platform>.boards")` to derive per-platform board pins. That ESPHome board-data introspection was added in #1166, after this workflow's install step was written; the workflow still installed only `.[test]` and carried a now-stale comment claiming "No esphome introspection here."

Fix: install `.[esphome,test]`, matching the already-green component-sync workflow. `esphome` is needed at runtime by `sync_boards.py`; `test` is kept because `script/validate_definitions.py` imports `jsonschema` from that extra. Comment updated to reflect the actual requirement.

Verified locally: `python script/sync_boards.py` exits 0 and produces no catalog drift.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
