### PR TITLE
Break extends cycles and prime CORE in the catalog sync

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2230,17 +2230,25 @@ def _promote_template_controls(component_id: str, entries: list[dict]) -> None:
             entry["advanced"] = False
 
 
-def _merge_extends_config_vars(schema_node: dict, schema_dir: Path) -> dict[str, Any]:
+def _merge_extends_config_vars(
+    schema_node: dict, schema_dir: Path, _seen_refs: frozenset[str] = frozenset()
+) -> dict[str, Any]:
     """
     Deep-merge a schema node's ``extends`` ancestry with its local config_vars.
 
     Per-field, not whole-field: a partial override like ``{"default": "x"}``
     keeps the base's inherited ``type`` / enum / docs. Values are usually field
     dicts; a malformed schema can carry a non-dict, hence ``dict[str, Any]``.
+
+    ``_seen_refs`` carries the ``extends`` targets already being expanded up the
+    convert stack; a ref in it is skipped to break self-referential cycles
+    (lvgl widgets extend ``lvgl.WIDGET_TYPES``, which contains a widget list).
     """
     config_vars = dict(schema_node.get("config_vars") or {})
     extended: dict[str, dict] = {}
     for ref in schema_node.get("extends") or []:
+        if ref in _seen_refs:
+            continue
         extended.update(_resolve_extends(ref, schema_dir))
     merged: dict[str, Any] = {}
     for key in {*extended, *config_vars}:
@@ -2258,9 +2266,15 @@ def _convert_config_vars(
     schema_dir: Path,
     *,
     component_id: str = "",
+    _seen_refs: frozenset[str] = frozenset(),
 ) -> list[dict]:
-    """Convert a ``schema`` node (config_vars + extends) to a list of entries."""
-    merged = _merge_extends_config_vars(schema_node, schema_dir)
+    """Convert a ``schema`` node (config_vars + extends) to a list of entries.
+
+    ``_seen_refs`` is threaded to break self-referential ``extends`` cycles; see
+    :func:`_merge_extends_config_vars`.
+    """
+    merged = _merge_extends_config_vars(schema_node, schema_dir, _seen_refs)
+    seen_refs = _seen_refs | set(schema_node.get("extends") or [])
 
     out: list[dict] = []
     for key, raw in merged.items():
