### PR TITLE
Strip comment after a quoted friendly_name or substitution value

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -8,6 +8,8 @@ from typing import NamedTuple
 from esphome import const
 from esphome.const import CONF_PACKAGES
 
+from ..yaml import _split_value_and_comment, _strip_yaml_quotes
+
 
 class EsphomeMeta(NamedTuple):
     """The user-facing ``esphome:`` meta fields; ``None`` for any the YAML omits."""
@@ -412,50 +414,16 @@ def _match_top_level_key(line: str) -> str | None:
     return stripped.split(":", 1)[0].strip()
 
 
-def _split_inline_comment(raw: str) -> str:
-    """
-    Return *raw* with a quote-aware trailing ``# comment`` removed.
-
-    A ``#`` opens a comment only outside quotes and whitespace-preceded (or at
-    the start of the post-key remainder); ``Room#2`` and ``"a # b"`` keep it.
-    Mirrors the frontend ``splitInlineComment`` in ``util/yaml-scalar.ts``.
-    """
-    in_single = in_double = False
-    i = 0
-    while i < len(raw):
-        c = raw[i]
-        if c == "\\" and in_double:
-            i += 2
-            continue
-        if c == '"' and not in_single:
-            in_double = not in_double
-        elif c == "'" and not in_double:
-            in_single = not in_single
-        elif c == "#" and not in_single and not in_double and (i == 0 or raw[i - 1] in " \t"):
-            return raw[:i]
-        i += 1
-    return raw
-
-
-def _strip_quotes(value: str) -> str:
-    """Strip matching outer quotes; unescape ``''`` in a single-quoted scalar."""
-    if len(value) >= 2 and value[0] == value[-1]:
-        if value[0] == '"':
-            return value[1:-1]
-        if value[0] == "'":
-            return value[1:-1].replace("''", "'")
-    return value
-
-
 def _parse_inline_value(raw: str) -> str:
     """
     Clean a raw YAML scalar value.
 
-    Drops a trailing inline ``# comment`` and matching surrounding quotes,
-    quote-aware: ``"Test #1"  # c`` -> ``Test #1`` and ``Room#2`` stays
-    literal. Mirrors the frontend ``parseScalar``.
+    Drops a trailing inline ``# comment`` (quote-aware, so ``"Test #1"  # c``
+    -> ``Test #1`` and ``Room#2`` stays literal) and matching surrounding
+    quotes.
     """
-    return _strip_quotes(_split_inline_comment(raw).strip())
+    value, _ = _split_value_and_comment(raw)
+    return _strip_yaml_quotes(value)
 
 
 _FLOW_AREA_NAME_RE = re.compile(r"""\bname\s*:\s*("[^"]*"|'[^']*'|[^,}]+)""")

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -412,25 +412,50 @@ def _match_top_level_key(line: str) -> str | None:
     return stripped.split(":", 1)[0].strip()
 
 
-_INLINE_COMMENT_RE = re.compile(r"(?:^|\s)#.*$")
+def _split_inline_comment(raw: str) -> str:
+    """
+    Return *raw* with a quote-aware trailing ``# comment`` removed.
+
+    A ``#`` opens a comment only outside quotes and whitespace-preceded (or at
+    the start of the post-key remainder); ``Room#2`` and ``"a # b"`` keep it.
+    Mirrors the frontend ``splitInlineComment`` in ``util/yaml-scalar.ts``.
+    """
+    in_single = in_double = False
+    i = 0
+    while i < len(raw):
+        c = raw[i]
+        if c == "\\" and in_double:
+            i += 2
+            continue
+        if c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "'" and not in_double:
+            in_single = not in_single
+        elif c == "#" and not in_single and not in_double and (i == 0 or raw[i - 1] in " \t"):
+            return raw[:i]
+        i += 1
+    return raw
+
+
+def _strip_quotes(value: str) -> str:
+    """Strip matching outer quotes; unescape ``''`` in a single-quoted scalar."""
+    if len(value) >= 2 and value[0] == value[-1]:
+        if value[0] == '"':
+            return value[1:-1]
+        if value[0] == "'":
+            return value[1:-1].replace("''", "'")
+    return value
 
 
 def _parse_inline_value(raw: str) -> str:
     """
     Clean a raw YAML scalar value.
 
-    Strips an inline ``# comment`` and matching surrounding quotes. A
-    ``#`` only opens a comment when whitespace-preceded (or at the
-    scalar start); ``Room#2`` is a literal, not ``Room``.
+    Drops a trailing inline ``# comment`` and matching surrounding quotes,
+    quote-aware: ``"Test #1"  # c`` -> ``Test #1`` and ``Room#2`` stays
+    literal. Mirrors the frontend ``parseScalar``.
     """
