### PR TITLE
Match the existing list indent when splicing a component

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -272,12 +272,34 @@ def _find_top_level_block_bounds(file_lines: list[str], key: str) -> tuple[int, 
     return block_start, block_end
 
 
+def _leading_ws(line: str) -> str:
+    """Leading whitespace of *line*."""
+    return line[: len(line) - len(line.lstrip())]
+
+
+def _list_item_indent(file_lines: list[str], header_idx: int, end_idx: int) -> str:
+    """
+    Dash indent of the first list item in a block body.
+
+    Falls back to the canonical indent when the body holds no item.
+    """
+    for idx in range(header_idx + 1, end_idx):
+        stripped = file_lines[idx].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- ") or stripped == "-":
+            return _leading_ws(file_lines[idx].rstrip("\n\r"))
+    return ESPHOME_YAML_INDENT
+
+
 def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | None:
     """
     Insert the platform-list item from *block* under an existing ``<domain>:``.
 
-    Returns ``None`` when the existing file has no ``<domain>:``
-    section so the caller can fall back to appending.
+    The item is re-indented to the existing list's dash indent so a
+    zero- or 4-space-indented block stays parseable (#1411). Returns
+    ``None`` when the existing file has no ``<domain>:`` section so
+    the caller can fall back to appending.
     """
     block_lines = block.splitlines()
     if len(block_lines) < 2 or block_lines[0].rstrip() != f"{domain}:":
@@ -286,13 +308,20 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
     bounds = _find_top_level_block_bounds(file_lines, domain)
     if bounds is None:
         return None
-    _, last_content = bounds
+    block_start, last_content = bounds
+
+    dash_indent = _list_item_indent(file_lines, block_start, last_content)
+    src_indent = _leading_ws(block_lines[1])
+    items = [
+        line if not line.strip() else dash_indent + line[len(src_indent) :]
+        for line in block_lines[1:]
+    ]
 
     before = "".join(file_lines[:last_content])
     after = "".join(file_lines[last_content:])
     if before and not before.endswith("\n"):
         before += "\n"
-    insertion = "\n".join(block_lines[1:]) + "\n"
+    insertion = "\n".join(items) + "\n"
     return before + insertion + after
 
 
@@ -337,27 +366,29 @@ def _normalize_multi_conf_block(existing: str, comp_id: str) -> str | None:
 
 def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
     """
-    Convert a 2-space-indented mapping body to a YAML list item.
+    Convert a mapping body at any indent to a canonically indented list item.
 
     The ``- `` marker is anchored on the first non-comment key line;
     a leading ``# ...`` keeps its position so a comment-decorated
     mapping doesn't demote into a ``- # comment`` null head item.
     """
+    body_indent = ""
+    for line in body_lines:
+        if line.strip() and not line.lstrip().startswith("#"):
+            body_indent = _leading_ws(line)
+            break
     result: list[str] = []
     marked = False
     for line in body_lines:
         if not line.strip():
             result.append(line)
             continue
-        indented = ESPHOME_YAML_INDENT + line
-        if (
-            not marked
-            and not line.lstrip().startswith("#")
-            and indented.startswith(ESPHOME_YAML_INDENT * 2)
-        ):
-            indented = f"{ESPHOME_YAML_INDENT}- " + indented[len(ESPHOME_YAML_INDENT * 2) :]
+        rest = line[len(body_indent) :] if line.startswith(body_indent) else line.lstrip()
+        if not marked and not line.lstrip().startswith("#"):
+            result.append(f"{ESPHOME_YAML_INDENT}- {rest}")
             marked = True
-        result.append(indented)
+        else:
+            result.append(ESPHOME_YAML_INDENT * 2 + rest)
     return result
 
 

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -297,9 +297,9 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
     Insert the platform-list item from *block* under an existing ``<domain>:``.
 
     The item is re-indented to the existing list's dash indent so a
-    zero- or 4-space-indented block stays parseable (#1411). Returns
-    ``None`` when the existing file has no ``<domain>:`` section so
-    the caller can fall back to appending.
+    zero- or 4-space-indented block stays parseable. Returns ``None``
+    when the existing file has no ``<domain>:`` section so the caller
+    can fall back to appending.
     """
     block_lines = block.splitlines()
     if len(block_lines) < 2 or block_lines[0].rstrip() != f"{domain}:":
@@ -312,10 +312,13 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
 
     dash_indent = _list_item_indent(file_lines, block_start, last_content)
     src_indent = _leading_ws(block_lines[1])
-    items = [
-        line if not line.strip() else dash_indent + line[len(src_indent) :]
-        for line in block_lines[1:]
-    ]
+    items: list[str] = []
+    for line in block_lines[1:]:
+        if not line.strip():
+            items.append(line)
+            continue
+        rest = line[len(src_indent) :] if line.startswith(src_indent) else line.lstrip()
+        items.append(dash_indent + rest)
 
     before = "".join(file_lines[:last_content])
     after = "".join(file_lines[last_content:])
@@ -369,7 +372,7 @@ def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
     Convert a mapping body at any indent to a canonically indented list item.
 
     The ``- `` marker is anchored on the first non-comment key line;
-    a leading ``# ...`` keeps its position so a comment-decorated
+    a leading ``# ...`` stays above the marker so a comment-decorated
     mapping doesn't demote into a ``- # comment`` null head item.
     """
     body_indent = ""

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1083,6 +1083,57 @@ def test_merge_component_yaml_splices_into_comment_only_block() -> None:
     assert len(yaml.safe_load(result)["switch"]) == 1
 
 
+@pytest.mark.parametrize(
+    ("dash_indent", "existing"),
+    [
+        pytest.param(
+            "",
+            "binary_sensor:\n- platform: template\n  name: a\n  filters:\n  - delayed_off: 5ms\n",
+            id="zero_indent",
+        ),
+        pytest.param(
+            "    ",
+            "binary_sensor:\n"
+            "    - platform: template\n"
+            "      name: a\n"
+            "      filters:\n"
+            "        - delayed_off: 5ms\n",
+            id="four_space",
+        ),
+    ],
+)
+def test_merge_component_yaml_splices_multi_level_item(dash_indent: str, existing: str) -> None:
+    """Every nesting level of a spliced multi-level item stays parseable and intact."""
+    component = _component(
+        component_id="binary_sensor.gpio", category=ComponentCategory.BINARY_SENSOR
+    )
+    fields: dict[str, Any] = {
+        "pin": {"number": "GPIO11", "mode": {"input": True}},
+        "filters": [{"delayed_on": "10ms"}],
+    }
+
+    result = merge_component_yaml(existing, component, fields)
+
+    expected_item = (
+        f"{dash_indent}- platform: gpio\n"
+        f"{dash_indent}  pin:\n"
+        f"{dash_indent}    number: GPIO11\n"
+        f"{dash_indent}    mode:\n"
+        f"{dash_indent}      input: true\n"
+        f"{dash_indent}  filters:\n"
+        f"{dash_indent}    - delayed_on: 10ms\n"
+    )
+    assert expected_item in result
+    assert yaml.safe_load(result)["binary_sensor"] == [
+        {"platform": "template", "name": "a", "filters": [{"delayed_off": "5ms"}]},
+        {
+            "platform": "gpio",
+            "pin": {"number": "GPIO11", "mode": {"input": True}},
+            "filters": [{"delayed_on": "10ms"}],
+        },
+    ]
+
+
 def test_splice_into_domain_block_preserves_blank_lines_in_item() -> None:
     """Blank lines inside the generated item survive the re-indent."""
     existing = "switch:\n- platform: template\n  name: a\n"

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -52,7 +52,12 @@ from esphome_device_builder.helpers.yaml import (
     rewrite_yaml_scalar,
     upsert_yaml_leaf_under_top_block,
 )
-from esphome_device_builder.helpers.yaml.scalar import _plain_is_fast_safe, _plain_is_safe
+from esphome_device_builder.helpers.yaml.component import _list_item_indent
+from esphome_device_builder.helpers.yaml.scalar import (
+    ESPHOME_YAML_INDENT,
+    _plain_is_fast_safe,
+    _plain_is_safe,
+)
 from esphome_device_builder.models.common import ConfigEntry, ConfigEntryType
 from esphome_device_builder.models.components import (
     ComponentCatalogEntry,
@@ -1132,6 +1137,20 @@ def test_merge_component_yaml_splices_multi_level_item(dash_indent: str, existin
             "filters": [{"delayed_on": "10ms"}],
         },
     ]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param([], id="empty"),
+        pytest.param(["  # populated later\n"], id="comment_only"),
+        pytest.param(["  key: value\n"], id="mapping_body"),
+    ],
+)
+def test_list_item_indent_falls_back_to_canonical(body: list[str]) -> None:
+    """A body with no list item yields the canonical dash indent."""
+    lines = ["switch:\n", *body]
+    assert _list_item_indent(lines, 0, len(lines)) == ESPHOME_YAML_INDENT
 
 
 def test_splice_into_domain_block_preserves_blank_lines_in_item() -> None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1071,6 +1071,28 @@ def test_merge_component_yaml_splices_into_four_space_list() -> None:
     assert len(yaml.safe_load(result)["switch"]) == 2
 
 
