### PR TITLE
Derive structured editors for top-level typed schemas

### DIFF
--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -466,9 +466,11 @@ class ConfigEntry(DataClassORJSONMixin):
     suggestions: list[ConfigPrimitive] | None = None
 
     # === conditional visibility ===
-    # `depends_on_value` and `depends_on_value_not` are mutually
-    # exclusive — set at most one. Frontend hides the entry when the
-    # predicate fails.
+    # `depends_on_value`, `depends_on_value_not` and
+    # `depends_on_value_any` are mutually exclusive — set at most one.
+    # Frontend hides the entry when the predicate fails. New catalog
+    # output emits only `depends_on_value_any`; the scalar forms remain
+    # for catalogs generated before it existed.
 
     # Key of another entry in the same component this entry depends on.
     # When None the entry is always visible.
@@ -481,6 +483,10 @@ class ConfigEntry(DataClassORJSONMixin):
     # Show this entry only when the dependency's current value does NOT
     # equal this. Ignored if `depends_on` is None.
     depends_on_value_not: ConfigPrimitive | None = None
+
+    # Show this entry only when the dependency's current value is in
+    # this list. Ignored if `depends_on` is None.
+    depends_on_value_any: list[ConfigPrimitive] | None = None
 
     # Hide this entry unless the named component is configured on the
     # same device. Used for cross-cutting fields that are only

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -319,7 +319,7 @@ _DEPRECATED_FIELDS: frozenset[tuple[str, str]] = frozenset(
 # Keep this list focused on cross-cutting infrastructure. Component-
 # specific gates (e.g. "this LED option requires this LED platform")
 # belong in the per-component schema via ``depends_on`` /
-# ``depends_on_value`` instead.
+# ``depends_on_value_any`` instead.
 _COMPONENT_GATED_KEYS: dict[str, str] = {
     # MQTT entity options (apply to every entity when ``mqtt:`` is set)
     "qos": "mqtt",
@@ -607,6 +607,14 @@ _FIELD_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
             "Log BLE NUS traffic to the ESPHome log for troubleshooting. "
             "Bare `debug:` enables hex logging with sensible defaults."
         ),
+    },
+    # ``ethernet.clk`` is ``cv.Optional`` in the schema but a final-validate
+    # step requires it for RMII PHYs unless the deprecated ``clk_mode``
+    # migrates into it (removal scheduled 2026.7.0). Mark it required on the
+    # main form; the variant gate already scopes it to the RMII types.
+    ("ethernet", "clk"): {
+        "required": True,
+        "advanced": False,
     },
 }
 
