### PR TITLE
Fix Apollo featured-image test after starter-kit image update

### DIFF
--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -228,7 +228,7 @@ async def test_get_component_name_from_manifest_field(
 
 
 _APOLLO_PIR_IMAGE = (
-    "https://wiki.apolloautomation.com/assets/esphome-starter-kit-pir-module-only.jpg"
+    "https://cdn.shopify.com/s/files/1/0792/0959/5187/files/pir_module.png?v=1781660489"
 )
 
 


### PR DESCRIPTION
## What does this implement/fix?

#1520 updated the apollo-esk-1 starter-kit module images to new Shopify CDN URLs, but `tests/test_featured_components.py` still pinned the old `wiki.apolloautomation.com` URL in `_APOLLO_PIR_IMAGE`. That left three tests failing on `main`:

- `test_shipped_apollo_featured_carries_module_image`
- `test_get_component_featured_image_override`
- `test_get_components_featured_image_override_in_list`

This points the constant at the manifest's current `motion_module` image so the tests track the shipped catalog again.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
