### PR TITLE
Reap idle esphome vscode editor subprocesses

### DIFF
--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -8,6 +8,7 @@ schema-driven completion, etc.) will live here too.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from dataclasses import dataclass, field
@@ -36,6 +37,12 @@ _VALIDATE_TIMEOUT = 30.0
 # collision risk negligible for the ≤dozens of buffers an editor
 # session sees inside one TTL window).
 _VALIDATE_CACHE_TTL = 60.0
+# Reap a warm ``esphome vscode`` subprocess after this long without a
+# validate request: it holds the esphome runtime + loaded config in RAM, so
+# leaving it resident for hours after the user navigates away is pure waste.
+# Long enough to survive a normal mid-edit pause; the next validate respawns it.
+_IDLE_SUBPROCESS_TIMEOUT = 600.0
+_REAP_INTERVAL = 60.0
 
 
 @dataclass
@@ -60,6 +67,7 @@ class _EditorSession:
     proc: asyncio.subprocess.Process | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     cached: _CachedValidation | None = None
+    last_used: float = field(default_factory=time.monotonic)
 
 
 class EditorController:
@@ -77,14 +85,23 @@ class EditorController:
         self._db = device_builder
         self._sessions: dict[str, _EditorSession] = {}
         self._esphome_cmd: list[str] = []
+        self._reaper_task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
         """Async initialize the controller."""
         # resolve the `esphome` CLI invocation used to spawn validator subprocesses
         self._esphome_cmd = _find_esphome_cmd()
+        self._reaper_task = asyncio.create_task(
+            self._reaper_loop(), name="editor-subprocess-reaper"
+        )
 
     async def stop(self) -> None:
         """Stop the controller.."""
+        if self._reaper_task is not None:
+            self._reaper_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reaper_task
+            self._reaper_task = None
         sessions = list(self._sessions.values())
         self._sessions.clear()
         # tear down every warm validator subprocess on app shutdown
@@ -165,6 +182,39 @@ class EditorController:
                 kill_quietly(proc)
                 await proc.wait()
 
+    async def _reaper_loop(self) -> None:
+        """Periodically reap subprocesses idle past ``_IDLE_SUBPROCESS_TIMEOUT``."""
+        while True:
+            await asyncio.sleep(_REAP_INTERVAL)
+            await self._reap_idle_subprocesses()
+
+    async def _reap_idle_subprocesses(self) -> None:
+        """Terminate each session's subprocess after a window of no validation.
+
+        Holds ``session.lock`` across the terminate so it can never interrupt an
+        in-flight ``_validate_locked`` round-trip; a busy (locked) session was
+        just used, so it's skipped. The session object stays — the next
+        ``validate_yaml`` respawns via ``_ensure_subprocess``.
+        """
+        for session in list(self._sessions.values()):
+            proc = session.proc
+            if proc is None or proc.returncode is not None:
+                continue
+            if time.monotonic() - session.last_used < _IDLE_SUBPROCESS_TIMEOUT:
+                continue
+            if session.lock.locked():
+                continue
+            async with session.lock:
+                # Re-check under the lock: a validate may have run (and stamped
+                # last_used) while we waited.
+                if (
+                    session.proc is None
+                    or time.monotonic() - session.last_used < _IDLE_SUBPROCESS_TIMEOUT
+                ):
+                    continue
+                _LOGGER.info("Reaping idle vscode subprocess for %s", session.configuration)
+                await self._terminate_subprocess(session)
+
     def _resolve_file(self, requested: str, configuration: str, content: str) -> str:
         """
         Answer a `read_file` request from the validator subprocess.
@@ -228,6 +278,9 @@ class EditorController:
         session = self._sessions.setdefault(
             configuration, _EditorSession(configuration=configuration)
         )
+        # Stamp before any await so the reaper (which re-checks last_used under
+        # the lock) never reaps a session with a request in flight.
+        session.last_used = time.monotonic()
         content_hash = fnv1a_32(content.encode("utf-8"))
         # Fast path: avoid the lock when the previous result is
         # still fresh for the same content.

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -186,7 +186,11 @@ class EditorController:
         """Periodically reap subprocesses idle past ``_IDLE_SUBPROCESS_TIMEOUT``."""
         while True:
             await asyncio.sleep(_REAP_INTERVAL)
-            await self._reap_idle_subprocesses()
+            try:
+                await self._reap_idle_subprocesses()
+            except Exception:  # pylint: disable=broad-except
+                # A failed sweep must not kill the reaper.
+                _LOGGER.exception("Idle vscode subprocess reaper sweep failed")
 
     async def _reap_idle_subprocesses(self) -> None:
         """Terminate each session's subprocess after a window of no validation.