@@ -1966,10 +1974,15 @@ def _extract_config_entries(
     ``component_id`` is used to filter ``_DEPRECATED_FIELDS`` at the
     top level only — nested fields with the same name are unaffected.
     """
-    schema = _config_schema(section).get("schema") or {}
-    if not schema:
-        return []
-    entries = _convert_config_vars(schema, schema_dir, component_id=component_id)
+    config_schema = _config_schema(section)
+    typed_node = _typed_node(config_schema, schema_dir)
+    if typed_node is not None:
+        entries = _build_typed_config_entries(typed_node, schema_dir, component_id=component_id)
+    else:
+        schema = config_schema.get("schema") or {}
+        if not schema:
+            return []
+        entries = _convert_config_vars(schema, schema_dir, component_id=component_id)
     # Apply the visibility-cascade rule once at the top of the
     # tree: a stricter parent forces all descendants at-least
     # as strict. ``YAML_ONLY`` > ``ADVANCED`` > no setting. The
@@ -2261,50 +2274,54 @@ def _typed_expanding() -> Iterator[None]:
         _expanding_typed[0] = False
 
 
-def _build_typed_config_entries(typed_node: dict, schema_dir: Path) -> list[dict]:
+def _build_typed_config_entries(
+    typed_node: dict, schema_dir: Path, *, component_id: str = ""
+) -> list[dict]:
     """
     Render a typed_schema node as a discriminator select + gated fields.
 
-    A field in every variant is ungated; one absent from a single variant
-    uses ``depends_on_value_not``; narrower overlaps emit a gated copy per
-    variant.
+    A field defined identically across variants is emitted once, gated on
+    the set of variants carrying it (``depends_on_value_any``); a field in
+    every variant is ungated. Differing definitions (e.g. a required local
+    ``path`` vs an optional git sub-path) stay per-variant so each gate
+    carries its own label / requiredness / default.
     """
     typed_key = typed_node.get("typed_key") or "type"
     types = typed_node.get("types") or {}
-    all_types = set(types)
 
-    discriminator = _convert_field(
-        typed_key, {"key": "Required", "values": {t: {} for t in types}}, schema_dir
-    )
+    with _typed_expanding():
+        discriminator = _convert_field(
+            typed_key, {"key": "Required", "values": {t: {} for t in types}}, schema_dir
+        )
 
-    # field key → [(type_name, converted entry)]; dict keeps first-seen order.
-    by_key: dict[str, list[tuple[str, dict]]] = {}
-    for type_name, variant in types.items():
-        body = variant if isinstance(variant, dict) else {}
-        for child in _convert_config_vars(body, schema_dir):
-            if child["key"] != typed_key:
-                by_key.setdefault(child["key"], []).append((type_name, child))
+        # field key → [(type_name, converted entry)]; dict keeps first-seen order.
+        by_key: dict[str, list[tuple[str, dict]]] = {}
+        for type_name, variant in types.items():
+            body = variant if isinstance(variant, dict) else {}
+            for child in _convert_config_vars(body, schema_dir, component_id=component_id):
+                if child["key"] != typed_key:
+                    by_key.setdefault(child["key"], []).append((type_name, child))
 
     variant_children: list[dict] = []
     for occurrences in by_key.values():
-        present = {t for t, _ in occurrences}
-        base = occurrences[0][1]
-        # Collapse to a single entry only when every variant defines the field
-        # identically. Differing definitions (e.g. a required local ``path``
-        # vs an optional git sub-path) must stay per-variant so each gate
-        # carries its own label / requiredness / default.
-        identical = all(child == base for _, child in occurrences)
-        if identical and present == all_types:
-            variant_children.append(base)
-        elif identical and len(present) == len(all_types) - 1:
-            (missing,) = all_types - present
-            variant_children.append(
-                {**base, "depends_on": typed_key, "depends_on_value_not": missing}
-            )
-        else:
-            for type_name, child in occurrences:
+        # Group identical definitions; each group's gate is the variant
+        # subset that carries it, in ``types`` declaration order.
+        groups: list[tuple[dict, list[str]]] = []
+        for type_name, child in occurrences:
+            for existing, gate in groups:
+                if child == existing:
+                    gate.append(type_name)
+                    break
+            else:
+                groups.append((child, [type_name]))
+        for child, gate in groups:
+            # Gate members are unique by construction, so a full-length
+            # gate means the field is in every variant: ungated.
+            if len(gate) == len(types):
+                variant_children.append(child)
+            else:
                 variant_children.append(
-                    {**child, "depends_on": typed_key, "depends_on_value": type_name}
+                    {**child, "depends_on": typed_key, "depends_on_value_any": gate}
                 )
 
     return [discriminator, *_sort_entries(variant_children)]
@@ -2561,8 +2578,7 @@ def _convert_field(  # noqa: PLR0912, PLR0915, C901
     typed_node = _typed_node(raw, schema_dir)
     if typed_node is not None and not _expanding_typed[0]:
         entry["type"] = "nested"
-        with _typed_expanding():
-            entry["config_entries"] = _build_typed_config_entries(typed_node, schema_dir) or None
+        entry["config_entries"] = _build_typed_config_entries(typed_node, schema_dir) or None
         return entry
 
     # Recurse into nested schemas for type=nested.

--- a/tests/test_sync_components_typed_schema.py
+++ b/tests/test_sync_components_typed_schema.py
@@ -15,10 +15,12 @@ from pathlib import Path
 
 import pytest
 
-from script.sync_components import (  # type: ignore[import-not-found]
+import script.sync_components as sc  # type: ignore[import-not-found]
+from script.sync_components import (
     _FONT_FILE_NODE,
     _RAW_NODE_OVERRIDES,
     _convert_field,
+    _extract_config_entries,
 )
 
 
@@ -53,13 +55,13 @@ def test_direct_typed_node_becomes_nested_discriminator(schema_dir: Path) -> Non
     assert {o["value"] for o in children["type"]["options"]} == {"local", "web", "memory"}
     # Variant fields are gated by the discriminator.
     assert children["path"]["depends_on"] == "type"
-    assert children["path"]["depends_on_value"] == "local"
-    assert children["url"]["depends_on_value"] == "web"
-    assert children["icon"]["depends_on_value"] == "memory"
+    assert children["path"]["depends_on_value_any"] == ["local"]
+    assert children["url"]["depends_on_value_any"] == ["web"]
+    assert children["icon"]["depends_on_value_any"] == ["memory"]
 
 
-def test_shared_field_uses_value_not_when_absent_from_one_type(schema_dir: Path) -> None:
-    """A field in every variant but one gates with ``depends_on_value_not``."""
+def test_subset_shared_field_gates_on_the_subset(schema_dir: Path) -> None:
+    """A field shared by a subset of variants emits once, gated on that subset."""
     raw = {
         "key": "Required",
         "type": "typed",
@@ -81,12 +83,12 @@ def test_shared_field_uses_value_not_when_absent_from_one_type(schema_dir: Path)
         },
     }
     children = _children(_convert_field("file", raw, schema_dir))
-    # ``weight`` lives in gfonts + web (all but ``local``) → single gated entry.
+    # ``weight`` lives in gfonts + web → single entry gated on both.
     assert children["weight"]["depends_on"] == "type"
-    assert children["weight"]["depends_on_value_not"] == "local"
+    assert children["weight"]["depends_on_value_any"] == ["gfonts", "web"]
     assert children["weight"]["depends_on_value"] is None
-    assert children["family"]["depends_on_value"] == "gfonts"
-    assert children["url"]["depends_on_value"] == "web"
+    assert children["family"]["depends_on_value_any"] == ["gfonts"]
+    assert children["url"]["depends_on_value_any"] == ["web"]
 
 
 def test_field_in_every_type_is_ungated(schema_dir: Path) -> None:
@@ -129,10 +131,8 @@ def test_typed_node_via_extends_ref(schema_dir: Path) -> None:
     assert entry["type"] == "nested"
     children = _children(entry)
     assert {o["value"] for o in children["source"]["options"]} == {"local", "web"}
-    # Two-type union: a single-type field is "all but one", so it gates with
-    # ``depends_on_value_not`` (path shows when source != web, i.e. local).
     assert children["path"]["depends_on"] == "source"
-    assert children["path"]["depends_on_value_not"] == "web"
+    assert children["path"]["depends_on_value_any"] == ["local"]
 
 
 def test_self_referential_typed_node_is_depth_bounded(schema_dir: Path) -> None:
@@ -207,9 +207,9 @@ def test_font_file_builds_local_gfonts_web_editor(schema_dir: Path) -> None:
     assert {o["value"] for o in children["type"]["options"]} == {"local", "gfonts", "web"}
     assert children["type"]["required"] is True
     # One required field per source.
-    assert children["path"]["depends_on_value"] == "local"
-    assert children["family"]["depends_on_value"] == "gfonts"
-    assert children["url"]["depends_on_value"] == "web"
+    assert children["path"]["depends_on_value_any"] == ["local"]
+    assert children["family"]["depends_on_value_any"] == ["gfonts"]
+    assert children["url"]["depends_on_value_any"] == ["web"]
     assert all(children[k]["required"] for k in ("path", "family", "url"))
 
 
@@ -219,7 +219,7 @@ def test_font_file_external_knobs_come_from_the_bundle(schema_dir: Path) -> None
 
     for key in ("weight", "italic", "refresh"):
         assert children[key]["depends_on"] == "type"
-        assert children[key]["depends_on_value_not"] == "local"
+        assert children[key]["depends_on_value_any"] == ["gfonts", "web"]
 
     assert children["italic"]["type"] == "boolean"
     assert children["italic"]["default_value"] is False
@@ -261,10 +261,258 @@ def test_differing_field_across_variants_stays_per_variant(schema_dir: Path) -> 
         },
     }
     paths = {
-        c["depends_on_value"]: c
+        c["depends_on_value_any"][0]: c
         for c in _convert_field("source", raw, schema_dir)["config_entries"]
         if c["key"] == "path"
     }
     assert set(paths) == {"local", "git"}
     assert paths["local"]["required"] is True
     assert paths["git"]["required"] is False
+
+
+# ---------------------------------------------------------------------------
+# Top-level typed CONFIG_SCHEMA (ethernet, spi, template.output, ...): the
+# whole component body is the discriminated union, not a nested field.
+# ---------------------------------------------------------------------------
+
+
+def _typed_section(types: dict, typed_key: str = "type") -> dict:
+    node = {"type": "typed", "typed_key": typed_key, "types": types}
+    return {"schemas": {"CONFIG_SCHEMA": node}}
+
+
+def _write_schemas(schema_dir: Path, name: str, schemas: dict) -> None:
+    (schema_dir / f"{name}.json").write_text(json.dumps({name: {"schemas": schemas}}))
+
+
+def test_top_level_typed_config_schema_builds_entries(schema_dir: Path) -> None:
+    """A typed CONFIG_SCHEMA yields a discriminator-first gated entry list."""
+    section = _typed_section(
+        {
+            "binary": {"config_vars": {"write_action": {"key": "Required"}}},
+            "float": {"config_vars": {"zero_means_zero": {"key": "Optional"}}},
+        }
+    )
+    entries = _extract_config_entries(section, schema_dir=schema_dir, component_id="template")
+    by_key = {e["key"]: e for e in entries}
+    assert entries[0]["key"] == "type"
+    assert entries[0]["required"] is True
+    assert {o["value"] for o in entries[0]["options"]} == {"binary", "float"}
+    assert by_key["write_action"]["depends_on_value_any"] == ["binary"]
+    assert by_key["zero_means_zero"]["depends_on_value_any"] == ["float"]
+
+
+def test_top_level_typed_with_intermediate_extends(schema_dir: Path) -> None:
+    """Variants sharing intermediate base schemas dedupe to one subset-gated entry."""
+    _write_schemas(
+        schema_dir,
+        "eth",
+        {
+            "BASE_SCHEMA": {
+                "type": "schema",
+                "schema": {"config_vars": {"domain": {"key": "Optional"}}},
+            },
+            "RMII_SCHEMA": {
+                "type": "schema",
+                "schema": {
+                    "extends": ["eth.BASE_SCHEMA"],
+                    "config_vars": {"mdc_pin": {"key": "Required", "type": "pin"}},
+                },
+            },
+            "SPI_SCHEMA": {
+                "type": "schema",
+                "schema": {
+                    "extends": ["eth.BASE_SCHEMA"],
+                    "config_vars": {"cs_pin": {"key": "Required", "type": "pin"}},
+                },
+            },
+        },
+    )
+    section = _typed_section(
+        {
+            "LAN8720": {"extends": ["eth.RMII_SCHEMA"]},
+            "RTL8201": {"extends": ["eth.RMII_SCHEMA"]},
+            "W5500": {"extends": ["eth.SPI_SCHEMA"]},
+        }
+    )
+    entries = _extract_config_entries(section, schema_dir=schema_dir, component_id="eth")
+    (mdc,) = [e for e in entries if e["key"] == "mdc_pin"]
+    assert mdc["depends_on_value_any"] == ["LAN8720", "RTL8201"]
+    (cs,) = [e for e in entries if e["key"] == "cs_pin"]
+    assert cs["depends_on_value_any"] == ["W5500"]
+    (domain,) = [e for e in entries if e["key"] == "domain"]
+    assert domain["depends_on"] is None
+    assert len(entries) == 4
+
+
+def test_top_level_typed_with_custom_discriminator_key(schema_dir: Path) -> None:
+    """A non-``type`` discriminator (i2s_audio's ``dac_type``) still sorts first."""
+    _write_schemas(
+        schema_dir,
+        "i2s",
+        {
+            "BASE_SCHEMA": {
+                "type": "schema",
+                "schema": {"config_vars": {"channel": {"key": "Optional"}}},
+            }
+        },
+    )
+    section = _typed_section(
+        {
+            "external": {
+                "extends": ["i2s.BASE_SCHEMA"],
+                "config_vars": {"i2s_dout_pin": {"key": "Required", "type": "pin"}},
+            },
+            "internal": {
+                "extends": ["i2s.BASE_SCHEMA"],
+                "config_vars": {"mode": {"key": "Optional"}},
+            },
+        },
+        typed_key="dac_type",
+    )
+    entries = _extract_config_entries(section, schema_dir=schema_dir, component_id="i2s.speaker")
+    assert entries[0]["key"] == "dac_type"
+    by_key = {e["key"]: e for e in entries}
+    assert by_key["i2s_dout_pin"]["depends_on"] == "dac_type"
+    assert by_key["i2s_dout_pin"]["depends_on_value_any"] == ["external"]
+    assert by_key["mode"]["depends_on_value_any"] == ["internal"]
+    assert by_key["channel"]["depends_on"] is None
+
+
+def test_top_level_typed_uptime_sensor_shape(schema_dir: Path) -> None:
+    """Variants sharing an entity base ungate it; per-variant extras gate singly."""
+    _write_schemas(
+        schema_dir,
+        "sensor",
+        {
+            "_SENSOR_SCHEMA": {
+                "type": "schema",
+                "schema": {
+                    "config_vars": {
+                        "icon": {"key": "Optional", "type": "icon"},
+                        "accuracy_decimals": {"key": "Optional", "type": "integer"},
+                    }
+                },
+            }
+        },
+    )
+    section = _typed_section(
+        {
+            "seconds": {
+                "extends": ["sensor._SENSOR_SCHEMA"],
+                "config_vars": {"update_interval": {"key": "Optional"}},
+            },
+            "timestamp": {
+                "extends": ["sensor._SENSOR_SCHEMA"],
+                "config_vars": {"time_id": {"key": "Optional"}},
+            },
+        }
+    )
+    entries = _extract_config_entries(section, schema_dir=schema_dir, component_id="sensor.uptime")
+    by_key = {e["key"]: e for e in entries}
+    assert by_key["icon"]["depends_on"] is None
+    assert by_key["accuracy_decimals"]["depends_on"] is None
+    assert by_key["update_interval"]["depends_on_value_any"] == ["seconds"]
+    assert by_key["time_id"]["depends_on_value_any"] == ["timestamp"]
+
+
+def test_variant_config_var_matching_typed_key_is_skipped(schema_dir: Path) -> None:
+    """A variant's own ``type`` var (template.datetime) never duplicates the discriminator."""
+    section = _typed_section(
+        {
+            "DATE": {
+                "config_vars": {
+                    "type": {"key": "Required"},
+                    "initial_value": {"key": "Optional"},
+                }
+            },
+            "TIME": {
+                "config_vars": {
+                    "type": {"key": "Required"},
+                    "initial_value": {"key": "Optional"},
+                }
+            },
+        }
+    )
+    entries = _extract_config_entries(
+        section, schema_dir=schema_dir, component_id="datetime.template"
+    )
+    (type_entry,) = [e for e in entries if e["key"] == "type"]
+    assert {o["value"] for o in type_entry["options"]} == {"DATE", "TIME"}
+    (initial,) = [e for e in entries if e["key"] == "initial_value"]
+    assert initial["depends_on"] is None
+
+
+def test_ethernet_clk_override_required_on_main_form(schema_dir: Path) -> None:
+    """``ethernet.clk`` flips to required + main-form; ``clk_mode`` stays advanced."""
+    _write_schemas(
+        schema_dir,
+        "eth",
+        {
+            "RMII_SCHEMA": {
+                "type": "schema",
+                "schema": {
+                    "config_vars": {
+                        "clk": {
+                            "key": "Optional",
+                            "type": "schema",
+                            "schema": {
+                                "config_vars": {
+                                    "mode": {
+                                        "key": "Required",
+                                        "type": "enum",
+                                        "values": {"CLK_EXT_IN": None},
+                                    },
+                                    "pin": {"key": "Required", "type": "pin"},
+                                }
+                            },
+                        },
+                        "clk_mode": {
+                            "key": "Optional",
+                            "type": "enum",
+                            "values": {"GPIO0_IN": None},
+                        },
+                    }
+                },
+            }
+        },
+    )
+    section = _typed_section(
+        {
+            "LAN8720": {"extends": ["eth.RMII_SCHEMA"]},
+            "W5500": {"config_vars": {"cs_pin": {"key": "Required", "type": "pin"}}},
+        }
+    )
+    entries = _extract_config_entries(section, schema_dir=schema_dir, component_id="ethernet")
+    (clk,) = [e for e in entries if e["key"] == "clk"]
+    assert clk["required"] is True
+    assert clk["advanced"] is False
+    assert clk["depends_on_value_any"] == ["LAN8720"]
+    # Cascade no longer buries the group's required children.
+    assert all(c["advanced"] is False for c in clk["config_entries"])
+    (clk_mode,) = [e for e in entries if e["key"] == "clk_mode"]
+    assert clk_mode["advanced"] is True
+
+
+def test_top_level_typed_applies_component_overrides(
+    schema_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deprecated-field filtering and field overrides key on the component id."""
+    monkeypatch.setattr(sc, "_DEPRECATED_FIELDS", sc._DEPRECATED_FIELDS | {("widget", "legacy")})
+    monkeypatch.setitem(sc._FIELD_OVERRIDES, ("widget", "mode"), {"advanced": True})
+    section = _typed_section(
+        {
+            "a": {
+                "config_vars": {
+                    "legacy": {"key": "Optional"},
+                    "mode": {"key": "Optional"},
+                }
+            },
+            "b": {"config_vars": {"mode": {"key": "Optional"}}},
+        }
+    )
+    entries = _extract_config_entries(section, schema_dir=schema_dir, component_id="widget")
+    keys = [e["key"] for e in entries]
+    assert "legacy" not in keys
+    (mode,) = [e for e in entries if e["key"] == "mode"]
+    assert mode["advanced"] is True


### PR DESCRIPTION
# What does this implement/fix?

Components whose whole `CONFIG_SCHEMA` is a `cv.typed_schema` union got no structured editor; the generator only understood plain schema nodes, so ethernet, spi, usb_uart, i2s_audio, template.output and about twenty more shipped empty bodies and fell back to YAML only.

The typed converter from #1394 is now wired into the top-level extraction path, and its gating is set-valued instead of per-variant copies. A field defined identically across a subset of variants is emitted once with the new `depends_on_value_any` list on `ConfigEntry`; the frontend shows it only while the selected type is in the list. Without the dedupe, ethernet's 15 PHY types sharing the RMII and SPI base schemas exploded to 117 entries and 417KB of JSON; with it the body is 23 entries. The component id now also threads through the typed path, so deprecated field filtering and per-component overrides apply there too.

The catalog is not regenerated here; the nightly catalog sync picks it up. Until the bumped frontend ships, an older frontend ignores the new field and shows subset-shared fields ungated, which is cosmetic and transitional.

Verified live with the companion frontend: ethernet renders a structured editor, switching the type from LAN8720 to W5500 swaps the RMII pin fields for the SPI ones, and the YAML round-trips flat. Live testing also caught `ethernet.clk`: the schema says optional but a final-validate step requires it for RMII PHYs (the deprecated `clk_mode` migrates into it, removal 2026.7.0), so a `_FIELD_OVERRIDES` row marks it required on the main form while `clk_mode` stays behind the advanced toggle.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1397

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#783

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
