### PR TITLE
Extract a shared variant filter for the board catalog

### DIFF
--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -39,6 +39,12 @@ def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, bool, str]:
     )
 
 
+def _filter_by_variant(boards: list[BoardCatalogIndex], variant: str) -> list[BoardCatalogIndex]:
+    """Boards whose variant equals *variant*, case-insensitively (empty if none)."""
+    target = variant.lower()
+    return [b for b in boards if b.esphome.variant and b.esphome.variant.value == target]
+
+
 class BoardCatalog:
     """In-memory slim board index + lazy-loaded full bodies."""
 
@@ -96,12 +102,7 @@ class BoardCatalog:
             results = [b for b in results if b.esphome.platform == platform]
 
         if variant:
-            variant_lower = variant.lower()
-            results = [
-                b
-                for b in results
-                if b.esphome.variant and b.esphome.variant.lower() == variant_lower
-            ]
+            results = _filter_by_variant(results, variant)
 
         if mcu:
             mcu_lower = mcu.lower()
@@ -195,14 +196,7 @@ class BoardCatalog:
         if not matches:
             return None
         if pio_variant:
-            pio_variant_lower = pio_variant.lower()
-            variant_matches = [
-                b
-                for b in matches
-                if b.esphome.variant and b.esphome.variant.value == pio_variant_lower
-            ]
-            if variant_matches:
-                matches = variant_matches
+            matches = _filter_by_variant(matches, pio_variant) or matches
         normalized_pio = pio_board.replace("_", "-")
         id_match = next((b for b in matches if b.id.replace("_", "-") == normalized_pio), None)
         generic = next((b for b in matches if b.is_generic), None)
@@ -235,12 +229,7 @@ class BoardCatalog:
         if not matches:
             return None
         if variant:
-            variant_lower = variant.lower()
-            variant_matches = [
-                b for b in matches if b.esphome.variant and b.esphome.variant.value == variant_lower
-            ]
-            if variant_matches:
-                matches = variant_matches
+            matches = _filter_by_variant(matches, variant) or matches
         for b in matches:
             if b.is_generic:
                 return b

--- a/esphome_device_builder/controllers/boards.py
+++ b/esphome_device_builder/controllers/boards.py
@@ -42,7 +42,7 @@ def _board_sort_key(board: BoardCatalogIndex) -> tuple[bool, bool, bool, str]:
 def _filter_by_variant(boards: list[BoardCatalogIndex], variant: str) -> list[BoardCatalogIndex]:
     """Boards whose variant equals *variant*, case-insensitively (empty if none)."""
     target = variant.lower()
-    return [b for b in boards if b.esphome.variant and b.esphome.variant.value == target]
+    return [b for b in boards if b.esphome.variant and b.esphome.variant.value.lower() == target]
 
 
 class BoardCatalog:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up cleanup to #1539. The case-insensitive variant match was duplicated across `get_boards`, `find_by_pio_board`, and `find_by_platform_variant`, with two different idioms (`.lower()` vs `.value`) and a copy-pasted "narrow to variant matches, else keep all" fallback block. This pulls it into one `_filter_by_variant` helper; the two `find_*` callers express the best-effort fallback as `... or matches`. No behaviour change; the existing board-catalog tests (including the #1539 regression tests) still pass.

**Related issue or feature (if applicable):**

- n/a (refactor on top of #1539)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
