### PR TITLE
Serve /version unauthenticated for the Docker healthcheck

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -47,7 +47,7 @@ from .helpers.auth import auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
-from .helpers.json import cors_middleware
+from .helpers.json import cors_middleware, json_response
 from .helpers.network_interfaces import ensure_single_host_for_ephemeral_port, resolve_bind_host
 from .helpers.peer_link_identity import PeerLinkIdentityStore
 from .helpers.secrets_state import write_secrets_locked
@@ -175,6 +175,11 @@ def _resolve_base_href(request: web.Request, *, tail: str = "") -> str:
     # re-added.
     normalized = base.strip("/")
     return f"/{normalized}/" if normalized else "/"
+
+
+async def _handle_version(_request: web.Request) -> web.Response:
+    """Return the esphome version as JSON for the Docker HEALTHCHECK."""
+    return json_response({"version": esphome_version})
 
 
 # Worker-thread budget for the default ``ThreadPoolExecutor``. asyncio's
@@ -762,6 +767,11 @@ class DeviceBuilder:
         # the ingress site). HTTP, not WS, so a large firmware.elf isn't capped
         # by a proxy's WebSocket max_msg_size.
         app.router.add_get("/api/firmware/download", firmware_http_download)
+
+        # Health/version endpoint. Public (see auth._PUBLIC_PATHS) and
+        # registered before the SPA catch-all so the upstream Docker image's
+        # HEALTHCHECK gets a deterministic JSON 200 instead of the SPA shell.
+        app.router.add_get("/version", _handle_version)
 
         # Static file serving for board images
         boards_dir = Path(__file__).parent / "definitions" / "boards"

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -313,7 +313,12 @@ def parse_basic_auth(authorization: str) -> tuple[str, str] | None:
 # bearer header; it carries its own single-use capability token instead, minted
 # over the authenticated WS (see firmware/download_token) and validated by the
 # handler — the token is the authorization.