@@ -2283,7 +2297,9 @@ def _convert_config_vars(
         # keys (docs, help link) survive (font.file).
         recovered = _RAW_NODE_OVERRIDES.get((component_id, key))
         field_raw = {**(raw or {}), **recovered} if recovered is not None else (raw or {})
-        entry = _convert_field(key, field_raw, schema_dir, top_level=bool(component_id))
+        entry = _convert_field(
+            key, field_raw, schema_dir, top_level=bool(component_id), _seen_refs=seen_refs
+        )
         if entry is None:
             continue
         # Per-(component, field) overrides patch up entries the schema
@@ -2445,7 +2461,11 @@ def _typed_expanding() -> Iterator[None]:
 
 
 def _build_typed_config_entries(
-    typed_node: dict, schema_dir: Path, *, component_id: str = ""
+    typed_node: dict,
+    schema_dir: Path,
+    *,
+    component_id: str = "",
+    _seen_refs: frozenset[str] = frozenset(),
 ) -> list[dict]:
     """
     Render a typed_schema node as a discriminator select + gated fields.
@@ -2468,7 +2488,9 @@ def _build_typed_config_entries(
         by_key: dict[str, list[tuple[str, dict]]] = {}
         for type_name, variant in types.items():
             body = variant if isinstance(variant, dict) else {}
-            for child in _convert_config_vars(body, schema_dir, component_id=component_id):
+            for child in _convert_config_vars(
+                body, schema_dir, component_id=component_id, _seen_refs=_seen_refs
+            ):
                 if child["key"] != typed_key:
                     by_key.setdefault(child["key"], []).append((type_name, child))
 
@@ -2531,13 +2553,19 @@ _RAW_NODE_OVERRIDES: dict[tuple[str, str], dict] = {
 
 
 def _convert_field(  # noqa: PLR0912, PLR0915, C901
-    key: str, raw: dict, schema_dir: Path, *, top_level: bool = False
+    key: str,
+    raw: dict,
+    schema_dir: Path,
+    *,
+    top_level: bool = False,
+    _seen_refs: frozenset[str] = frozenset(),
 ) -> dict | None:
     """Build a single ConfigEntry dict from a schema's config_var entry.
 
     ``top_level`` is True only for a component's own (direct) config
     vars; it gates the action-list ``type: trigger`` → TRIGGER override
-    so nested trigger fields stay ``nested`` (see below).
+    so nested trigger fields stay ``nested`` (see below). ``_seen_refs``
+    is threaded into nested recursion to break ``extends`` cycles.
     """
     if not isinstance(raw, dict):
         # Some schemas use bare ``{}``-shaped placeholders for fields
@@ -2748,12 +2776,14 @@ def _convert_field(  # noqa: PLR0912, PLR0915, C901
     typed_node = _typed_node(raw, schema_dir)
     if typed_node is not None and not _expanding_typed[0]:
         entry["type"] = "nested"
-        entry["config_entries"] = _build_typed_config_entries(typed_node, schema_dir) or None
+        entry["config_entries"] = (
+            _build_typed_config_entries(typed_node, schema_dir, _seen_refs=_seen_refs) or None
+        )
         return entry
 
     # Recurse into nested schemas for type=nested.
     if entry_type == "nested" and isinstance(inner_schema, dict):
-        inner = _convert_config_vars(inner_schema, schema_dir)
+        inner = _convert_config_vars(inner_schema, schema_dir, _seen_refs=_seen_refs)
         entry["config_entries"] = inner or None
         entry["platform_type"] = _detect_platform_type(inner_schema)
         # When every child would render as advanced anyway, hide the
@@ -4149,6 +4179,13 @@ def _get_esphome_loader() -> Any:
     _ESPHOME_LOADER_CACHE["resolved"] = True
     try:
         from esphome import loader
+        from esphome.const import KEY_CORE, KEY_TARGET_PLATFORM
+        from esphome.core import CORE
+
+        # usb_uart (and any component evaluating a platform-gated schema at
+        # import time) reads CORE.is_esp32; without a target_platform slot the
+        # lookup raises KeyError and introspection silently drops the component.
+        CORE.data.setdefault(KEY_CORE, {}).setdefault(KEY_TARGET_PLATFORM, None)
 
         _ESPHOME_LOADER_CACHE["module"] = loader
         _LOGGER.info("esphome introspection enabled (esphome.loader importable)")

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2268,13 +2268,14 @@ def _convert_config_vars(
     component_id: str = "",
     _seen_refs: frozenset[str] = frozenset(),
 ) -> list[dict]:
-    """Convert a ``schema`` node (config_vars + extends) to a list of entries.
+    """
+    Convert a ``schema`` node (config_vars + extends) to a list of entries.
 
     ``_seen_refs`` is threaded to break self-referential ``extends`` cycles; see
     :func:`_merge_extends_config_vars`.
     """
     merged = _merge_extends_config_vars(schema_node, schema_dir, _seen_refs)
-    seen_refs = _seen_refs | set(schema_node.get("extends") or [])
+    seen_refs = _seen_refs | frozenset(schema_node.get("extends") or [])
 
     out: list[dict] = []
     for key, raw in merged.items():

--- a/tests/test_sync_components_extends_cycle.py
+++ b/tests/test_sync_components_extends_cycle.py
@@ -1,0 +1,58 @@
+"""Tests for the ``extends``-cycle guard and CORE priming in the catalog sync."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from esphome.const import KEY_CORE, KEY_TARGET_PLATFORM
+from esphome.core import CORE
+
+_SCRIPT_DIR = Path(__file__).parent.parent / "script"
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+import sync_components  # noqa: E402
+
+# A field shape the converter treats as a nested sub-schema (``schema`` maps to
+# ``nested`` in _TYPE_MAP; the inner ``schema`` is the recursion target).
+_CYCLE_FIELD = {"key": "Optional", "type": "schema", "schema": {"extends": ["CYCLE"]}}
+
+
+def test_convert_config_vars_breaks_self_referential_extends(monkeypatch) -> None:
+    """A schema whose nested field re-extends its own base terminates (no RecursionError).
+
+    Mirrors lvgl's ``WIDGET_TYPES`` cycle (a widget contains a widget list).
+    """
+
+    def fake_resolve(ref: str, schema_dir: Path) -> dict:
+        # ``CYCLE`` resolves to a node carrying a nested field that extends
+        # ``CYCLE`` again — an infinite loop without the _seen_refs guard.
+        return {"child": dict(_CYCLE_FIELD)} if ref == "CYCLE" else {}
+
+    monkeypatch.setattr(sync_components, "_resolve_extends", fake_resolve)
+
+    entries = sync_components._convert_config_vars({"extends": ["CYCLE"]}, Path("/nonexistent"))
+
+    # First expansion surfaces the child; its re-expansion of CYCLE is pruned.
+    assert [e["key"] for e in entries] == ["child"]
+    assert entries[0]["type"] == "nested"
+    assert entries[0].get("config_entries") is None
+
+
+def test_merge_extends_skips_seen_refs() -> None:
+    """A ref already on the expansion path is not re-resolved."""
+    node = {"extends": ["CYCLE"], "config_vars": {"local": {"key": "Optional"}}}
+    merged = sync_components._merge_extends_config_vars(
+        node, Path("/nonexistent"), frozenset({"CYCLE"})
+    )
+    assert set(merged) == {"local"}
+
+
+def test_get_esphome_loader_primes_core_target_platform() -> None:
+    """The loader gives CORE a target_platform slot so import-time CORE.is_esp32 can't KeyError."""
+    sync_components._ESPHOME_LOADER_CACHE.update(resolved=False, module=None)
+    CORE.data.pop(KEY_CORE, None)
+
+    assert sync_components._get_esphome_loader() is not None
+    assert KEY_TARGET_PLATFORM in CORE.data[KEY_CORE]

--- a/tests/test_sync_components_extends_cycle.py
+++ b/tests/test_sync_components_extends_cycle.py
@@ -49,9 +49,12 @@ def test_merge_extends_skips_seen_refs() -> None:
     assert set(merged) == {"local"}
 
 
-def test_get_esphome_loader_primes_core_target_platform() -> None:
+def test_get_esphome_loader_primes_core_target_platform(monkeypatch) -> None:
     """The loader gives CORE a target_platform slot so import-time CORE.is_esp32 can't KeyError."""
-    sync_components._ESPHOME_LOADER_CACHE.update(resolved=False, module=None)
+    # Work on copies so the forced re-resolution + CORE mutation unwind on teardown.
+    monkeypatch.setattr(CORE, "data", dict(CORE.data))
+    monkeypatch.setitem(sync_components._ESPHOME_LOADER_CACHE, "resolved", False)
+    monkeypatch.setitem(sync_components._ESPHOME_LOADER_CACHE, "module", None)
     CORE.data.pop(KEY_CORE, None)
 
     assert sync_components._get_esphome_loader() is not None


### PR DESCRIPTION
# What does this implement/fix?

Now that the catalog sync tracks the latest beta esphome (2026.6.0b3), the run surfaced two defects the stable schema never hit; both were silently swallowed, so the catalog degraded without failing the sync.

`lvgl` was dropped entirely with a `RecursionError`. Its widgets extend `lvgl.WIDGET_TYPES` (a widget can contain a widget list) and `lvgl.STYLE_SCHEMA`, so the converter followed the nested widget schema and re-expanded `WIDGET_TYPES` forever. The raw JSON is shallow, so this is a reference cycle, not deep data; a depth cap would expand the cycle and balloon the 1.6 MB schema. The fix threads a `_seen_refs` set through the convert recursion so an `extends` target already being expanded up the stack is not re-expanded, which bounds the nested widget list.

`usb_uart` shipped without introspection (`KeyError: 'target_platform'`). In beta it evaluates a platform-gated schema (`CORE.is_esp32`) at import time, and the sync imported it with a `CORE` whose `KEY_CORE` dict lacked a `target_platform` slot. The loader now gives `CORE` that slot (set to `None`) when first resolved, so the lookup returns False instead of raising.

Verified locally against 2026.6.0b3: the sync log no longer shows the `lvgl` RecursionError or the `usb_uart` load failure; `lvgl` builds bounded (depth 6, 194 top-level entries) and `usb_uart` carries its introspected fields.

Heads-up for the catalog refresh: with `lvgl` restored, its body file is large (~14 MB; b3's lvgl inlines the full style schema on every widget) versus the 341-byte stub stable produced. It is lazy-loaded per-id, but it is a real wheel-size bump worth a look when the b3 catalog PR regenerates.

**Related issue or feature (if applicable):**

- Follow-up to the beta-tracking work (#1495, #1500)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
