### PR TITLE
Rank exact name/id matches first in component search

### DIFF
--- a/esphome_device_builder/controllers/components/controller.py
+++ b/esphome_device_builder/controllers/components/controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from ...definitions import (
@@ -407,6 +408,10 @@ class ComponentCatalog:
                     or query_lower in c.description.lower()
                     or query_lower in c.id.lower()
                 ]
+                # Rank exact id/name matches first so e.g. searching "uart"
+                # surfaces UART Bus above components that only mention it in
+                # their description. Stable sort keeps catalog order per rank.
+                results = sorted(results, key=partial(_query_rank, query_lower=query_lower))
 
         total_featured = len(featured_entries)
         total = total_featured + len(results)
@@ -666,6 +671,9 @@ class ComponentCatalog:
                 or query_lower in e.description.lower()
                 or query_lower in e.id.lower()
             ]
+            # Rank like the regular results so an exact hit leads the featured
+            # cards too, instead of staying in curated order.
+            entries = sorted(entries, key=partial(_query_rank, query_lower=query_lower))
         return entries
 
     def _resolve_platform(
@@ -702,3 +710,18 @@ class ComponentCatalog:
         if board is None or board.esphome.variant is None:
             return None
         return variant_to_key(board.esphome.variant.value)
+
+
+def _query_rank(entry: ComponentCatalogIndexEntry, query_lower: str) -> int:
+    """Search relevance rank for *entry* against *query_lower*; lower sorts first."""
+    name = entry.name.lower()
+    cid = entry.id.lower()
+    if query_lower in (cid, name):
+        return 0  # exact id / name
+    if cid.startswith(query_lower) or name.startswith(query_lower):
+        return 1
+    if query_lower in name:
+        return 2
+    if query_lower in cid:
+        return 3
+    return 4  # description-only match

--- a/tests/controllers/test_components.py
+++ b/tests/controllers/test_components.py
@@ -293,6 +293,38 @@ async def test_get_components_provides_filters_featured_entries() -> None:
     assert {c.id for c in res.components} == {"featured.b.adc"}
 
 
+async def test_get_components_query_ranks_featured_entries() -> None:
+    """A query ranks featured cards by match strength, not just curated order."""
+    cat = ComponentCatalog()
+    cat._by_id = {
+        "sensor.hub": _make_entry(entry_id="sensor.hub", category=ComponentCategory.SENSOR),
+        "uart": _make_entry(entry_id="uart", name="UART Bus", category=ComponentCategory.SENSOR),
+    }
+    cat._featured_by_id = {
+        "featured.b.hub": _FeaturedRecord(
+            full_id="featured.b.hub",
+            board_id="b",
+            featured=FeaturedComponent(
+                id="hub", component_id="sensor.hub", name="Sensor Hub", description="talks UART"
+            ),
+            underlying_id="sensor.hub",
+        ),
+        "featured.b.uart": _FeaturedRecord(
+            full_id="featured.b.uart",
+            board_id="b",
+            featured=FeaturedComponent(id="uart", component_id="uart", name="UART"),
+            underlying_id="uart",
+        ),
+    }
+    # Curated order lists the description-only hub first; ranking floats the
+    # exact name match (uart) above it.
+    cat._featured_by_board = {"b": ["featured.b.hub", "featured.b.uart"]}
+    res = await cat.get_components(
+        category=ComponentCategory.FEATURED.value, board_id="b", query="uart"
+    )
+    assert [c.id for c in res.components] == ["featured.b.uart", "featured.b.hub"]
+
+
 async def test_get_components_query_matches_name_description_or_id() -> None:
     """``query`` is a substring match against name / description / id."""
     cat = ComponentCatalog()
@@ -309,6 +341,27 @@ async def test_get_components_query_matches_name_description_or_id() -> None:
     # Match by id stem too.
     res = await cat.get_components(query="dht")
     assert {c.id for c in res.components} == {"dht"}
+
+
+async def test_get_components_query_ranks_by_match_strength() -> None:
+    """Hits sort exact id/name, then prefix, name substring, id substring, description."""
+    cat = ComponentCatalog()
+    cat._components = [
+        _make_entry(entry_id="ble_nus", name="Nordic UART Service (NUS)"),  # name substring
+        _make_entry(entry_id="myuartx", name="Custom Board"),  # id substring only
+        _make_entry(entry_id="dlms_meter", name="DLMS Meter", description="Talks over UART"),
+        _make_entry(entry_id="uart_bridge", name="UART Bridge"),  # prefix
+        _make_entry(entry_id="uart", name="UART Bus"),  # exact id
+    ]
+    cat._by_id = {c.id: c for c in cat._components}
+    res = await cat.get_components(query="uart")
+    assert [c.id for c in res.components] == [
+        "uart",
+        "uart_bridge",
+        "ble_nus",
+        "myuartx",
+        "dlms_meter",
+    ]
 
 
 async def test_get_components_response_categories_track_query_filter() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Component search filtered matches by substring but never ranked them, so searching an exact name like `uart` listed components that only mention UART in their description above the actual UART Bus. Results are now sorted after filtering; exact id or name first, then prefix, then name substring, then id, then description only. The sort is stable, so catalog order is preserved within a rank.

**Related issue or feature (if applicable):**

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
