### PR TITLE
Auto-close fork PRs we can't work with

### DIFF
--- a/.github/workflows/close-uneditable-fork-pr.yml
+++ b/.github/workflows/close-uneditable-fork-pr.yml
@@ -44,6 +44,7 @@ jobs:
 
             const headRepo = pr.head.repo.full_name;
             const forkDefaultBranch = pr.head.repo.default_branch;
+            const baseBranch = pr.base.ref;  // upstream branch this PR targets (main)
             const noMaintainerEdits = pr.maintainer_can_modify === false;
             const fromForkDefaultBranch = pr.head.ref === forkDefaultBranch;
 
@@ -72,7 +73,7 @@ jobs:
               lines.push(
                 `This PR was also opened from the \`${forkDefaultBranch}\` branch of your fork (\`${headRepo}\`), your fork's default branch. Working directly on it causes problems:`,
                 ``,
-                `- Your fork's \`${forkDefaultBranch}\` permanently diverges from \`${owner}/${repo}:${forkDefaultBranch}\`, making it hard to keep your fork up to date.`,
+                `- Your fork's \`${forkDefaultBranch}\` permanently diverges from \`${owner}/${repo}:${baseBranch}\`, making it hard to keep your fork up to date.`,
                 `- Any commit you push to \`${forkDefaultBranch}\` is added to this PR, so you can't work on multiple changes at once.`,
                 `- It makes local collaboration painful — \`${forkDefaultBranch}\` becomes ambiguous between upstream and your fork.`,
                 ``,
@@ -81,7 +82,7 @@ jobs:
                 `\`\`\`bash`,
                 `git remote add upstream https://github.com/${owner}/${repo}.git  # if you haven't already`,
                 `git fetch upstream`,
-                `git checkout -b my-feature-branch upstream/${forkDefaultBranch}`,
+                `git checkout -b my-feature-branch upstream/${baseBranch}`,
                 `# ...re-apply your changes, then:`,
                 `git push origin my-feature-branch`,
                 `\`\`\``,

--- a/.github/workflows/close-uneditable-fork-pr.yml
+++ b/.github/workflows/close-uneditable-fork-pr.yml
@@ -4,10 +4,15 @@ on:
   # pull_request_target is required so we have permission to comment and close PRs from forks.
   pull_request_target:
     types: [opened, reopened]
+    branches: [main]
 
 permissions:
   pull-requests: write  # pulls.update to close the PR
   issues: write         # issues.createComment to explain to the contributor why
+
+concurrency:
+  group: close-uneditable-fork-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   close:
@@ -32,6 +37,11 @@ jobs:
               pull_number: prNumber,
             });
 
+            // Fork deleted between the event and this fetch — nothing left to act on.
+            if (!pr.head.repo) {
+              return;
+            }
+
             const headRepo = pr.head.repo.full_name;
             const forkDefaultBranch = pr.head.repo.default_branch;
             const noMaintainerEdits = pr.maintainer_can_modify === false;
@@ -53,7 +63,7 @@ jobs:
                 ``,
                 `This happens when **Allow edits by maintainers** is off. Either it was unchecked when the PR was created (GitHub doesn't let you toggle it afterward), or the fork is owned by an **organization** — GitHub never permits maintainer pushes to org-owned fork branches.`,
                 ``,
-                `Please re-open this from a **personal** fork with **Allow edits by maintainers** checked.`,
+                `Reopening this PR won't help — the setting is fixed at creation. Please open a **new** PR from a **personal** fork with **Allow edits by maintainers** checked.`,
                 ``,
               );
             }