-_PUBLIC_PATHS = frozenset({"/", "/ws", "/favicon.ico", "/manifest.json", "/api/firmware/download"})
+# /version is public so the upstream Docker image's HEALTHCHECK
+# (curl --fail .../version) keeps passing when a password is set; it
+# exposes only the esphome version, matching the legacy dashboard.
+_PUBLIC_PATHS = frozenset(
+    {"/", "/ws", "/favicon.ico", "/manifest.json", "/version", "/api/firmware/download"}
+)
 _PUBLIC_PREFIXES = ("/assets/", "/boards/images/")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,10 @@ _STARTUP_BLOCKING_OK: tuple[tuple[str, str], ...] = (
     # once at HA-add-on startup as an aiohttp ``on_startup`` hook —
     # the cost is paid once, not on the request path.
     ("device_builder.py", "_start_ingress_site"),
+    # ``create_app`` stat-checks the boards-images directory while
+    # assembling the route table. Runs once per site at startup, off
+    # the request path.
+    ("device_builder.py", "create_app"),
     # ``_find_sibling_cli`` probes for ``<bin>/esphome`` and
     # ``<bin>/esptool`` to pick between a sibling script and
     # ``python -m <cli>``. The result is ``lru_cache``-d so the

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -2,18 +2,23 @@
 
 The upstream esphome Docker image's HEALTHCHECK curls ``/version`` with no
 credentials. It must return a JSON 200 even when a password is set, so the
-route sits in ``auth_middleware``'s public allowlist. This drives the real
-middleware + ``_handle_version`` through an aiohttp test client and pins that
-a password-protected install still answers with ``{"version": ...}``.
+route sits in ``auth_middleware``'s public allowlist and is registered before
+the SPA catch-all. Two layers here: a focused test driving the real middleware
++ ``_handle_version`` in isolation, and an integration test driving the real
+``create_app`` so the route ordering vs the SPA fallback is pinned too.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 from aiohttp import web
 from esphome.const import __version__ as esphome_version
 from pytest_aiohttp.plugin import AiohttpClient
 
-from esphome_device_builder.device_builder import _handle_version
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.device_builder import DeviceBuilder, _handle_version
 from esphome_device_builder.helpers.auth import auth_middleware
 
 
@@ -66,3 +71,34 @@ async def test_version_endpoint_answers_without_auth(aiohttp_client: AiohttpClie
 
     assert resp.status == 200
     assert await resp.json() == {"version": esphome_version}
+
+
+async def test_version_route_wins_over_spa_catch_all(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """Real ``create_app``: ``/version`` serves JSON, not the SPA shell.
+
+    Pins that ``add_get("/version")`` lands before the SPA catch-all in
+    aiohttp's FIFO route table — a future refactor moving it after
+    ``_register_frontend`` would return ``index.html`` (still a 200, so a
+    bare status check wouldn't notice) and this JSON assertion would catch it.
+    Auth is off here so the deep-link probe reaches the catch-all; the
+    public-allowlist bypass with a password set is pinned separately above.
+    """
+    pytest.importorskip("esphome_device_builder_frontend")
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.absolute_config_dir = tmp_path.resolve()
+    db = DeviceBuilder(settings)
+    client = await aiohttp_client(db.create_app(with_lifecycle=False))
+
+    version_resp = await client.get("/version")
+    assert version_resp.status == 200
+    assert await version_resp.json() == {"version": esphome_version}
+
+    # The SPA catch-all is live (a deep link returns the shell), so the
+    # JSON above proves /version won the FIFO match rather than there
+    # being no catch-all to lose to.
+    spa_resp = await client.get("/some/deep/link")
+    assert spa_resp.status == 200
+    assert "<!doctype html>" in (await spa_resp.text()).lower()

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -1,12 +1,4 @@
-"""Coverage for the public ``GET /version`` health/version endpoint.
-
-The upstream esphome Docker image's HEALTHCHECK curls ``/version`` with no
-credentials. It must return a JSON 200 even when a password is set, so the
-route sits in ``auth_middleware``'s public allowlist and is registered before
-the SPA catch-all. Two layers here: a focused test driving the real middleware
-+ ``_handle_version`` in isolation, and an integration test driving the real
-``create_app`` so the route ordering vs the SPA fallback is pinned too.
-"""
+"""Coverage for the public ``GET /version`` health/version endpoint."""
 
 from __future__ import annotations
 
@@ -76,15 +68,7 @@ async def test_version_endpoint_answers_without_auth(aiohttp_client: AiohttpClie
 async def test_version_route_wins_over_spa_catch_all(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """Real ``create_app``: ``/version`` serves JSON, not the SPA shell.
-
-    Pins that ``add_get("/version")`` lands before the SPA catch-all in
-    aiohttp's FIFO route table — a future refactor moving it after
-    ``_register_frontend`` would return ``index.html`` (still a 200, so a
-    bare status check wouldn't notice) and this JSON assertion would catch it.
-    Auth is off here so the deep-link probe reaches the catch-all; the
-    public-allowlist bypass with a password set is pinned separately above.
-    """
+    """Real ``create_app``: ``/version`` serves JSON, not the SPA shell."""
     pytest.importorskip("esphome_device_builder_frontend")
     settings = DashboardSettings()
     settings.config_dir = tmp_path

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -1,0 +1,68 @@
+"""Coverage for the public ``GET /version`` health/version endpoint.
+
+The upstream esphome Docker image's HEALTHCHECK curls ``/version`` with no
+credentials. It must return a JSON 200 even when a password is set, so the
+route sits in ``auth_middleware``'s public allowlist. This drives the real
+middleware + ``_handle_version`` through an aiohttp test client and pins that
+a password-protected install still answers with ``{"version": ...}``.
+"""
+
+from __future__ import annotations
+
+from aiohttp import web
+from esphome.const import __version__ as esphome_version
+from pytest_aiohttp.plugin import AiohttpClient
+
+from esphome_device_builder.device_builder import _handle_version
+from esphome_device_builder.helpers.auth import auth_middleware
+
+
+class _StubSessionStore:
+    async def validate(self, token: str) -> object | None:
+        return None
+
+
+class _StubRateLimiter:
+    def remaining_lockout(self, ip: str) -> float:
+        return 0.0
+
+    def clear(self, ip: str) -> None: ...
+
+    def record_failure(self, ip: str) -> None: ...
+
+
+class _StubAuth:
+    def __init__(self) -> None:
+        self.session_store = _StubSessionStore()
+        self.rate_limiter = _StubRateLimiter()
+
+
+class _StubSettings:
+    def __init__(self, *, using_password: bool) -> None:
+        self.using_password = using_password
+
+    def check_password(self, username: str, password: str) -> bool:
+        return False
+
+
+class _StubDeviceBuilder:
+    def __init__(self, *, using_password: bool) -> None:
+        self.settings = _StubSettings(using_password=using_password)
+        self.auth = _StubAuth()
+
+
+def _make_app(db: _StubDeviceBuilder) -> web.Application:
+    app = web.Application(middlewares=[auth_middleware])
+    app["device_builder"] = db
+    app.router.add_get("/version", _handle_version)
+    return app
+
+
+async def test_version_endpoint_answers_without_auth(aiohttp_client: AiohttpClient) -> None:
+    """``/version`` returns the esphome version JSON even with a password set."""
+    client = await aiohttp_client(_make_app(_StubDeviceBuilder(using_password=True)))
+
+    resp = await client.get("/version")
+
+    assert resp.status == 200
+    assert await resp.json() == {"version": esphome_version}


### PR DESCRIPTION
# What does this implement/fix?

The upstream esphome Docker image's HEALTHCHECK runs `curl --fail http://localhost:6052/version`. When a password is set (ESPHOME_USERNAME / ESPHOME_PASSWORD), that unauthenticated request hit auth_middleware and got a 401, so the container reported unhealthy after upgrading 2026.5.3 to 2026.6.0; a reverse proxy like traefik then filters the unhealthy container and the dashboard becomes unreachable.

There was no real `/version` route; it fell through to the SPA catch-all and was never in the public allowlist, so it only ever worked unauthenticated when no password was set.

This adds a real `GET /version` route returning `{"version": <esphome version>}`, matching the legacy dashboard, and adds `/version` to auth_middleware's public allowlist so the healthcheck gets a deterministic JSON 200 without credentials.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1552

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
