### PR TITLE
Surface the resolved logger baud_rate on the device model

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -23,6 +23,7 @@ from ._parsing import (
     detect_platform_from_yaml,
     extract_directly_referenced_integrations,
     extract_esphome_meta_from_config,
+    extract_logger_baud_rate,
     get_api_encryption_block,
     parse_esphome_meta,
     yaml_has_api_encryption,
@@ -148,6 +149,8 @@ def load_device_from_storage(
     # reader can't see when it lives in a merge-key / ``!include`` /
     # ``packages:`` file, so this fills meta the main file omits (#1153).
     cfg_meta = extract_esphome_meta_from_config(resolved_config, extra_subs)
+    # Drives the Web Serial log stream's port baud; None ⇒ frontend default.
+    logger_baud_rate = extract_logger_baud_rate(resolved_config, extra_subs)
 
     fallback_name = configuration_stem(filename)
     storage_name = storage.name if storage else None
@@ -351,6 +354,7 @@ def load_device_from_storage(
         bluetooth_mac=bluetooth_mac,
         build_size_bytes=build_size_bytes,
         labels=list(labels),
+        logger_baud_rate=logger_baud_rate,
     )
 
 

--- a/esphome_device_builder/helpers/device_yaml/_parsing.py
+++ b/esphome_device_builder/helpers/device_yaml/_parsing.py
@@ -359,6 +359,31 @@ def extract_esphome_meta_from_config(
     )
 
 
+def extract_logger_baud_rate(
+    config: dict | None,
+    extra_substitutions: dict[str, str] | None = None,
+) -> int | None:
+    """
+    Read the resolved ``logger: baud_rate`` off a config, or ``None`` when absent.
+
+    ``$var`` / ``${var}`` resolve against *extra_substitutions*. ``0`` passes
+    through (UART logging disabled); a non-numeric, unresolved, or negative
+    value is ``None``.
+    """
+    logger = config.get(const.CONF_LOGGER) if isinstance(config, dict) else None
+    value = logger.get(const.CONF_BAUD_RATE) if isinstance(logger, dict) else None
+    if isinstance(value, str):
+        try:
+            value = int(_resolve_substitutions(value, extra_substitutions or {}) or "")
+        except ValueError:
+            value = None
+    # bool is an int subclass; reject ``true``. Negative baud is invalid (Web
+    # Serial rejects it), so treat it as unset.
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
 def _str_or_none(value: object) -> str | None:
     """Return *value* when it's a string, else ``None``."""
     return value if isinstance(value, str) else None

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -210,6 +210,10 @@ class Device(DashboardModel):
     # the catalog entry, so a label rename / recolor needs no
     # device-level write.
     labels: list[str] = field(default_factory=list)
+    # Resolved ``logger: baud_rate`` for the Web Serial log port. ``None`` ⇒
+    # unset (frontend uses 115200); ``0`` ⇒ UART logging disabled; positive ⇒
+    # that baud.
+    logger_baud_rate: int | None = None
 
 
 @dataclass

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -34,7 +34,10 @@ from esphome_device_builder.helpers.device_yaml import (
     parse_esphome_meta,
     parse_platform_from_yaml,
 )
-from esphome_device_builder.helpers.device_yaml._parsing import _is_valid_esphome_name
+from esphome_device_builder.helpers.device_yaml._parsing import (
+    _is_valid_esphome_name,
+    extract_logger_baud_rate,
+)
 from esphome_device_builder.models import (
     BoardCatalogEntry,
     BoardEsphomeConfig,
@@ -768,6 +771,47 @@ def test_extract_meta_from_config_dict_area_uses_name() -> None:
 def test_extract_meta_from_config_no_esphome_block(config: Any) -> None:
     """Missing / malformed config or ``esphome:`` block yields all-``None``."""
     assert extract_esphome_meta_from_config(config) == (None, None, None, None)
+
+
+def test_extract_logger_baud_rate_int() -> None:
+    """A plain integer baud is returned as-is."""
+    assert extract_logger_baud_rate({"logger": {"baud_rate": 19200}}) == 19200
+
+
+def test_extract_logger_baud_rate_string_coerced() -> None:
+    """A quoted-string baud coerces to int."""
+    assert extract_logger_baud_rate({"logger": {"baud_rate": "19200"}}) == 19200
+
+
+def test_extract_logger_baud_rate_resolves_substitution() -> None:
+    """A ``${var}`` baud resolves against the supplied substitutions."""
+    config = {"logger": {"baud_rate": "${log_baud}"}}
+    assert extract_logger_baud_rate(config, {"log_baud": "9600"}) == 9600
+
+
+def test_extract_logger_baud_rate_zero_disabled() -> None:
+    """``baud_rate: 0`` passes through (UART logging disabled)."""
+    assert extract_logger_baud_rate({"logger": {"baud_rate": 0}}) == 0
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        None,
+        {},
+        {"logger": "not-a-dict"},
+        {"logger": {}},  # no baud_rate key
+        {"logger": {"baud_rate": "${unset}"}},  # unresolved token
+        {"logger": {"baud_rate": "fast"}},  # non-numeric
+        {"logger": {"baud_rate": True}},  # bool is not a baud
+        {"logger": {"baud_rate": -1}},  # negative is invalid
+        {"logger": {"baud_rate": "-9600"}},  # negative via string
+        {"logger": {"baud_rate": [115200]}},  # non-scalar
+    ],
+)
+def test_extract_logger_baud_rate_none(config: Any) -> None:
+    """Missing / malformed / unresolvable / negative baud yields ``None``."""
+    assert extract_logger_baud_rate(config) is None
 
 
 def test_parse_meta_top_level_comment_does_not_close_esphome_block() -> None:
@@ -1806,6 +1850,50 @@ def test_load_device_local_substitution_wins_over_package(tmp_path: Path) -> Non
     device = load_device_from_storage(yaml_path)
 
     assert device.friendly_name == "Local Override"
+
+
+def test_load_device_logger_baud_rate(tmp_path: Path) -> None:
+    """A literal ``logger: baud_rate`` surfaces on the device."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "esphome:\n  name: lamp\nlogger:\n  baud_rate: 19200\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.logger_baud_rate == 19200
+
+
+def test_load_device_logger_baud_rate_from_substitution(tmp_path: Path) -> None:
+    """A ``${var}`` baud resolves through the substitutions pass."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text(
+        "substitutions:\n"
+        "  log_baud: '9600'\n"
+        "esphome:\n"
+        "  name: lamp\n"
+        "logger:\n"
+        "  baud_rate: ${log_baud}\n",
+        encoding="utf-8",
+    )
+    write_storage_json(tmp_path, "lamp.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.logger_baud_rate == 9600
+
+
+def test_load_device_logger_baud_rate_absent(tmp_path: Path) -> None:
+    """No ``logger:`` block leaves the baud unset (frontend defaults to 115200)."""
+    yaml_path = tmp_path / "lamp.yaml"
+    yaml_path.write_text("esphome:\n  name: lamp\n", encoding="utf-8")
+    write_storage_json(tmp_path, "lamp.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.logger_baud_rate is None
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")


### PR DESCRIPTION
# What does this implement/fix?

Web Serial log streaming in the dashboard opens the serial port at a hardcoded 115200, so a device configured with `logger: baud_rate: 19200` (common on ESP8266) produces no readable logs. This resolves the device's logger `baud_rate` from its YAML, with `substitutions:` and `!include` expanded, mirroring how `name` / `friendly_name` are already resolved, and surfaces it on the `Device` model as `logger_baud_rate` so the frontend can open the log port at the right baud.

Semantics: `None` means the YAML didn't set one (frontend assumes ESPHome's 115200 default); `0` means UART logging is disabled; a positive value is the baud to use.

**Related issue or feature (if applicable):**

Found while testing serial logs on an ESP8266 with a non-default logger baud.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#874

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
