### PR TITLE
Accept underscores in esphome.name so mDNS matches

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -152,7 +152,7 @@ def load_device_from_storage(
     fallback_name = configuration_stem(filename)
     storage_name = storage.name if storage else None
     # Pick the first valid ESPHome slug from (yaml_name, storage_name).
-    # Real ESPHome ``esphome.name`` values are ``[a-z0-9-]+`` — a parsed
+    # Real ESPHome ``esphome.name`` values are ``[a-z0-9_-]+`` — a parsed
     # value with dots / spaces / uppercase is something else (a package
     # id like ``ratgdo.esphome``, a friendly_name leaked through, etc.).
     # ``device.name`` is the key the state monitor uses to match mDNS

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -35,12 +35,12 @@ _UNRESOLVED_SUBSTITUTION_RE = re.compile(r"\$\{|\$[a-zA-Z_]")
 # deep chains a user might write.
 _SUBSTITUTION_MAX_PASSES = 16
 
-# ``esphome.name``'s char class; keep in sync with ESPHome's
-# ``ALLOWED_NAME_CHARS`` (underscore included — it broadcasts verbatim over
-# mDNS): https://github.com/esphome/esphome/blob/dev/esphome/const.py
-# Anything else (dots, spaces, uppercase) is a wrong field (a package id, a
-# leaked friendly_name), rejected so it can't become the device key.
-_VALID_ESPHOME_NAME_RE = re.compile(r"\A[a-z0-9_-]+\Z")
+# Built from ESPHome's ``esphome.name`` char class so it can't drift from
+# upstream (a hand-written class missing ``_`` is the bug this fixes):
+# https://github.com/esphome/esphome/blob/dev/esphome/const.py
+# Rejects wrong fields (a package id's dots, a friendly_name's spaces /
+# uppercase) so they can't become the device key.
+_VALID_ESPHOME_NAME_RE = re.compile(rf"\A[{re.escape(const.ALLOWED_NAME_CHARS)}]+\Z")
 
 
 def _is_valid_esphome_name(value: str) -> bool:

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -35,13 +35,10 @@ _UNRESOLVED_SUBSTITUTION_RE = re.compile(r"\$\{|\$[a-zA-Z_]")
 # deep chains a user might write.
 _SUBSTITUTION_MAX_PASSES = 16
 
-# ESPHome's ``esphome.name`` accepts lowercase ASCII letters, digits,
-# hyphens, and underscores (``esphome.const.ALLOWED_NAME_CHARS``); the
-# underscore broadcasts verbatim over mDNS, so we must accept it or an
-# underscore-named device never matches its announcement (#1453). A
-# parsed value with anything else (dots, spaces, uppercase, ...) means
-# we picked up the wrong field (a package id, a friendly_name leaked
-# through, etc.) and should be rejected so it doesn't end up as the key.
+# ``esphome.name``'s char class, matching ``esphome.const.ALLOWED_NAME_CHARS``
+# (underscore included — it broadcasts verbatim over mDNS). Anything else
+# (dots, spaces, uppercase) is a wrong field — a package id, a leaked
+# friendly_name — and is rejected so it can't become the device key.
 _VALID_ESPHOME_NAME_RE = re.compile(r"\A[a-z0-9_-]+\Z")
 
 

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -36,12 +36,13 @@ _UNRESOLVED_SUBSTITUTION_RE = re.compile(r"\$\{|\$[a-zA-Z_]")
 _SUBSTITUTION_MAX_PASSES = 16
 
 # ESPHome's ``esphome.name`` accepts lowercase ASCII letters, digits,
-# and hyphens — the same character class an mDNS hostname / API
-# endpoint can carry. A parsed value with anything else (dots, spaces,
-# uppercase, ...) means we picked up the wrong field (a package id, a
-# friendly_name leaked through, etc.) and should be rejected so it
-# doesn't end up as the catalog key.
-_VALID_ESPHOME_NAME_RE = re.compile(r"\A[a-z0-9-]+\Z")
+# hyphens, and underscores (``esphome.const.ALLOWED_NAME_CHARS``); the
+# underscore broadcasts verbatim over mDNS, so we must accept it or an
+# underscore-named device never matches its announcement (#1453). A
+# parsed value with anything else (dots, spaces, uppercase, ...) means
+# we picked up the wrong field (a package id, a friendly_name leaked
+# through, etc.) and should be rejected so it doesn't end up as the key.
+_VALID_ESPHOME_NAME_RE = re.compile(r"\A[a-z0-9_-]+\Z")
 
 
 def _is_valid_esphome_name(value: str) -> bool:

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -35,10 +35,11 @@ _UNRESOLVED_SUBSTITUTION_RE = re.compile(r"\$\{|\$[a-zA-Z_]")
 # deep chains a user might write.
 _SUBSTITUTION_MAX_PASSES = 16
 
-# ``esphome.name``'s char class, matching ``esphome.const.ALLOWED_NAME_CHARS``
-# (underscore included — it broadcasts verbatim over mDNS). Anything else
-# (dots, spaces, uppercase) is a wrong field — a package id, a leaked
-# friendly_name — and is rejected so it can't become the device key.
+# ``esphome.name``'s char class; keep in sync with ESPHome's
+# ``ALLOWED_NAME_CHARS`` (underscore included — it broadcasts verbatim over
+# mDNS): https://github.com/esphome/esphome/blob/dev/esphome/const.py
+# Anything else (dots, spaces, uppercase) is a wrong field (a package id, a
+# leaked friendly_name), rejected so it can't become the device key.
 _VALID_ESPHOME_NAME_RE = re.compile(r"\A[a-z0-9_-]+\Z")
 
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -840,21 +840,21 @@ def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Pa
     ("value", "expected"),
     [
         ("hf-display", True),
-        ("hf_display", True),  # ESPHome allows underscores (#1453)
+        ("hf_display", True),
         ("node1", True),
-        ("ratgdo.esphome", False),  # dotted package id, not a name
-        ("Hf Display", False),  # friendly_name (space + uppercase)
+        ("ratgdo.esphome", False),
+        ("Hf Display", False),
         ("my device", False),
     ],
 )
 def test_is_valid_esphome_name(value: str, expected: bool) -> None:
