### PR TITLE
Add has_publish_command to device metadata

### DIFF
--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -119,7 +119,7 @@ def list_archived_sync(controller: DevicesController) -> list[dict[str, Any]]:
         except OSError:
             _LOGGER.debug("Failed to read archived YAML %s", path, exc_info=True)
             continue
-        name, friendly_name, comment, _ = parse_esphome_meta(content)
+        name, friendly_name, comment, _, _ = parse_esphome_meta(content)
         if not name or not friendly_name or comment is None:
             # Sparse ``esphome:`` block; fall back to StorageJSON so legacy
             # archives (and externally-dropped files) still surface a label.

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -300,7 +300,7 @@ async def edit_friendly_name(
     # ``# Board:`` at column 0, treated it as a fresh top-level
     # key, dropped the ``esphome:`` context, and silently lost
     # ``friendly_name`` on every load.
-    _, parsed_friendly, _, _ = parse_esphome_meta(new_content)
+    _, parsed_friendly, _, _, _ = parse_esphome_meta(new_content)
     if parsed_friendly != new_friendly_name:
         raise CommandError(
             ErrorCode.INTERNAL_ERROR,

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -182,6 +182,9 @@ def load_device_from_storage(
     # cover older builds and never-compiled devices.
     storage_area = getattr(storage, "area", None) if storage else None
     area = _pick_meta(yaml_meta.area, cfg_meta.area, storage_area) or ""
+    has_publish_command = bool(
+        _pick_meta(yaml_meta.publish_shell_command, cfg_meta.publish_shell_command, None)
+    )
 
     yaml_mtime = path.stat().st_mtime if path.exists() else None
     bin_mtime: float | None = None
@@ -307,6 +310,7 @@ def load_device_from_storage(
         configuration=filename,
         comment=comment,
         area=area,
+        has_publish_command=has_publish_command,
         board_id=board_id,
         target_platform=target_platform,
         # StorageJSON only exists after a successful compile, so a

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -16,6 +16,7 @@ class EsphomeMeta(NamedTuple):
     friendly_name: str | None
     comment: str | None
     area: str | None
+    publish_shell_command: str | None
 
 
 _PLATFORM_KEYS = frozenset({"esp32", "esp8266", "rp2040", "bk72xx", "rtl87xx", "ln882x", "nrf52"})
@@ -265,7 +266,7 @@ def parse_esphome_meta(
     extra_substitutions: dict[str, str] | None = None,
 ) -> EsphomeMeta:
     """
-    Parse the top-level ``esphome:`` block for ``(name, friendly_name, comment, area)``.
+    Parse the top-level ``esphome:`` block into an :class:`EsphomeMeta` tuple.
 
     Returns ``None`` for any field that isn't present in the YAML so
     callers can distinguish "key absent" (fall through to storage) from
@@ -327,7 +328,13 @@ def parse_esphome_meta(
         for field in _ESPHOME_META_FIELDS:
             meta[field] = _resolve_substitutions(meta[field], merged)
 
-    return EsphomeMeta(meta["name"], meta["friendly_name"], meta["comment"], meta["area"])
+    return EsphomeMeta(
+        meta["name"],
+        meta["friendly_name"],
+        meta["comment"],
+        meta["area"],
+        meta["publish_shell_command"],
+    )
 
 
 def extract_esphome_meta_from_config(
@@ -335,16 +342,16 @@ def extract_esphome_meta_from_config(
     extra_substitutions: dict[str, str] | None = None,
 ) -> EsphomeMeta:
     """
-    Read ``(name, friendly_name, comment, area)`` off a resolved config's ``esphome:`` block.
+    Read an :class:`EsphomeMeta` tuple off a resolved config's ``esphome:`` block.
 
     ``None`` for any field absent. ``$var`` / ``${var}`` resolve against
     *extra_substitutions*; tokens the resolver can't expand are left intact.
     """
     if not isinstance(config, dict):
-        return EsphomeMeta(None, None, None, None)
+        return EsphomeMeta(None, None, None, None, None)
     esphome = config.get(const.CONF_ESPHOME)
     if not isinstance(esphome, dict):
-        return EsphomeMeta(None, None, None, None)
+        return EsphomeMeta(None, None, None, None, None)
     subs = extra_substitutions or {}
 
     def _resolved(value: str | None) -> str | None:
@@ -355,6 +362,8 @@ def extract_esphome_meta_from_config(
         _resolved(_str_or_none(esphome.get(const.CONF_FRIENDLY_NAME))),
         _resolved(_str_or_none(esphome.get(const.CONF_COMMENT))),
         _resolved(_area_name_from_config(esphome.get(const.CONF_AREA))),
+        # TODO: replace with const.CONF_PUBLISH_SHELL_COMMAND once the esphome change is merged
+        _resolved(_str_or_none(esphome.get("publish_shell_command"))),
     )
 
 
@@ -431,7 +440,7 @@ def _parse_inline_value(raw: str) -> str:
 
 _FLOW_AREA_NAME_RE = re.compile(r"""\bname\s*:\s*("[^"]*"|'[^']*'|[^,}]+)""")
 
-_ESPHOME_META_FIELDS = ("name", "friendly_name", "comment", "area")
+_ESPHOME_META_FIELDS = ("name", "friendly_name", "comment", "area", "publish_shell_command")
 
 
 def _parse_flow_area_name(raw: str) -> str | None:

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -102,6 +102,7 @@ class Device(DataClassORJSONMixin):
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
+    has_publish_command: bool = False  # Whether `esphome.publish_shell_command` is set in the YAML
     # Native API surface flags — drive the lock-icon indicator in
     # the device list. Both fields are computed in
     # ``helpers.device_yaml.load_device_from_storage`` as the

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -638,7 +638,7 @@ async def test_edit_friendly_name_raises_internal_error_on_round_trip_mismatch(
 
     monkeypatch.setattr(
         "esphome_device_builder.controllers.devices.mutations_simple.parse_esphome_meta",
-        lambda _content: (None, None, None, None),
+        lambda _content: (None, None, None, None, None),
     )
 
     with pytest.raises(CommandError) as excinfo:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -141,6 +141,7 @@ esphome:
         "My Device",
         "A useful little box",
         None,
+        None,
     )
 
 
@@ -150,7 +151,7 @@ def test_parse_meta_missing_keys_return_none() -> None:
 esphome:
   name: my-device
 """
-    assert parse_esphome_meta(yaml_content) == ("my-device", None, None, None)
+    assert parse_esphome_meta(yaml_content) == ("my-device", None, None, None, None)
 
 
 def test_parse_meta_resolves_dollar_substitution() -> None:
@@ -162,7 +163,7 @@ esphome:
   name: living-room-lamp
   friendly_name: $friendly_name
 """
-    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Living Room Lamp"
 
 
@@ -175,7 +176,7 @@ esphome:
   name: kitchen
   friendly_name: ${friendly_name}
 """
-    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Kitchen"
 
 
@@ -187,7 +188,7 @@ substitutions:
 esphome:
   friendly_name: "${room} Lamp"
 """
-    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Bedroom Lamp"
 
 
@@ -199,7 +200,7 @@ esphome:
 substitutions:
   friendly_name: "Office"
 """
-    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Office"
 
 
@@ -211,7 +212,7 @@ substitutions:
 esphome:
   friendly_name: $missing
 """
-    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "$missing"
 
 
@@ -224,7 +225,7 @@ esphome:
   name: well
   comment: "${area} sensor"
 """
-    _, _, comment, _ = parse_esphome_meta(yaml_content)
+    _, _, comment, _, _ = parse_esphome_meta(yaml_content)
     assert comment == "Outside sensor"
 
 
@@ -243,7 +244,7 @@ esphome:
   name: well
   comment: ${comment}
 """
-    _, _, comment, _ = parse_esphome_meta(yaml_content)
+    _, _, comment, _, _ = parse_esphome_meta(yaml_content)
     assert comment == "Outside, Well | Irrigation A"
 
 
@@ -259,7 +260,7 @@ esphome:
 """
     # Should return without hanging; the exact stuck value is irrelevant
     # — what matters is that the resolver terminates safely.
-    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    _, friendly_name, _, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name in {"${a}", "${b}"}
 
 
@@ -276,7 +277,7 @@ esphome:
   name: living-room-lamp
   friendly_name: $room
 """
-    _, friendly_name, _, _ = parse_esphome_meta(
+    _, friendly_name, _, _, _ = parse_esphome_meta(
         yaml_content,
         extra_substitutions={"room": "Living Room"},
     )
@@ -295,7 +296,7 @@ substitutions:
 esphome:
   friendly_name: $room
 """
-    _, friendly_name, _, _ = parse_esphome_meta(
+    _, friendly_name, _, _, _ = parse_esphome_meta(
         yaml_content,
         extra_substitutions={"room": "Living Room"},
     )
@@ -314,7 +315,7 @@ substitutions:
 esphome:
   friendly_name: "${room} ${suffix}"
 """
-    _, friendly_name, _, _ = parse_esphome_meta(
+    _, friendly_name, _, _, _ = parse_esphome_meta(
         yaml_content,
         extra_substitutions={"suffix": "Lamp"},
     )
@@ -503,7 +504,7 @@ esphome:
   name: my-device
   comment: Hand-built controller
 """
-    name, friendly_name, comment, _ = parse_esphome_meta(yaml_content)
+    name, friendly_name, comment, _, _ = parse_esphome_meta(yaml_content)
     assert name == "my-device"
     assert friendly_name is None
     assert comment == "Hand-built controller"
@@ -523,7 +524,7 @@ esphome:
   # friendly_name: this is just a comment, ignore me
   comment: real comment
 """
-    name, friendly_name, comment, _ = parse_esphome_meta(yaml_content)
+    name, friendly_name, comment, _, _ = parse_esphome_meta(yaml_content)
     assert name == "my-device"
     assert friendly_name is None  # comment line wasn't picked up
     assert comment == "real comment"
@@ -542,7 +543,7 @@ esphome:
   friendly_name: Kitchen Lamp
   area: Kitchen
 """
-    name, friendly_name, _, area = parse_esphome_meta(yaml_content)
+    name, friendly_name, _, area, _ = parse_esphome_meta(yaml_content)
     assert name == "kitchen-lamp"
     assert friendly_name == "Kitchen Lamp"
     assert area == "Kitchen"
@@ -554,7 +555,7 @@ def test_parse_meta_area_absent_returns_none() -> None:
 esphome:
   name: my-device
 """
-    *_, area = parse_esphome_meta(yaml_content)
+    _, _, _, area, _ = parse_esphome_meta(yaml_content)
     assert area is None
 
 
@@ -567,7 +568,7 @@ esphome:
   name: lamp
   area: ${room}
 """
-    *_, area = parse_esphome_meta(yaml_content)
+    _, _, _, area, _ = parse_esphome_meta(yaml_content)
     assert area == "Living Room"
 
 
@@ -679,7 +680,7 @@ esphome:
 )
 def test_parse_meta_area_object_shapes(yaml_content: str, expected_area: str | None) -> None:
     """``esphome.area`` resolves across every shape the schema accepts."""
-    *_, area = parse_esphome_meta(yaml_content)
+    _, _, _, area, _ = parse_esphome_meta(yaml_content)
     assert area == expected_area
 
 
@@ -693,16 +694,51 @@ esphome:
     name: "Kitchen"
   comment: "real comment"
 """
-    name, _, comment, area = parse_esphome_meta(yaml_content)
+    name, _, comment, area, _ = parse_esphome_meta(yaml_content)
     assert name == "lamp"
     assert area == "Kitchen"
     assert comment == "real comment"
 
 
+# parse_esphome_meta — publish_shell_command field
+# ----------------------------------------------------------------------
+
+
+def test_parse_meta_publish_shell_command_field() -> None:
+    """``esphome.publish_shell_command`` is captured as a plain string."""
+    yaml_content = """
+esphome:
+  name: my-device
+  publish_shell_command: python3 publish.py
+"""
+    *_, publish_shell_command = parse_esphome_meta(yaml_content)
+    assert publish_shell_command == "python3 publish.py"
+
+
+def test_parse_meta_publish_shell_command_absent_returns_none() -> None:
+    """Without a ``publish_shell_command:`` line, the field is ``None``."""
+    yaml_content = """
+esphome:
+  name: my-device
+"""
+    *_, publish_shell_command = parse_esphome_meta(yaml_content)
+    assert publish_shell_command is None
+
+
+def test_extract_meta_from_config_publish_shell_command() -> None:
+    """``publish_shell_command`` is read from the resolved config."""
+    config = {"esphome": {"name": "my-device", "publish_shell_command": "python3 publish.py"}}
+    *_, publish_shell_command = extract_esphome_meta_from_config(config)
+    assert publish_shell_command == "python3 publish.py"
+
+
+# ----------------------------------------------------------------------
+
+
 def test_extract_meta_from_config_string_area() -> None:
     """String-form ``area`` resolves against the supplied substitutions."""
     config = {"esphome": {"name": "lamp", "area": "${room}"}}
-    name, _, _, area = extract_esphome_meta_from_config(config, {"room": "Kitchen"})
+    name, _, _, area, _ = extract_esphome_meta_from_config(config, {"room": "Kitchen"})
     assert name == "lamp"
     assert area == "Kitchen"
 
@@ -710,14 +746,14 @@ def test_extract_meta_from_config_string_area() -> None:
 def test_extract_meta_from_config_dict_area_uses_name() -> None:
     """The ``{id, name}`` mapping form surfaces its ``name``, resolved."""
     config = {"esphome": {"area": {"id": "${aid}", "name": "${room}"}}}
-    *_, area = extract_esphome_meta_from_config(config, {"aid": "k", "room": "Kitchen"})
+    _, _, _, area, _ = extract_esphome_meta_from_config(config, {"aid": "k", "room": "Kitchen"})
     assert area == "Kitchen"
 
 
 @pytest.mark.parametrize("config", [None, {}, {"esphome": "not-a-dict"}, "nope"])
 def test_extract_meta_from_config_no_esphome_block(config: Any) -> None:
     """Missing / malformed config or ``esphome:`` block yields all-``None``."""
-    assert extract_esphome_meta_from_config(config) == (None, None, None, None)
+    assert extract_esphome_meta_from_config(config) == (None, None, None, None, None)
 
 
 def test_parse_meta_top_level_comment_does_not_close_esphome_block() -> None:
@@ -729,7 +765,7 @@ esphome:
   friendly_name: Kitchen Lamp
   area: Kitchen
 """
-    name, friendly_name, _, area = parse_esphome_meta(yaml_content)
+    name, friendly_name, _, area, _ = parse_esphome_meta(yaml_content)
     assert name == "lamp"
     assert friendly_name == "Kitchen Lamp"
     assert area == "Kitchen"
@@ -746,7 +782,7 @@ esphome:
       - -DSOMETHING
   comment: after-block comment
 """
-    name, _, comment, area = parse_esphome_meta(yaml_content)
+    name, _, comment, area, _ = parse_esphome_meta(yaml_content)
     assert name == "lamp"
     assert comment == "after-block comment"
     assert area is None


### PR DESCRIPTION
# What does this implement/fix?

This is the dashboard backend part of this feature: https://github.com/esphome/esphome/pull/16906

To determine whether or not to show the "Publish" button in the install dialog, it needs to know if a `publish_shell_command` is configured in the device config.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [X] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [X] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [X] The code change is tested and works locally.
- [X] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [X] Tests have been added or updated under `tests/` where applicable.
- [X] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
