### PR TITLE
Emit action triggers in the automation catalog

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2047,29 +2047,19 @@ def _promote_template_controls(component_id: str, entries: list[dict]) -> None:
             entry["advanced"] = False
 
 
-def _convert_config_vars(  # noqa: C901
-    schema_node: dict,
-    schema_dir: Path,
-    *,
-    component_id: str = "",
-) -> list[dict]:
-    """Convert a ``schema`` node (config_vars + extends) to a list of entries."""
-    config_vars = dict(schema_node.get("config_vars") or {})
+def _merge_extends_config_vars(schema_node: dict, schema_dir: Path) -> dict[str, Any]:
+    """
+    Deep-merge a schema node's ``extends`` ancestry with its local config_vars.
 
-    # Inline ``extends`` references and merge them with the local
-    # config_vars. The schema uses partial overrides — entity
-    # sub-readings like ``dht.sensor.humidity.device_class`` only
-    # specify ``{"default": "humidity"}`` and inherit the rest
-    # (``type: enum``, the 60-value list of accepted device classes,
-    # the docs string) from ``sensor._SENSOR_SCHEMA``. A flat
-    # ``{**extended, **local}`` would replace the whole field,
-    # silently dropping the values list. Deep-merge per-field so
-    # local entries override individual keys but inherited metadata
-    # survives.
+    Per-field, not whole-field: a partial override like ``{"default": "x"}``
+    keeps the base's inherited ``type`` / enum / docs. Values are usually field
+    dicts; a malformed schema can carry a non-dict, hence ``dict[str, Any]``.
+    """
+    config_vars = dict(schema_node.get("config_vars") or {})
     extended: dict[str, dict] = {}
     for ref in schema_node.get("extends") or []:
         extended.update(_resolve_extends(ref, schema_dir))
-    merged: dict[str, dict] = {}
+    merged: dict[str, Any] = {}
     for key in {*extended, *config_vars}:
         base = extended.get(key)
         local = config_vars.get(key)
