### PR TITLE
Fix bare components borrowing a platform sub-page's catalog metadata

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1190,7 +1190,7 @@ def build_catalog(
     _backfill_descriptions_from_mdx(out)
 
     # After the MDX backfill so a real MDX title still wins.
-    _fix_borrowed_page_titles(out)
+    _fix_borrowed_page_titles(out, _components_with_own_docs_page())
 
     # Synthesise umbrella entries for legacy bare-key domains so that
     # ``get_component("ota")`` / ``get_component("time")`` resolve for
@@ -1215,24 +1215,42 @@ def build_catalog(
     return out
 
 
-def _fix_borrowed_page_titles(entries: list[dict]) -> None:
+def _fix_borrowed_page_titles(entries: list[dict], own_page_ids: frozenset[str]) -> None:
     """
-    Re-derive a name borrowed from another component's docs page.
+    Re-derive metadata borrowed from another component's docs page.
 
-    Rewrites an entry whose page slug is owned by a different component and
-    whose own stem is unrelated to that slug. In-place.
+    Two borrow shapes, both rewritten in-place:
+
+    - A component links another's *top-level* page (``preferences`` ->
+      ``components/esphome``): re-derive only the name; the shared page stays.
+    - A *bare* component that owns its own docs page (in *own_page_ids*) links a
+      *platform* sub-page ``<domain>/<stem>`` owned by ``<domain>.<stem>``
+      (``lvgl`` took ``number.lvgl``'s page, ``audio_file`` took
+      ``media_source.audio_file``'s): reset to its own identity — name, docs_url,
+      and drop the borrowed description / image. The own-page gate is what
+      distinguishes this from a single-platform component legitimately
+      documented under its category (``adc128s102`` -> ``sensor/adc128s102``),
+      which must keep its page-derived name.
     """
     ids = {entry["id"] for entry in entries}
     for entry in entries:
         cid = entry["id"]
         stem = cid.split(".", 1)[-1]
-        slug = (entry.get("docs_url") or "").rstrip("/").rsplit("/", 1)[-1]
-        # Same page or a same-family variant (``pn532_spi`` -> ``pn532``): the
-        # shared title is correct.
-        if not slug or slug == stem or stem.startswith(slug):
+        segs = (entry.get("docs_url") or "").rstrip("/").split("/")
+        if len(segs) < 2:
             continue
-        if slug in ids:
+        slug, parent = segs[-1], segs[-2]
+        if parent == "components":
+            # Same page or a same-family variant (``pn532_spi`` -> ``pn532``):
+            # the shared title is correct.
+            if slug and slug != stem and not stem.startswith(slug) and slug in ids:
+                entry["name"] = _name_from_stem(stem)
+            continue
+        if cid in own_page_ids and slug == stem and "." not in cid and f"{parent}.{slug}" in ids:
             entry["name"] = _name_from_stem(stem)
+            entry["docs_url"] = _derive_docs_url(cid)
+            entry["description"] = ""
+            entry["image_url"] = ""
 
 
 def _resolve_provides(entries: list[dict], schema_dir: Path) -> None:
@@ -1624,6 +1642,22 @@ def _load_mdx_descriptions() -> dict[str, str]:
             stem = parts[-1]
             out.setdefault(stem, text)
     return out
+
+
+def _components_with_own_docs_page() -> frozenset[str]:
+    """Bare component ids that have a dedicated docs directory (``<stem>/index.mdx``).
+
+    These are hubs documented on their own page (``lvgl``, ``audio_file``); used
+    to tell a genuine page borrow from a single-platform component legitimately
+    documented under its category (``sensor/adc128s102``).
+    """
+    docs_dir = _ensure_docs_repo()
+    if docs_dir is None:
+        return frozenset()
+    root = docs_dir / "src" / "content" / "docs" / "components"
+    if not root.exists():
+        return frozenset()
+    return frozenset(p.parent.name for p in root.glob("*/index.mdx"))
 
 
 def _load_mdx_titles() -> dict[str, str]:
@@ -3715,6 +3749,7 @@ _ACRONYM_NORMALISATIONS: dict[str, str] = {
     "Cwww": "CWWW",
     "Led": "LED",
     "Lcd": "LCD",
+    "Lvgl": "LVGL",
     "Oled": "OLED",
     "Tft": "TFT",
     "Usb": "USB",

--- a/tests/test_sync_components_borrowed_titles.py
+++ b/tests/test_sync_components_borrowed_titles.py
@@ -26,9 +26,45 @@ def test_borrowed_title_is_rederived_from_stem() -> None:
         _entry("esphome", "ESPHome Core Configuration", "esphome"),
         _entry("preferences", "ESPHome Core Configuration", "esphome"),
     ]
-    _fix_borrowed_page_titles(entries)
+    _fix_borrowed_page_titles(entries, frozenset())
     assert entries[0]["name"] == "ESPHome Core Configuration"  # page owner, untouched
     assert entries[1]["name"] == "Preferences"
+
+
+def test_bare_hub_with_own_page_borrowing_platform_page_resets_identity() -> None:
+    """A bare hub that owns a docs page but links a platform sub-page resets itself."""
+    entries = [
+        {
+            "id": "lvgl",
+            "name": "LVGL Number",
+            "docs_url": "https://esphome.io/components/number/lvgl",
+            "description": "The `lvgl` number platform creates a number component.",
+            "image_url": "https://esphome.io/images/lvgl_c_num.png",
+        },
+        _entry("number.lvgl", "LVGL Number", "number/lvgl"),
+    ]
+    _fix_borrowed_page_titles(entries, frozenset({"lvgl"}))
+    assert entries[0]["name"] == "LVGL"
+    assert entries[0]["docs_url"] == "https://esphome.io/components/lvgl"
+    assert entries[0]["description"] == ""
+    assert entries[0]["image_url"] == ""
+    # The platform entry that actually owns the page is left alone.
+    assert entries[1]["name"] == "LVGL Number"
+
+
+def test_single_platform_component_without_own_page_keeps_its_name() -> None:
+    """A bare component documented under its category (no own page) is NOT reset.
+
+    Regression guard: ``adc128s102`` lives at ``sensor/adc128s102`` and its
+    page-derived name is correct — the own-page gate must leave it alone.
+    """
+    name = "ADC128S102 8-Channel 12-Bit A/D Converter"
+    entries = [
+        _entry("adc128s102", name, "sensor/adc128s102"),
+        _entry("sensor.adc128s102", name, "sensor/adc128s102"),
+    ]
+    _fix_borrowed_page_titles(entries, frozenset())  # no own page for adc128s102
+    assert entries[0]["name"] == name
 
 
 def test_same_family_variant_keeps_shared_title() -> None:
@@ -37,19 +73,19 @@ def test_same_family_variant_keeps_shared_title() -> None:
         _entry("pn532", "PN532 NFC/RFID", "pn532"),
         _entry("pn532_spi", "PN532 NFC/RFID", "pn532"),
     ]
-    _fix_borrowed_page_titles(entries)
+    _fix_borrowed_page_titles(entries, frozenset())
     assert entries[1]["name"] == "PN532 NFC/RFID"
 
 
 def test_platform_entry_on_its_own_page_untouched() -> None:
     """A ``<domain>.<stem>`` entry whose page is its own stem is left alone."""
     entries = [_entry("sensor.dht", "DHT Temperature+Humidity Sensor", "dht")]
-    _fix_borrowed_page_titles(entries)
+    _fix_borrowed_page_titles(entries, frozenset())
     assert entries[0]["name"] == "DHT Temperature+Humidity Sensor"
 
 
 def test_unrelated_page_with_no_owner_entry_untouched() -> None:
     """No rewrite when the linked page isn't owned by another catalog entry."""
     entries = [_entry("as3935_spi", "AMS AS3935 Franklin Lightning Sensor", "as3935")]
-    _fix_borrowed_page_titles(entries)
+    _fix_borrowed_page_titles(entries, frozenset())
     assert entries[0]["name"] == "AMS AS3935 Franklin Lightning Sensor"


### PR DESCRIPTION
# What does this implement/fix?

The bare `lvgl` component shipped with `number.lvgl`'s identity: name "LVGL Number", the number-widget image, the "lvgl number platform" description, and a `docs_url` of `components/number/lvgl`. The docs index pointed the bare hub at a platform sub-page, and `_fix_borrowed_page_titles` missed it because the URL slug (`lvgl`) matches the stem even though the URL's domain segment (`number`) belongs to `number.lvgl`.

Generalize the borrow detection: when a bare component's `docs_url` is `components/<domain>/<stem>` and `<domain>.<stem>` exists as its own entry, reset the bare component to its own name, derive its own `docs_url`, and drop the borrowed description/image. The existing top-level-page case (e.g. `preferences` linking `esphome`'s page) is unchanged. Added `lvgl` to the acronym map so the stem title-cases to "LVGL".

Verified against `2026.6.0b3`: the regenerated `lvgl` entry is name "LVGL", `docs_url` `components/lvgl`, empty description; the nine other bare-components-documented-under-a-platform-path (airthings_ble, pn532_spi, …) keep their correct names since none has a distinct `<domain>.<stem>` owner. Corrected catalog ships via the next sync run, not this PR.

**Related issue or feature (if applicable):**

- Follow-up to the b3 catalog sync (#1498)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#862

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

