### PR TITLE
Treat a literal "None" docstring as no description

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1039,7 +1039,12 @@ class CleanedDocs:
 
 
 def clean_docs(raw: str | None) -> CleanedDocs:
-    """Strip type prefix and ``See also`` footer; surface both as fields."""
+    """
+    Strip type prefix and ``See also`` footer; surface both as fields.
+
+    A body that is exactly ``"None"`` (ESPHome's empty-docstring sentinel)
+    becomes empty text, keeping any extracted name/url.
+    """
     if not raw:
         return CleanedDocs("")
     text = raw.strip()

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1050,8 +1050,13 @@ def clean_docs(raw: str | None) -> CleanedDocs:
         name = m.group(1).strip()
         url = m.group(2).strip()
         text = text[: m.start()].rstrip()
-    text = _DOCS_TYPE_PREFIX.sub("", text)
-    return CleanedDocs(text=text.strip(), name=name, url=url)
+    text = _DOCS_TYPE_PREFIX.sub("", text).strip()
+    # ESPHome's schema dump serializes a missing docstring as the literal
+    # string "None" (often with a real See-also footer); treat the body as
+    # absent so the MDX backfill can fill in. Keep the extracted name/url.
+    if text == "None":
+        text = ""
+    return CleanedDocs(text=text, name=name, url=url)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_components_clean_docs.py
+++ b/tests/test_sync_components_clean_docs.py
@@ -1,0 +1,33 @@
+"""Unit tests for ``clean_docs`` in ``script/sync_components.py``."""
+
+from __future__ import annotations
+
+from script.sync_components import clean_docs  # type: ignore[import-not-found]
+
+
+def test_clean_docs_treats_literal_none_as_empty() -> None:
+    """ESPHome's schema dump writes a missing docstring as the string "None"."""
+    assert clean_docs("None").text == ""
+    assert clean_docs("  None  ").text == ""
+
+
+def test_clean_docs_none_body_keeps_see_also_footer() -> None:
+    """A "None" body with a real See-also footer drops the body, keeps name/url."""
+    cleaned = clean_docs(
+        "None\n\n*See also: [ATM90E32 Power Sensor](https://esphome.io/components/sensor/atm90e32)*"
+    )
+    assert cleaned.text == ""
+    assert cleaned.name == "ATM90E32 Power Sensor"
+    assert cleaned.url == "https://esphome.io/components/sensor/atm90e32"
+
+
+def test_clean_docs_keeps_text_starting_with_none() -> None:
+    """Only an exact "None" body is dropped — a real description is preserved."""
+    assert clean_docs("None of the channels are enabled by default.").text == (
+        "None of the channels are enabled by default."
+    )
+
+
+def test_clean_docs_passes_through_a_normal_description() -> None:
+    """A regular description round-trips with its type prefix stripped."""
+    assert clean_docs("**string**: The friendly name.").text == "The friendly name."


### PR DESCRIPTION
# What does this implement/fix?

The Add Component dialog for several components (e.g. ATM90E32 Power Sensor, the `*.copy` family) showed a useless body with the description rendered as the literal word "None". ESPHome's schema dump serializes a component with no docstring as the string "None" (often followed by a real `*See also:` footer), and `clean_docs` passed that body straight through, so the catalog shipped `description: "None"`. Worse, the MDX backfill only fills empty descriptions, so the bogus "None" blocked the real docs-page description from ever filling in. `clean_docs` now drops a body that is exactly "None" (checked after the See-also footer and type prefix are stripped, so the footer's name/url survive), which both removes the garbage and unblocks the backfill.

I confirmed locally by regenerating the catalog against the committed 2026.5.3 schema: all 49 bodies that had `description: "None"` are fixed, and the backfill supplies real text (button.atm90e32 / text_sensor.atm90e32 become "ATM90E32 energy metering sensors", the copy family becomes "Copy component in ESPHome"). The regenerated catalog is intentionally not committed here; the nightly sync workflow will pick up this script change and regenerate the definitions.

A related issue (all four atm90e32 platforms sharing the catalog name "ATM90E32 Power Sensor", a `_resolve_name` borrowed-title concern) is filed separately as #1426.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1424

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (the catalog regen is left to the nightly sync workflow).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