+def test_merge_component_yaml_splices_into_comment_only_block() -> None:
+    """A body with no list item falls back to the canonical dash indent."""
+    component = _component(component_id="switch.gpio", category=ComponentCategory.SWITCH)
+    fields: dict[str, Any] = {"pin": "GPIO11"}
+
+    existing = "switch:\n  # populated later\n"
+    result = merge_component_yaml(existing, component, fields)
+
+    assert "\n  - platform: gpio\n    pin: GPIO11\n" in result
+    assert len(yaml.safe_load(result)["switch"]) == 1
+
+
+def test_splice_into_domain_block_preserves_blank_lines_in_item() -> None:
+    """Blank lines inside the generated item survive the re-indent."""
+    existing = "switch:\n- platform: template\n  name: a\n"
+    block = "switch:\n  - platform: gpio\n\n    pin: GPIO11\n"
+    result = _splice_into_domain_block(existing, "switch", block)
+
+    assert result is not None
+    assert "\n- platform: gpio\n\n  pin: GPIO11\n" in result
+
+
 def test_merge_component_yaml_multi_conf_non_canonical_list() -> None:
     """A ``multi_conf`` splice follows the existing list's 4-space dash indent."""
     component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1047,6 +1047,41 @@ def test_merge_component_yaml_splice_handles_trailing_blank_lines() -> None:
     assert "- platform: dht" in sensor_block
 
 
