### PR TITLE
Compare rename against the device name, not the filename stem

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -203,35 +203,49 @@ async def rename_device(
     Default path delegates to ``esphome rename`` (compile + OTA install,
     via the firmware queue); only succeeds against a reachable device.
     ``config_only`` rewrites the YAML + ``esphome.name`` and renames the
-    file without compiling or flashing, for an offline device.
+    file without compiling or flashing, for an offline device. An in-place
+    rename (target filename equals the device's own file) is always
+    config-only since ``esphome rename`` can't keep the same filename.
     """
     new_filename = f"{new_name}.yaml"
+    loop = asyncio.get_running_loop()
+    old_path = controller._db.settings.rel_path(configuration)
+    new_path = controller._db.settings.rel_path(new_filename)
 
-    # Reject same-name renames up-front; a no-op at the YAML
-    # level but still queues a real ``esphome rename`` job that
-    # re-compiles and OTA-flashes. Compare on the *stem* so
-    # cloning ``kitchen.yml`` to ``new_name=kitchen`` is rejected
-    # too (the device's mDNS hostname comes from the stem and
-    # stays the same either way).
-    source_stem = configuration_stem(configuration)
-    if new_name == source_stem:
+    content = await _read_device_yaml_or_raise(controller, configuration)
+
+    # Reject same-name renames up-front. Compare against the device's real
+    # ``esphome.name``, not the filename stem: an uploaded config keeps its
+    # raw name (``test_1``) while the file is slugified (``test-1.yaml``), so
+    # a stem compare wrongly rejects the legitimate ``test_1`` -> ``test-1``
+    # rename and wrongly accepts a real no-op whose filename differs from its
+    # name. Falls back to the stem when the name can't be parsed.
+    current_name = parse_esphome_meta(content).name or configuration_stem(configuration)
+    if new_name == current_name:
         raise CommandError(
             ErrorCode.INVALID_ARGS,
             "new_name must differ from the current device name",
         )
-    # Reject up-front if the target filename is in use; ``esphome
-    # rename`` itself doesn't check collisions and would silently
-    # overwrite an unrelated device's config and OTA-flash that
-    # firmware to the wrong device. Both ``rel_path`` and
-    # ``.exists()`` are blocking; push the pair to the executor.
-    loop = asyncio.get_running_loop()
-    new_path = controller._db.settings.rel_path(new_filename)
-    if await loop.run_in_executor(None, new_path.exists):
+
+    # When the slugified target filename is the device's own file, the rename
+    # changes ``esphome.name`` without moving the file. ``esphome rename``
+    # refuses that (it requires a new filename), so route it in place.
+    in_place = new_path == old_path
+    # Reject up-front if a *different* file already owns the target filename;
+    # ``esphome rename`` doesn't check collisions and would silently overwrite
+    # an unrelated device's config and OTA-flash firmware to the wrong device.
+    if not in_place and await loop.run_in_executor(None, new_path.exists):
         msg = f"A device named {new_filename} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
-    if config_only:
-        return await _config_only_rename(controller, configuration=configuration, new_name=new_name)
+    if config_only or in_place:
+        return await _config_only_rename(
+            controller,
+            configuration=configuration,
+            new_name=new_name,
+            content=content,
+            in_place=in_place,
+        )
 
     if controller._db.firmware is None:
         msg = "Firmware controller is unavailable"
@@ -267,20 +281,23 @@ async def _config_only_rename(
     *,
     configuration: str,
     new_name: str,
+    content: str,
+    in_place: bool,
 ) -> dict[str, Any]:
     """
     Rename the YAML + ``esphome.name`` with no compile or OTA.
 
     Validates the rewritten config before touching disk, writes the new
     file atomically, removes the old, and migrates the StorageJSON +
-    sidecar metadata. Returns ``job: None`` (nothing is queued).
+    sidecar metadata. Returns ``job: None`` (nothing is queued). When
+    *in_place* the target filename is the device's own file: the rewrite
+    lands on it and the old-file / old-sidecar removals are skipped so the
+    just-written file isn't deleted.
     """
     new_filename = f"{new_name}.yaml"
     loop = asyncio.get_running_loop()
     old_path = controller._db.settings.rel_path(configuration)
     new_path = controller._db.settings.rel_path(new_filename)
-
-    content = await _read_device_yaml_or_raise(controller, configuration)
 
     # ``esphome.name`` must be retargetable in place: a plain literal (rewrite
     # the leaf) or a pure ``${var}`` ref whose definition lives in this file's
@@ -306,7 +323,8 @@ async def _config_only_rename(
     await controller._validate_rewritten_yaml_or_raise(new_filename, new_content, action="rename")
 
     await controller._write_yaml_atomic_async(new_path, new_content)
-    await loop.run_in_executor(None, lambda: old_path.unlink(missing_ok=True))
+    if not in_place:
+        await loop.run_in_executor(None, lambda: old_path.unlink(missing_ok=True))
     # The YAML is already renamed; storage migration is best-effort (logs on
     # failure) and the shared metadata-migrate-then-scan always rescans.
     await loop.run_in_executor(None, _migrate_storage_json, configuration, new_filename, new_name)
@@ -327,6 +345,7 @@ def _migrate_storage_json(old_configuration: str, new_filename: str, new_name: s
     """
     try:
         old_storage_path = resolve_storage_path(old_configuration)
+        new_storage_path = resolve_storage_path(new_filename)
         storage = StorageJSON.load(old_storage_path)
         if storage is None:
             return
@@ -337,7 +356,10 @@ def _migrate_storage_json(old_configuration: str, new_filename: str, new_name: s
         if storage.address == default_mdns_address(old_name):
             storage.address = default_mdns_address(new_name)
         save_device_storage(new_filename, storage)
-        old_storage_path.unlink(missing_ok=True)
+        # An in-place rename saves the sidecar back to the same path; unlinking
+        # the "old" path would delete the file we just wrote.
+        if old_storage_path != new_storage_path:
+            old_storage_path.unlink(missing_ok=True)
     except OSError:
         # Filesystem hiccup only; a logic bug here should surface, not hide.
         _LOGGER.exception("Could not migrate StorageJSON for %s", new_filename)

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from esphome.storage_json import StorageJSON
@@ -237,9 +238,10 @@ async def rename_device(
     # When the slugified target filename is the device's own file, the rename
     # changes ``esphome.name`` without moving the file. ``esphome rename``
     # refuses that (it requires a new filename), so route it in place. Compare
-    # resolved paths so a configuration with redundant segments (``./x.yaml``)
-    # still reads as the same file.
-    in_place = new_path.resolve() == old_path.resolve()
+    # lexically-normalized paths so a configuration with redundant segments
+    # (``./x.yaml``) still reads as the same file, without the blocking
+    # filesystem access ``Path.resolve()`` would do in this async path.
+    in_place = os.path.normpath(old_path) == os.path.normpath(new_path)
     # Reject up-front if a *different* file already owns the target filename;
     # ``esphome rename`` doesn't check collisions and would silently overwrite
     # an unrelated device's config and OTA-flash firmware to the wrong device.

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -219,8 +219,15 @@ async def rename_device(
     # raw name (``test_1``) while the file is slugified (``test-1.yaml``), so
     # a stem compare wrongly rejects the legitimate ``test_1`` -> ``test-1``
     # rename and wrongly accepts a real no-op whose filename differs from its
-    # name. Falls back to the stem when the name can't be parsed.
-    current_name = parse_esphome_meta(content).name or configuration_stem(configuration)
+    # name. A nonlocal ``${var}`` (package / !include) stays an unresolved
+    # token, so treat that as unknown and fall back to the filename stem
+    # rather than comparing against the literal ``${var}``.
+    parsed_name = parse_esphome_meta(content).name
+    current_name = (
+        parsed_name
+        if parsed_name and parse_substitution_ref(parsed_name) is None
+        else configuration_stem(configuration)
+    )
     if new_name == current_name:
         raise CommandError(
             ErrorCode.INVALID_ARGS,
@@ -229,8 +236,10 @@ async def rename_device(
 
     # When the slugified target filename is the device's own file, the rename
     # changes ``esphome.name`` without moving the file. ``esphome rename``
-    # refuses that (it requires a new filename), so route it in place.
-    in_place = new_path == old_path
+    # refuses that (it requires a new filename), so route it in place. Compare
+    # resolved paths so a configuration with redundant segments (``./x.yaml``)
+    # still reads as the same file.
+    in_place = new_path.resolve() == old_path.resolve()
     # Reject up-front if a *different* file already owns the target filename;
     # ``esphome rename`` doesn't check collisions and would silently overwrite
     # an unrelated device's config and OTA-flash firmware to the wrong device.

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -247,6 +247,12 @@ async def rename_device(
         msg = f"A device named {new_filename} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
+    # An in-place rename can't go through ``esphome rename`` (same filename),
+    # so it rewrites the name with no flash even when the caller wanted the OTA
+    # path. The firmware (which broadcasts the raw ``esphome.name``) keeps its
+    # old hostname until the next install; the resulting expected/deployed hash
+    # mismatch surfaces as a pending-changes indicator, same as the offline
+    # ``config_only`` rename, so the divergence is visible rather than silent.
     if config_only or in_place:
         return await _config_only_rename(
             controller,

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -310,11 +310,20 @@ async def _config_only_rename(
     # A pure ``${var}`` ref whose def isn't in this file would be flattened.
     nonlocal_sub = var is not None and read_yaml_scalar(content, ("substitutions", var)) is None
     if current is None or not is_retargetable_name(current) or nonlocal_sub:
+        # The OTA rename resolves packages / includes / embedded substitutions,
+        # so steer there for a file-move rename. An in-place rename can't fall
+        # back to it (``esphome rename`` won't keep the same filename), so the
+        # only fix is editing the name to a plain value.
+        remedy = (
+            "Edit esphome.name to a plain value and try again."
+            if in_place
+            else "Bring the device online to rename it."
+        )
         raise CommandError(
             ErrorCode.INVALID_ARGS,
-            "Can't rename offline: esphome.name isn't a plain literal or a local "
+            "Can't rename: esphome.name isn't a plain literal or a local "
             "${substitution} (it may come from packages, an !include, or an "
-            "embedded substitution). Bring the device online to rename it.",
+            f"embedded substitution). {remedy}",
         )
 
     new_content = rewrite_name_or_substitution(content, ESPHOME_NAME_PATH, new_name)

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -1,35 +1,32 @@
 """
 Tests for ``DevicesController.rename_device``.
 
-The handler is now a thin pass-through to ``esphome rename`` via
-the firmware queue. The CLI owns the full atomic flow (YAML edit
-→ revalidate → compile → OTA install → rollback on failure), so
-the dashboard only enforces two preconditions before queueing:
+The default path is a thin pass-through to ``esphome rename`` via the
+firmware queue (YAML edit -> revalidate -> compile -> OTA install ->
+rollback on failure). The dashboard enforces preconditions before
+queueing:
 
-- target filename collision — rejected up-front because the CLI
-  would happily overwrite an unrelated device's YAML
-- same-name renames — rejected up-front because they're a no-op
-  at the YAML level but still queue a real compile + flash
+- target filename collision — rejected up-front because the CLI would
+  happily overwrite an unrelated device's YAML
+- same-name renames — rejected up-front, compared against the device's
+  real ``esphome.name`` (not the filename stem) so a config whose file
+  was slugified away from its name (uploaded ``name: test_1`` ->
+  ``test-1.yaml``) can still be renamed to fix the name
 
-What we used to also do — pre-validate via ``esphome config`` and
-fall back to a file-level rename when validation failed — is gone.
-The fallback silently renamed the YAML on disk while the running
-firmware kept broadcasting the old hostname, leaving dashboard
-label and device state diverged with no error to the user. Rename
-now refuses cleanly when the CLI's own validation fails so the
-user fixes the YAML and retries.
+An in-place rename — the target filename is the device's own file —
+can't go through ``esphome rename`` (it requires a new filename), so it
+rewrites the name in place via the config-only path.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.yaml import read_yaml_scalar
 from esphome_device_builder.models import (
     ErrorCode,
     FirmwareJob,
@@ -39,46 +36,39 @@ from esphome_device_builder.models import (
 
 from .conftest import MakeControllerFactory
 
+_YAML = """\
+esphome:
+  name: kitchen
+  friendly_name: Kitchen Light
 
-def _wire_fake_path(controller: DevicesController) -> None:
-    """Swap the factory's tmp_path-based ``rel_path`` for the ``_FakePath`` shim."""
-    controller._db.settings.rel_path = _FakePath
+esp32:
+  board: esp32dev
+"""
 
+# An uploaded config whose file was slugified (``test_1`` -> ``test-1.yaml``)
+# while the body keeps the underscore name.
+_UNDERSCORE_YAML = """\
+esphome:
+  name: test_1
+  friendly_name: Test_1
 
-class _FakePath:
-    """Path stand-in: ``existing`` set drives ``.exists()`` results."""
-
-    existing: ClassVar[set[str]] = set()
-
-    def __init__(self, configuration: str) -> None:
-        self._configuration = configuration
-
-    def __str__(self) -> str:
-        return f"./{self._configuration}"
-
-    def exists(self) -> bool:
-        return self._configuration in _FakePath.existing
-
-
-@pytest.fixture(autouse=True)
-def _reset_fake_path_existing() -> Any:
-    _FakePath.existing = set()
-    yield
-    _FakePath.existing = set()
+esp32:
+  board: esp32dev
+"""
 
 
 async def test_rename_target_filename_collision_raises(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Renaming onto an existing config rejects before any work runs.
+    """Renaming onto a different existing config rejects before any work runs.
 
     The CLI ``esphome rename`` doesn't check this itself — it would
     happily overwrite the unrelated device's YAML and OTA-install
     the wrong firmware. We have to catch it ourselves at the gate.
     """
     controller = make_controller(tmp_path, esphome_cmd=["esphome"])
-    _wire_fake_path(controller)
-    _FakePath.existing.add("livingroom.yaml")
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
+    (tmp_path / "livingroom.yaml").write_text(_YAML, encoding="utf-8")
 
     with pytest.raises(CommandError) as excinfo:
         await controller.rename_device(configuration="kitchen.yaml", new_name="livingroom")
@@ -98,7 +88,7 @@ async def test_rename_same_name_raises(
     renaming."
     """
     controller = make_controller(tmp_path, esphome_cmd=["esphome"])
-    _wire_fake_path(controller)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
 
     with pytest.raises(CommandError) as excinfo:
         await controller.rename_device(configuration="kitchen.yaml", new_name="kitchen")
@@ -107,26 +97,68 @@ async def test_rename_same_name_raises(
     assert "must differ" in excinfo.value.message
 
 
-async def test_rename_same_name_raises_for_yml_extension(
+async def test_rename_same_name_compares_real_esphome_name(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Stem comparison catches ``kitchen.yml`` → ``new_name=kitchen``.
+    """A no-op is judged by ``esphome.name``, not the filename stem.
 
-    The literal filenames differ (``kitchen.yml`` vs the
-    constructed ``kitchen.yaml``) but the device's mDNS hostname
-    comes from the stem and stays the same either way, so the
-    rename would still be a no-op rewrite + redundant flash. A
-    naive ``new_filename == configuration`` check would let this
-    through; comparing on stems catches it.
+    The file is ``test-1.yaml`` but the device is named ``test_1``;
+    renaming to ``test_1`` is the real no-op and must be rejected even
+    though it differs from the filename stem.
     """
     controller = make_controller(tmp_path, esphome_cmd=["esphome"])
-    _wire_fake_path(controller)
+    (tmp_path / "test-1.yaml").write_text(_UNDERSCORE_YAML, encoding="utf-8")
 
     with pytest.raises(CommandError) as excinfo:
-        await controller.rename_device(configuration="kitchen.yml", new_name="kitchen")
+        await controller.rename_device(configuration="test-1.yaml", new_name="test_1")
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "must differ" in excinfo.value.message
+
+
+async def test_rename_underscore_name_to_hyphen_in_place(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """``test_1`` (file ``test-1.yaml``) renames to ``test-1`` in place.
+
+    The slugified filename already matches the new name, so the rename
+    rewrites ``esphome.name`` on the same file instead of moving it; the
+    file must survive and nothing is queued.
+    """
+    controller = make_controller(tmp_path)
+    config = tmp_path / "test-1.yaml"
+    config.write_text(_UNDERSCORE_YAML, encoding="utf-8")
+
+    result = await controller.rename_device(configuration="test-1.yaml", new_name="test-1")
+
+    assert result == {"configuration": "test-1.yaml", "job": None}
+    assert config.exists()
+    new_content = config.read_text(encoding="utf-8")
+    assert read_yaml_scalar(new_content, ("esphome", "name")) == "test-1"
+    assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Test_1"
+    assert controller._scanner.calls == [("scan",)]
+
+
+async def test_rename_in_place_ignores_config_only_flag(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An in-place rename rewrites the name even with the default (online) arg.
+
+    ``esphome rename`` can't keep the same filename, so the in-place case
+    routes to the config-only rewrite regardless of ``config_only``; the
+    firmware queue is never touched.
+    """
+    controller = make_controller(tmp_path)
+    controller._db.firmware = MagicMock()
+    controller._db.firmware.rename = AsyncMock()
+    config = tmp_path / "test-1.yaml"
+    config.write_text(_UNDERSCORE_YAML, encoding="utf-8")
+
+    result = await controller.rename_device(configuration="test-1.yaml", new_name="test-1")
+
+    assert result["job"] is None
+    controller._db.firmware.rename.assert_not_awaited()
+    assert read_yaml_scalar(config.read_text(encoding="utf-8"), ("esphome", "name")) == "test-1"
 
 
 async def test_rename_queues_firmware_job(
@@ -134,7 +166,7 @@ async def test_rename_queues_firmware_job(
 ) -> None:
     """Pre-conditions clear → firmware queue, response carries the queued job."""
     controller = make_controller(tmp_path, esphome_cmd=["esphome"])
-    _wire_fake_path(controller)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
 
     queued = FirmwareJob(
         job_id="abc123",
@@ -163,7 +195,7 @@ async def test_rename_missing_firmware_controller_raises(
 ) -> None:
     """Lifecycle race where firmware controller hasn't started yet."""
     controller = make_controller(tmp_path, esphome_cmd=["esphome"])
-    _wire_fake_path(controller)
+    (tmp_path / "kitchen.yaml").write_text(_YAML, encoding="utf-8")
     controller._db.firmware = None
 
     with pytest.raises(CommandError) as excinfo:

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -116,6 +116,25 @@ async def test_rename_same_name_compares_real_esphome_name(
     assert "must differ" in excinfo.value.message
 
 
+async def test_rename_same_name_falls_back_to_stem_for_nonlocal_substitution(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An unresolved ``${var}`` name is treated as unknown, comparing on the stem.
+
+    ``esphome.name: ${devicename}`` with no local definition can't be
+    resolved here, so the no-op guard falls back to the filename stem
+    rather than comparing ``new_name`` against the literal ``${devicename}``.
+    """
+    controller = make_controller(tmp_path, esphome_cmd=["esphome"])
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: ${devicename}\n", encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(configuration="kitchen.yaml", new_name="kitchen")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "must differ" in excinfo.value.message
+
+
 async def test_rename_underscore_name_to_hyphen_in_place(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -158,6 +158,27 @@ async def test_rename_underscore_name_to_hyphen_in_place(
     assert controller._scanner.calls == [("scan",)]
 
 
+async def test_rename_in_place_with_redundant_path_segments(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A denormalized configuration (``foo/../test-1.yaml``) still reads as in-place.
+
+    ``normpath`` collapses the redundant segment lexically; a textual path
+    compare would miss it and the rename would false-collide with the
+    device's own file.
+    """
+    controller = make_controller(tmp_path)
+    (tmp_path / "foo").mkdir()
+    config = tmp_path / "test-1.yaml"
+    config.write_text(_UNDERSCORE_YAML, encoding="utf-8")
+
+    result = await controller.rename_device(configuration="foo/../test-1.yaml", new_name="test-1")
+
+    assert result["job"] is None
+    assert config.exists()
+    assert read_yaml_scalar(config.read_text(encoding="utf-8"), ("esphome", "name")) == "test-1"
+
+
 async def test_rename_in_place_ignores_config_only_flag(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -162,8 +162,30 @@ async def test_config_only_rename_refuses_non_literal_name(
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "literal" in excinfo.value.message
+    # File-move refusal steers to the OTA rename, which resolves the indirection.
+    assert "online" in excinfo.value.message
     assert (tmp_path / "kitchen.yaml").exists()
     assert not (tmp_path / "livingroom.yaml").exists()
+
+
+async def test_in_place_rename_non_retargetable_name_points_to_editing(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An in-place non-retargetable name can't fall back to the OTA rename.
+
+    ``esphome rename`` won't keep the same filename, so the refusal must
+    point at editing the name, not at bringing the device online.
+    """
+    controller = make_controller(tmp_path)
+    (tmp_path / "livingroom.yaml").write_text("esphome:\n  name: ${devicename}\n", encoding="utf-8")
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.rename_device(configuration="livingroom.yaml", new_name="livingroom")
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "Edit esphome.name" in excinfo.value.message
+    assert "online" not in excinfo.value.message
+    assert (tmp_path / "livingroom.yaml").exists()
 
 
 async def test_config_only_rename_rewrites_local_substitution(

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -174,18 +174,24 @@ async def test_in_place_rename_non_retargetable_name_points_to_editing(
     """An in-place non-retargetable name can't fall back to the OTA rename.
 
     ``esphome rename`` won't keep the same filename, so the refusal must
-    point at editing the name, not at bringing the device online.
+    point at editing the name, not at bringing the device online. The
+    embedded ``${suffix}`` resolves to ``kitchen_a1`` (not a pure ref, so it
+    differs from the slugified ``kitchen-a1`` stem and clears the same-name
+    guard) but still isn't retargetable in place.
     """
     controller = make_controller(tmp_path)
-    (tmp_path / "livingroom.yaml").write_text("esphome:\n  name: ${devicename}\n", encoding="utf-8")
+    (tmp_path / "kitchen-a1.yaml").write_text(
+        "substitutions:\n  suffix: a1\nesphome:\n  name: kitchen_${suffix}\n",
+        encoding="utf-8",
+    )
 
     with pytest.raises(CommandError) as excinfo:
-        await controller.rename_device(configuration="livingroom.yaml", new_name="livingroom")
+        await controller.rename_device(configuration="kitchen-a1.yaml", new_name="kitchen-a1")
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert "Edit esphome.name" in excinfo.value.message
     assert "online" not in excinfo.value.message
-    assert (tmp_path / "livingroom.yaml").exists()
+    assert (tmp_path / "kitchen-a1.yaml").exists()
 
 
 async def test_config_only_rename_rewrites_local_substitution(


### PR DESCRIPTION
# What does this implement/fix?

When a config is brought in via Upload / Paste YAML, the filename is slugified from the name (`slugify_hostname('test_1')` is `test-1`), so the file lands as `test-1.yaml` while the body keeps `esphome.name: test_1`; the user-upload flow deliberately writes the YAML as-is. The rename same-name guard compared the new name to the filename stem (`test-1`), so renaming `test_1` to `test-1` (the user fixing the underscore) was rejected with "new_name must differ from the current device name".

This compares against the real `esphome.name` instead, matching what `esphome rename` itself does. When the slugified target filename is the device's own file, the rename can't go through `esphome rename` (it requires a new filename), so it rewrites the name in place via the config-only path; the same-file unlinks are skipped so the file isn't deleted.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1551

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
</content>
