### PR TITLE
Sort WiFi-capable boards ahead of non-WiFi peers in the picker

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -30,9 +30,13 @@ _BODY_CACHE_MAXSIZE = 128
 
 
 def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, bool, str]:
-    """Catalog display order: featured, WiFi generics, plain generics, then by name."""
-    wifi_generic = board.is_generic and BoardTag.WIFI in board.tags
-    return (not board.featured, not board.is_generic, not wifi_generic, board.name.lower())
+    """Catalog display order: featured, generics, WiFi-capable within each, then by name."""
+    return (
+        not board.featured,
+        not board.is_generic,
+        BoardTag.WIFI not in board.tags,
+        board.name.lower(),
+    )
 
 
 class BoardCatalog:
@@ -78,10 +82,10 @@ class BoardCatalog:
         Get boards with optional filtering, search, and pagination.
 
         ``query`` matches the board id, name, manufacturer, description
-        and tags. Sort order: featured first; WiFi-capable generics;
-        plain generics; then the rest alphabetically. Returns slim
-        :class:`BoardCatalogIndex` entries — the frontend's board
-        detail view fetches full bodies via ``boards/get_board``.
+        and tags. Sort order: featured first; generics next; WiFi-capable
+        boards ahead of non-WiFi within each group; then alphabetically.
+        Returns slim :class:`BoardCatalogIndex` entries — the frontend's
+        board detail view fetches full bodies via ``boards/get_board``.
         """
         results: list[BoardCatalogIndex] = self._boards
 

--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -29,9 +29,10 @@ _LOGGER = logging.getLogger(__name__)
 _BODY_CACHE_MAXSIZE = 128
 
 
-def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, str]:
-    """Catalog display order: featured first, generics next, then by name."""
-    return (not board.featured, not board.is_generic, board.name.lower())
+def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, bool, str]:
+    """Catalog display order: featured, WiFi generics, plain generics, then by name."""
+    wifi_generic = board.is_generic and BoardTag.WIFI in board.tags
+    return (not board.featured, not board.is_generic, not wifi_generic, board.name.lower())
 
 
 class BoardCatalog:
@@ -77,8 +78,8 @@ class BoardCatalog:
         Get boards with optional filtering, search, and pagination.
 
         ``query`` matches the board id, name, manufacturer, description
-        and tags. Featured boards are sorted first; generic fallback
-        boards next; the rest alphabetically. Returns slim
+        and tags. Sort order: featured first; WiFi-capable generics;
+        plain generics; then the rest alphabetically. Returns slim
         :class:`BoardCatalogIndex` entries — the frontend's board
         detail view fetches full bodies via ``boards/get_board``.
         """

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -301,8 +301,7 @@ async def test_get_boards_sorts_featured_first_generic_after_featured(
     Drives the dashboard's "browse all" listing — generics are the
     safe catch-all most users want, so they sit at the top of each
     list (below the separately-rendered featured boards). A refactor
-    that flipped the sort key tuple would surface here. The WiFi
-    intra-generic tie-break is pinned separately below.
+    that flipped the sort key tuple would surface here.
     """
     resp = await catalog.get_boards()
     ids = [b.id for b in resp.boards]
@@ -316,19 +315,15 @@ async def test_get_boards_sorts_featured_first_generic_after_featured(
     assert ids[-1] == "m5stack-cores3"
 
 
-async def test_get_boards_sorts_wifi_generics_above_plain_generics() -> None:
-    """Order: featured, WiFi generics, plain generics, then everything by name.
-
-    WiFi floats generics only — a WiFi-capable non-generic board still
-    sorts by name, not above its alphabetical neighbours.
-    """
+async def test_get_boards_sorts_wifi_first_within_generic_and_nongeneric_tiers() -> None:
+    """Pin tier order: featured, WiFi generic, generic, WiFi non-generic, non-generic."""
     cat = BoardCatalog()
     _seed_catalog(
         cat,
         [
             _board(board_id="featured", name="Featured Board", featured=True),
-            # WiFi generic named after the plain generic — WiFi must win the
-            # intra-generic tie-break despite the later name.
+            # WiFi generic named after the plain generic; WiFi wins the
+            # tie-break despite the later name.
             _board(
                 board_id="generic-wifi",
                 name="Generic Zzz",
@@ -336,10 +331,10 @@ async def test_get_boards_sorts_wifi_generics_above_plain_generics() -> None:
                 is_generic=True,
             ),
             _board(board_id="generic-plain", name="Generic Aaa", is_generic=True),
-            # Non-generic WiFi board named after a non-generic plain board —
-            # WiFi must NOT float it; name decides among non-generics.
-            _board(board_id="nongeneric-wifi", name="Zeta", tags=[BoardTag.WIFI]),
-            _board(board_id="nongeneric-plain", name="Alpha"),
+            # Alphabetically-first WiFi non-generic; still sorts below both
+            # generics (generics-first outranks both name and WiFi).
+            _board(board_id="nongeneric-wifi", name="Aaa Vendor", tags=[BoardTag.WIFI]),
+            _board(board_id="nongeneric-plain", name="Zzz Vendor"),
         ],
     )
 
@@ -350,8 +345,8 @@ async def test_get_boards_sorts_wifi_generics_above_plain_generics() -> None:
         "featured",
         "generic-wifi",
         "generic-plain",
-        "nongeneric-plain",
         "nongeneric-wifi",
+        "nongeneric-plain",
     ]
 
 

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -301,7 +301,8 @@ async def test_get_boards_sorts_featured_first_generic_after_featured(
     Drives the dashboard's "browse all" listing — generics are the
     safe catch-all most users want, so they sit at the top of each
     list (below the separately-rendered featured boards). A refactor
-    that flipped the sort key tuple would surface here.
+    that flipped the sort key tuple would surface here. The WiFi
+    intra-generic tie-break is pinned separately below.
     """
     resp = await catalog.get_boards()
     ids = [b.id for b in resp.boards]
@@ -313,6 +314,45 @@ async def test_get_boards_sorts_featured_first_generic_after_featured(
     assert ids[2:5] == ["generic-esp32c3", "generic-esp32s3", "generic-esp8266"]
     # Non-featured non-generic falls to the end.
     assert ids[-1] == "m5stack-cores3"
+
+
+async def test_get_boards_sorts_wifi_generics_above_plain_generics() -> None:
+    """Order: featured, WiFi generics, plain generics, then everything by name.
+
+    WiFi floats generics only — a WiFi-capable non-generic board still
+    sorts by name, not above its alphabetical neighbours.
+    """
+    cat = BoardCatalog()
+    _seed_catalog(
+        cat,
+        [
+            _board(board_id="featured", name="Featured Board", featured=True),
+            # WiFi generic named after the plain generic — WiFi must win the
+            # intra-generic tie-break despite the later name.
+            _board(
+                board_id="generic-wifi",
+                name="Generic Zzz",
+                tags=[BoardTag.WIFI],
+                is_generic=True,
+            ),
+            _board(board_id="generic-plain", name="Generic Aaa", is_generic=True),
+            # Non-generic WiFi board named after a non-generic plain board —
+            # WiFi must NOT float it; name decides among non-generics.
+            _board(board_id="nongeneric-wifi", name="Zeta", tags=[BoardTag.WIFI]),
+            _board(board_id="nongeneric-plain", name="Alpha"),
+        ],
+    )
+
+    resp = await cat.get_boards()
+    ids = [b.id for b in resp.boards]
+
+    assert ids == [
+        "featured",
+        "generic-wifi",
+        "generic-plain",
+        "nongeneric-plain",
+        "nongeneric-wifi",
+    ]
 
 
 async def test_get_boards_paginates_via_offset_and_limit(


### PR DESCRIPTION
# What does this implement/fix?

Sorts WiFi-capable boards ahead of their non-WiFi peers in the board picker. New display order: featured, WiFi generics, generics, WiFi non-generics, then non-generics; alphabetical by name within each tier.

This mainly affects RP2040. Most RP2040 boards have no WiFi, and the picker truncates to the first 50 results, so the Pico W / Pico 2 W previously sorted well past the fold (rank ~99) and were invisible unless the user searched. They now land in the top of the list, right after the generic board.

Picking the non-WiFi look-alike is one of the more common reasons we get ESPHome issue reports: it is not obvious that you have to add a single "w" (pico vs picow) to get WiFi support, so people flash the plain Pico and then wonder why WiFi does not work. Surfacing the WiFi variants (alongside the WiFi chip badge added in #1496) makes the right choice visible up front.

A non-generic board never sorts ahead of a generic; the generics-first term outranks the WiFi term in the sort key.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