@@ -213,7 +217,13 @@ class EditorController:
                 ):
                     continue
                 _LOGGER.info("Reaping idle vscode subprocess for %s", session.configuration)
-                await self._terminate_subprocess(session)
+                # One stuck terminate must not strand the rest of the sweep.
+                try:
+                    await self._terminate_subprocess(session)
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception(
+                        "Failed to reap idle vscode subprocess for %s", session.configuration
+                    )
 
     def _resolve_file(self, requested: str, configuration: str, content: str) -> str:
         """

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -37,10 +37,7 @@ _VALIDATE_TIMEOUT = 30.0
 # collision risk negligible for the ≤dozens of buffers an editor
 # session sees inside one TTL window).
 _VALIDATE_CACHE_TTL = 60.0
-# Reap a warm ``esphome vscode`` subprocess after this long without a
-# validate request: it holds the esphome runtime + loaded config in RAM, so
-# leaving it resident for hours after the user navigates away is pure waste.
-# Long enough to survive a normal mid-edit pause; the next validate respawns it.
+# Idle seconds before a warm vscode subprocess is reaped (respawned on next validate).
 _IDLE_SUBPROCESS_TIMEOUT = 600.0
 _REAP_INTERVAL = 60.0
 
@@ -96,7 +93,7 @@ class EditorController:
         )
 
     async def stop(self) -> None:
-        """Stop the controller.."""
+        """Stop the controller."""
         if self._reaper_task is not None:
             self._reaper_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -162,8 +159,8 @@ class EditorController:
     async def _terminate_subprocess(self, session: _EditorSession) -> None:
         """Terminate the session's subprocess."""
         proc = session.proc
-        session.proc = None
         if proc is None or proc.returncode is not None:
+            session.proc = None
             return
         try:
             if proc.stdin is not None and not proc.stdin.is_closing():
@@ -181,6 +178,9 @@ class EditorController:
             except TimeoutError:
                 kill_quietly(proc)
                 await proc.wait()
+        # Cleared only after the process is gone, so a cancel mid-await leaves
+        # the handle on the session for stop()'s teardown to reap.
+        session.proc = None
 
     async def _reaper_loop(self) -> None:
         """Periodically reap subprocesses idle past ``_IDLE_SUBPROCESS_TIMEOUT``."""

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -37,7 +37,9 @@ _VALIDATE_TIMEOUT = 30.0
 # collision risk negligible for the ≤dozens of buffers an editor
 # session sees inside one TTL window).
 _VALIDATE_CACHE_TTL = 60.0
-# Idle seconds before a warm vscode subprocess is reaped (respawned on next validate).
+# Idle seconds before a warm vscode subprocess is reaped, respawned on next
+# validate. 10 min outlasts a normal mid-edit pause but frees RAM once the
+# user leaves.
 _IDLE_SUBPROCESS_TIMEOUT = 600.0
 _REAP_INTERVAL = 60.0
 
@@ -188,7 +190,7 @@ class EditorController:
             await asyncio.sleep(_REAP_INTERVAL)
             try:
                 await self._reap_idle_subprocesses()
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 # A failed sweep must not kill the reaper.
                 _LOGGER.exception("Idle vscode subprocess reaper sweep failed")
 
@@ -211,8 +213,10 @@ class EditorController:
             async with session.lock:
                 # Re-check under the lock: a validate may have run (and stamped
                 # last_used) while we waited.
+                proc = session.proc
                 if (
-                    session.proc is None
+                    proc is None
+                    or proc.returncode is not None
                     or time.monotonic() - session.last_used < _IDLE_SUBPROCESS_TIMEOUT
                 ):
                     continue
@@ -220,7 +224,7 @@ class EditorController:
                 # One stuck terminate must not strand the rest of the sweep.
                 try:
                     await self._terminate_subprocess(session)
-                except Exception:  # pylint: disable=broad-except
+                except Exception:
                     _LOGGER.exception(
                         "Failed to reap idle vscode subprocess for %s", session.configuration
                     )

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -882,12 +882,51 @@ async def test_reap_keeps_recently_used_session(tmp_path: Path) -> None:
     terminated.assert_not_awaited()
 
 