@@ -80,7 +90,7 @@ jobs:
             }
 
             lines.push(
-              `Closing this for now — sorry for the friction, and thanks again for contributing! :heart:`,
+              `Closing this one — please open a fresh PR using the steps above. Sorry for the friction, and thanks again for contributing! :heart:`,
             );
 
             await github.rest.issues.createComment({

--- a/.github/workflows/close-uneditable-fork-pr.yml
+++ b/.github/workflows/close-uneditable-fork-pr.yml
@@ -1,0 +1,98 @@
+name: Close Uneditable Fork PR
+
+on:
+  # pull_request_target is required so we have permission to comment and close PRs from forks.
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write  # pulls.update to close the PR
+  issues: write         # issues.createComment to explain to the contributor why
+
+jobs:
+  close:
+    name: Close fork PR maintainers can't push to
+    runs-on: ubuntu-latest
+    # Only fork PRs can hit either problem; same-repo PRs always allow maintainer pushes.
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+
+            // Re-fetch: the webhook payload's maintainer_can_modify can be stale at
+            // open time, and a false close annoys contributors.
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const headRepo = pr.head.repo.full_name;
+            const forkDefaultBranch = pr.head.repo.default_branch;
+            const noMaintainerEdits = pr.maintainer_can_modify === false;
+            const fromForkDefaultBranch = pr.head.ref === forkDefaultBranch;
+
+            if (!noMaintainerEdits && !fromForkDefaultBranch) {
+              // Normal, pushable fork PR — leave it alone.
+              return;
+            }
+
+            const lines = [
+              `Hi @${author}, thanks for opening a pull request! :tada:`,
+              ``,
+            ];
+
+            if (noMaintainerEdits) {
+              lines.push(
+                `Unfortunately maintainers can't push to this PR's branch (\`${headRepo}:${pr.head.ref}\`), so we can't apply small fixes like a rebase or a test tweak ourselves — every change has to bounce back to you, or we end up opening a duplicate PR.`,
+                ``,
+                `This happens when **Allow edits by maintainers** is off. Either it was unchecked when the PR was created (GitHub doesn't let you toggle it afterward), or the fork is owned by an **organization** — GitHub never permits maintainer pushes to org-owned fork branches.`,
+                ``,
+                `Please re-open this from a **personal** fork with **Allow edits by maintainers** checked.`,
+                ``,
+              );
+            }
+
+            if (fromForkDefaultBranch) {
+              lines.push(
+                `This PR was also opened from the \`${forkDefaultBranch}\` branch of your fork (\`${headRepo}\`), your fork's default branch. Working directly on it causes problems:`,
+                ``,
+                `- Your fork's \`${forkDefaultBranch}\` permanently diverges from \`${owner}/${repo}:${forkDefaultBranch}\`, making it hard to keep your fork up to date.`,
+                `- Any commit you push to \`${forkDefaultBranch}\` is added to this PR, so you can't work on multiple changes at once.`,
+                `- It makes local collaboration painful — \`${forkDefaultBranch}\` becomes ambiguous between upstream and your fork.`,
+                ``,
+                `Open your change from a dedicated feature branch instead:`,
+                ``,
+                `\`\`\`bash`,
+                `git remote add upstream https://github.com/${owner}/${repo}.git  # if you haven't already`,
+                `git fetch upstream`,
+                `git checkout -b my-feature-branch upstream/${forkDefaultBranch}`,
+                `# ...re-apply your changes, then:`,
+                `git push origin my-feature-branch`,
+                `\`\`\``,
+                ``,
+              );
+            }
+
+            lines.push(
+              `Closing this for now — sorry for the friction, and thanks again for contributing! :heart:`,
+            );
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: lines.join('\n'),
+            });
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });

--- a/.github/workflows/close-uneditable-fork-pr.yml
+++ b/.github/workflows/close-uneditable-fork-pr.yml
@@ -19,8 +19,10 @@ jobs:
     name: Close fork PR we can't work with
     runs-on: ubuntu-latest
     # Only fork PRs can hit either problem; same-repo PRs always allow maintainer pushes.
+    # Skip bots (dependabot et al. use same-repo branches anyway, but never close a bot's fork PR).
     if: >-
       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      && github.event.pull_request.user.type != 'Bot'
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:

--- a/.github/workflows/close-uneditable-fork-pr.yml
+++ b/.github/workflows/close-uneditable-fork-pr.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   close:
-    name: Close fork PR maintainers can't push to
+    name: Close fork PR we can't work with
     runs-on: ubuntu-latest
     # Only fork PRs can hit either problem; same-repo PRs always allow maintainer pushes.
     if: >-


### PR DESCRIPTION
## What does this implement/fix?

Auto-closes a fork PR at open/reopen time when we can't reasonably work with it, so we don't repeat the #1520 → #1521 dance (org-owned fork, `maintainer_can_modify: false`; we couldn't push a one-line test fix and had to open a separate PR).

The job runs on `pull_request_target` (so it has write access to fork PRs), scoped to PRs targeting `main`, and only fires for cross-repo PRs. It re-fetches the PR (the webhook's `maintainer_can_modify` can be stale at open time) and closes with an explanatory comment when **either**:

- **Maintainers can't edit** — `maintainer_can_modify == false`. Either "Allow edits by maintainers" was unchecked, or the fork is owned by an organization (GitHub never allows maintainer pushes to org-owned forks). The comment tells the contributor to open a *new* PR from a personal fork with edits enabled (reopening this one retriggers the close and can't flip the flag).
- **Opened from the fork's default branch** — closed regardless of pushability. This is intentionally broader than just the maintainer-edit case: working on a fork's default branch causes divergence and branch-name collisions, and these drive-by `main` PRs are ones we'd rather have re-opened from a feature branch. Mirrors `esphome/esphome`'s `close-pr-from-fork-default-branch.yml`, which closes them unconditionally.

A normal, workable fork PR (personal fork, feature branch, edits allowed) hits the early `return` and is left untouched. Guards: bails if the fork was deleted between the event and the re-fetch; per-PR `concurrency` group cancels stale runs.

Reuses the `actions/github-script` SHA already pinned in this repo.

## Types of changes

- [x] CI / workflow change — `ci`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] `check yaml` + `actionlint` pass; embedded github-script body passes `node --check`.
