### PR TITLE
Persist device and secrets editor layout in preferences

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -282,7 +282,7 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 | `config/version` | — | `{server_version, esphome_version}` | Get versions |
 | `config/serial_ports` | — | `[{port, desc}]` | List serial ports |
 | `config/get_preferences` | — | `UserPreferences` | Get user preferences |
-| `config/set_preferences` | `{theme?, dashboard_view?, experience_level?, remote_compute_only?, device_editor_layout?, secrets_editor_layout?, ...}` | `UserPreferences` | Update preferences (partial). `experience_level` is `beginner` / `expert` (or `null` until chosen); `remote_compute_only` marks an install as a remote build node. `device_editor_layout` / `secrets_editor_layout` are `visual` / `yaml` / `both` (secrets never uses `both`); they persist which editor panes the user keeps open. |
+| `config/set_preferences` | `{theme?, dashboard_view?, experience_level?, remote_compute_only?, device_editor_layout?, secrets_editor_layout?, ...}` | `UserPreferences` | Update preferences (partial). `experience_level` is `beginner` / `expert` (or `null` until chosen); `remote_compute_only` marks an install as a remote build node. `device_editor_layout` is `visual` / `yaml` / `both` and `secrets_editor_layout` is `visual` / `yaml` (the secrets editor has no split view); they persist which editor panes the user keeps open. |
 | `config/get_secrets` | — | `[string]` | List secret key names |
 | `config/set_secret` | `{key, value, overwrite?}` | `{created}` | Atomically set one secret in secrets.yaml under a write lock; `overwrite=false` is create-if-absent |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -282,7 +282,7 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 | `config/version` | — | `{server_version, esphome_version}` | Get versions |
 | `config/serial_ports` | — | `[{port, desc}]` | List serial ports |
 | `config/get_preferences` | — | `UserPreferences` | Get user preferences |
-| `config/set_preferences` | `{theme?, dashboard_view?, experience_level?, remote_compute_only?, ...}` | `UserPreferences` | Update preferences (partial). `experience_level` is `beginner` / `expert` (or `null` until chosen); `remote_compute_only` marks an install as a remote build node. |
+| `config/set_preferences` | `{theme?, dashboard_view?, experience_level?, remote_compute_only?, device_editor_layout?, secrets_editor_layout?, ...}` | `UserPreferences` | Update preferences (partial). `experience_level` is `beginner` / `expert` (or `null` until chosen); `remote_compute_only` marks an install as a remote build node. `device_editor_layout` / `secrets_editor_layout` are `visual` / `yaml` / `both` (secrets never uses `both`); they persist which editor panes the user keeps open. |
 | `config/get_secrets` | — | `[string]` | List secret key names |
 | `config/set_secret` | `{key, value, overwrite?}` | `{created}` | Atomically set one secret in secrets.yaml under a write lock; `overwrite=false` is create-if-absent |
 

--- a/esphome_device_builder/models/preferences.py
+++ b/esphome_device_builder/models/preferences.py
@@ -31,11 +31,18 @@ class SortDirection(StrEnum):
 
 
 class EditorLayout(StrEnum):
-    """Editor pane layout; secrets only ever uses VISUAL or YAML."""
+    """Device editor pane layout: the form, the YAML pane, or both."""
 
     VISUAL = "visual"
     YAML = "yaml"
     BOTH = "both"
+
+
+class SecretsEditorLayout(StrEnum):
+    """Secrets editor layout: the form or the YAML pane, never both."""
+
+    VISUAL = "visual"
+    YAML = "yaml"
 
 
 class ExperienceLevel(StrEnum):
@@ -67,9 +74,10 @@ class UserPreferences(DataClassORJSONMixin):
     # Device editor
     navigator_visible: bool = True
     # Which editor panes the user last had open, persisted so the choice