-    """``esphome.name`` accepts ``[a-z0-9_-]`` (incl. underscore), rejects other fields."""
+    """``esphome.name`` accepts ``[a-z0-9_-]``; other fields (dots/spaces/uppercase) fail."""
     assert _is_valid_esphome_name(value) is expected
 
 
 def test_load_device_from_storage_keeps_underscore_name(tmp_path: Path) -> None:
-    """An underscore ``esphome.name`` keys the device, not the filename stem (#1453)."""
-    # Filename differs from the name, so the stem fallback would shadow a
+    """An underscore ``esphome.name`` keys the device, not the filename stem."""
+    # Filename differs from the name so the stem fallback would shadow a
     # wrongly-rejected name; the underscore name must still win.
     yaml_file = tmp_path / "hf-display-renamed.yaml"
     yaml_file.write_text(

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -32,6 +32,7 @@ from esphome_device_builder.helpers.device_yaml import (
     parse_esphome_meta,
     parse_platform_from_yaml,
 )
+from esphome_device_builder.helpers.device_yaml._parsing import _is_valid_esphome_name
 from esphome_device_builder.models import (
     BoardCatalogEntry,
     BoardEsphomeConfig,
@@ -833,6 +834,35 @@ def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Pa
         device = load_device_from_storage(yaml_file)
     assert device.target_platform == "esp32"
     assert spy.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("hf-display", True),
+        ("hf_display", True),  # ESPHome allows underscores (#1453)
+        ("node1", True),
+        ("ratgdo.esphome", False),  # dotted package id, not a name
+        ("Hf Display", False),  # friendly_name (space + uppercase)
+        ("my device", False),
+    ],
+)
+def test_is_valid_esphome_name(value: str, expected: bool) -> None:
+    """``esphome.name`` accepts ``[a-z0-9_-]`` (incl. underscore), rejects other fields."""
+    assert _is_valid_esphome_name(value) is expected
+
+
+def test_load_device_from_storage_keeps_underscore_name(tmp_path: Path) -> None:
+    """An underscore ``esphome.name`` keys the device, not the filename stem (#1453)."""
+    # Filename differs from the name, so the stem fallback would shadow a
+    # wrongly-rejected name; the underscore name must still win.
+    yaml_file = tmp_path / "hf-display-renamed.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: hf_display\nesp32:\n  board: esp32dev\n",
+        encoding="utf-8",
+    )
+    device = load_device_from_storage(yaml_file)
+    assert device.name == "hf_display"
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -17,6 +17,7 @@ import pytest
 import yaml
 from esphome.components import wifi as esphome_wifi
 from esphome.components.rp2040.boards import BOARDS as ESPHOME_RP2040_BOARDS
+from esphome.const import ALLOWED_NAME_CHARS
 
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
@@ -850,6 +851,11 @@ def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Pa
 def test_is_valid_esphome_name(value: str, expected: bool) -> None:
     """``esphome.name`` accepts ``[a-z0-9_-]``; other fields (dots/spaces/uppercase) fail."""
     assert _is_valid_esphome_name(value) is expected
+
+
+def test_is_valid_esphome_name_covers_allowed_name_chars() -> None:
+    """The pattern accepts every character ESPHome permits, so it can't drift."""
+    assert _is_valid_esphome_name(ALLOWED_NAME_CHARS)
 
 
 def test_load_device_from_storage_keeps_underscore_name(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

A device whose `esphome.name` contains an underscore (e.g. `hf_display`) was never recognized: its MAC, version, config hash and IP stayed empty, even though `aioesphomeapi-discover` and `esphome logs` resolve it and the legacy dashboard matches it.

ESPHome allows underscores in `name:` (`esphome.const.ALLOWED_NAME_CHARS`) and broadcasts the name verbatim over mDNS, but our `_VALID_ESPHOME_NAME_RE` was `[a-z0-9-]+`, missing the underscore. So `_is_valid_esphome_name("hf_display")` was false and `load_device_from_storage` fell back to the filename stem, keying the device under the wrong name. The mDNS browse then looked up the verbatim `hf_display`, missed, and bailed, so nothing was applied. Our mDNS side was already correct (it preserves the underscore on purpose).

The fix adds the underscore to the regex to mirror ESPHome. Genuinely-wrong fields (a dotted package id, a friendly_name with spaces/uppercase) still fail, so the stem fallback they were guarding still works.

**Related issue or feature (if applicable):**

- fixes esphome/device-builder#1453

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

The drawer copy that surfaces an undiscovered device (device-builder-frontend#833) is a separate UX improvement and stays open.

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