-    value = raw.strip()
-    if not value.startswith(('"', "'")):
-        value = _INLINE_COMMENT_RE.sub("", value).strip()
-    if (value.startswith('"') and value.endswith('"')) or (
-        value.startswith("'") and value.endswith("'")
-    ):
-        value = value[1:-1]
-    return value
+    return _strip_quotes(_split_inline_comment(raw).strip())
 
 
 _FLOW_AREA_NAME_RE = re.compile(r"""\bname\s*:\s*("[^"]*"|'[^']*'|[^,}]+)""")

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -419,10 +419,14 @@ def _parse_inline_value(raw: str) -> str:
     Clean a raw YAML scalar value.
 
     Drops a trailing inline ``# comment`` (quote-aware, so ``"Test #1"  # c``
-    -> ``Test #1`` and ``Room#2`` stays literal) and matching surrounding
-    quotes.
+    -> ``Test #1`` and ``Room#2`` stays literal), strips matching surrounding
+    quotes, and unwinds the single-quoted ``''`` escape so ``'Bob''s Room'``
+    -> ``Bob's Room``.
     """
     value, _ = _split_value_and_comment(raw)
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1].replace("''", "'")
     return _strip_yaml_quotes(value)
 
 

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -60,6 +60,7 @@ from .scalar import ESPHOME_YAML_INDENT as ESPHOME_YAML_INDENT
 from .scalar import YamlUpsertNotSupportedError as YamlUpsertNotSupportedError
 from .scalar import _quote as _quote
 from .scalar import _safe_yaml_scalar as _safe_yaml_scalar
+from .scalar import _split_value_and_comment as _split_value_and_comment
 from .scalar import _strip_yaml_quotes as _strip_yaml_quotes
 from .scalar import is_plain_literal_scalar as is_plain_literal_scalar
 from .scalar import read_yaml_scalar as read_yaml_scalar

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -937,15 +937,14 @@ def test_parse_inline_value_strips_trailing_comment() -> None:
     # (YAML rule), so it must not truncate the value.
     assert _parse_inline_value("Room#2") == "Room#2"
     assert _parse_inline_value("Living#Room") == "Living#Room"
-    # A leading ``#`` is a comment-only value → empty.
-    assert _parse_inline_value("# just a comment") == ""
+    # A whitespace-preceded ``#`` (the shape the remainder after ``key:`` takes)
+    # is a comment-only value → empty.
+    assert _parse_inline_value(" # just a comment") == ""
     # A comment after a *quoted* value is dropped, quotes and all (#1525); a
     # ``#`` inside the quotes stays literal.
     assert _parse_inline_value('"Test #1"  # Hello') == "Test #1"
     assert _parse_inline_value("'Test #1'  # Hello") == "Test #1"
     assert _parse_inline_value('"with #hash"  # c') == "with #hash"
-    # YAML single-quote escape: a doubled ``''`` is a literal ``'``.
-    assert _parse_inline_value("'it''s'") == "it's"
 
 
 def test_parse_inline_value_strips_matched_quotes() -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -526,7 +526,7 @@ esphome:
 
 
 def test_parse_meta_strips_comment_after_quoted_friendly_name() -> None:
-    """A comment after a quoted ``friendly_name`` is dropped, quotes too (#1525)."""
+    """A comment after a quoted ``friendly_name`` is dropped, quotes too."""
     yaml_content = """
 esphome:
   name: test-1
@@ -537,7 +537,7 @@ esphome:
 
 
 def test_parse_meta_strips_comment_after_quoted_substitution_value() -> None:
-    """A comment after a quoted substitution value doesn't leak into the resolved meta (#1525)."""
+    """A comment after a quoted substitution value doesn't leak into the resolved meta."""
     yaml_content = """
 substitutions:
   fname: "Test #2"  # Hello fname
@@ -546,6 +546,17 @@ esphome:
 """
     _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
     assert friendly_name == "Test #2"
+
+
+def test_parse_meta_unwinds_single_quote_escape_in_friendly_name() -> None:
+    """A single-quoted ``''`` escape collapses to one ``'`` in the parsed value."""
+    yaml_content = """
+esphome:
+  name: test-1
+  friendly_name: 'Bob''s Room'
+"""
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    assert friendly_name == "Bob's Room"
 
 
 def test_parse_meta_skips_blank_and_comment_lines_inside_block() -> None:
@@ -940,11 +951,13 @@ def test_parse_inline_value_strips_trailing_comment() -> None:
     # A whitespace-preceded ``#`` (the shape the remainder after ``key:`` takes)
     # is a comment-only value → empty.
     assert _parse_inline_value(" # just a comment") == ""
-    # A comment after a *quoted* value is dropped, quotes and all (#1525); a
-    # ``#`` inside the quotes stays literal.
+    # A comment after a *quoted* value is dropped, quotes and all; a ``#``
+    # inside the quotes stays literal.
     assert _parse_inline_value('"Test #1"  # Hello') == "Test #1"
     assert _parse_inline_value("'Test #1'  # Hello") == "Test #1"
     assert _parse_inline_value('"with #hash"  # c') == "with #hash"
+    # YAML single-quote escape: a doubled ``''`` is a literal ``'``.
+    assert _parse_inline_value("'it''s'") == "it's"
 
 
 def test_parse_inline_value_strips_matched_quotes() -> None:

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -969,6 +969,36 @@ def test_parse_inline_value_strips_matched_quotes() -> None:
     assert _parse_inline_value("\"mismatched'") == "\"mismatched'"
 
 
+def test_parse_inline_value_unwinds_single_quote_escape_only() -> None:
+    """``''`` is an escape inside single quotes only; double quotes keep it literal."""
+    # Single-quoted: each ``''`` collapses to one ``'``.
+    assert _parse_inline_value("'it''s'") == "it's"
+    assert _parse_inline_value("'a''''b'") == "a''b"
+    # Double-quoted: ``''`` is two literal apostrophes — must NOT be unwound.
+    assert _parse_inline_value("\"it''s\"") == "it''s"
+    assert _parse_inline_value("\"a''''b\"") == "a''''b"
+    # Unquoted: nothing to unwind.
+    assert _parse_inline_value("plain''text") == "plain''text"
+
+
+def test_parse_inline_value_leaves_backslash_and_lone_quotes_literal() -> None:
+    """No backslash unescaping in either quote style; a lone inner quote stays literal."""
+    # Single quotes don't honour ``\`` escapes — the backslash is literal.
+    assert _parse_inline_value(r"'a\nb'") == r"a\nb"
+    assert _parse_inline_value(r"'C:\path'") == r"C:\path"
+    # Double quotes: we deliberately don't unescape ``\n`` etc. (mirrors the
+    # frontend), so it stays the two characters.
+    assert _parse_inline_value(r'"a\nb"') == r"a\nb"
+    # ``\"`` is left literal too — the frontend's stripQuotes doesn't unwind it
+    # either, so the round-trip of the backend's own ``_quote('Say "hi"')``
+    # (which emits ``"Say \"hi\""``) parses identically on both sides.
+    assert _parse_inline_value('"Say \\"hi\\""') == 'Say \\"hi\\"'
+    # A lone single quote inside double quotes is literal (no ``''`` escaping).
+    assert _parse_inline_value('"it\'s"') == "it's"
+    # A double quote inside single quotes is literal.
+    assert _parse_inline_value("'say \"hi\"'") == 'say "hi"'
+
+
 # ----------------------------------------------------------------------
 # generate_device_yaml — ESP32 platform branch
 # ----------------------------------------------------------------------

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -525,6 +525,29 @@ esphome:
     assert comment == "Cost50#tag"
 
 
+def test_parse_meta_strips_comment_after_quoted_friendly_name() -> None:
+    """A comment after a quoted ``friendly_name`` is dropped, quotes too (#1525)."""
+    yaml_content = """
+esphome:
+  name: test-1
+  friendly_name: "Test #1"  # Hello fr_name
+"""
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    assert friendly_name == "Test #1"
+
+
+def test_parse_meta_strips_comment_after_quoted_substitution_value() -> None:
+    """A comment after a quoted substitution value doesn't leak into the resolved meta (#1525)."""
+    yaml_content = """
+substitutions:
+  fname: "Test #2"  # Hello fname
+esphome:
+  friendly_name: "${fname}"
+"""
+    _, friendly_name, _, _ = parse_esphome_meta(yaml_content)
+    assert friendly_name == "Test #2"
+
+
 def test_parse_meta_skips_blank_and_comment_lines_inside_block() -> None:
     """Comment lines and blank lines inside the ``esphome:`` block are skipped.
 
@@ -916,6 +939,13 @@ def test_parse_inline_value_strips_trailing_comment() -> None:
     assert _parse_inline_value("Living#Room") == "Living#Room"
     # A leading ``#`` is a comment-only value → empty.
     assert _parse_inline_value("# just a comment") == ""
+    # A comment after a *quoted* value is dropped, quotes and all (#1525); a
+    # ``#`` inside the quotes stays literal.
+    assert _parse_inline_value('"Test #1"  # Hello') == "Test #1"
+    assert _parse_inline_value("'Test #1'  # Hello") == "Test #1"
+    assert _parse_inline_value('"with #hash"  # c') == "with #hash"
+    # YAML single-quote escape: a doubled ``''`` is a literal ``'``.
+    assert _parse_inline_value("'it''s'") == "it's"
 
 
 def test_parse_inline_value_strips_matched_quotes() -> None:


### PR DESCRIPTION
# What does this implement/fix?

The lightweight `esphome:` meta parser stripped inline comments with a quote-unaware regex that only ran when the value did not start with a quote; a quoted value followed by a comment kept its quotes and the comment, so `friendly_name: "Test #1"  # c` showed up in the device title as `"Test #1" # c`. The same happened for a quoted substitution value feeding `friendly_name`.

The editor form field already renders these correctly because the frontend parses the scalar itself in `util/yaml-scalar.ts`; the title leaks because it reads the backend-supplied `friendly_name`. This ports the frontend's two primitives (`splitInlineComment`, `stripQuotes`) to the backend so both sides parse scalars identically: a quote-aware, escape-aware walk that opens a comment only outside quotes and whitespace-preceded, keeping a mid-scalar `Room#2` literal.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1525

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