-async def test_reap_skips_busy_session_then_reaps_when_free(tmp_path: Path) -> None:
-    """A stale session whose lock is held (validate in flight) isn't reaped.
+async def test_reap_skips_session_without_live_proc(tmp_path: Path) -> None:
+    """A session with no proc, or an already-exited one, is skipped."""
+    controller = _make_controller(tmp_path)
+    no_proc = _EditorSession(configuration="a.yaml")
+    no_proc.last_used = time.monotonic() - _IDLE_SUBPROCESS_TIMEOUT - 1.0
+    dead = _idle_session("b.yaml")
+    assert dead.proc is not None
+    dead.proc.returncode = 0
+    controller._sessions["a.yaml"] = no_proc
+    controller._sessions["b.yaml"] = dead
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
 
-    Termination must only happen under the lock, so a busy session is skipped;
-    once the lock frees, the next sweep reaps it.
-    """
+    await controller._reap_idle_subprocesses()
+
+    terminated.assert_not_awaited()
+
+
+async def test_reap_rechecks_under_lock_and_skips_if_freshly_used(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A validate that stamps last_used while the reaper waits on the lock spares the proc."""
+    controller = _make_controller(tmp_path)
+    proc, _reader, _stdin = _make_fake_proc([])
+    session = _EditorSession(configuration="kitchen.yaml")
+    session.proc = proc
+    session.last_used = 0.0
+    controller._sessions["kitchen.yaml"] = session
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    # Stale at the pre-lock check, fresh at the under-lock re-check.
+    clock = iter([1000.0, 100.0])
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor.time.monotonic",
+        lambda: next(clock, 100.0),
+    )
+
+    await controller._reap_idle_subprocesses()
+
+    terminated.assert_not_awaited()
+
+
+async def test_reap_skips_busy_session_then_reaps_when_free(tmp_path: Path) -> None:
+    """A stale session whose lock is held is skipped, then reaped once free."""
     controller = _make_controller(tmp_path)
     session = _idle_session("kitchen.yaml")
     controller._sessions["kitchen.yaml"] = session
@@ -922,6 +961,57 @@ async def test_start_creates_reaper_task_stop_cancels_it(
     await controller.stop()
     assert controller._reaper_task is None
     assert task.cancelled()
+
+
+async def test_reaper_loop_logs_and_continues_after_sweep_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed sweep is logged and the loop runs the next one."""
+    controller = _make_controller(tmp_path)
+    sweeps: list[int] = []
+
+    async def _reap() -> None:
+        sweeps.append(1)
+        if len(sweeps) == 1:
+            raise RuntimeError("boom")
+
+    controller._reap_idle_subprocesses = _reap  # type: ignore[method-assign]
+
+    sleeps: list[int] = []
+
+    async def _sleep(_: float) -> None:
+        sleeps.append(1)
+        if len(sleeps) >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr("esphome_device_builder.controllers.editor.asyncio.sleep", _sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await controller._reaper_loop()
+
+    assert sweeps == [1, 1]  # ran again after the first sweep raised
+
+
+async def test_terminate_keeps_proc_handle_when_cancelled_mid_wait(tmp_path: Path) -> None:
+    """A cancel mid-terminate leaves session.proc set so stop() can still reap it."""
+    controller = _make_controller(tmp_path)
+    proc, _reader, _stdin = _make_fake_proc([])
+
+    async def _hang() -> int:
+        await asyncio.Event().wait()
+        return 0
+
+    proc.wait = _hang
+    session = _EditorSession(configuration="kitchen.yaml")
+    session.proc = proc
+
+    task = asyncio.create_task(controller._terminate_subprocess(session))
+    await asyncio.sleep(0)  # let it reach the proc.wait await
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert session.proc is proc  # handle retained, not cleared early
 
 
 async def test_reap_continues_after_one_session_fails(tmp_path: Path) -> None:

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -38,6 +39,7 @@ import pytest
 
 from esphome_device_builder.controllers import editor as editor_module
 from esphome_device_builder.controllers.editor import (
+    _IDLE_SUBPROCESS_TIMEOUT,
     EditorController,
     _EditorSession,
 )
@@ -56,6 +58,7 @@ def _make_controller(config_dir: Path) -> EditorController:
     controller._db.settings.config_dir = config_dir
     controller._sessions = {}
     controller._esphome_cmd = ["esphome"]
+    controller._reaper_task = None
     return controller
 
 
@@ -836,6 +839,89 @@ async def test_validate_yaml_cache_misses_on_different_content(tmp_path: Path) -
     )
 
     assert calls == ["esphome:\n  name: kitchen\n", "esphome:\n  name: kitchen-2\n"]
+
+
+# ---------------------------------------------------------------------------
+# Idle subprocess reaping
+# ---------------------------------------------------------------------------
+
+
+def _idle_session(configuration: str) -> _EditorSession:
+    """Build a session with a live proc whose last_used is past the idle timeout."""
+    proc, _reader, _stdin = _make_fake_proc([])
+    session = _EditorSession(configuration=configuration)
+    session.proc = proc
+    session.last_used = time.monotonic() - _IDLE_SUBPROCESS_TIMEOUT - 1.0
+    return session
+
+
+async def test_reap_terminates_idle_session(tmp_path: Path) -> None:
+    """A session idle past the timeout has its subprocess terminated."""
+    controller = _make_controller(tmp_path)
+    session = _idle_session("kitchen.yaml")
+    controller._sessions["kitchen.yaml"] = session
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    await controller._reap_idle_subprocesses()
+
+    terminated.assert_awaited_once_with(session)
+
+
+async def test_reap_keeps_recently_used_session(tmp_path: Path) -> None:
+    """A session used within the idle window is left warm."""
+    controller = _make_controller(tmp_path)
+    session = _idle_session("kitchen.yaml")
+    session.last_used = time.monotonic()  # fresh
+    controller._sessions["kitchen.yaml"] = session
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    await controller._reap_idle_subprocesses()
+
+    terminated.assert_not_awaited()
+
+
+async def test_reap_skips_busy_session_then_reaps_when_free(tmp_path: Path) -> None:
+    """A stale session whose lock is held (validate in flight) isn't reaped.
+
+    Termination must only happen under the lock, so a busy session is skipped;
+    once the lock frees, the next sweep reaps it.
+    """
+    controller = _make_controller(tmp_path)
+    session = _idle_session("kitchen.yaml")
+    controller._sessions["kitchen.yaml"] = session
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    await session.lock.acquire()
+    try:
+        await controller._reap_idle_subprocesses()
+        terminated.assert_not_awaited()
+    finally:
+        session.lock.release()
+
+    await controller._reap_idle_subprocesses()
+    terminated.assert_awaited_once_with(session)
+
+
+async def test_validate_yaml_stamps_last_used(tmp_path: Path) -> None:
+    """Each validate request refreshes last_used so an active editor stays warm."""
+    controller = _make_controller(tmp_path)
+
+    async def _ok(session: Any, configuration: str, content: str) -> dict:
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _ok  # type: ignore[method-assign]
+    # Seed a stale session so we can observe last_used jump forward.
+    session = _EditorSession(configuration="kitchen.yaml")
+    session.last_used = time.monotonic() - 10_000.0
+    controller._sessions["kitchen.yaml"] = session
+    before = session.last_used
+
+    await controller.validate_yaml(configuration="kitchen.yaml", content="x")
+
+    assert session.last_used > before
 
 
 async def test_validate_yaml_cache_expires_after_ttl(

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -905,6 +905,38 @@ async def test_reap_skips_busy_session_then_reaps_when_free(tmp_path: Path) -> N
     terminated.assert_awaited_once_with(session)
 
 
+async def test_start_creates_reaper_task_stop_cancels_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``start()`` launches the reaper; ``stop()`` cancels and clears it."""
+    controller = _make_controller(tmp_path)
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.editor._find_esphome_cmd",
+        lambda: ["esphome"],
+    )
+
+    await controller.start()
+    task = controller._reaper_task
+    assert task is not None and not task.done()
+
+    await controller.stop()
+    assert controller._reaper_task is None
+    assert task.cancelled()
+
+
+async def test_reap_continues_after_one_session_fails(tmp_path: Path) -> None:
+    """A failed terminate is logged and the sweep moves on to other sessions."""
+    controller = _make_controller(tmp_path)
+    controller._sessions["a.yaml"] = _idle_session("a.yaml")
+    controller._sessions["b.yaml"] = _idle_session("b.yaml")
+    terminated = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    await controller._reap_idle_subprocesses()  # must not raise
+
+    assert terminated.await_count == 2
+
+
 async def test_validate_yaml_stamps_last_used(tmp_path: Path) -> None:
     """Each validate request refreshes last_used so an active editor stays warm."""
     controller = _make_controller(tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

The YAML editor keeps a warm `esphome vscode --ace` validator subprocess per configuration. It was only torn down on app shutdown, so once a user edited a device, that subprocess held the esphome runtime and loaded config in RAM for hours after they navigated away. On an HA add-on with several devices that's real memory pressure for no benefit.

Add a periodic reaper that terminates a session's subprocess after 10 minutes without a validate request; the next `validate_yaml` respawns it lazily (the spawn path already runs on every cold or crashed session). The reaper terminates only while holding `session.lock`, so it can never interrupt an in-flight validation, and `validate_yaml` stamps `last_used` before taking the lock, so a request landing exactly at the timeout either keeps the proc warm (reaper re-checks and skips) or transparently respawns it via `_ensure_subprocess`. The session object stays (tiny, bounded by device count); only the subprocess is freed.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
