### PR TITLE
Add a test for the friendly-slug-filename underscore-name case

### DIFF
--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -871,6 +871,23 @@ def test_load_device_from_storage_keeps_underscore_name(tmp_path: Path) -> None:
     assert device.name == "hf_display"
 
 
+def test_load_device_from_storage_keeps_underscore_name_under_friendly_slug_file(
+    tmp_path: Path,
+) -> None:
+    """A friendly-name-slug filename doesn't shadow the YAML's underscore ``name``."""
+    # A device created from a friendly name lands in ``<slug>.yaml`` while its
+    # YAML ``name`` keeps underscores; the real name must win over the slug stem
+    # so the rename dialog pre-fills the actual hostname (not a slug it equals).
+    yaml_file = tmp_path / "my-esp-device.yaml"
+    yaml_file.write_text(
+        "esphome:\n  name: my_esp-device_2\n  friendly_name: My ESP Device\n"
+        "esp32:\n  board: esp32dev\n",
+        encoding="utf-8",
+    )
+    device = load_device_from_storage(yaml_file)
+    assert device.name == "my_esp-device_2"
+
+
 # ----------------------------------------------------------------------
 # extract_directly_referenced_integrations — key walk
 # ----------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Follow-up test coverage for the underscore-name fix (#1459, merged). A second report showed the same root cause from a different angle: a device created from a friendly name lands in `<slug>.yaml` while its YAML `name:` carries underscores (`my-esp-device.yaml` with `name: my_esp-device_2`). Before #1459 the validator rejected the underscore name, so `device.name` fell back to the friendly-slug filename stem — which broke mDNS matching and left the rename dialog pre-filled with the wrong name and the Rename button disabled.

This adds a regression test for that exact scenario (slug filename + underscore `name` + a `friendly_name`) asserting `device.name` resolves to `my_esp-device_2`, not the stem. The existing `hf_display` test is left as is.

**Related issue or feature (if applicable):**

- Re: esphome/device-builder#1453

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
