### PR TITLE
Resolve dotted-subdomain extends refs in component sync

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -152,21 +152,25 @@ def generate_component_yaml(  # noqa: C901, PLR0912
     # empty. ESPHome multi-sensor parents (HLW8012, BME280, ...)
     # expose their readings as ``platform_type``-tagged ConfigEntry
     # blocks; an unnamed sub-sensor won't surface in HA, and one
-    # without an id can't be referenced from automations.
+    # without an id can't be referenced from automations. Only fill a
+    # field the sub-schema declares: config sub-blocks like the speaker
+    # media_player ``announcement_pipeline`` are ``platform_type``-tagged
+    # too but take no ``name``.
     for entry in component.config_entries:
         if not entry.platform_type or not entry.config_entries:
             continue
         sub = fields.get(entry.key)
         if not isinstance(sub, dict):
             continue
+        sub_keys = {c.key for c in entry.config_entries}
         if sub.get("name") and sub.get("id"):
             continue
         # Build a fresh dict with name/id at the front so the emitted
         # YAML reads naturally (humans put name/id first).
         autofill: dict[str, Any] = {}
-        if not sub.get("name"):
+        if "name" in sub_keys and not sub.get("name"):
             autofill["name"] = entry.label or entry.key.replace("_", " ").title()
-        if not sub.get("id"):
+        if "id" in sub_keys and not sub.get("id"):
             autofill["id"] = f"{parent_id}_{entry.key}"
         autofill.update(sub)
         fields[entry.key] = autofill

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2117,10 +2117,16 @@ def _convert_config_vars(  # noqa: C901
 def _lookup_schema_ref(ref: str, schema_dir: Path) -> dict | None:
     """Resolve an ``extends`` reference to its target schema body.
 
-    *ref* is shaped ``<file>.<schema_name>`` — e.g.
+    *ref* is shaped ``<domain>.<schema_name>`` — e.g.
     ``sensor._SENSOR_SCHEMA``, ``switch.SWITCH_ACTION_SCHEMA``. Returns the
     referenced schema's body dict (the ``{maybe?, schema, type}`` node), or
     ``None`` when the reference can't be located.
+
+    ``<domain>`` may itself be dotted (a platform sub-namespace):
+    ``speaker.media_player.PIPELINE_SCHEMA`` is keyed bare as
+    ``PIPELINE_SCHEMA`` under the ``speaker.media_player`` top-level key.
+    Resolve by the last segment, preferring the entry whose key matches the
+    full dotted domain.
 
     ``<file_name>.json`` is the obvious lookup, but a few shared scopes are
     housed in ``esphome.json`` under a top-level key matching their ref prefix
@@ -2135,12 +2141,19 @@ def _lookup_schema_ref(ref: str, schema_dir: Path) -> dict | None:
     if len(parts) < 2:
         return None
     file_name = parts[0]
-    schema_name = ".".join(parts[1:])
+    domain = ".".join(parts[:-1])
+    schema_name = parts[-1]
 
     for path in (schema_dir / f"{file_name}.json", schema_dir / "esphome.json"):
         if not path.exists():
             continue
         raw = json.loads(path.read_text(encoding="utf-8"))
+        # Exact dotted-domain key first; the fallback then matches the bare
+        # schema name across all entries (the long-standing 2-segment
+        # behaviour) — intentionally name-only, don't re-narrow it.
+        exact = raw.get(domain)
+        if isinstance(exact, dict) and schema_name in (exact.get("schemas") or {}):
+            return exact["schemas"][schema_name]
         for top_value in raw.values():
             if not isinstance(top_value, dict):
                 continue

--- a/tests/test_sync_components_dotted_extends_ref.py
+++ b/tests/test_sync_components_dotted_extends_ref.py
@@ -1,0 +1,66 @@
+"""Dotted-subdomain ``extends`` refs resolve to their bundle schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _lookup_schema_ref,
+    _resolve_extends,
+)
+
+# A platform sub-namespace keyed whole (``speaker.media_player``) with its
+# schema keyed bare (``PIPELINE_SCHEMA``); the plain ``speaker`` entry beside
+# it guards against a loose match on the bare name.
+_SPEAKER_JSON = {
+    "speaker": {
+        "schemas": {
+            "SPEAKER_SCHEMA": {
+                "schema": {"config_vars": {"channel": {"key": "Optional"}}},
+            },
+        },
+    },
+    "speaker.media_player": {
+        "schemas": {
+            "PIPELINE_SCHEMA": {
+                "schema": {
+                    "config_vars": {
+                        "speaker": {"key": "Required", "type": "use_id"},
+                        "format": {"key": "Optional", "type": "enum"},
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+def _schema_dir(tmp_path: Path) -> Path:
+    (tmp_path / "speaker.json").write_text(json.dumps(_SPEAKER_JSON), encoding="utf-8")
+    return tmp_path
+
+
+def test_three_segment_dotted_domain_ref_resolves(tmp_path: Path) -> None:
+    """``speaker.media_player.PIPELINE_SCHEMA`` finds the bare-keyed schema."""
+    body = _lookup_schema_ref("speaker.media_player.PIPELINE_SCHEMA", _schema_dir(tmp_path))
+    assert body is not None
+    assert set(body["schema"]["config_vars"]) == {"speaker", "format"}
+
+
+def test_two_segment_ref_still_resolves(tmp_path: Path) -> None:
+    """A plain ``<domain>.<schema>`` ref keeps resolving (no regression)."""
+    body = _lookup_schema_ref("speaker.SPEAKER_SCHEMA", _schema_dir(tmp_path))
+    assert body is not None
+    assert set(body["schema"]["config_vars"]) == {"channel"}
+
+
+def test_resolve_extends_flattens_pipeline_config_vars(tmp_path: Path) -> None:
+    """The nested pipeline's required ``speaker`` ref reaches the caller."""
+    cvs = _resolve_extends("speaker.media_player.PIPELINE_SCHEMA", _schema_dir(tmp_path))
+    assert set(cvs) == {"speaker", "format"}
+
+
+def test_unresolvable_ref_returns_none(tmp_path: Path) -> None:
+    """A ref into a missing file is a clean miss, not a crash."""
+    assert _lookup_schema_ref("nope.media_player.PIPELINE_SCHEMA", _schema_dir(tmp_path)) is None

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -915,6 +915,38 @@ def test_generate_component_yaml_preserves_direct_lambda_field_tag() -> None:
     assert "_lambda" not in result
 
 
+def test_generate_component_yaml_skips_name_autofill_without_name_field() -> None:
+    """A ``platform_type`` sub-block whose sub-schema omits ``name`` gets only an id."""
+    pipeline = ConfigEntry(
+        key="announcement_pipeline",
+        type=ConfigEntryType.NESTED,
+        label="Announcement Pipeline",
+        platform_type="speaker",
+        config_entries=[
+            ConfigEntry(key="speaker", type=ConfigEntryType.ID, label="Speaker"),
+            ConfigEntry(key="id", type=ConfigEntryType.ID, label="ID"),
+        ],
+    )
+    component = ComponentCatalogEntry(
+        id="media_player.speaker",
+        name="Speaker Audio Media Player",
+        description="",
+        category=ComponentCategory.MEDIA_PLAYER,
+        config_entries=[pipeline],
+    )
+
+    result = generate_component_yaml(
+        component,
+        {"name": "My Speaker", "announcement_pipeline": {"speaker": "spk"}},
+    )
+
+    assert "announcement_pipeline:" in result
+    assert "speaker: spk" in result
+    assert "id: speaker_my_speaker_announcement_pipeline" in result
+    # The label-derived name must not leak into the name-less sub-block.
+    assert "name: Announcement Pipeline" not in result
+
+
 def test_merge_component_yaml_appends_first_platform_block() -> None:
     """First sensor in a YAML with no ``sensor:`` section gets appended.
 


### PR DESCRIPTION
# What does this implement/fix?

Adding the "Speaker Audio Media Player" component failed with `internal_error: Command failed: devices/add_component`. Two backend bugs combined.

First, the catalog generator could not resolve a nested field whose schema extends a platform sub-namespace ref like `speaker.media_player.PIPELINE_SCHEMA`; `_lookup_schema_ref` split the ref on the first dot and looked for `media_player.PIPELINE_SCHEMA`, but the bundle keys that entry whole as `speaker.media_player` with the schema named bare `PIPELINE_SCHEMA`. The field then shipped with empty `config_entries`, so the editor rendered no form for it and the required `announcement_pipeline` could never be supplied. The fix resolves an extends ref by its bare schema name, preferring the exact dotted-domain key; this restores the dropped sub-fields for the speaker media player pipelines plus ~25 other multi-channel sensor and climate sub-schemas.

Second, once the pipeline fields render, the YAML generator injected an invalid `name` into the `announcement_pipeline` block; the nested sub-block autofill assumed every `platform_type` group was an entity sub-reading needing name and id. It now only fills a field the sub-schema actually declares, so the pipeline gets an id and the user's speaker, no spurious name. Verified end to end against `esphome config`.

The last commit regenerates the catalog against schema 2026.5.3 so the fix can be verified in the editor; it is meant to be reverted before merge so the nightly sync regenerates the real catalog.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1372

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
