### PR TITLE
Sort generic boards above vendor boards in the picker

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -30,8 +30,8 @@ _BODY_CACHE_MAXSIZE = 128
 
 
 def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, str]:
-    """Catalog display order: featured first, generics last, then by name."""
-    return (not board.featured, board.is_generic, board.name.lower())
+    """Catalog display order: featured first, generics next, then by name."""
+    return (not board.featured, not board.is_generic, board.name.lower())
 
 
 class BoardCatalog:
@@ -78,7 +78,7 @@ class BoardCatalog:
 
         ``query`` matches the board id, name, manufacturer, description
         and tags. Featured boards are sorted first; generic fallback
-        boards last; the rest alphabetically. Returns slim
+        boards next; the rest alphabetically. Returns slim
         :class:`BoardCatalogIndex` entries — the frontend's board
         detail view fetches full bodies via ``boards/get_board``.
         """
@@ -199,7 +199,7 @@ class BoardCatalog:
         pio_board: str,
         platform: Platform | str | None = None,
     ) -> list[BoardCatalogIndex]:
-        """All catalog entries on the same PlatformIO board, featured first then generics last."""
+        """All catalog entries on the same PlatformIO board, featured first then generics next."""
         return sorted(self._matches_pio_board(pio_board, platform), key=_board_sort_key)
 
     def find_by_platform_variant(

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -293,15 +293,15 @@ async def test_get_boards_filters_compose(catalog: BoardCatalog) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_get_boards_sorts_featured_first_generic_last(
+async def test_get_boards_sorts_featured_first_generic_after_featured(
     catalog: BoardCatalog,
 ) -> None:
-    """Featured first, generic fallbacks last, the rest alphabetical.
+    """Featured first, generic fallbacks next, the rest alphabetical.
 
-    Drives the dashboard's "browse all" listing — featured boards
-    are what users actually buy, generics are the fallback catch-
-    all. A refactor that flipped the sort key tuple would surface
-    here.
+    Drives the dashboard's "browse all" listing — generics are the
+    safe catch-all most users want, so they sit at the top of each
+    list (below the separately-rendered featured boards). A refactor
+    that flipped the sort key tuple would surface here.
     """
     resp = await catalog.get_boards()
     ids = [b.id for b in resp.boards]
@@ -309,10 +309,10 @@ async def test_get_boards_sorts_featured_first_generic_last(
     # Featured pair, tie-broken alphabetically by name —
     # "Seeed ..." < "Wemos D1 Mini" so Seeed comes first.
     assert ids[0:2] == ["seeed-xiao-esp32c3", "d1-mini"]
-    # Generic fallbacks at the end.
-    assert ids[-3:] == ["generic-esp32c3", "generic-esp32s3", "generic-esp8266"]
-    # Non-featured non-generic in the middle.
-    assert ids[2] == "m5stack-cores3"
+    # Generic fallbacks right after the featured pair.
+    assert ids[2:5] == ["generic-esp32c3", "generic-esp32s3", "generic-esp8266"]
+    # Non-featured non-generic falls to the end.
+    assert ids[-1] == "m5stack-cores3"
 
 
 async def test_get_boards_paginates_via_offset_and_limit(
@@ -330,9 +330,8 @@ async def test_get_boards_paginates_via_offset_and_limit(
     assert resp.offset == 2
     assert resp.limit == 2
     assert len(resp.boards) == 2
-    # After-featured slice: the non-featured M5Stack and the first
-    # generic alphabetically.
-    assert [b.id for b in resp.boards] == ["m5stack-cores3", "generic-esp32c3"]
+    # After-featured slice: the first two generics alphabetically.
+    assert [b.id for b in resp.boards] == ["generic-esp32c3", "generic-esp32s3"]
 
 
 async def test_get_boards_offset_past_end_returns_empty_page(


### PR DESCRIPTION
# What does this implement/fix?

The board picker showed each platform's generic fallback board last, below every vendor board, where it could even drop off the first page on busy chip families. Generics are the safe default most people reach for, so this sorts them right after the featured boards; featured stays first, the rest stays alphabetical.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
