### PR TITLE
Decompose wait_until shorthand condition

### DIFF
--- a/esphome_device_builder/controllers/automations/_decompose.py
+++ b/esphome_device_builder/controllers/automations/_decompose.py
@@ -189,9 +189,9 @@ def _decompose_action(action_id: str, raw_params: Any) -> ActionNode:
     )
 
 
-def _is_dict_shorthand_condition(action: AutomationAction, body: dict) -> bool:
+def _is_dict_shorthand_condition(action: AutomationAction, body: dict[str, Any]) -> bool:
     """Whether *body* is a ``wait_until``-style condition with the gate key omitted."""
-    if action.scalar_shorthand_key not in _CONDITION_GATE_KEYS:
+    if not body or action.scalar_shorthand_key not in _CONDITION_GATE_KEYS:
         return False
     keys = body.keys()
     if keys & _CONDITION_GATE_KEYS:

--- a/esphome_device_builder/controllers/automations/_decompose.py
+++ b/esphome_device_builder/controllers/automations/_decompose.py
@@ -18,7 +18,12 @@ from ruamel.yaml.scalarstring import LiteralScalarString
 
 from ...helpers.api import CommandError
 from ...models.api import ErrorCode
-from ...models.automations import ActionNode, AutomationTree, ConditionNode
+from ...models.automations import (
+    ActionNode,
+    AutomationAction,
+    AutomationTree,
+    ConditionNode,
+)
 from . import catalog
 
 
@@ -149,14 +154,21 @@ def _decompose_action(action_id: str, raw_params: Any) -> ActionNode:
         params: dict[str, Any] = {}
     elif isinstance(raw_params, dict):
         params = {}
-        for key, value in raw_params.items():
-            if key in action.accepts_action_list:
-                children[key] = _decompose_action_list(value)
-                continue
-            if key in _CONDITION_GATE_KEYS:
-                conditions = _decompose_condition_list(value)
-                continue
-            params[key] = _render_value(value)
+        if _is_dict_shorthand_condition(action, raw_params):
+            # ``wait_until: {api.connected:}`` — the ``condition:`` wrapper is
+            # optional (ESPHome ``maybe_simple_value``); the whole mapping is
+            # the condition. Without this the condition id lands in ``params``
+            # and the gate renders empty.
+            conditions = _decompose_condition_list(raw_params)
+        else:
+            for key, value in raw_params.items():
+                if key in action.accepts_action_list:
+                    children[key] = _decompose_action_list(value)
+                    continue
+                if key in _CONDITION_GATE_KEYS:
+                    conditions = _decompose_condition_list(value)
+                    continue
+                params[key] = _render_value(value)
     else:
         # Bare-scalar shorthand (``logger.log: "hi"`` / ``light.turn_on: id``):
         # surface the scalar under the action's own ``maybe_simple_value`` key
@@ -175,6 +187,17 @@ def _decompose_action(action_id: str, raw_params: Any) -> ActionNode:
         children=children,
         conditions=conditions,
     )
+
+
+def _is_dict_shorthand_condition(action: AutomationAction, body: dict) -> bool:
+    """Whether *body* is a ``wait_until``-style condition with the gate key omitted."""
+    if action.scalar_shorthand_key not in _CONDITION_GATE_KEYS:
+        return False
+    keys = body.keys()
+    if keys & _CONDITION_GATE_KEYS:
+        return False
+    known = {e.key for e in action.config_entries} | set(action.accepts_action_list)
+    return not (keys & known)
 
 
 def _decompose_condition_list(body: Any) -> list[ConditionNode]:

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -351,6 +351,27 @@ def test_decompose_action_scalar_falls_back_to_id_for_gate_keyed_shorthand() -> 
     assert node.params == {"id": "some_id"}
 
 
+def test_decompose_wait_until_dict_shorthand_is_a_condition() -> None:
+    """``wait_until: {api.connected:}`` decodes the omitted-gate condition."""
+    node = _decompose_action("wait_until", {"api.connected": None})
+    assert node.params == {}
+    assert [c.condition_id for c in node.conditions] == ["api.connected"]
+
+
+def test_decompose_wait_until_full_form_keeps_timeout_param() -> None:
+    """The explicit ``condition:`` gate still yields its condition plus ``timeout``."""
+    node = _decompose_action("wait_until", {"condition": {"api.connected": None}, "timeout": "5s"})
+    assert node.params == {"timeout": "5s"}
+    assert [c.condition_id for c in node.conditions] == ["api.connected"]
+
+
+def test_decompose_wait_until_timeout_only_dict_is_not_a_condition() -> None:
+    """A real config key (``timeout``) is never mistaken for a shorthand condition."""
+    node = _decompose_action("wait_until", {"timeout": "5s"})
+    assert node.params == {"timeout": "5s"}
+    assert node.conditions == []
+
+
 def test_decompose_condition_scalar_uses_value_shorthand_key() -> None:
     """A value condition's scalar lands under its ``maybe`` key."""
     node = _decompose_condition({"display.is_displaying_page": "home_page"})

--- a/tests/test_automations_branches.py
+++ b/tests/test_automations_branches.py
@@ -372,6 +372,13 @@ def test_decompose_wait_until_timeout_only_dict_is_not_a_condition() -> None:
     assert node.conditions == []
 
 
+def test_decompose_wait_until_empty_dict_is_not_a_phantom_condition() -> None:
+    """An empty ``wait_until: {}`` stays an empty action, not a phantom condition."""
+    node = _decompose_action("wait_until", {})
+    assert node.params == {}
+    assert node.conditions == []
+
+
 def test_decompose_condition_scalar_uses_value_shorthand_key() -> None:
     """A value condition's scalar lands under its ``maybe`` key."""
     node = _decompose_condition({"display.is_displaying_page": "home_page"})

--- a/tests/test_automations_writer.py
+++ b/tests/test_automations_writer.py
@@ -825,6 +825,29 @@ def test_wait_until_emits_condition_before_timeout() -> None:
     assert text.index("condition:") < text.index("timeout:")
 
 
+def test_wait_until_shorthand_condition_round_trips_to_full_form() -> None:
+    """``wait_until: {api.connected:}`` parses the condition and re-emits the gate."""
+    yaml_text = (
+        "esphome:\n"
+        "  name: x\n"
+        "  on_boot:\n"
+        "    then:\n"
+        "      - wait_until:\n"
+        "          api.connected:\n"
+    )
+    parsed = parse_device_yaml(yaml_text)[0]
+    action = parsed.automation.actions[0]
+    assert action.action_id == "wait_until"
+    assert action.params == {}
+    assert [c.condition_id for c in action.conditions] == ["api.connected"]
+    new_text, _diff = render_upsert(
+        yaml_text,
+        tree=parsed.automation,
+        location=parsed.location,
+    )
+    assert "condition:" in new_text
+
+
 # ---------------------------------------------------------------------------
 # Light effects
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

wait_until accepts an optional condition: wrapper; you can write either the full form with condition: or the shorthand `wait_until: api.connected:`. The shorthand was decoded with the inner condition mapping treated as a plain param, so the action ended up with no condition; the Visual Editor then rendered an empty required condition gate and dropped the condition the user wrote. This detects the omitted gate form and routes the whole mapping through the condition decomposer, a real config key like timeout still blocks the shorthand path.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1399

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
