### PR TITLE
Follow file= config references in the device sync

### DIFF
--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1217,7 +1217,7 @@ def _make_record(  # noqa: C901, PLR0911 — distinct skip reasons each get thei
     if not isinstance(title, str) or not title.strip():
         return None, "no frontmatter title"
     if src.config_yaml is None:
-        return None, "no parseable inline yaml"
+        return None, "no parseable yaml config"
     if not src.images:
         return None, "no local images"
     # ``type:`` is optional — only used downstream for tag inference.

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -4,11 +4,12 @@ Generate ``definitions/boards/<id>/manifest.yaml`` from devices.esphome.io.
 
 The upstream repo (https://github.com/esphome/devices.esphome.io) is a
 Docusaurus site whose 760+ device pages each have YAML front matter
-plus an inline ``yaml`` config. This script clones the repo, walks
-the device pages, and emits one ``boards/<id>/manifest.yaml`` per
-device that meets the strict acceptance bar (parseable inline yaml,
-identifiable board id, at least one local image, at least one
-extractable featured component).
+plus a ``yaml`` config, either inline or referenced from a sibling file
+(``yaml file=config.yaml``). This script clones the repo, walks the
+device pages, and emits one ``boards/<id>/manifest.yaml`` per device
+that meets the strict acceptance bar (parseable yaml config, identifiable
+board id, at least one local image, at least one extractable featured
+component).
 
 Imported manifests carry a ``source:`` block. Hand-curated manifests
 in ``boards/`` (no ``source:``) are never read or written; the
@@ -251,7 +252,7 @@ class _DeviceSource:
     frontmatter: dict[str, Any]
     body: str
     content_hash: str
-    inline_yaml: dict[str, Any] | None
+    config_yaml: dict[str, Any] | None  # from the inline fence or a file= sibling
     images: list[str]  # filenames relative to the device folder
 
 
@@ -414,7 +415,11 @@ def _get_repo_revision(repo: Path) -> str:
 
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
-_YAML_FENCE_RE = re.compile(r"```ya?ml\s*\n(.*?)\n```", re.DOTALL)
+# Capture the fence info string (group 1) so a ``file=`` reference is
+# honoured; group 2 is the inline body, which is empty for a file-backed
+# fence (``\n?`` makes the body and its trailing newline optional).
+_YAML_FENCE_RE = re.compile(r"```ya?ml([^\n]*)\n(.*?)\n?```", re.DOTALL)
+_FENCE_FILE_RE = re.compile(r"\bfile=(\S+)")
 _IMAGE_REF_RE = re.compile(r"!\[[^\]]*\]\(([^)\s]+?)(?:\s+\"[^\"]*\")?\)")
 
 
@@ -433,12 +438,37 @@ def _split_frontmatter(text: str) -> tuple[dict[str, Any] | None, str]:
     return {str(k).lower(): v for k, v in parsed.items()}, body
 
 
-def _extract_first_yaml_block(body: str) -> dict[str, Any] | None:
-    """Find the first fenced ```yaml block in *body* and parse it."""
+def _resolve_fenced_yaml(info: str, inline: str, device_dir: Path) -> str | None:
+    """
+    YAML text for a ``yaml`` fence, following a ``file=`` info attribute.
+
+    Pages may keep their config in a sibling file (``yaml file=config.yaml``)
+    that the rendered site inlines; read it so those devices aren't dropped.
+    Traversal-guarded like image refs. A ``url=`` ref points off-repo and
+    falls through to the inline body (empty), so url-backed pages still skip.
+    """
+    match = _FENCE_FILE_RE.search(info)
+    if match is None:
+        return inline
+    ref = match.group(1).removeprefix("./")
+    if "/" in ref or "\\" in ref or ".." in ref:
+        return None
+    path = device_dir / ref
+    try:
+        return path.read_text(encoding="utf-8") if path.is_file() else None
+    except OSError:
+        return None
+
+
+def _first_config_yaml(body: str, device_dir: Path) -> tuple[dict[str, Any], str] | None:
+    """First parseable ``yaml`` config fence as ``(parsed, raw_text)``, following ``file=``."""
     for match in _YAML_FENCE_RE.finditer(body):
-        parsed = _safe_load_yaml(match.group(1))
+        text = _resolve_fenced_yaml(match.group(1), match.group(2), device_dir)
+        if text is None:
+            continue
+        parsed = _safe_load_yaml(text)
         if isinstance(parsed, dict):
-            return parsed
+            return parsed, text
     return None
 
 
@@ -491,13 +521,19 @@ def _iter_devices(repo: Path) -> Iterator[_DeviceSource]:
         frontmatter, body = _split_frontmatter(text)
         if frontmatter is None:
             continue
+        config = _first_config_yaml(body, device_dir)
+        # Fold a ``file=``-referenced config into the hash so a config-
+        # only edit still changes the recorded source hash; an inline
+        # config is already part of *text*.
+        config_text = config[1] if config is not None else None
+        hash_src = text if config_text is None or config_text in text else f"{text}\n{config_text}"
         yield _DeviceSource(
             folder_name=device_dir.name,
             page_path=page_path,
             frontmatter=frontmatter,
             body=body,
-            content_hash=_hash_content(text),
-            inline_yaml=_extract_first_yaml_block(body),
+            content_hash=_hash_content(hash_src),
+            config_yaml=config[0] if config is not None else None,
             images=_extract_local_images(body, device_dir),
         )
 
@@ -1180,7 +1216,7 @@ def _make_record(  # noqa: C901, PLR0911 — distinct skip reasons each get thei
     title = fm.get("title")
     if not isinstance(title, str) or not title.strip():
         return None, "no frontmatter title"
-    if src.inline_yaml is None:
+    if src.config_yaml is None:
         return None, "no parseable inline yaml"
     if not src.images:
         return None, "no local images"
@@ -1188,7 +1224,7 @@ def _make_record(  # noqa: C901, PLR0911 — distinct skip reasons each get thei
     # A page without it is still importable.
     type_field = fm.get("type") if isinstance(fm.get("type"), str) else None
 
-    soc, soc_block = _resolve_soc(fm, src.inline_yaml)
+    soc, soc_block = _resolve_soc(fm, src.config_yaml)
     if soc is None:
         return None, "soc family not in upstream enum"
     board, variant, framework = _resolve_board_and_variant(soc, soc_block)
@@ -1196,7 +1232,7 @@ def _make_record(  # noqa: C901, PLR0911 — distinct skip reasons each get thei
         return None, f"no concrete board id for {soc}"
 
     featured, bundles, gpio_occupancy = _extract_featured_components(
-        src.inline_yaml, components_index
+        src.config_yaml, components_index
     )
     if not featured:
         return None, "no extractable featured components"

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -440,18 +440,19 @@ def _split_frontmatter(text: str) -> tuple[dict[str, Any] | None, str]:
 
 def _resolve_fenced_yaml(info: str, inline: str, device_dir: Path) -> str | None:
     """
-    YAML text for a ``yaml`` fence, following a ``file=`` info attribute.
+    YAML for a ``yaml`` fence; a ``file=`` ref reads the sibling, traversal-guarded.
 
-    Pages may keep their config in a sibling file (``yaml file=config.yaml``)
-    that the rendered site inlines; read it so those devices aren't dropped.
-    Traversal-guarded like image refs. A ``url=`` ref points off-repo and
-    falls through to the inline body (empty), so url-backed pages still skip.
+    ``url=`` and absent refs return the inline body; a guarded or missing
+    ``file=`` returns ``None``.
     """
     match = _FENCE_FILE_RE.search(info)
     if match is None:
         return inline
     ref = match.group(1).removeprefix("./")
     if "/" in ref or "\\" in ref or ".." in ref:
+        # Same single-folder scope as image refs; warn so the resulting
+        # drop is diagnosable instead of a silent "no config" skip.
+        _LOGGER.warning("ignoring out-of-folder file= config ref %r (%s)", ref, device_dir.name)
         return None
     path = device_dir / ref
     try:

--- a/tests/test_sync_esphome_devices_config_fence.py
+++ b/tests/test_sync_esphome_devices_config_fence.py
@@ -1,0 +1,61 @@
+"""
+Tests for ``yaml`` config-fence resolution in ``script/sync_esphome_devices.py``.
+
+Pins the ``file=config.yaml`` sibling-reference path: device pages whose
+config lives in a sibling file (the rendered site inlines it) must parse
+instead of being dropped as if they had no config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from script.sync_esphome_devices import _first_config_yaml  # type: ignore[import-not-found]
+
+_INLINE_BODY = """\
+## Basic Config
+
+```yaml
+esphome:
+  name: inline-device
+bk72xx:
+  board: cb2s
+```
+"""
+
+_FILE_BODY = """\
+## Basic Config
+
+```yaml file=config.yaml
+```
+"""
+
+
+def test_reads_inline_fence(tmp_path: Path) -> None:
+    parsed = _first_config_yaml(_INLINE_BODY, tmp_path)
+    assert parsed is not None
+    assert parsed[0]["bk72xx"]["board"] == "cb2s"
+
+
+def test_follows_file_reference(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("esphome:\n  name: x\nbk72xx:\n  board: cb2s\n")
+    parsed = _first_config_yaml(_FILE_BODY, tmp_path)
+    assert parsed is not None
+    assert parsed[0]["bk72xx"]["board"] == "cb2s"
+    # The raw text is the sibling file's content (drives the source hash).
+    assert "board: cb2s" in parsed[1]
+
+
+def test_missing_file_falls_through(tmp_path: Path) -> None:
+    assert _first_config_yaml(_FILE_BODY, tmp_path) is None
+
+
+def test_skips_url_reference(tmp_path: Path) -> None:
+    body = "```yaml url=https://example.com/c.yaml\n```\n"
+    assert _first_config_yaml(body, tmp_path) is None
+
+
+def test_rejects_path_traversal(tmp_path: Path) -> None:
+    (tmp_path.parent / "secret.yaml").write_text("esphome:\n  name: leak\n")
+    body = "```yaml file=../secret.yaml\n```\n"
+    assert _first_config_yaml(body, tmp_path) is None

--- a/tests/test_sync_esphome_devices_config_fence.py
+++ b/tests/test_sync_esphome_devices_config_fence.py
@@ -59,3 +59,19 @@ def test_rejects_path_traversal(tmp_path: Path) -> None:
     (tmp_path.parent / "secret.yaml").write_text("esphome:\n  name: leak\n")
     body = "```yaml file=../secret.yaml\n```\n"
     assert _first_config_yaml(body, tmp_path) is None
+
+
+def test_rejects_subdirectory_reference(tmp_path: Path) -> None:
+    sub = tmp_path / "configs"
+    sub.mkdir()
+    (sub / "device.yaml").write_text("esphome:\n  name: x\nbk72xx:\n  board: cb2s\n")
+    body = "```yaml file=configs/device.yaml\n```\n"
+    assert _first_config_yaml(body, tmp_path) is None
+
+
+def test_strips_dot_slash_prefix(tmp_path: Path) -> None:
+    (tmp_path / "config.yaml").write_text("esphome:\n  name: x\nbk72xx:\n  board: cb2s\n")
+    body = "```yaml file=./config.yaml\n```\n"
+    parsed = _first_config_yaml(body, tmp_path)
+    assert parsed is not None
+    assert parsed[0]["bk72xx"]["board"] == "cb2s"


### PR DESCRIPTION
# What does this implement/fix?

Some device pages keep their config in a sibling file (`yaml file=config.yaml`) instead of inline; the rendered devices.esphome.io site inlines it, but our sync only read inline YAML, so it dropped those pages as if they had no config. The last device sync removed `tuya_smart_plug_16a_il` and the kogan smart plug for this reason, even though both pages are still valid upstream.

The sync now follows a `file=` reference, reading the sibling from the device folder with the same traversal guard the image refs use, and folds it into the source hash so editing just the config file still triggers a sync. External `url=` references stay out of scope.

**Related issue or feature (if applicable):**

- fixes the device drop seen in #1360

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
