### PR TITLE
Reject literal !secret tags passed as wifi credentials

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
 # A wifi credential of ``!secret wifi_ssid`` is a caller passing the YAML
 # secret *tag* as a literal value; the field takes literals (empty means
 # "use !secret refs"), so this would silently land an unquoted-looking
-# tag that the generator quotes into a dead string. Match the tag form
-# (``!secret`` + whitespace + key) so an odd-but-real password like
-# ``!secretsauce`` is left alone.
-_SECRET_TAG_RE = re.compile(r"^\s*!secret\s")
+# tag that the generator quotes into a dead string. Match the full tag
+# form (``!secret`` + whitespace + a key char) so an odd-but-real password
+# like ``!secretsauce`` or a literal ``!secret `` without a key is left alone.
+_SECRET_TAG_RE = re.compile(r"^\s*!secret\s+\S")
 
 
 async def create_device(  # noqa: C901, PLR0912

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import TYPE_CHECKING
 
 from esphome.helpers import write_file as atomic_write_file
@@ -16,6 +17,14 @@ from .helpers import _looks_binary, clean_friendly_name, slugify_hostname
 
 if TYPE_CHECKING:
     from .controller import DevicesController
+
+# A wifi credential of ``!secret wifi_ssid`` is a caller passing the YAML
+# secret *tag* as a literal value; the field takes literals (empty means
+# "use !secret refs"), so this would silently land an unquoted-looking
+# tag that the generator quotes into a dead string. Match the tag form
+# (``!secret`` + whitespace + key) so an odd-but-real password like
+# ``!secretsauce`` is left alone.
+_SECRET_TAG_RE = re.compile(r"^\s*!secret\s")
 
 
 async def create_device(  # noqa: C901, PLR0912
@@ -66,6 +75,14 @@ async def create_device(  # noqa: C901, PLR0912
             ErrorCode.INVALID_ARGS,
             f"name {friendly!r} has no hostname-safe characters",
         )
+
+    for field, value in (("ssid", ssid), ("psk", psk)):
+        if _SECRET_TAG_RE.match(value):
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                f"{field} must be a literal value; leave it empty to use "
+                "secrets.yaml (the generated config emits !secret wifi_ssid / wifi_password)",
+            )
 
     filename = f"{name}.yaml"
     config_path = controller._db.settings.rel_path(filename)

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -76,13 +76,17 @@ async def create_device(  # noqa: C901, PLR0912
             f"name {friendly!r} has no hostname-safe characters",
         )
 
-    for field, value in (("ssid", ssid), ("psk", psk)):
-        if _SECRET_TAG_RE.match(value):
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                f"{field} must be a literal value; leave it empty to use "
-                "secrets.yaml (the generated config emits !secret wifi_ssid / wifi_password)",
-            )
+    # ssid/psk are literal credentials only for the generated flows; the
+    # file_content upload writes user YAML as-is and ignores them. A JSON
+    # null arrives as None (the empty-credential signal), so skip it too.
+    if file_content is None:
+        for field, value in (("ssid", ssid), ("psk", psk)):
+            if value and _SECRET_TAG_RE.match(value):
+                raise CommandError(
+                    ErrorCode.INVALID_ARGS,
+                    f"{field} must be a literal value; leave it empty to use "
+                    "secrets.yaml (the generated config emits !secret wifi_ssid / wifi_password)",
+                )
 
     filename = f"{name}.yaml"
     config_path = controller._db.settings.rel_path(filename)

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -77,9 +77,10 @@ async def create_device(  # noqa: C901, PLR0912
         )
 
     # ssid/psk are literal credentials only for the generated flows; the
