### PR TITLE
Check the exact release tag, not a prefix match

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # Use the singular ``git/ref/tags`` endpoint: it matches the tag
+          # exactly and 404s when absent. The plural ``git/refs/tags`` does
+          # PREFIX matching, so an ``X.Y.Z`` query returns 200 with the
+          # ``X.Y.ZbN`` prerelease tags and false-positives "already exists".
           # `gh api` exits 0 on 2xx and non-zero on any other outcome
           # (HTTP error or transport failure), so a bare exit-code check
           # can't tell "tag doesn't exist" apart from "the network ate
           # the request". Capture stderr and require an HTTP 404 before
           # treating the tag as absent — anything else fails loudly.
-          if err=$(gh api "repos/${{ github.repository }}/git/refs/tags/${{ inputs.version }}" --silent 2>&1); then
+          if err=$(gh api "repos/${{ github.repository }}/git/ref/tags/${{ inputs.version }}" --silent 2>&1); then
             echo "::error::Tag '${{ inputs.version }}' already exists. Pick a new version."
             exit 1
           elif ! grep -q "HTTP 404" <<<"$err"; then


### PR DESCRIPTION
# What does this implement/fix?

The release workflow's "Reject already-existing tag" check used GitHub's plural refs endpoint, `git/refs/tags/<version>`, which does **prefix** matching. For a stable `X.Y.Z` whose `X.Y.ZbN` betas already exist, that query returns HTTP 200 with the beta refs, and the step reads any 2xx as "tag exists" and refuses to release.

This blocks the normal flow, since every stable release follows its prereleases. The 1.0.2 release hit exactly this: `1.0.2b1`..`1.0.2b4` existed, so the check false-positived on `1.0.2` even though no `1.0.2` tag was ever created. As a workaround I skipped 1.0.2 and released 1.0.3 (no `1.0.3bN` betas, so the prefix query 404'd); 1.0.2 was never tagged or published anywhere, so there's no gap.

The fix switches to the singular `git/ref/tags/<version>` endpoint, which matches the tag exactly and 404s when absent. The surrounding 404-capture logic is unchanged. Verified against the live repo: singular `git/ref/tags/1.0.2` returns 404 (would proceed) and `git/ref/tags/1.0.2b4` returns the object (would still reject an existing tag); beta releases are unaffected.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
