### PR TITLE
Skip external package git fetch during the device scan

### DIFF
--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -213,6 +213,11 @@ class DashboardSettings:
             host.strip().lower() for host in raw_trusted.split(",") if host.strip()
         ]
         CORE.config_path = self.config_dir / _DASHBOARD_SENTINEL_FILE
+        # The long-lived process never fetches external packages in-process:
+        # metadata resolution reads cached checkouts, and real builds run in
+        # esphome CLI subprocesses with their own CORE. Set once here so the
+        # device-scan package merge doesn't git-fetch per repo on every startup.
+        CORE.skip_external_update = True
 
     def rel_path(self, *parts: str) -> Path:
         """

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -445,20 +445,12 @@ def load_device_yaml(path: Path) -> dict | None:
     # misses them. We delegate to ESPHome internals — the loader
     # and merge algorithm live upstream.
     #
-    # ``load_device_yaml`` runs on a worker thread (the device
-    # scanner uses ``run_in_executor``; the devices controller
-    # threads it through too), NOT the WS event loop. Same trade
-    # the validate path lives with: ESPHome's ``vscode`` subprocess
-    # runs the full resolve on every validate call, so a
-    # remote-package config that fires ``git clone`` synchronously
-    # blocks this worker thread for as long as the clone takes
-    # (minutes on a slow connection / large repo) but the dashboard
-    # stays responsive to other clients. The follow-up that mirrors
-    # the validate-style subprocess pattern for metadata refresh
-    # (so a slow remote clone doesn't stall the whole scan) is
-    # tracked separately; this PR closes the local-package gap
-    # behind #288 without trying to solve the remote-package
-    # latency problem at the same time.
+    # This resolves offline: the dashboard sets ``CORE.skip_external_update`` at
+    # startup (``DashboardSettings.parse_args``), so esphome's git layer treats
+    # an already-cloned package as a local no-op and the scan merges from cached
+    # content with no per-repo ``git fetch``. The legacy dashboard read
+    # StorageJSON only and never resolved packages, so it did no git work here;
+    # real builds refresh via the esphome CLI's own resolve.
     if isinstance(config.get(CONF_PACKAGES), (dict, list)):
         try:
             if _resolve_packages is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,17 @@ def _core_config_path_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.fixture(autouse=True)
+def _core_skip_external_update_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from esphome's default so ``parse_args`` can't leak the flag.
+
+    ``DashboardSettings.parse_args`` pins ``CORE.skip_external_update = True`` on
+    the process-global ``CORE``; reset it per-test so a test that calls
+    ``parse_args`` doesn't leak ``True`` into siblings on the same xdist worker.
+    """
+    monkeypatch.setattr(CORE, "skip_external_update", False)
+
+
+@pytest.fixture(autouse=True)
 def _stub_icmp_privilege_probe(monkeypatch: pytest.MonkeyPatch) -> None:
     """Bypass ``PingSource.run``'s ICMP socket privilege probe.
 

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from aiohttp import web
+from esphome.core import CORE
 from pytest_aiohttp.plugin import AiohttpClient
 
 from esphome_device_builder.api import ws as ws_module
@@ -282,6 +283,15 @@ def test_settings_parses_cli_flag(tmp_path: object) -> None:
         )
     )
     assert settings.trusted_domains == ["dashboard.local", "192.168.1.10"]
+
+
+def test_settings_parse_args_disables_external_package_fetch(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``parse_args`` pins ``skip_external_update`` so the scan never git-fetches."""
+    monkeypatch.setattr(CORE, "skip_external_update", False)
+    DashboardSettings().parse_args(_ns(configuration=str(tmp_path)))
+    assert CORE.skip_external_update is True
 
 
 def test_settings_parses_env_var_when_flag_unset(tmp_path: object) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The startup device scan loads every YAML for metadata. For configs with a `packages:` block it runs esphome's package resolution, which by default refreshes each external repo with a `git fetch` (package default `refresh: "1d"`). On a fleet that is a wall of `[esphome.git] Updating https://github.com/...` lines on every startup and dominates the post-serve `controllers` phase (~10s on an 86-device install).

The legacy ESPHome dashboard never did this: `DashboardEntry.load_from_disk` reads `StorageJSON.load()` only, so its scan never parsed YAML, never resolved packages, and did no git work at all. Device Builder added in-process package resolution so metadata behind `packages:` is visible (the api/wifi/platform blocks for flag detection, #288), and that inadvertently pulled esphome's git refresh into the scan.

The long-lived process never needs an in-process fetch: metadata reads cached checkouts, and real builds run in esphome CLI subprocesses with their own `CORE`. So this sets `CORE.skip_external_update` once at dashboard startup (`DashboardSettings.parse_args`), where the dashboard already initializes `CORE`. esphome's git layer then treats an already-cloned package as a local no-op, so the scan merges from cached content with no fetch. Setting it once is also why this avoids toggling the process-global per resolve from shared executor threads (a racy pattern an earlier draft used); nothing in-process ever wants a real fetch, so the flag is just on for the process. A first-time clone still happens once (the content has to exist to merge), and real compiles are unchanged.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