-    # file_content upload writes user YAML as-is and ignores them. A JSON
-    # null arrives as None (the empty-credential signal), so skip it too.
-    if file_content is None:
+    # file_content upload writes user YAML as-is and ignores them. Match
+    # yaml_content_for_create's truthiness selection (``if file_content:``)
+    # so an empty string falls through to the same template flow this guards.
+    if not file_content:
         for field, value in (("ssid", ssid), ("psk", psk)):
             if value and _SECRET_TAG_RE.match(value):
                 raise CommandError(

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -101,6 +101,44 @@ async def test_create_device_rejects_unknown_board_id(
     assert ctrl._scanner.calls == []
 
 
+@pytest.mark.parametrize("field", ["ssid", "psk"])
+async def test_create_device_rejects_literal_secret_tag_credentials(
+    tmp_path: Path, make_controller: MakeControllerFactory, field: str
+) -> None:
+    """A ``!secret wifi_ssid`` literal in ssid/psk raises ``INVALID_ARGS``.
+
+    The field takes literals; passing the YAML secret tag as a value would
+    be quoted into an unresolvable string. Refuse it so the caller sends
+    empty (which emits a real !secret reference) instead.
+    """
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(
+            name="kitchen", board_id="esp32dev", **{field: "!secret wifi_ssid"}
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert field in excinfo.value.message
+    assert ctrl._scanner.calls == []
+
+
+async def test_create_device_allows_credential_with_bang_secret_prefix_word(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A password like ``!secretsauce`` is a literal, not the secret tag, so it's accepted."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    StubBoardLookups(ctrl).get_board_returns(None)
+
+    # Unknown board short-circuits after the credential check; reaching the
+    # board error proves the credential guard let this value through.
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", board_id="bogus", psk="!secretsauce")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "bogus" in excinfo.value.message
+
+
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -169,6 +169,22 @@ async def test_create_device_skips_credential_guard_for_file_content(
     assert (tmp_path / "kitchen.yaml").read_text("utf-8") == VALID_FILE_CONTENT
 
 
+async def test_create_device_guards_credentials_when_file_content_is_empty(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An empty file_content falls through to the template flow, so the guard still fires."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(
+            name="kitchen", board_id="esp32dev", file_content="", ssid="!secret wifi_ssid"
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "ssid" in excinfo.value.message
+    assert ctrl._scanner.calls == []
+
+
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -139,6 +139,36 @@ async def test_create_device_allows_credential_with_bang_secret_prefix_word(
     assert "bogus" in excinfo.value.message
 
 
+async def test_create_device_allows_none_credentials(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A JSON ``null`` ssid/psk is the empty-credential signal, not a guard crash."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    StubBoardLookups(ctrl).get_board_returns(None)
+
+    # Reaching the unknown-board error proves None passed the credential
+    # guard without a TypeError from re.match(None).
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", board_id="bogus", ssid=None, psk=None)  # type: ignore[arg-type]
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "bogus" in excinfo.value.message
+
+
+async def test_create_device_skips_credential_guard_for_file_content(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The file_content upload writes YAML as-is; ignored ssid/psk aren't guard-checked."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+
+    result = await ctrl.create_device(
+        name="kitchen", file_content=VALID_FILE_CONTENT, ssid="!secret wifi_ssid"
+    )
+
+    assert result.configuration == "kitchen.yaml"
+    assert (tmp_path / "kitchen.yaml").read_text("utf-8") == VALID_FILE_CONTENT
+
+
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")
 async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     tmp_path: Path, make_controller: MakeControllerFactory

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -139,6 +139,20 @@ async def test_create_device_allows_credential_with_bang_secret_prefix_word(
     assert "bogus" in excinfo.value.message
 
 
+async def test_create_device_allows_secret_word_without_a_key(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """``!secret `` with no key is a literal, not the tag form, so it's accepted."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    StubBoardLookups(ctrl).get_board_returns(None)
+
+    with pytest.raises(CommandError) as excinfo:
+        await ctrl.create_device(name="kitchen", board_id="bogus", ssid="!secret ")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "bogus" in excinfo.value.message
+
+
 async def test_create_device_allows_none_credentials(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 import pytest
 import yaml
+from esphome import yaml_util
 from esphome.components import wifi as esphome_wifi
 from esphome.components.rp2040.boards import BOARDS as ESPHOME_RP2040_BOARDS
 from esphome.const import ALLOWED_NAME_CHARS
@@ -1043,6 +1044,52 @@ def test_generate_yaml_emits_explicit_wifi_credentials_when_provided() -> None:
     secret = generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk="")
     assert "  ssid: !secret wifi_ssid\n" in secret
     assert "  password: !secret wifi_password\n" in secret
+
+
+def test_generate_yaml_secret_refs_resolve_through_esphome_loader(tmp_path: Path) -> None:
+    """Empty ssid/psk emit !secret tags ESPHome's loader resolves from secrets.yaml.
+
+    Pins the contract the wizard depends on (it sends empty creds so
+    the backend emits real references): a regression that quoted them
+    would load as the literal string "!secret wifi_ssid" and silently
+    break wifi.
+    """
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    (tmp_path / "secrets.yaml").write_text(
+        "wifi_ssid: RealNetwork-7f3a\nwifi_password: RealPass-9b21\n", encoding="utf-8"
+    )
+    device = tmp_path / "kitchen.yaml"
+    device.write_text(
+        generate_device_yaml("kitchen", "Kitchen", board, ssid="", psk=""), encoding="utf-8"
+    )
+
+    cfg = yaml_util.load_yaml(device)
+    assert cfg["wifi"]["ssid"] == "RealNetwork-7f3a"
+    assert cfg["wifi"]["password"] == "RealPass-9b21"
+
+
+def test_generate_yaml_literal_secret_string_stays_a_literal(tmp_path: Path) -> None:
+    """A literal "!secret wifi_ssid" ssid is quoted, so the loader keeps it a plain string.
+
+    The devices/create API takes literal credentials; passing the
+    magic secret string yields a literal, not a resolved secret, so
+    the wizard must send empty rather than the string itself.
+    """
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+    (tmp_path / "secrets.yaml").write_text(
+        "wifi_ssid: RealNetwork\nwifi_password: RealPass\n", encoding="utf-8"
+    )
+    device = tmp_path / "kitchen.yaml"
+    device.write_text(
+        generate_device_yaml(
+            "kitchen", "Kitchen", board, ssid="!secret wifi_ssid", psk="!secret wifi_password"
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = yaml_util.load_yaml(device)
+    assert cfg["wifi"]["ssid"] == "!secret wifi_ssid"
+    assert cfg["wifi"]["password"] == "!secret wifi_password"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

The devices/create ssid/psk fields take literal wifi credentials; an empty value is the signal to emit !secret references. A client that instead passed the literal string "!secret wifi_ssid" as the value would have it safe-scalar quoted into ssid: "!secret wifi_ssid", a dead string that silently fails to join wifi with no error. That is exactly the regression a frontend wizard hit in esphome/device-builder-frontend#859.

This rejects a credential that is actually the YAML secret tag (!secret followed by whitespace and a key) with a typed INVALID_ARGS, so the failure is loud at create time instead of a silently broken config; a normal literal like "Home #2" or an odd-but-real password like "!secretsauce" is untouched. Adds regression tests that load the generated YAML through ESPHome's secret-aware loader to prove the empty path resolves a real secret and the literal path stays a literal.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1490

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#859

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
