### PR TITLE
Log startup phase timings

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -9,6 +9,7 @@ import os
 import signal
 import sys
 import threading
+import time
 from contextlib import suppress
 from logging.handlers import RotatingFileHandler
 from types import TracebackType
@@ -24,10 +25,14 @@ from .constants import (
     __version__,
 )
 from .helpers.logging import activate_log_queue_handler
+from .helpers.startup_timing import StartupTimer
 
 if TYPE_CHECKING:
     from .controllers.config import DashboardSettings
     from .device_builder import DeviceBuilder
+
+# Timestamp at module load; origin for the startup phase timer.
+_STARTUP_ORIGIN = time.monotonic()
 
 _FORMAT = "%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -318,17 +323,28 @@ def main() -> None:
         )
         sys.exit(1)
 
+    startup_timer = StartupTimer(_STARTUP_ORIGIN)
+    startup_timer.mark("early")
+
+    # Sub-marks separate the esphome base import from our controllers/models tree.
     from esphome.core import CORE  # noqa: PLC0415
 
+    startup_timer.mark("esphome")
+
     from .controllers.config import DashboardSettings  # noqa: PLC0415
+
+    startup_timer.mark("config")
+
     from .device_builder import DeviceBuilder  # noqa: PLC0415
     from .helpers.single_instance import ensure_single_execution  # noqa: PLC0415
     from .helpers.windows_build_paths import windows_short_build_paths  # noqa: PLC0415
 
+    startup_timer.mark("builder")
+
     settings = DashboardSettings()
     settings.parse_args(args)
-
     _warn_if_unprotected(settings)
+    startup_timer.mark("settings")
 
     # Keyed on ``CORE.data_dir`` (not ``config_dir``) so the HA
     # addon's Prod/Beta/DEV flavors — each with its own per-instance
@@ -346,7 +362,9 @@ def main() -> None:
     ):
         if lock.exit_code is not None:
             sys.exit(lock.exit_code)
-        _serve_until_stop(DeviceBuilder(settings))
+        device_builder = DeviceBuilder(settings, startup_timer=startup_timer)
+        startup_timer.mark("init")
+        _serve_until_stop(device_builder)
 
 
 def _serve_until_stop(device_builder: DeviceBuilder) -> None:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -51,6 +51,7 @@ from .helpers.json import cors_middleware
 from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
 from .helpers.peer_link_identity import PeerLinkIdentityStore
 from .helpers.secrets_state import write_secrets_locked
+from .helpers.startup_timing import StartupTimer
 from .helpers.subscriber_presence import SubscriberPresence
 from .models import EventType
 
