### PR TITLE
Raise CommandError instead of bare ValueError in add_component

### DIFF
--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ...helpers.api import CommandError
 from ...helpers.yaml import merge_component_yaml
-from ...models import AddComponentResponse
+from ...models import AddComponentResponse, ErrorCode
 from .helpers import _apply_featured_presets, _drop_unconfigured_dependent_fields
 
 if TYPE_CHECKING:
@@ -46,12 +47,12 @@ async def add_component(
         record = controller._db.components.get_featured_record(component_id)
         if record is None:
             msg = f"Unknown featured component: {component_id}"
-            raise ValueError(msg)
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
         underlying_component_id = record.underlying_id
         underlying_body = await controller._db.components.get_body(underlying_component_id)
         if underlying_body is None:
             msg = f"Unknown component body for featured ref: {underlying_component_id}"
-            raise ValueError(msg)
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
         fields = _apply_featured_presets(record, fields, underlying_body)
         # The frontend's featured-id suggestion contains the board's
         # dashes (e.g. ``featured_athom-smart-plug-v3_power_monitor_1``),
@@ -64,12 +65,12 @@ async def add_component(
     component = await controller._db.components.get_component(component_id=underlying_component_id)
     if component is None:
         msg = f"Unknown component: {underlying_component_id}"
-        raise ValueError(msg)
+        raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
     for entry in component.config_entries:
         if entry.required and entry.key not in fields:
-            msg = f"Missing required field: {entry.key}"
-            raise ValueError(msg)
+            msg = f"Missing required field: {entry.label or entry.key}"
+            raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
     if yaml is None:
         config_path = controller._db.settings.rel_path(configuration)

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -34,6 +34,7 @@ import pytest
 
 import esphome_device_builder.controllers.devices.api_key as api_key_mod
 from esphome_device_builder.controllers._device_scanner import ScanChange
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.build_size import BuildDirSignal, BuildSizeRefreshResult
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import (
@@ -44,6 +45,7 @@ from esphome_device_builder.models import (
     ConfigEntryType,
     Device,
     DeviceState,
+    ErrorCode,
     EventType,
     JobStatus,
     JobType,
@@ -461,7 +463,7 @@ async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
 async def test_add_component_unknown_id_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """An unknown component id raises ``ValueError`` before touching the YAML.
+    """An unknown component id raises ``CommandError(INVALID_ARGS)`` before touching the YAML.
 
     Frontend should never send an unknown id (the catalog is the
     source of suggestions), but pin the guard so a desync between
@@ -473,24 +475,25 @@ async def test_add_component_unknown_id_raises(
     controller._db.components.get_component = AsyncMock(return_value=None)
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Unknown component: never-heard-of-this"):
+    with pytest.raises(CommandError, match="Unknown component: never-heard-of-this") as exc:
         await controller.add_component(
             configuration="kitchen.yaml",
             component_id="never-heard-of-this",
         )
+    assert exc.value.code is ErrorCode.INVALID_ARGS
 
 
 async def test_add_component_missing_required_field_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """A required field absent from ``fields`` raises before serialising.
+    """A missing required field raises ``CommandError(INVALID_ARGS)`` before serialising.
 
     The frontend's input form already enforces required fields
     via the schema, but the backend's guard catches API clients
     bypassing the form (the WS surface is public). Pin it so a
     regression that defaulted required fields silently can't slip
     through and produce an invalid YAML the user has to discover
-    at compile time.
+    at compile time. The message carries the field's human label.
     """
     controller = make_controller(tmp_path)
     component = MagicMock()
@@ -502,12 +505,13 @@ async def test_add_component_missing_required_field_raises(
     controller._db.components.get_component = AsyncMock(return_value=component)
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="Missing required field: pin"):
+    with pytest.raises(CommandError, match="Missing required field: Pin") as exc:
         await controller.add_component(
             configuration="kitchen.yaml",
             component_id="dht",
             fields={"name": "Bedroom Temp"},
         )
+    assert exc.value.code is ErrorCode.INVALID_ARGS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -34,8 +34,9 @@ from esphome_device_builder.definitions import (
     _load_featured_bundle,
     _load_featured_component,
 )
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.yaml import generate_component_yaml
-from esphome_device_builder.models import ComponentCategory
+from esphome_device_builder.models import ComponentCategory, ErrorCode
 from esphome_device_builder.models.common import FieldPreset
 
 # Pin every test in the file onto the same xdist worker as the rest of
@@ -716,15 +717,16 @@ async def test_add_component_featured_keeps_user_typed_id(
 async def test_add_component_featured_unknown_id_raises(
     catalog: ComponentCatalog, tmp_path: Any
 ) -> None:
-    """An unknown ``featured.*`` id surfaces as a clear ValueError."""
+    """An unknown ``featured.*`` id surfaces as a ``CommandError(INVALID_ARGS)``."""
     ctrl = _make_controller(catalog, tmp_path)
 
-    with pytest.raises(ValueError, match="Unknown featured component"):
+    with pytest.raises(CommandError, match="Unknown featured component") as exc:
         await ctrl.add_component(
             configuration="plug.yaml",
             component_id="featured.no-such-board.x",
             fields={},
         )
+    assert exc.value.code is ErrorCode.INVALID_ARGS
 
 
 async def test_add_component_featured_missing_body_raises(
@@ -739,12 +741,13 @@ async def test_add_component_featured_missing_body_raises(
     """
     ctrl = _make_controller(catalog, tmp_path)
     monkeypatch.setattr(catalog, "get_body", AsyncMock(return_value=None))
-    with pytest.raises(ValueError, match="Unknown component body for featured ref"):
+    with pytest.raises(CommandError, match="Unknown component body for featured ref") as exc:
         await ctrl.add_component(
             configuration="plug.yaml",
             component_id="featured.sonoff-basic.relay",
             fields={},
         )
+    assert exc.value.code is ErrorCode.INVALID_ARGS
 
 
 async def test_add_component_featured_emits_explicit_name_and_id(


### PR DESCRIPTION
# What does this implement/fix?

Adding a component whose required field has no editable form (the speaker media player announcement pipeline in #1372, and the `image` component's required fields) failed with the opaque `internal_error: Command failed: devices/add_component`. The four guard clauses in `devices/add_component` raised a bare `ValueError`, which the WS dispatcher reports as a generic internal error.

They now raise `CommandError(INVALID_ARGS)` so the client gets the actual reason; the missing-required-field message carries the field's human label. Verified live: adding `image` with no fields now returns `invalid_args: Missing required field: Type` instead of `internal_error`.

This is the error-handling companion to #1373; that PR made the speaker pipeline fillable, this one makes any remaining required-field gap report cleanly.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1372

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
