### PR TITLE
Only dispatch the component catalog sync on a release

### DIFF
--- a/.github/workflows/sync-on-esphome-release.yml
+++ b/.github/workflows/sync-on-esphome-release.yml
@@ -1,14 +1,10 @@
-name: Sync catalog on ESPHome release
+name: Sync component catalog on ESPHome release
 
 # Dispatched by esphome/version-notifier right after an ESPHome release. Waits
-# for the new schema to publish, then dispatches the existing component and
-# device/board catalog sync workflows so both refresh immediately instead of
-# waiting for their schedules. Only the component sync needs the version; the
-# device/board sync always tracks the latest prerelease esphome.
-#
-# This only orchestrates; the actual regeneration lives in
-# sync-component-catalog.yml and sync-device-catalog.yml, which stay
-# self-contained (each already tracks the latest prerelease esphome).
+# for the new schema to publish, then dispatches the component catalog sync so
+# it refreshes immediately instead of waiting for the nightly. The device/board
+# catalog is sourced from devices.esphome.io plus curated manifests, so a
+# release doesn't change it; it stays on its own schedule.
 
 on:
   workflow_dispatch:
@@ -19,7 +15,7 @@ on:
         type: string
 
 permissions:
-  actions: write  # createWorkflowDispatch on this repo's sync workflows
+  actions: write  # createWorkflowDispatch on this repo's component sync
 
 concurrency:
   group: sync-on-esphome-release-${{ inputs.version }}
@@ -35,14 +31,16 @@ jobs:
         # release event, so the bundle can lag the release by a few minutes. The
         # component sync consumes it, so wait before kicking that off. ``version``
         # comes through ``env`` rather than expression-interpolation into the
-        # shell so a crafted input can't inject command substitution.
+        # shell so a crafted input can't inject command substitution. The esphome
+        # wheel the component sync installs isn't gated here; if it lags the
+        # schema the sync fails and the nightly retries.
         env:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           url="https://schema.esphome.io/${VERSION}/schema.zip"
           for attempt in $(seq 1 40); do
-            if curl -fsSL -A "device-builder-release-sync" --head -o /dev/null "$url"; then
+            if curl -fsSL --connect-timeout 10 --max-time 30 -A "device-builder-release-sync" --head -o /dev/null "$url"; then
               echo "Schema ready: $url"
               exit 0
             fi
@@ -52,25 +50,16 @@ jobs:
           echo "::error::Schema $url did not publish within 20 minutes"
           exit 1
 
-      - name: Dispatch the catalog sync workflows
+      - name: Dispatch the component catalog sync
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           VERSION: ${{ inputs.version }}
         with:
           script: |
-            // Component sync: pass the released version so it pins that schema.
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: "sync-component-catalog.yml",
               ref: "main",
               inputs: { version: process.env.VERSION },
-            });
-            // Device/board sync takes no version: it always tracks the latest
-            // prerelease esphome, which is this release.
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "sync-device-catalog.yml",
-              ref: "main",
             });


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1505. The device/board catalog is sourced from devices.esphome.io plus curated manifests, so an ESPHome release doesn't change it; only the component catalog is schema-driven. So the release orchestrator now dispatches just the component catalog sync and leaves the device/board sync on its own schedule.

Also folds in the late review on #1505: bounds the schema-poll curl with `--connect-timeout 10 --max-time 30` so each probe stays inside the documented 20-minute budget, and notes that the esphome wheel the component sync installs isn't gated by the wait (the nightly retries if it lags).

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