@@ -194,9 +195,12 @@ class DeviceBuilder:
     All device state lives in DevicesController.
     """
 
-    def __init__(self, settings: DashboardSettings) -> None:
+    def __init__(
+        self, settings: DashboardSettings, *, startup_timer: StartupTimer | None = None
+    ) -> None:
         """Initialize the Device Builder."""
         self.settings = settings
+        self._startup_timer = startup_timer
         self.bus = EventBus()
         self.peer_link_identity_store = PeerLinkIdentityStore(settings.config_dir)
         # Reference-counted "is anyone watching the dashboard?" gate.
@@ -437,6 +441,10 @@ class DeviceBuilder:
             self.settings.config_dir,
             len(self.command_handlers),
         )
+
+        if self._startup_timer is not None:
+            self._startup_timer.mark("controllers")
+            _LOGGER.info("Startup phases: %s", self._startup_timer.summary())
 
     async def stop(self) -> None:  # noqa: C901, PLR0912
         """Shut down the application."""
@@ -864,6 +872,8 @@ class DeviceBuilder:
                 settings.port,
             )
             app = self.create_app(trusted=True, with_ingress_site=False)
+            if self._startup_timer is not None:
+                self._startup_timer.mark("app")
             hosts = resolve_bind_host(settings.ingress_host or "0.0.0.0")
             ensure_single_host_for_ephemeral_port(hosts, settings.ingress_port, "--ingress-port")
             web.run_app(
@@ -875,6 +885,8 @@ class DeviceBuilder:
             )
             return
         app = self.create_app()
+        if self._startup_timer is not None:
+            self._startup_timer.mark("app")
         hosts = resolve_bind_host(settings.host)
         ensure_single_host_for_ephemeral_port(hosts, settings.port, "--port")
         # ``handle_signals=False``: keep our ``__main__`` SIGTERM/SIGBREAK trap

--- a/esphome_device_builder/helpers/startup_timing.py
+++ b/esphome_device_builder/helpers/startup_timing.py
@@ -1,0 +1,43 @@
+"""Monotonic startup phase timer; cross-platform, no OS-specific calls."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+
+__all__ = ["StartupTimer"]
+
+_LOGGER = logging.getLogger("esphome_device_builder.startup")
+
+
+class StartupTimer:
+    """Accumulates named startup phase durations off a monotonic origin."""
+
+    def __init__(self, origin: float, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._origin = origin
+        self._last = origin
+        self._phases: list[tuple[str, float]] = []
+
+    def mark(self, name: str) -> float:
+        """Record the delta since the previous mark and return it (seconds)."""
+        now = self._clock()
+        delta = now - self._last
+        self._last = now
+        self._phases.append((name, delta))
+        _LOGGER.debug("startup phase %s: %.3fs", name, delta)
+        return delta
+
+    @property
+    def total(self) -> float:
+        """Seconds from the origin to the last mark."""
+        return self._last - self._origin
+
+    def summary(self) -> str:
+        """One-line breakdown, e.g. ``total=12.7s (import=9.4s app=0.1s)``."""
+        # Total is the sum of the rounded parts so the line is self-consistent.
+        rounded = [(name, round(delta, 1)) for name, delta in self._phases]
+        total = sum(delta for _, delta in rounded)
+        phases = " ".join(f"{name}={delta:.1f}s" for name, delta in rounded)
+        return f"total={total:.1f}s ({phases})"

--- a/tests/test_startup_timing.py
+++ b/tests/test_startup_timing.py
@@ -1,0 +1,102 @@
+"""Tests for ``helpers.startup_timing.StartupTimer`` and its wiring."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.helpers.startup_timing import StartupTimer
+
+from .conftest import MakeSettingsFactory
+
+
+def _timer(ticks: list[float]) -> StartupTimer:
+    """Build a timer whose clock yields ``ticks`` in order; origin is ``ticks[0]``."""
+    it = iter(ticks)
+    origin = next(it)
+    return StartupTimer(origin, clock=lambda: next(it))
+
+
+def test_marks_accumulate_phase_deltas() -> None:
+    timer = _timer([100.0, 109.4, 109.6, 109.7, 112.7])
+    assert timer.mark("import") == pytest.approx(9.4)
+    assert timer.mark("settings") == pytest.approx(0.2)
+    assert timer.mark("app") == pytest.approx(0.1)
+    assert timer.mark("controllers") == pytest.approx(3.0)
+
+
+def test_total_is_origin_to_last_mark() -> None:
+    timer = _timer([100.0, 109.4, 112.7])
+    timer.mark("import")
+    timer.mark("controllers")
+    assert timer.total == pytest.approx(12.7)
+
+
+def test_summary_format() -> None:
+    timer = _timer([0.0, 9.4, 12.4])
+    timer.mark("import")
+    timer.mark("controllers")
+    assert timer.summary() == "total=12.4s (import=9.4s controllers=3.0s)"
+
+
+def test_summary_total_is_sum_of_rounded_parts() -> None:
+    # Many sub-0.1s phases: the printed total must equal the sum of the printed
+    # parts, not the independently-rounded origin-to-last span.
+    timer = _timer([0.0, 0.04, 0.08, 0.12, 0.16])
+    for name in ("a", "b", "c", "d"):
+        timer.mark(name)
+    assert timer.summary() == "total=0.0s (a=0.0s b=0.0s c=0.0s d=0.0s)"
+
+
+def _stub_run(db: DeviceBuilder) -> None:
+    """Run the server with ``web.run_app`` stubbed so it returns immediately."""
+    with patch("esphome_device_builder.device_builder.web.run_app", lambda *a, **k: None):
+        db.run()
+
+
+def test_run_marks_app_phase_on_normal_path(make_settings: MakeSettingsFactory) -> None:
+    timer = StartupTimer(0.0)
+    settings = make_settings()
+    settings.on_ha_addon = True
+    settings.using_password = True
+    settings.username = "admin"
+    settings.password_hash = b"x" * 32
+    settings.host = "0.0.0.0"
+    settings.port = 6052
+    _stub_run(DeviceBuilder(settings, startup_timer=timer))
+    assert "app=" in timer.summary()
+
+
+def test_run_marks_app_phase_on_ingress_only_path(
+    make_settings: MakeSettingsFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DISABLE_HA_AUTHENTICATION", raising=False)
+    timer = StartupTimer(0.0)
+    settings = make_settings()
+    settings.on_ha_addon = True
+    settings.using_password = False
+    settings.host = "0.0.0.0"
+    settings.port = 6052
+    settings.ingress_port = 6053
+    settings.ingress_host = ""
+    _stub_run(DeviceBuilder(settings, startup_timer=timer))
+    assert "app=" in timer.summary()
+
+
+async def test_start_marks_controllers_and_logs_summary(
+    make_settings: MakeSettingsFactory,
+    caplog: pytest.LogCaptureFixture,
+    _hermetic_lifecycle: None,
+) -> None:
+    timer = StartupTimer(0.0)
+    db = DeviceBuilder(make_settings(with_core_path=True), startup_timer=timer)
+    try:
+        with caplog.at_level(logging.INFO, logger="esphome_device_builder.device_builder"):
+            await db.start()
+        assert "controllers=" in timer.summary()
+        assert any("Startup phases" in rec.getMessage() for rec in caplog.records)
+    finally:
+        await db.stop()


### PR DESCRIPTION
# What does this implement/fix?

Startup is slow on a Home Assistant Green, and we have no attribution for where the time goes. This adds a small monotonic `StartupTimer` threaded from `__main__` through the server, so every boot logs one phase line:

```
Startup phases: total=12.7s (early=0.1s esphome=0.0s config=8.2s builder=1.1s settings=0.0s init=0.1s app=0.1s controllers=3.2s)
```

The import phase is split into `esphome` (the esphome package base), `config` (our controllers/models tree, the dominant import) and `builder` (the rest), so the line distinguishes esphome from our own code; `settings` is arg parsing, `init` is the lock plus `DeviceBuilder` construction, `app` is `create_app`/serving the frontend, and `controllers` is `start()`. It is pure `time.monotonic`, no `/proc` or `os.sysconf`, so it behaves the same on Linux, macOS, and Windows. The timer arg is optional, so existing `DeviceBuilder(settings)` construction is unchanged.

This is durable observability that ships in the build; it doubles as ongoing regression visibility in add-on logs and a support diagnostic, and it tells us whether to aim the next optimization at the import graph or at controller startup.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

