### PR TITLE
Match board variant case-insensitively

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -195,8 +195,11 @@ class BoardCatalog:
         if not matches:
             return None
         if pio_variant:
+            pio_variant_lower = pio_variant.lower()
             variant_matches = [
-                b for b in matches if b.esphome.variant and b.esphome.variant.value == pio_variant
+                b
+                for b in matches
+                if b.esphome.variant and b.esphome.variant.value == pio_variant_lower
             ]
             if variant_matches:
                 matches = variant_matches
@@ -232,8 +235,9 @@ class BoardCatalog:
         if not matches:
             return None
         if variant:
+            variant_lower = variant.lower()
             variant_matches = [
-                b for b in matches if b.esphome.variant and b.esphome.variant.value == variant
+                b for b in matches if b.esphome.variant and b.esphome.variant.value == variant_lower
             ]
             if variant_matches:
                 matches = variant_matches

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -589,6 +589,34 @@ def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> No
     assert board.id == "alt-s3-board"
 
 
+def test_find_by_pio_board_matches_uppercase_variant(catalog: BoardCatalog) -> None:
+    """``pio_variant`` filter is case-insensitive — uppercase ``ESP32S3`` narrows.
+
+    Mirrors the canonicalized YAML variant reaching the lookup (#1538).
+    """
+    catalog._boards.append(
+        _board(
+            board_id="alt-c3-board",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32C3,
+            pio_board="shared-pio-upper",
+        )
+    )
+    catalog._boards.append(
+        _board(
+            board_id="alt-s3-board",
+            platform=Platform.ESP32,
+            variant=Esp32Variant.ESP32S3,
+            pio_board="shared-pio-upper",
+        )
+    )
+
+    board = catalog.find_by_pio_board("shared-pio-upper", pio_variant="ESP32S3")
+
+    assert board is not None
+    assert board.id == "alt-s3-board"
+
+
 def test_find_by_pio_board_falls_back_to_first_when_variant_unmatched(
     catalog: BoardCatalog,
 ) -> None:
@@ -755,6 +783,22 @@ def test_find_by_platform_variant_no_generic_returns_first(
 
     assert board is not None
     assert board.id == "m5stack-cores3"
+
+
+def test_find_by_platform_variant_matches_uppercase_variant(
+    catalog: BoardCatalog,
+) -> None:
+    """Uppercase ``variant`` matches the lowercase catalog enum (#1538).
+
+    ESPHome canonicalizes ``variant:`` to ``ESP32S3``; a case-sensitive
+    compare missed every board and fell through to the first generic of
+    another variant (``generic-esp32c3`` here, ``esp32-c6-devkitm-1`` in
+    the shipped catalog).
+    """
+    board = catalog.find_by_platform_variant("esp32", variant="ESP32S3")
+
+    assert board is not None
+    assert board.id == "generic-esp32s3"
 
 
 def test_find_by_platform_variant_without_variant_falls_through(

--- a/tests/controllers/test_boards.py
+++ b/tests/controllers/test_boards.py
@@ -590,10 +590,7 @@ def test_find_by_pio_board_prefers_matching_variant(catalog: BoardCatalog) -> No
 
 
 def test_find_by_pio_board_matches_uppercase_variant(catalog: BoardCatalog) -> None:
-    """``pio_variant`` filter is case-insensitive — uppercase ``ESP32S3`` narrows.
-
-    Mirrors the canonicalized YAML variant reaching the lookup (#1538).
-    """
+    """An uppercase ``pio_variant`` still narrows to the matching board."""
     catalog._boards.append(
         _board(
             board_id="alt-c3-board",
@@ -788,13 +785,7 @@ def test_find_by_platform_variant_no_generic_returns_first(
 def test_find_by_platform_variant_matches_uppercase_variant(
     catalog: BoardCatalog,
 ) -> None:
-    """Uppercase ``variant`` matches the lowercase catalog enum (#1538).
-
-    ESPHome canonicalizes ``variant:`` to ``ESP32S3``; a case-sensitive
-    compare missed every board and fell through to the first generic of
-    another variant (``generic-esp32c3`` here, ``esp32-c6-devkitm-1`` in
-    the shipped catalog).
-    """
+    """An uppercase ``variant`` resolves to that variant's board, not a generic of another."""
     board = catalog.find_by_platform_variant("esp32", variant="ESP32S3")
 
     assert board is not None


### PR DESCRIPTION
# What does this implement/fix?

A never-compiled config that sets `esp32: variant: ESP32S3` with no `board:` made the web flasher ("Plug into computer") expect an **esp32c6**, so flashing a real S3 chip aborted with a chip-mismatch error.

ESPHome canonicalizes the `variant:` value to uppercase (`ESP32S3`), but the board catalog stores variants lowercase (`esp32s3`). The variant filters in `find_by_pio_board` and `find_by_platform_variant` compared case-sensitively, so the uppercase value matched no board; the filter was silently dropped and the lookup fell through to the first generic esp32 board (`esp32-c6-devkitm-1`). That derived `board_id` then drove the flasher's expected chip. The fix lowercases the incoming variant before comparing, matching what `get_boards` already does.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1538

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