+def test_merge_component_yaml_splices_into_zero_indented_list() -> None:
+    """The new item adopts a column-0 dash indent so the result stays parseable."""
+    component = _component(component_id="switch.gpio", category=ComponentCategory.SWITCH)
+    fields: dict[str, Any] = {"pin": "GPIO11"}
+
+    existing = "switch:\n- platform: template\n  name: a\n"
+    result = merge_component_yaml(existing, component, fields)
+
+    assert "\n- platform: gpio\n  pin: GPIO11\n" in result
+    assert len(yaml.safe_load(result)["switch"]) == 2
+
+
+def test_merge_component_yaml_splices_into_four_space_list() -> None:
+    """The new item adopts a 4-space dash indent so the result stays parseable."""
+    component = _component(component_id="switch.gpio", category=ComponentCategory.SWITCH)
+    fields: dict[str, Any] = {"pin": "GPIO11"}
+
+    existing = "switch:\n    - platform: template\n      name: a\n"
+    result = merge_component_yaml(existing, component, fields)
+
+    assert "\n    - platform: gpio\n      pin: GPIO11\n" in result
+    assert len(yaml.safe_load(result)["switch"]) == 2
+
+
+def test_merge_component_yaml_multi_conf_non_canonical_list() -> None:
+    """A ``multi_conf`` splice follows the existing list's 4-space dash indent."""
+    component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
+
+    existing = "rtttl:\n    - id: rtttl_1\n      output: out1\n"
+    result = merge_component_yaml(existing, component, {"id": "rtttl_2", "output": "buzz"})
+
+    assert "\n    - id: rtttl_2\n      output: buzz\n" in result
+    assert len(yaml.safe_load(result)["rtttl"]) == 2
+
+
 def test_merge_component_yaml_accepts_incomplete_draft() -> None:
     """A syntactically broken draft is appended-merged, not rejected."""
     component = _component(component_id="i2c", category=ComponentCategory.BUS)
@@ -1205,6 +1240,26 @@ def test_mapping_body_to_list_item_preserves_blank_lines() -> None:
         "",
         "    output: buzz",
     ]
+
+
+def test_mapping_body_to_list_item_single_space_body() -> None:
+    """A 1-space-indented body still gets the ``- `` marker, re-emitted canonically."""
+    body = [" sda: GPIO21", " scl: GPIO22"]
+    assert _mapping_body_to_list_item(body) == [
+        "  - sda: GPIO21",
+        "    scl: GPIO22",
+    ]
+
+
+def test_merge_component_yaml_multi_conf_single_space_mapping_body() -> None:
+    """A 1-space mapping body normalises to list form and the merge stays parseable."""
+    component = _component(component_id="rtttl", category=ComponentCategory.MISC, multi_conf=True)
+
+    existing = "rtttl:\n id: rtttl_1\n output: out1\n"
+    result = merge_component_yaml(existing, component, {"id": "rtttl_2", "output": "buzz"})
+
+    parsed = yaml.safe_load(result)["rtttl"]
+    assert [item["id"] for item in parsed] == ["rtttl_1", "rtttl_2"]
 
 
 def test_generate_component_yaml_multi_conf_emits_list_form() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The line based splice helpers assumed the canonical 2 space layout, so "Add component" into a zero indented or 4 space list emitted YAML that fails to parse, and a 1 space mapping body silently lost its dash during multi_conf normalisation.

The splice now derives the dash indent from the existing block's first list item and re indents the generated item to match, mirroring the frontend fix in esphome/device-builder-frontend#786; mapping bodies convert to list form by stripping their actual indent instead of prefix arithmetic against the canonical constant.

**Related issue or feature (if applicable):**

- fixes #1411

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
