### PR TITLE
Add config-only rename for offline devices

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -447,11 +447,19 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         *,
         configuration: str,
         new_name: str,
+        config_only: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Rename a device configuration via ``esphome rename``."""
+        """
+        Rename a device configuration.
+
+        Default path delegates to ``esphome rename`` (compile + OTA).
+        ``config_only`` rewrites the YAML + ``esphome.name`` without
+        flashing; the caller uses it after the user confirms renaming
+        an offline device.
+        """
         return await mutations_simple.rename_device(
-            self, configuration=configuration, new_name=new_name
+            self, configuration=configuration, new_name=new_name, config_only=config_only
         )
 
     @api_command("devices/clone")

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -51,7 +51,7 @@ def on_job_completed(controller: DevicesController, event: Event[JobLifecycleDat
             # ``livingroom.yaml.yaml`` and target the wrong entry.
             new_configuration = f"{Path(new_name).stem}.yaml"
             controller._db.create_background_task(
-                _migrate_metadata_then_scan(controller, old_configuration, new_configuration)
+                migrate_metadata_then_scan(controller, old_configuration, new_configuration)
             )
         else:
             controller._db.create_background_task(controller._scanner.scan())
@@ -163,7 +163,7 @@ def sync_deployed_hash_after_flash(controller: DevicesController, configuration:
     controller._state_monitor.apply_config_hash(device.name, device.expected_config_hash)
 
 
-async def _migrate_metadata_then_scan(
+async def migrate_metadata_then_scan(
     controller: DevicesController, old_configuration: str, new_configuration: str
 ) -> None:
     """Move the renamed device's metadata before the scan rebuilds it."""

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem
 from ...helpers.yaml import (
+    ESPHOME_FRIENDLY_NAME_PATH,
+    ESPHOME_NAME_PATH,
     generate_api_encryption_key,
     rewrite_api_encryption_key,
     rewrite_name_or_substitution,
@@ -108,7 +110,7 @@ async def clone_device(  # noqa: C901
     # ``_rewrite_required_yaml_leaf`` rejects when the leaf is
     # missing entirely so a package-driven source can't silently
     # produce a duplicate hostname.
-    new_content = _rewrite_required_yaml_leaf(source_content, ("esphome", "name"), new_name)
+    new_content = _rewrite_required_yaml_leaf(source_content, ESPHOME_NAME_PATH, new_name)
     # ``friendly_name`` is optional on the clone path; the
     # underlying helper is already a no-op when the leaf is
     # missing, so skip the required-leaf wrapper here. The clone
@@ -119,7 +121,7 @@ async def clone_device(  # noqa: C901
     if new_friendly_name:
         new_content = rewrite_name_or_substitution(
             new_content,
-            ("esphome", "friendly_name"),
+            ESPHOME_FRIENDLY_NAME_PATH,
             clean_friendly_name(new_friendly_name),
         )
     # No-op when the source uses ``!secret`` / ``${...}`` for

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -163,6 +163,18 @@ async def create_device(  # noqa: C901, PLR0912
     return WizardResponse(configuration=filename)
 
 
+def default_mdns_address(name: str) -> str:
+    """Return the mDNS address ESPHome derives from a device *name* by default."""
+    return f"{name}.local"
+
+
+def save_device_storage(filename: str, storage: StorageJSON) -> None:
+    """Persist *storage* to *filename*'s sidecar path, creating the dir."""
+    storage_path = resolve_storage_path(filename)
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage.save(storage_path)
+
+
 def init_device_storage(filename: str, name: str, friendly_name: str | None, platform: str) -> None:
     """Write a fresh StorageJSON sidecar for a newly created / imported device."""
     storage = StorageJSON(
@@ -172,7 +184,7 @@ def init_device_storage(filename: str, name: str, friendly_name: str | None, pla
         comment=None,
         esphome_version=None,
         src_version=None,
-        address=f"{name}.local",
+        address=default_mdns_address(name),
         web_port=None,
         target_platform=platform,
         build_path=None,
@@ -181,6 +193,4 @@ def init_device_storage(filename: str, name: str, friendly_name: str | None, pla
         loaded_platforms=[],
         no_mdns=False,
     )
-    storage_path = resolve_storage_path(filename)
-    storage_path.parent.mkdir(parents=True, exist_ok=True)
-    storage.save(storage_path)
+    save_device_storage(filename, storage)

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -24,7 +24,7 @@ from ...constants import SECRETS_FILENAME
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem, parse_platform_from_yaml
 from ...helpers.secrets_state import merge_secrets_file
-from ...helpers.yaml import read_yaml_scalar
+from ...helpers.yaml import ESPHOME_FRIENDLY_NAME_PATH, read_yaml_scalar
 from ...models import ErrorCode, ImportBundleResponse
 from .helpers import _validate_archive_configuration
 from .mutations_create import init_device_storage
@@ -254,7 +254,7 @@ def _init_bundle_storage(config_dir: Path, config_filename: str) -> None:
         # metadata from the YAML on its next pass.
         _LOGGER.warning("Couldn't read %s to seed its sidecar (%s); skipping", config_filename, err)
         return
-    friendly = read_yaml_scalar(content, ("esphome", "friendly_name"))
+    friendly = read_yaml_scalar(content, ESPHOME_FRIENDLY_NAME_PATH)
     if friendly and "${" in friendly:
         friendly = None
     platform, _pio_board, _variant = parse_platform_from_yaml(content)

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -3,17 +3,33 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
+
+from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem, parse_esphome_meta
-from ...helpers.yaml import YamlUpsertNotSupportedError, upsert_yaml_leaf_under_top_block
+from ...helpers.storage_path import resolve_storage_path
+from ...helpers.yaml import (
+    ESPHOME_NAME_PATH,
+    YamlUpsertNotSupportedError,
+    is_retargetable_name,
+    parse_substitution_ref,
+    read_yaml_scalar,
+    rewrite_name_or_substitution,
+    upsert_yaml_leaf_under_top_block,
+)
 from ...models import Device, ErrorCode, UpdateDeviceResponse
 from ..config import set_device_labels
 from . import archive
+from .firmware_sync import migrate_metadata_then_scan
+from .mutations_create import default_mdns_address, save_device_storage
 
 if TYPE_CHECKING:
     from .controller import DevicesController
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def update_device(
@@ -179,18 +195,15 @@ async def rename_device(
     *,
     configuration: str,
     new_name: str,
+    config_only: bool = False,
 ) -> dict[str, Any]:
     """
     Rename a device configuration.
 
-    Thin pass-through to ``esphome rename``: the CLI owns the
-    whole atomic flow (YAML edit, revalidation, compile + OTA
-    install, rollback on failure). Routed through the firmware
-    queue so streaming output shows up alongside other firmware
-    tasks. Deliberately no file-level fallback: a fallback would
-    silently rename the YAML on disk while the running firmware
-    keeps broadcasting the old hostname (dashboard label and
-    device state diverge with no error to the user).
+    Default path delegates to ``esphome rename`` (compile + OTA install,
+    via the firmware queue); only succeeds against a reachable device.
+    ``config_only`` rewrites the YAML + ``esphome.name`` and renames the
+    file without compiling or flashing, for an offline device.
     """
     new_filename = f"{new_name}.yaml"
 
@@ -217,11 +230,117 @@ async def rename_device(
         msg = f"A device named {new_filename} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
+    if config_only:
+        return await _config_only_rename(controller, configuration=configuration, new_name=new_name)
+
     if controller._db.firmware is None:
         msg = "Firmware controller is unavailable"
         raise CommandError(ErrorCode.INTERNAL_ERROR, msg)
     job = await controller._db.firmware.rename(configuration=configuration, new_name=new_name)
     return {"configuration": new_filename, "job": job.to_dict()}
+
+
+async def _read_device_yaml_or_raise(controller: DevicesController, configuration: str) -> str:
+    """
+    Return *configuration*'s YAML text, raising INVALID_ARGS if it's gone.
+
+    A single ``read_text`` with no preceding ``exists()`` check, so a file
+    deleted mid-call surfaces as the typed "device gone" error instead of
+    leaking ``FileNotFoundError`` as INTERNAL_ERROR.
+    """
+    path = controller._db.settings.rel_path(configuration)
+
+    def _read() -> str | None:
+        try:
+            return path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+    content = await asyncio.get_running_loop().run_in_executor(None, _read)
+    if content is None:
+        raise CommandError(ErrorCode.INVALID_ARGS, f"Device {configuration} not found")
+    return content
+
+
+async def _config_only_rename(
+    controller: DevicesController,
+    *,
+    configuration: str,
+    new_name: str,
+) -> dict[str, Any]:
+    """
+    Rename the YAML + ``esphome.name`` with no compile or OTA.
+
+    Validates the rewritten config before touching disk, writes the new
+    file atomically, removes the old, and migrates the StorageJSON +
+    sidecar metadata. Returns ``job: None`` (nothing is queued).
+    """
+    new_filename = f"{new_name}.yaml"
+    loop = asyncio.get_running_loop()
+    old_path = controller._db.settings.rel_path(configuration)
+    new_path = controller._db.settings.rel_path(new_filename)
+
+    content = await _read_device_yaml_or_raise(controller, configuration)
+
+    # ``esphome.name`` must be retargetable in place: a plain literal (rewrite
+    # the leaf) or a pure ``${var}`` ref whose definition lives in this file's
+    # ``substitutions:`` block (rewrite the def). A missing leaf, a tag, an
+    # embedded substitution (``kitchen_${suffix}``), or a ``${var}`` defined in
+    # a package / !include would flatten the indirection to a literal, so refuse
+    # those and steer to the OTA rename, which resolves them.
+    current = read_yaml_scalar(content, ESPHOME_NAME_PATH)
+    var = parse_substitution_ref(current) if current is not None else None
+    # A pure ``${var}`` ref whose def isn't in this file would be flattened.
+    nonlocal_sub = var is not None and read_yaml_scalar(content, ("substitutions", var)) is None
+    if current is None or not is_retargetable_name(current) or nonlocal_sub:
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            "Can't rename offline: esphome.name isn't a plain literal or a local "
+            "${substitution} (it may come from packages, an !include, or an "
+            "embedded substitution). Bring the device online to rename it.",
+        )
+
+    new_content = rewrite_name_or_substitution(content, ESPHOME_NAME_PATH, new_name)
+
+    # Validate before any disk change so a bad rewrite never lands on disk.
+    await controller._validate_rewritten_yaml_or_raise(new_filename, new_content, action="rename")
+
+    await controller._write_yaml_atomic_async(new_path, new_content)
+    await loop.run_in_executor(None, lambda: old_path.unlink(missing_ok=True))
+    # The YAML is already renamed; storage migration is best-effort (logs on
+    # failure) and the shared metadata-migrate-then-scan always rescans.
+    await loop.run_in_executor(None, _migrate_storage_json, configuration, new_filename, new_name)
+    await migrate_metadata_then_scan(controller, configuration, new_filename)
+    return {"configuration": new_filename, "job": None}
+
+
+def _migrate_storage_json(old_configuration: str, new_filename: str, new_name: str) -> None:
+    """Move the StorageJSON sidecar to the new filename, retargeting the name.
+
+    Best-effort (errors are logged, not raised): the YAML rename has already
+    landed, so a sidecar failure must not fail the rename. The trade-off is
+    that on failure the rename still returns success while the device shows as
+    never-built until its next compile regenerates the sidecar, and the old
+    sidecar is left orphaned. Recoverable, so it's logged rather than surfaced
+    to the client. ``friendly_name`` / ``address`` are only retargeted when
+    they still carry the old-name defaults.
+    """
+    try:
+        old_storage_path = resolve_storage_path(old_configuration)
+        storage = StorageJSON.load(old_storage_path)
+        if storage is None:
+            return
+        old_name = storage.name
+        storage.name = new_name
+        if storage.friendly_name == old_name:
+            storage.friendly_name = new_name
+        if storage.address == default_mdns_address(old_name):
+            storage.address = default_mdns_address(new_name)
+        save_device_storage(new_filename, storage)
+        old_storage_path.unlink(missing_ok=True)
+    except OSError:
+        # Filesystem hiccup only; a logic bug here should surface, not hide.
+        _LOGGER.exception("Could not migrate StorageJSON for %s", new_filename)
 
 
 async def edit_friendly_name(
@@ -260,25 +379,7 @@ async def edit_friendly_name(
     if not new_friendly_name:
         raise CommandError(ErrorCode.INVALID_ARGS, "new_friendly_name is required")
 
-    loop = asyncio.get_running_loop()
-    config_path = controller._db.settings.rel_path(configuration)
-
-    def _read() -> str | None:
-        # Single read_text call, no preceding exists() check;
-        # a file deleted between the two would leak
-        # FileNotFoundError as INTERNAL_ERROR instead of the
-        # typed INVALID_ARGS we want for "device gone".
-        try:
-            return config_path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            return None
-
-    content = await loop.run_in_executor(None, _read)
-    if content is None:
-        raise CommandError(
-            ErrorCode.INVALID_ARGS,
-            f"Device {configuration} not found",
-        )
+    content = await _read_device_yaml_or_raise(controller, configuration)
 
     try:
         new_content = upsert_yaml_leaf_under_top_block(

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -54,13 +54,17 @@ from .inline import remove_subentity_handler as remove_subentity_handler
 from .inline import synthetic_instance_index as synthetic_instance_index
 from .inline import upsert_inline_handler as upsert_inline_handler
 from .inline import upsert_subentity_handler as upsert_subentity_handler
+from .scalar import ESPHOME_FRIENDLY_NAME_PATH as ESPHOME_FRIENDLY_NAME_PATH
+from .scalar import ESPHOME_NAME_PATH as ESPHOME_NAME_PATH
 from .scalar import ESPHOME_YAML_INDENT as ESPHOME_YAML_INDENT
 from .scalar import YamlUpsertNotSupportedError as YamlUpsertNotSupportedError
 from .scalar import _quote as _quote
 from .scalar import _safe_yaml_scalar as _safe_yaml_scalar
 from .scalar import _strip_yaml_quotes as _strip_yaml_quotes
+from .scalar import is_plain_literal_scalar as is_plain_literal_scalar
 from .scalar import read_yaml_scalar as read_yaml_scalar
 from .scalar import rewrite_yaml_scalar as rewrite_yaml_scalar
+from .substitution import is_retargetable_name as is_retargetable_name
 from .substitution import parse_substitution_ref as parse_substitution_ref
 from .substitution import rewrite_name_or_substitution as rewrite_name_or_substitution
 from .top_block import (

--- a/esphome_device_builder/helpers/yaml/scalar.py
+++ b/esphome_device_builder/helpers/yaml/scalar.py
@@ -31,6 +31,11 @@ def is_lambda_sentinel(value: Any) -> bool:
 # emit the same shape the user sees in the editor's auto-indent.
 ESPHOME_YAML_INDENT = "  "
 
+# Mapping-path tuples for the device-identity leaves the helpers read /
+# rewrite most; hoisted so call sites share one spelling.
+ESPHOME_NAME_PATH: tuple[str, str] = ("esphome", "name")
+ESPHOME_FRIENDLY_NAME_PATH: tuple[str, str] = ("esphome", "friendly_name")
+
 
 def block_body_is_list(lines: list[str], header_idx: int, end_idx: int) -> bool:
     """Return True when a block body — lines ``(header_idx, end_idx)`` — is a YAML list."""
@@ -323,3 +328,16 @@ def _strip_yaml_quotes(value: str) -> str:
     if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ('"', "'"):
         return stripped[1:-1]
     return stripped
+
+
+def is_plain_literal_scalar(value: str) -> bool:
+    """
+    Return True when *value* is a non-empty plain literal safe to rewrite.
+
+    False for an empty value, a YAML tag (``!include``), or anything
+    carrying a substitution (``$var`` / ``${var}``, including embedded
+    forms like ``kitchen_${suffix}``) — those can't be retargeted as a
+    flat literal without dropping the indirection.
+    """
+    unquoted = _strip_yaml_quotes(value)
+    return bool(unquoted) and not unquoted.startswith("!") and "$" not in unquoted

--- a/esphome_device_builder/helpers/yaml/substitution.py
+++ b/esphome_device_builder/helpers/yaml/substitution.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from .scalar import _safe_yaml_scalar, _strip_yaml_quotes, read_yaml_scalar, rewrite_yaml_scalar
+from .scalar import (
+    _safe_yaml_scalar,
+    _strip_yaml_quotes,
+    is_plain_literal_scalar,
+    read_yaml_scalar,
+    rewrite_yaml_scalar,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -34,6 +40,19 @@ def parse_substitution_ref(value: str) -> str | None:
     if not m:
         return None
     return m.group(1) or m.group(2)
+
+
+def is_retargetable_name(value: str) -> bool:
+    """
+    Return True when :func:`rewrite_name_or_substitution` can retarget *value*.
+
+    A plain literal (rewrite the leaf) or a pure ``${var}`` reference
+    (rewrite the substitution definition) is retargetable. An empty
+    value, a YAML tag (``!include``), or an embedded substitution
+    (``kitchen_${suffix}``) is not — flattening those would silently drop
+    the tag / indirection.
+    """
+    return is_plain_literal_scalar(value) or parse_substitution_ref(value) is not None
 
 
 def rewrite_name_or_substitution(

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -1,0 +1,259 @@
+"""Tests for the ``config_only`` rename path (rewrite name + file, no flash)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from esphome.storage_json import StorageJSON
+
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.yaml import read_yaml_scalar
+from esphome_device_builder.models import ErrorCode
+from tests._storage_fixtures import write_storage_json
+
+from .conftest import MakeControllerFactory
+
+_YAML = """\
+esphome:
+  name: kitchen
+  friendly_name: Kitchen Light
+
+esp32:
+  board: esp32dev
+"""
+
+
+async def test_config_only_rename_rewrites_name_and_renames_file(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The YAML name is rewritten, the file moves, nothing is queued."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+
+    result = await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    assert result == {"configuration": "livingroom.yaml", "job": None}
+    assert not (tmp_path / "kitchen.yaml").exists()
+    new_content = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    assert read_yaml_scalar(new_content, ("esphome", "name")) == "livingroom"
+    # Untouched siblings survive the rewrite.
+    assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Kitchen Light"
+    assert controller._scanner.calls == [("scan",)]
+
+
+async def test_config_only_rename_migrates_sidecar_metadata(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Labels / comment follow the file to the new name."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+    await controller._shared_sidecar.update("kitchen.yaml", labels=["a", "b"], comment="downstairs")
+
+    await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    assert await controller._shared_sidecar.get("kitchen.yaml") == {}
+    moved = await controller._shared_sidecar.get("livingroom.yaml")
+    assert moved.get("labels") == ["a", "b"]
+    assert moved.get("comment") == "downstairs"
+
+
+async def test_config_only_rename_migrates_storage_json(
+    tmp_path: Path, make_controller: MakeControllerFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The StorageJSON sidecar moves with the file, retargeting name/address."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.mutations_simple.resolve_storage_path",
+        lambda configuration: storage_dir / f"{configuration}.json",
+    )
+    write_storage_json(
+        tmp_path,
+        "kitchen.yaml",
+        overrides={"name": "kitchen", "friendly_name": "kitchen", "address": "kitchen.local"},
+    )
+
+    await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    assert not (storage_dir / "kitchen.yaml.json").exists()
+    moved = StorageJSON.load(storage_dir / "livingroom.yaml.json")
+    assert moved is not None
+    assert moved.name == "livingroom"
+    assert moved.friendly_name == "livingroom"
+    assert moved.address == "livingroom.local"
+
+
+async def test_config_only_rename_survives_storage_migration_failure(
+    tmp_path: Path, make_controller: MakeControllerFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A StorageJSON-migration error still completes the rename and rescans."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+    storage_dir = tmp_path / ".esphome" / "storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.mutations_simple.resolve_storage_path",
+        lambda configuration: storage_dir / f"{configuration}.json",
+    )
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"name": "kitchen"})
+
+    def _boom(*_: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.mutations_simple.save_device_storage", _boom
+    )
+
+    result = await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    assert result == {"configuration": "livingroom.yaml", "job": None}
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert (tmp_path / "livingroom.yaml").exists()
+    assert controller._scanner.calls == [("scan",)]
+
+
+async def test_config_only_rename_rejects_invalid_rewrite(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A rewrite that fails validation refuses and leaves disk untouched."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+    controller._db.editor.validate_yaml = AsyncMock(
+        return_value={"yaml_errors": [{"message": "boom"}], "validation_errors": []}
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(
+            configuration="kitchen.yaml", new_name="livingroom", config_only=True
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    # Old file stays, new file never lands.
+    assert (tmp_path / "kitchen.yaml").exists()
+    assert not (tmp_path / "livingroom.yaml").exists()
+
+
+async def test_config_only_rename_refuses_non_literal_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """No literal ``esphome.name`` leaf (packages / !include) → clean refusal."""
+    controller = make_controller(tmp_path)
+    # ``name`` is supplied elsewhere (e.g. a package); this file has no leaf.
+    (tmp_path / "kitchen.yaml").write_text(
+        "esphome:\n  friendly_name: Kitchen Light\n", encoding="utf-8"
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(
+            configuration="kitchen.yaml", new_name="livingroom", config_only=True
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "literal" in excinfo.value.message
+    assert (tmp_path / "kitchen.yaml").exists()
+    assert not (tmp_path / "livingroom.yaml").exists()
+
+
+async def test_config_only_rename_rewrites_local_substitution(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A pure ``${var}`` name rewrites the substitution def, keeping the indirection."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(
+        "substitutions:\n  devicename: kitchen\nesphome:\n  name: ${devicename}\n",
+        encoding="utf-8",
+    )
+
+    result = await controller.rename_device(
+        configuration="kitchen.yaml", new_name="livingroom", config_only=True
+    )
+
+    assert result == {"configuration": "livingroom.yaml", "job": None}
+    assert not (tmp_path / "kitchen.yaml").exists()
+    content = (tmp_path / "livingroom.yaml").read_text(encoding="utf-8")
+    # Indirection preserved: the ``${devicename}`` leaf stays, the sub def moves.
+    assert "name: ${devicename}" in content
+    assert "devicename: livingroom" in content
+
+
+async def test_config_only_rename_refuses_nonlocal_substitution_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A ``${var}`` with no local ``substitutions:`` def is refused, not flattened."""
+    controller = make_controller(tmp_path)
+    # ``devicename`` would come from a package / !include, not this file.
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: ${devicename}\n", encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(
+            configuration="kitchen.yaml", new_name="livingroom", config_only=True
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    content = (tmp_path / "kitchen.yaml").read_text(encoding="utf-8")
+    assert "${devicename}" in content
+    assert not (tmp_path / "livingroom.yaml").exists()
+
+
+async def test_config_only_rename_refuses_embedded_substitution_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An embedded ``${var}`` (``kitchen_${suffix}``) is refused, not flattened."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(
+        "substitutions:\n  suffix: a1\nesphome:\n  name: kitchen_${suffix}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(
+            configuration="kitchen.yaml", new_name="livingroom", config_only=True
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    content = (tmp_path / "kitchen.yaml").read_text(encoding="utf-8")
+    assert "${suffix}" in content
+    assert not (tmp_path / "livingroom.yaml").exists()
+
+
+async def test_config_only_rename_missing_file_raises(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A vanished source config refuses with a typed error, not a traceback."""
+    controller = make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(
+            configuration="kitchen.yaml", new_name="livingroom", config_only=True
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+
+
+async def test_config_only_rename_still_rejects_collision(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The collision guard runs before the config-only branch."""
+    controller = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+    (tmp_path / "livingroom.yaml").write_text(_YAML, encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(
+            configuration="kitchen.yaml", new_name="livingroom", config_only=True
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "already exists" in excinfo.value.message

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -43,6 +43,8 @@ from esphome_device_builder.helpers.yaml import (
     _strip_yaml_quotes,
     generate_api_encryption_key,
     generate_component_yaml,
+    is_plain_literal_scalar,
+    is_retargetable_name,
     load_yaml_fast_then_esphome,
     merge_component_yaml,
     parse_substitution_ref,
@@ -117,6 +119,45 @@ def test_parse_substitution_ref(value: str, expected: str | None) -> None:
     back to a literal rewrite rather than wreck a partial match.
     """
     assert parse_substitution_ref(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("kitchen", True),
+        ('"kitchen"', True),
+        ("'kitchen-1'", True),
+        ("", False),
+        ("   ", False),
+        ("${devicename}", False),
+        ("$devicename", False),
+        ("kitchen_${suffix}", False),  # embedded substitution
+        ("${loc}-sensor", False),
+        ("!include name.yaml", False),
+        ("!secret node_name", False),
+    ],
+)
+def test_is_plain_literal_scalar(value: str, expected: bool) -> None:
+    """Plain literals pass; empty, tagged, or substitution-bearing values don't."""
+    assert is_plain_literal_scalar(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("kitchen", True),
+        ("${devicename}", True),  # pure ref -> rewrite the substitution def
+        ("$devicename", True),
+        ('"${devicename}"', True),
+        ("kitchen_${suffix}", False),  # embedded -> would flatten
+        ("${loc}-sensor", False),
+        ("!include name.yaml", False),
+        ("", False),
+    ],
+)
+def test_is_retargetable_name(value: str, expected: bool) -> None:
+    """Plain literals and pure ${var} refs are retargetable; embedded/tag aren't."""
+    assert is_retargetable_name(value) is expected
 
 
 def test_rewrite_name_or_substitution_redirects_through_substitution() -> None:


### PR DESCRIPTION
## What this does

Adds an opt-in `config_only` flag to `devices/rename`. Default behavior is unchanged — `esphome rename` (compile + OTA install), which can only succeed against a reachable device. `config_only=True` rewrites `esphome.name` and renames the file **without compiling or flashing**, for an offline device where there's no running firmware to keep in sync.

This is the backend half of the fix for renaming offline devices. Verified live on an ESP32-C3: an online rename still goes through the OTA path; an offline `config_only` rename renames the file + `esphome.name` instantly (`job: null`).

## How

Mirrors `edit_friendly_name`'s config-only mutation pattern:
- rewrite the scalar via `rewrite_yaml_scalar(("esphome","name"))`
- validate the rewritten YAML before touching disk
- atomic write the new file + unlink the old
- migrate the StorageJSON sidecar + the metadata stores (`_migrate_device_metadata`)

A name that isn't a literal `esphome.name` leaf (supplied via substitutions / packages / `!include`) is refused cleanly rather than renamed into divergence. The same-name and collision guards run for both paths.

The old *silent* file-level fallback was removed in #402 because it desynced on-disk state from a running device with no error. This is the explicit, validated, opt-in version; the frontend (follow-up PR) only sends `config_only` after the user confirms an offline rename.

Backend-only and opt-in (default `False`), so it's safe to merge ahead of the frontend.

Refs https://github.com/esphome/device-builder/issues/1465

## Types of changes

- [x] New feature (non-breaking change which adds functionality) — `new-feature`

## Testing

- New `tests/controllers/devices/test_rename_config_only.py`: rewrite + file move, sidecar migration, validation-failure refusal, non-literal-name refusal, missing-file + collision guards.
- 477 passing in the devices controller suite; ruff clean.
