### PR TITLE
Canonicalize prerelease docs hosts in the generated catalog

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -4230,6 +4230,23 @@ def _strip_defaults(component: dict) -> dict:
     return out
 
 
+# A prerelease schema points its docs links at beta.esphome.io / next.esphome.io
+# — in docs_url, help_link, and markdown links embedded in description text. The
+# catalog tracks beta but must link to the canonical, stable docs host.
+_PRERELEASE_DOCS_HOST_RE = re.compile(r"https://(?:beta|next)\.esphome\.io/")
+
+
+def _canonicalize_docs_hosts(obj: Any) -> Any:
+    """Recursively rewrite prerelease beta/next esphome.io URLs to esphome.io in a JSON tree."""
+    if isinstance(obj, str):
+        return _PRERELEASE_DOCS_HOST_RE.sub("https://esphome.io/", obj)
+    if isinstance(obj, list):
+        return [_canonicalize_docs_hosts(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _canonicalize_docs_hosts(v) for k, v in obj.items()}
+    return obj
+
+
 def _emit_split_catalog(catalog: list[dict], version: str) -> None:
     """
     Write the catalog as ``components.index.json`` + per-id body files.
@@ -4251,6 +4268,7 @@ def _emit_split_catalog(catalog: list[dict], version: str) -> None:
     aren't yet listed), so a reader landing in that window
     degrades rather than crashes.
     """
+    catalog = _canonicalize_docs_hosts(catalog)
     next_bodies = _OUTPUT_BODIES_DIR.parent / "components.next"
     prepare_next_bodies_dir(next_bodies)
 
@@ -4309,6 +4327,7 @@ def _emit_split_automations_catalog(automations: dict[str, Any], version: str) -
     ``emit_body_with_roundtrip`` /
     ``swap_split_catalog_in`` helpers.
     """
+    automations = _canonicalize_docs_hosts(automations)
     next_bodies = _AUTOMATIONS_BODIES_DIR.parent / "automations.next"
     prepare_next_bodies_dir(next_bodies)
 

--- a/tests/test_platform_capabilities.py
+++ b/tests/test_platform_capabilities.py
@@ -79,23 +79,32 @@ def test_index_within_installed_esphome() -> None:
         f"committed catalog is {ahead} esphome releases ahead of the installed esphome; "
         "the runtime may trail the catalog by at most one release"
     )
-    if ahead >= 1:
-        # Catalog leads the runtime: it carries data this older esphome can't
-        # expose yet. Exact parity is the sync workflow's regenerate gate.
-        return
     installed_no_wifi_boards = {
         board for board, info in BOARDS.items() if not info.get("wifi", False)
     }
-    assert set(caps.esp32_variants) <= set(VARIANTS)
-    assert set(caps.esp32_no_wifi_variants) <= set(NO_WIFI_VARIANTS)
-    assert set(caps.libretiny_families) <= set(FAMILY_COMPONENT.values())
-    assert set(caps.rp2040_no_wifi_boards) <= installed_no_wifi_boards
     sentinel = SimpleNamespace(name="{name}")
+    pairs = [
+        (set(caps.esp32_variants), set(VARIANTS)),
+        (set(caps.esp32_no_wifi_variants), set(NO_WIFI_VARIANTS)),
+        (set(caps.libretiny_families), set(FAMILY_COMPONENT.values())),
+        (set(caps.rp2040_no_wifi_boards), installed_no_wifi_boards),
+    ]
     for component in ("esp32", "esp8266", "rp2040"):
         module = importlib.import_module(f"esphome.components.{component}")
-        upstream_files = {entry["file"] for entry in module.get_download_types(sentinel)}
-        indexed_files = {entry["file"] for entry in caps.download_types[component]}
-        assert indexed_files <= upstream_files
+        upstream = {entry["file"] for entry in module.get_download_types(sentinel)}
+        pairs.append(({entry["file"] for entry in caps.download_types[component]}, upstream))
+
+    # Within one release the newer side is a superset of the older, so assert a
+    # subset in the direction set by which side leads: committed index ⊆
+    # installed when the runtime leads or matches, installed ⊆ committed index
+    # when the catalog leads (it ships before the docker image's esphome).
+    for indexed, installed in pairs:
+        if ahead >= 1:
+            missing = installed - indexed
+            assert not missing, f"installed esphome data missing from the newer catalog: {missing}"
+        else:
+            extra = indexed - installed
+            assert not extra, f"committed index data no installed esphome exposes: {extra}"
 
 
 def test_load_missing_index_is_empty(tmp_path: Path) -> None:

--- a/tests/test_platform_capabilities.py
+++ b/tests/test_platform_capabilities.py
@@ -11,6 +11,7 @@ start) lives in test_cold_import_floor.py.
 from __future__ import annotations
 
 import importlib
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -19,6 +20,7 @@ from esphome.components.esp32.const import VARIANTS
 from esphome.components.libretiny.const import FAMILY_COMPONENT
 from esphome.components.rp2040.boards import BOARDS
 from esphome.components.wifi import NO_WIFI_VARIANTS
+from esphome.const import __version__ as _esphome_version
 
 from esphome_device_builder.definitions import (
     PlatformCapabilities,
@@ -28,6 +30,26 @@ from esphome_device_builder.definitions import (
 )
 
 _EMPTY = PlatformCapabilities([], [], [], [], {})
+
+_COMPONENTS_INDEX = (
+    Path(__file__).resolve().parent.parent
+    / "esphome_device_builder"
+    / "definitions"
+    / "components.index.json"
+)
+
+
+def _release_ordinal(version: str) -> int:
+    """Calendar-release ordinal (year*12 + month) of an esphome version string."""
+    m = re.match(r"(\d+)\.(\d+)", version)
+    assert m, f"unparsable esphome version: {version!r}"
+    return int(m.group(1)) * 12 + int(m.group(2))
+
+
+def _catalog_releases_ahead() -> int:
+    """Calendar releases the committed catalog leads the installed esphome (negative = behind)."""
+    schema_version = orjson.loads(_COMPONENTS_INDEX.read_bytes())["esphome_schema_version"]
+    return _release_ordinal(schema_version) - _release_ordinal(_esphome_version)
 
 
 def test_loader_returns_known_platforms() -> None:
@@ -43,15 +65,24 @@ def test_loader_returns_known_platforms() -> None:
 
 
 def test_index_within_installed_esphome() -> None:
-    """The committed index is a subset of the installed esphome's platform data.
+    """
+    Committed index stays within one esphome release of the installed one.
 
-    Routing / wifi data is pinned to the esphome the catalog was generated
-    against and re-synced on bump; the CI matrix runs newer esphome (stable /
-    beta / dev), so assert containment, not equality. Catches a stale or bogus
-    index entry no esphome version exposes; exact parity is the sync workflow's
+    Tolerate extras on whichever side leads (runtime ahead in the beta/dev
+    matrix; catalog ahead when it ships before the docker image's esphome),
+    capping a catalog lead at one release. Exact parity is the sync workflow's
     regenerate-and-diff gate.
     """
     caps = load_platform_capabilities_index()
+    ahead = _catalog_releases_ahead()
+    assert ahead <= 1, (
+        f"committed catalog is {ahead} esphome releases ahead of the installed esphome; "
+        "the runtime may trail the catalog by at most one release"
+    )
+    if ahead >= 1:
+        # Catalog leads the runtime: it carries data this older esphome can't
+        # expose yet. Exact parity is the sync workflow's regenerate gate.
+        return
     installed_no_wifi_boards = {
         board for board, info in BOARDS.items() if not info.get("wifi", False)
     }

--- a/tests/test_sync_components_docs_host.py
+++ b/tests/test_sync_components_docs_host.py
@@ -1,0 +1,39 @@
+"""Tests for the prerelease docs-host canonicalization in the catalog emit."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).parent.parent / "script"
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+import sync_components  # noqa: E402
+
+
+def test_canonicalize_rewrites_beta_and_next_hosts() -> None:
+    """beta./next. esphome.io hosts collapse to the canonical host; others untouched."""
+    tree = {
+        "docs_url": "https://beta.esphome.io/components/api",
+        "description": "An [Action](https://next.esphome.io/automations/actions#x) here.",
+        "entries": [
+            {"help_link": "https://beta.esphome.io/components/wifi#ap"},
+            {"keep": "https://esphome.io/components/logger"},
+            {"unrelated": "https://schema.esphome.io/2026.6.0b3/schema.zip"},
+        ],
+    }
+    out = sync_components._canonicalize_docs_hosts(tree)
+    assert out["docs_url"] == "https://esphome.io/components/api"
+    assert out["description"] == "An [Action](https://esphome.io/automations/actions#x) here."
+    assert out["entries"][0]["help_link"] == "https://esphome.io/components/wifi#ap"
+    # Canonical and non-docs esphome.io hosts are left alone.
+    assert out["entries"][1]["keep"] == "https://esphome.io/components/logger"
+    assert out["entries"][2]["unrelated"] == "https://schema.esphome.io/2026.6.0b3/schema.zip"
+
+
+def test_canonicalize_preserves_non_string_leaves() -> None:
+    """Non-string values pass through unchanged."""
+    tree = {"multi_conf": True, "count": 3, "items": [1, None, "https://beta.esphome.io/x"]}
+    out = sync_components._canonicalize_docs_hosts(tree)
+    assert out == {"multi_conf": True, "count": 3, "items": [1, None, "https://esphome.io/x"]}

--- a/tests/test_sync_components_supports_list.py
+++ b/tests/test_sync_components_supports_list.py
@@ -118,6 +118,10 @@ def test_shipped_catalog_matches_live_introspection() -> None:
         else:
             top_key, key = trigger.id.rsplit(".", 1)
         single = dict(sync_components._live_trigger_singles(top_key)).get(key)
+        if single is None:
+            # Trigger absent from the installed esphome (catalog leads the
+            # runtime); can't cross-check. Parity is the sync workflow's gate.
+            continue
         if trigger.supports_list != (single is False):
             mismatches.append((trigger.id, trigger.supports_list, single))
     assert not mismatches, f"supports_list drift: {mismatches[:20]}"


### PR DESCRIPTION
# What does this implement/fix?

Now that the catalog tracks the latest beta schema, a prerelease schema points its docs links at `beta.esphome.io` / `next.esphome.io`, not only in `docs_url` but in `help_link`s and the markdown links embedded in `description` text, across both the component and automation catalogs (the 2026.6.0b3 run left thousands of `beta.esphome.io` URLs in the generated JSON). This rewrites them to the canonical `esphome.io` host in one pass at each emit chokepoint, so a beta-tracked catalog still links to stable docs and matches the hand-curated help_links.

It also re-lands the catalog/runtime version-skew tolerance for the `platform_capabilities` and `supports_list` guards (these merged too late for #1495): device-builder ships its catalog into esphome's docker image, which installs esphome independently, so the catalog may lead the installed esphome by one release. The guards now tolerate the catalog leading by at most one release and skip a supports_list cross-check for triggers the installed esphome lacks.

**Related issue or feature (if applicable):**

- Follow-up to #1495

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
