### PR TITLE
Map a missing config in get_config to NOT_FOUND, not internal_error

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -635,8 +635,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     @api_command("devices/get_config")
     async def get_config(self, *, configuration: str, **kwargs: Any) -> str:
-        """Read device config YAML."""
-        return await self._read_yaml_async(self._db.settings.rel_path(configuration))
+        """Read device config YAML; a missing file is NOT_FOUND, not internal_error."""
+        try:
+            return await self._read_yaml_async(self._db.settings.rel_path(configuration))
+        except FileNotFoundError as err:
+            raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found") from err
 
     @api_command("devices/update_config")
     async def update_config(self, *, configuration: str, content: str, **kwargs: Any) -> None:

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -96,22 +96,22 @@ async def test_get_config_decodes_utf8_with_unicode(
     assert result == yaml_content
 
 
-async def test_get_config_propagates_file_not_found(
+async def test_get_config_missing_file_raises_not_found(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Missing file → ``FileNotFoundError`` bubbles to the dispatcher.
+    """Missing file → ``CommandError(NOT_FOUND)``, not a generic internal error.
 
-    The api dispatcher catches it and turns it into a generic
-    error frame; we don't try to swallow / map it here. Pin the
-    pass-through so a defensive refactor that returned ``""``
-    instead would surface (the editor would silently load an
-    empty buffer for a typo'd configuration).
+    Pin the typed mapping so a defensive refactor that returned ``""``
+    instead would surface (the editor would silently load an empty
+    buffer for a typo'd configuration), and so the dispatcher no longer
+    reports the miss as an opaque ``internal_error``.
     """
     controller = make_controller(tmp_path)
     _stub_regenerate(controller)
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(CommandError) as excinfo:
         await controller.get_config(configuration="ghost.yaml")
+    assert excinfo.value.code == ErrorCode.NOT_FOUND
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

`devices/get_config` read the YAML straight off the executor, so a typo'd or just-deleted configuration raised a bare `FileNotFoundError` that the WS dispatcher reported as the opaque `internal_error: Command failed: devices/get_config`. It now folds the missing file into `CommandError(NOT_FOUND)`, mirroring the `set_device_labels` guard. Verified live: requesting a missing configuration returns `not_found: Device '<name>' not found` instead of `internal_error`.

Surfaced in the logs on #1372; same family as #1375, different command.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