@@ -2077,6 +2067,17 @@ def _convert_config_vars(  # noqa: C901
             merged[key] = {**base, **local}
         else:
             merged[key] = local if local is not None else base or {}
+    return merged
+
+
+def _convert_config_vars(
+    schema_node: dict,
+    schema_dir: Path,
+    *,
+    component_id: str = "",
+) -> list[dict]:
+    """Convert a ``schema`` node (config_vars + extends) to a list of entries."""
+    merged = _merge_extends_config_vars(schema_node, schema_dir)
 
     out: list[dict] = []
     for key, raw in merged.items():
@@ -5714,7 +5715,7 @@ def _convert_automation_action(
         accepts_action_list,
         key=lambda k: (k != "then", k),
     )
-    is_control_flow = bool(accepts_action_list) or has_condition_gate
+    is_control_flow = any(k in _ACTION_LIST_KEYS for k in accepts_action_list) or has_condition_gate
     has_else_branch = "else" in (accepts_action_list or [])
     qualified = f"{wire_prefix}.{name}" if top_key != "core" else name
     config_entries, scalar_shorthand_key = _resolve_automation_lambda(
@@ -6391,42 +6392,27 @@ def _extract_automation_param_schema(
     raw_entries = _convert_config_vars(schema, schema_dir)
     accepts_action_list: list[str] = []
     has_condition_gate = False
-    out: list[dict] = []
-    # ``_convert_config_vars`` doesn't see registry-typed fields the
-    # way it sees normal config_vars; specifically, ``then: { type:
-    # trigger }`` and ``then: { type: registry, registry: action }``
-    # get coerced into something we'd render. Walk the raw schema
-    # directly to detect those, and strip them from the entry list.
-    raw_cvs = schema.get("config_vars") or {}
-    for key, raw in raw_cvs.items():
+    # ``_convert_config_vars`` skips ``on_*`` triggers and keeps ``then`` /
+    # ``else`` as plain fields; walk the merged config_vars (``extends``
+    # resolved, so ``http_request.get`` sees its inherited triggers) to
+    # collect every trigger / action-registry key into ``accepts_action_list``,
+    # stripping any that did reach the form entries.
+    stripped: set[str] = set()
+    for key, raw in _merge_extends_config_vars(schema, schema_dir).items():
         if not isinstance(raw, dict):
             continue
         rtype = raw.get("type")
-        registry = raw.get("registry")
-        if rtype == "trigger" or (rtype == "registry" and registry == "action"):
-            if key in _ACTION_LIST_KEYS:
-                accepts_action_list.append(key)
-            # Drop the key from the converted entry list — the
-            # frontend renders it as a recursive action list, not
-            # as a form field.
-            raw_entries = [e for e in raw_entries if e.get("key") != key]
-            continue
-        if key in _CONDITION_GATE_KEYS:
-            # ``condition`` / ``all`` / ``any`` on a control-flow
-            # action are always boolean gates, never user-typed
-            # values. The schema sometimes tags them with
-            # ``type: registry, registry: condition`` and sometimes
-            # carries only a ``docs`` string (e.g. ``if.any``); the
-            # by-name strip catches both shapes uniformly.
+        if rtype == "trigger" or (rtype == "registry" and raw.get("registry") == "action"):
+            accepts_action_list.append(key)
+            stripped.add(key)
+        elif key in _CONDITION_GATE_KEYS:
+            # ``condition`` / ``all`` / ``any`` are boolean gates, never
+            # user-typed values; strip by name since the schema tags them
+            # inconsistently (``registry: condition`` or just a ``docs`` string).
             has_condition_gate = True
-            raw_entries = [e for e in raw_entries if e.get("key") != key]
-            continue
-    # The walker uses ``is_trigger_key`` to skip ``on_`` config_vars,
-    # which is correct for the *component form* path but wrong here — a
-    # triggered automation has no ``on_`` keys as parameters anyway, so
-    # it's a no-op for us.
-    out.extend(raw_entries)
-    return out, accepts_action_list, has_condition_gate
+            stripped.add(key)
+    config_entries = [e for e in raw_entries if e.get("key") not in stripped]
+    return config_entries, accepts_action_list, has_condition_gate
 
 
 def _automation_label(domain: str, name: str, docs_name: str | None) -> str:

--- a/tests/test_automations_sync.py
+++ b/tests/test_automations_sync.py
@@ -214,6 +214,104 @@ def test_build_automations_strips_then_from_control_flow_action_params(
     assert "condition" not in cfg_keys
 
 
+def test_build_automations_promotes_inline_trigger_keys_to_action_list(
+    tmp_path: Path,
+) -> None:
+    """Inline ``on_*`` triggers on an action surface on ``accepts_action_list``."""
+    schema_dir = _write_schema(
+        tmp_path,
+        "wifi.json",
+        {
+            "wifi": {
+                "action": {
+                    "configure": {
+                        "schema": {
+                            "config_vars": {
+                                "ssid": {"key": "Required", "type": "string"},
+                                "on_connect": {
+                                    "key": "Optional",
+                                    "type": "trigger",
+                                    "docs": "Run on connect.",
+                                },
+                                "on_error": {
+                                    "key": "Optional",
+                                    "type": "trigger",
+                                    "docs": "Run on error.",
+                                },
+                            },
+                        },
+                        "type": "schema",
+                        "docs": "Reconfigure WiFi.",
+                    },
+                },
+                "schemas": {},
+            },
+        },
+    )
+    result = sync_components.build_automations(schema_dir=schema_dir, component_ids=set())
+    action = next(a for a in result["actions"] if a["id"] == "wifi.configure")
+    assert action["accepts_action_list"] == ["on_connect", "on_error"]
+    # A triggered action is not control flow; it keeps its normal form fields.
+    assert action["is_control_flow"] is False
+    assert action["has_else_branch"] is False
+    cfg_keys = {e["key"] for e in action["config_entries"]}
+    assert "ssid" in cfg_keys
+    assert "on_connect" not in cfg_keys
+    assert "on_error" not in cfg_keys
+
+
+def test_build_automations_promotes_extends_inherited_trigger_keys(
+    tmp_path: Path,
+) -> None:
+    """``on_*`` triggers inherited through ``extends`` reach ``accepts_action_list``."""
+    schema_dir = _write_schema(
+        tmp_path,
+        "http_request.json",
+        {
+            "http_request": {
+                "action": {
+                    "get": {
+                        "schema": {
+                            "config_vars": {"method": {"key": "Optional", "type": "string"}},
+                            "extends": ["http_request.HTTP_REQUEST_ACTION_SCHEMA"],
+                        },
+                        "type": "schema",
+                        "docs": "Send a GET request.",
+                    },
+                },
+                "schemas": {
+                    "HTTP_REQUEST_ACTION_SCHEMA": {
+                        "schema": {
+                            "config_vars": {
+                                "url": {"key": "Required", "type": "string"},
+                                "on_response": {
+                                    "key": "Optional",
+                                    "type": "trigger",
+                                    "docs": "Run on response.",
+                                },
+                                "on_error": {
+                                    "key": "Optional",
+                                    "type": "trigger",
+                                    "docs": "Run on error.",
+                                },
+                            },
+                        },
+                        "type": "schema",
+                    },
+                },
+            },
+        },
+    )
+    result = sync_components.build_automations(schema_dir=schema_dir, component_ids=set())
+    action = next(a for a in result["actions"] if a["id"] == "http_request.get")
+    assert action["accepts_action_list"] == ["on_error", "on_response"]
+    assert action["is_control_flow"] is False
+    cfg_keys = {e["key"] for e in action["config_entries"]}
+    assert "url" in cfg_keys  # inherited form field survives
+    assert "on_response" not in cfg_keys
+    assert "on_error" not in cfg_keys
+
+
 def test_build_automations_extracts_condition_combinator(tmp_path: Path) -> None:
     """A boolean combinator (``and``) declares ``accepts_condition_list=True``."""
     schema_dir = _write_schema(


### PR DESCRIPTION
# What does this implement/fix?

The structured (visual) editor dropped the inline automation triggers on several actions; on `http_request.get` you could not add `on_response` or `on_error` handlers, and the same applied to `wifi.configure` (`on_connect`), `espnow.send` / `espnow.broadcast` (`on_sent`), and `homeassistant.action` / `homeassistant.service` (`on_success`).

The catalog generator stripped every `type: trigger` config var but only promoted `then` / `else` onto `accepts_action_list`. It now promotes all trigger and action-registry keys, resolving `extends` first so `http_request` inherits its triggers from the shared action schema; `is_control_flow` stays scoped to `then` / `else` plus condition gates so a plain triggered action is not mislabeled as control flow.

This PR is the generator change plus tests only; the generated `definitions/` catalog is left for the nightly catalog sync to regenerate and commit. Eight actions gain `accepts_action_list` once it runs: `http_request.{get,post,send}` (`on_response`, `on_error`), `wifi.configure` (`on_connect`, `on_error`), `espnow.{send,broadcast}` (`on_sent`, `on_error`), `homeassistant.{action,service}` (`on_success`, `on_error`).

The frontend already renders `accepts_action_list` keys as recursive action lists; the companion PR labels the nested lists by key so `on_response` and `on_error` read distinctly. Verified end to end in the live editor: the http_request.get node renders "On Response" / "On Error" nested action lists from the freshly generated catalog.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1390

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#775

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