-    # survives a new browser. Secrets only ever stores VISUAL or YAML.
+    # survives a new browser. The secrets editor has no split view, so a
+    # dedicated enum makes "never both" a type rather than a comment.
     device_editor_layout: EditorLayout = EditorLayout.BOTH
-    secrets_editor_layout: EditorLayout = EditorLayout.VISUAL
+    secrets_editor_layout: SecretsEditorLayout = SecretsEditorLayout.VISUAL
 
     # Table view settings
     table_page_size: int = 25

--- a/esphome_device_builder/models/preferences.py
+++ b/esphome_device_builder/models/preferences.py
@@ -30,6 +30,14 @@ class SortDirection(StrEnum):
     DESC = "desc"
 
 
+class EditorLayout(StrEnum):
+    """Editor pane layout; secrets only ever uses VISUAL or YAML."""
+
+    VISUAL = "visual"
+    YAML = "yaml"
+    BOTH = "both"
+
+
 class ExperienceLevel(StrEnum):
     """
     How much ESPHome the user knows; tailors UI weight.
@@ -58,6 +66,10 @@ class UserPreferences(DataClassORJSONMixin):
 
     # Device editor
     navigator_visible: bool = True
+    # Which editor panes the user last had open, persisted so the choice
+    # survives a new browser. Secrets only ever stores VISUAL or YAML.
+    device_editor_layout: EditorLayout = EditorLayout.BOTH
+    secrets_editor_layout: EditorLayout = EditorLayout.VISUAL
 
     # Table view settings
     table_page_size: int = 25

--- a/tests/controllers/config/test_preferences_store.py
+++ b/tests/controllers/config/test_preferences_store.py
@@ -14,7 +14,7 @@ from esphome_device_builder.controllers.config._preferences_store import (
     PreferencesStore,
 )
 from esphome_device_builder.models import UserPreferences
-from esphome_device_builder.models.preferences import Theme
+from esphome_device_builder.models.preferences import EditorLayout, Theme
 
 
 def _make_store(tmp_path: Path) -> PreferencesStore:
@@ -287,3 +287,21 @@ async def test_round_trip_after_migration(tmp_path: Path) -> None:
     await second.async_load()
     assert second.snapshot().theme == Theme.LIGHT
     assert second.snapshot().navigator_visible is False
+
+
+async def test_round_trip_preserves_editor_layout_enum(tmp_path: Path) -> None:
+    """An ``EditorLayout`` field survives the StrEnum encode/decode through disk."""
+    store = _make_store(tmp_path)
+    await store.async_load()
+    store.update(
+        {
+            "device_editor_layout": EditorLayout.YAML,
+            "secrets_editor_layout": EditorLayout.YAML,
+        }
+    )
+    await store._store.async_save_now()
+
+    reloaded = _make_store(tmp_path)
+    await reloaded.async_load()
+    assert reloaded.snapshot().device_editor_layout is EditorLayout.YAML
+    assert reloaded.snapshot().secrets_editor_layout is EditorLayout.YAML

--- a/tests/controllers/config/test_preferences_store.py
+++ b/tests/controllers/config/test_preferences_store.py
@@ -14,7 +14,11 @@ from esphome_device_builder.controllers.config._preferences_store import (
     PreferencesStore,
 )
 from esphome_device_builder.models import UserPreferences
-from esphome_device_builder.models.preferences import EditorLayout, Theme
+from esphome_device_builder.models.preferences import (
+    EditorLayout,
+    SecretsEditorLayout,
+    Theme,
+)
 
 
 def _make_store(tmp_path: Path) -> PreferencesStore:
@@ -296,7 +300,7 @@ async def test_round_trip_preserves_editor_layout_enum(tmp_path: Path) -> None:
     store.update(
         {
             "device_editor_layout": EditorLayout.YAML,
-            "secrets_editor_layout": EditorLayout.YAML,
+            "secrets_editor_layout": SecretsEditorLayout.YAML,
         }
     )
     await store._store.async_save_now()
@@ -304,4 +308,4 @@ async def test_round_trip_preserves_editor_layout_enum(tmp_path: Path) -> None:
     reloaded = _make_store(tmp_path)
     await reloaded.async_load()
     assert reloaded.snapshot().device_editor_layout is EditorLayout.YAML
-    assert reloaded.snapshot().secrets_editor_layout is EditorLayout.YAML
+    assert reloaded.snapshot().secrets_editor_layout is SecretsEditorLayout.YAML

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -85,6 +85,7 @@ from esphome_device_builder.models import (
 )
 from esphome_device_builder.models.preferences import (
     DashboardView,
+    EditorLayout,
     Theme,
     UserPreferences,
 )
@@ -759,12 +760,16 @@ async def test_set_prefs_concurrent_updates_do_not_lose_writes(tmp_path: Path) -
         controller.set_prefs(theme=Theme.DARK),
         controller.set_prefs(dashboard_view=DashboardView.TABLE),
         controller.set_prefs(navigator_visible=False),
+        controller.set_prefs(device_editor_layout=EditorLayout.YAML),
+        controller.set_prefs(secrets_editor_layout=EditorLayout.YAML),
     )
 
     snap = controller.prefs.snapshot()
     assert snap.theme == Theme.DARK
     assert snap.dashboard_view == DashboardView.TABLE
     assert snap.navigator_visible is False
+    assert snap.device_editor_layout is EditorLayout.YAML
+    assert snap.secrets_editor_layout is EditorLayout.YAML
 
 
 async def test_get_secrets_returns_empty_when_missing(tmp_path: Path) -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -86,6 +86,7 @@ from esphome_device_builder.models import (
 from esphome_device_builder.models.preferences import (
     DashboardView,
     EditorLayout,
+    SecretsEditorLayout,
     Theme,
     UserPreferences,
 )
@@ -761,7 +762,7 @@ async def test_set_prefs_concurrent_updates_do_not_lose_writes(tmp_path: Path) -
         controller.set_prefs(dashboard_view=DashboardView.TABLE),
         controller.set_prefs(navigator_visible=False),
         controller.set_prefs(device_editor_layout=EditorLayout.YAML),
-        controller.set_prefs(secrets_editor_layout=EditorLayout.YAML),
+        controller.set_prefs(secrets_editor_layout=SecretsEditorLayout.YAML),
     )
 
     snap = controller.prefs.snapshot()
@@ -769,7 +770,15 @@ async def test_set_prefs_concurrent_updates_do_not_lose_writes(tmp_path: Path) -
     assert snap.dashboard_view == DashboardView.TABLE
     assert snap.navigator_visible is False
     assert snap.device_editor_layout is EditorLayout.YAML
-    assert snap.secrets_editor_layout is EditorLayout.YAML
+    assert snap.secrets_editor_layout is SecretsEditorLayout.YAML
+
+
+async def test_set_prefs_rejects_both_for_secrets_layout(tmp_path: Path) -> None:
+    """``both`` is not a valid secrets layout, so the decode rejects it."""
+    controller = _make_controller(tmp_path)
+    with pytest.raises(ValueError, match="secrets_editor_layout"):
+        await controller.set_prefs(secrets_editor_layout="both")
+    assert controller.prefs.snapshot().secrets_editor_layout is SecretsEditorLayout.VISUAL
 
 
 async def test_get_secrets_returns_empty_when_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Persists which editor panes a user keeps open so the choice survives a new browser and gives us a server-side signal of who prefers working in YAML.

Adds an `EditorLayout` enum (`visual` / `yaml` / `both`) and two `UserPreferences` fields, `device_editor_layout` and `secrets_editor_layout`. The device editor uses all three values; the secrets editor only ever stores `visual` / `yaml`. Fresh-install defaults are the current layouts (device `both`, secrets `visual`). `config/set_preferences` is a generic pass-through, so no controller or store change is needed; the fields ride the existing snapshot and debounced write.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#856

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
