### PR TITLE
Serve top-level frontend bundles without auth

### DIFF
--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -11,7 +11,6 @@ import asyncio
 import contextlib
 import html
 import logging
-import re
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
@@ -43,7 +42,7 @@ from .controllers.remote_build import OffloaderController, ReceiverController
 from .controllers.version_history import VersionHistoryController
 from .helpers.api import CommandHandler, collect_api_commands
 from .helpers.async_ import create_eager_task
-from .helpers.auth import auth_middleware
+from .helpers.auth import HASHED_FILENAME_RE, auth_middleware
 from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
 from .helpers.event_bus import Event, EventBus, StreamControls, stream_events
@@ -88,7 +87,6 @@ _SHUTDOWN_TIMEOUT_SECONDS = 5.0
 #     on every rebuild, so they're safe to cache forever.
 _NO_CACHE_HEADERS = {"Cache-Control": "no-cache"}
 _IMMUTABLE_HEADERS = {"Cache-Control": "public, max-age=31536000, immutable"}
-_HASHED_FILENAME_RE = re.compile(r"\.[a-f0-9]{8,}\.")
 
 # Path extensions that should NEVER fall back to ``index.html``. The
 # frontend bundle's entry script is emitted with a relative ``src``
@@ -1036,7 +1034,7 @@ class DeviceBuilder:
                 resolved = await asyncio.to_thread(_resolve_static, candidate)
                 if resolved is not None:
                     headers = (
-                        _IMMUTABLE_HEADERS if _HASHED_FILENAME_RE.search(tail) else shell_headers
+                        _IMMUTABLE_HEADERS if HASHED_FILENAME_RE.search(tail) else shell_headers
                     )
                     return web.FileResponse(resolved, headers=headers)
             # 404 asset-shaped requests instead of returning the SPA

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -324,13 +324,10 @@ _PUBLIC_PATHS = frozenset(
 _PUBLIC_PREFIXES = ("/assets/", "/boards/images/")
 
 # Content-hash segment in a frontend bundle filename (app.<hash>.js,
-# <chunk>.<hash>.js, vendors.<hash>.js, plus .js.map / .js.LICENSE.txt
-# sidecars). index.html loads its entry script with a flat ``src``, so
-# these land at the deploy root, not under /assets/, and must be reachable
-# before login or the SPA can't boot to render the login form (#1560).
-# The hash is what makes serving them pre-auth safe: no API/legacy route
-# (/devices, /json-config, /compile, /upload, /api/*) is content-addressed,
-# so this can never expose a sensitive endpoint.
+# chunks, vendors, .js.map / .js.LICENSE.txt sidecars). These load from the
+# deploy root, not /assets/, so auth must let them through pre-login. Safe
+# because no API/legacy route is content-addressed, so a hashed top-level
+# path can never resolve to a sensitive endpoint.
 HASHED_FILENAME_RE = re.compile(r"\.[a-f0-9]{8,}\.")
 
 

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -6,11 +6,13 @@ import asyncio
 import base64
 import hashlib
 import logging
+import re
 import secrets
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
+from functools import lru_cache
 from pathlib import Path
 
 from aiohttp import web
@@ -321,6 +323,16 @@ _PUBLIC_PATHS = frozenset(
 )
 _PUBLIC_PREFIXES = ("/assets/", "/boards/images/")
 
+# Content-hash segment in a frontend bundle filename (app.<hash>.js,
+# <chunk>.<hash>.js, vendors.<hash>.js, plus .js.map / .js.LICENSE.txt
+# sidecars). index.html loads its entry script with a flat ``src``, so
+# these land at the deploy root, not under /assets/, and must be reachable
+# before login or the SPA can't boot to render the login form (#1560).
+# The hash is what makes serving them pre-auth safe: no API/legacy route
+# (/devices, /json-config, /compile, /upload, /api/*) is content-addressed,
+# so this can never expose a sensitive endpoint.
+HASHED_FILENAME_RE = re.compile(r"\.[a-f0-9]{8,}\.")
+
 
 @web.middleware
 async def auth_middleware(  # noqa: PLR0911
@@ -343,7 +355,11 @@ async def auth_middleware(  # noqa: PLR0911
         return await handler(request)
 
     path = request.path
-    if path in _PUBLIC_PATHS or any(path.startswith(p) for p in _PUBLIC_PREFIXES):
+    if (
+        path in _PUBLIC_PATHS
+        or any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+        or _is_public_hashed_asset(request.method, path)
+    ):
         return await handler(request)
 
     header = request.headers.get("Authorization", "")
@@ -364,6 +380,23 @@ async def auth_middleware(  # noqa: PLR0911
         db.auth.rate_limiter.record_failure(ip)
 
     return _unauthorized()
+
+
+# Bounded so adversarial distinct paths can't grow it without limit; the
+# legitimate working set (every top-level bundle/chunk/map/sidecar, GET+HEAD)
+# is only a few dozen entries.
+@lru_cache(maxsize=1024)
+def _is_public_hashed_asset(method: str, path: str) -> bool:
+    """Return True for a safe-method request to a top-level content-hashed bundle.
+
+    ``path.count("/") == 1`` anchors to the deploy root so a deep-link
+    asset (``/device/app.<hash>.js``) stays gated.
+    """
+    return (
+        method in ("GET", "HEAD")
+        and path.count("/") == 1
+        and HASHED_FILENAME_RE.search(path) is not None
+    )
 
 
 def _unauthorized(message: str = "Authentication required") -> web.Response:

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -118,7 +118,7 @@ def _build_app(device_builder: _StubDeviceBuilder) -> web.Application:
     - ``/assets/app.js`` — ``_PUBLIC_PREFIXES`` allowlist (the
       hashed bundles).
     - top-level content-hashed bundles (``/app.<hash>.js`` etc.) —
-      the deploy-root assets the SPA needs before login (#1560).
+      the deploy-root assets the SPA needs before login.
     """
     app = web.Application(middlewares=[auth_middleware])
     app["device_builder"] = device_builder
@@ -253,13 +253,7 @@ async def test_auth_middleware_top_level_hashed_bundle_passes_through(
     aiohttp_client: AiohttpClient,
     path: str,
 ) -> None:
-    """Top-level content-hashed bundles load pre-auth (#1560).
-
-    ``index.html`` loads its entry script with a flat ``src``, so the
-    bundle and its lazy chunks land at the deploy root, not under
-    ``/assets/``. Without this they 401 with a password set and the SPA
-    can't boot to render the login form — the blank-screen bug.
-    """
+    """Top-level content-hashed bundles pass auth pre-login."""
     db = _StubDeviceBuilder(_StubSettings(using_password=True))
     client = await aiohttp_client(_build_app(db))
 
@@ -277,18 +271,13 @@ async def test_auth_middleware_hashed_bundle_head_passes_through(
 
     resp = await client.head("/app.5ec0f3c42890e1a7.js")
 
-    assert resp.status != 401
+    assert resp.status == 200
 
 
 async def test_auth_middleware_unhashed_top_level_path_still_gated(
     aiohttp_client: AiohttpClient,
 ) -> None:
-    """A top-level path without a hash segment is not broadened into public.
-
-    Pins that the hashed-asset bypass didn't open the sensitive legacy
-    REST API (``/devices``, ``/json-config``, …) — those carry no
-    ``.<hash>.`` segment, so they still require auth.
-    """
+    """A top-level path with no hash segment stays gated."""
     db = _StubDeviceBuilder(_StubSettings(using_password=True))
     client = await aiohttp_client(_build_app(db))
 

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -24,11 +24,14 @@ demands.
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 
 import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
+from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.device_builder import DeviceBuilder
 from esphome_device_builder.helpers.auth import auth_middleware
 
 
@@ -503,3 +506,51 @@ async def test_auth_middleware_malformed_authorization_header_returns_401(
     )
 
     assert resp.status == 401
+
+
+# ---------------------------------------------------------------------------
+# Real route table — gated-by-default guard
+# ---------------------------------------------------------------------------
+
+# Plain routes the real app intends to be reachable without credentials:
+# / and the SPA catch-all serve the public shell, /ws authenticates in-band,
+# /version is the healthcheck, /api/firmware/download carries its own token.
+# Static dirs (/assets, /boards/images) and the catch-all are non-plain
+# resources and are skipped (public frontend surfaces).
+_PUBLIC_PLAIN_ROUTES = frozenset({"/", "/ws", "/version", "/api/firmware/download"})
+
+
+async def test_create_app_gates_every_non_public_route(
+    tmp_path: Path,
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Every plain route in the real ``create_app`` is auth-gated unless allowlisted.
+
+    Drives the actual route table (not a stub) so a new route landing in
+    ``_PUBLIC_PATHS`` or matching the hashed-asset bypass by accident fails
+    here; a deliberately-public route must be added to
+    ``_PUBLIC_PLAIN_ROUTES`` to pass.
+    """
+    settings = DashboardSettings()
+    settings.config_dir = tmp_path
+    settings.absolute_config_dir = tmp_path.resolve()
+    settings.using_password = True
+    # No auth controller needed: with no Authorization header the middleware
+    # 401s before touching db.auth, and before reaching any handler.
+    app = DeviceBuilder(settings).create_app(with_lifecycle=False)
+    client = await aiohttp_client(app)
+
+    gated: set[str] = set()
+    for route in app.router.routes():
+        canonical = route.resource.canonical
+        if type(route.resource).__name__ != "PlainResource":
+            continue
+        if canonical in _PUBLIC_PLAIN_ROUTES:
+            continue
+        resp = await client.request(route.method, canonical)
+        assert resp.status == 401, f"{route.method} {canonical} is reachable without auth"
+        gated.add(canonical)
+
+    # The sensitive legacy REST surface must have actually been exercised —
+    # guards against the loop silently skipping everything.
+    assert gated >= {"/devices", "/json-config", "/compile", "/upload"}

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -117,6 +117,8 @@ def _build_app(device_builder: _StubDeviceBuilder) -> web.Application:
       without auth.
     - ``/assets/app.js`` — ``_PUBLIC_PREFIXES`` allowlist (the
       hashed bundles).
+    - top-level content-hashed bundles (``/app.<hash>.js`` etc.) —
+      the deploy-root assets the SPA needs before login (#1560).
     """
     app = web.Application(middlewares=[auth_middleware])
     app["device_builder"] = device_builder
@@ -130,8 +132,25 @@ def _build_app(device_builder: _StubDeviceBuilder) -> web.Application:
     app.router.add_get("/favicon.ico", _ok)
     app.router.add_get("/boards/images/esp32.png", _ok)
     app.router.add_route("OPTIONS", "/api/anything", _ok)
+    # Top-level content-hashed bundles + sidecars served from the deploy root.
+    for hashed in _HASHED_BUNDLES:
+        app.router.add_get(hashed, _ok)
+    # A hashed-looking asset nested under a deep-link path — must stay gated.
+    app.router.add_get("/device/app.5ec0f3c42890e1a7.js", _ok)
 
     return app
+
+
+# Representative top-level frontend bundles: entry script, a numbered lazy
+# chunk, vendors, and the .js.map / .js.LICENSE.txt sidecars — all carry the
+# ``.<hash>.`` segment and live at the deploy root, not under /assets/.
+_HASHED_BUNDLES = (
+    "/app.5ec0f3c42890e1a7.js",
+    "/493.d5c6840fa646b2c4.js",
+    "/vendors.25bbebc05765afee.js",
+    "/app.5ec0f3c42890e1a7.js.map",
+    "/app.5ec0f3c42890e1a7.js.LICENSE.txt",
+)
 
 
 def _basic_auth_header(username: str, password: str) -> str:
@@ -227,6 +246,85 @@ async def test_auth_middleware_public_prefixes_pass_through(
     resp = await client.get(path)
 
     assert resp.status == 200
+
+
+@pytest.mark.parametrize("path", _HASHED_BUNDLES)
+async def test_auth_middleware_top_level_hashed_bundle_passes_through(
+    aiohttp_client: AiohttpClient,
+    path: str,
+) -> None:
+    """Top-level content-hashed bundles load pre-auth (#1560).
+
+    ``index.html`` loads its entry script with a flat ``src``, so the
+    bundle and its lazy chunks land at the deploy root, not under
+    ``/assets/``. Without this they 401 with a password set and the SPA
+    can't boot to render the login form — the blank-screen bug.
+    """
+    db = _StubDeviceBuilder(_StubSettings(using_password=True))
+    client = await aiohttp_client(_build_app(db))
+
+    resp = await client.get(path)
+
+    assert resp.status == 200
+
+
+async def test_auth_middleware_hashed_bundle_head_passes_through(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """HEAD on a hashed bundle is allowed too (aiohttp auto-handles HEAD for GET)."""
+    db = _StubDeviceBuilder(_StubSettings(using_password=True))
+    client = await aiohttp_client(_build_app(db))
+
+    resp = await client.head("/app.5ec0f3c42890e1a7.js")
+
+    assert resp.status != 401
+
+
+async def test_auth_middleware_unhashed_top_level_path_still_gated(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A top-level path without a hash segment is not broadened into public.
+
+    Pins that the hashed-asset bypass didn't open the sensitive legacy
+    REST API (``/devices``, ``/json-config``, …) — those carry no
+    ``.<hash>.`` segment, so they still require auth.
+    """
+    db = _StubDeviceBuilder(_StubSettings(using_password=True))
+    client = await aiohttp_client(_build_app(db))
+
+    resp = await client.get("/api/anything")
+
+    assert resp.status == 401
+
+
+async def test_auth_middleware_nested_hashed_path_still_gated(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A hashed asset under a deep-link path stays gated (top-level anchor)."""
+    db = _StubDeviceBuilder(_StubSettings(using_password=True))
+    client = await aiohttp_client(_build_app(db))
+
+    resp = await client.get("/device/app.5ec0f3c42890e1a7.js")
+
+    assert resp.status == 401
+
+
+async def test_auth_middleware_non_get_hashed_path_still_gated(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Only GET/HEAD bypass — a write method to a hashed path still needs auth."""
+
+    async def _ok(_request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    db = _StubDeviceBuilder(_StubSettings(using_password=True))
+    app = _build_app(db)
+    app.router.add_post("/app.5ec0f3c42890e1a7.js", _ok)
+    client = await aiohttp_client(app)
+
+    resp = await client.post("/app.5ec0f3c42890e1a7.js")
+
+    assert resp.status == 401
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

When HTTP auth is enabled (ESPHOME_USERNAME + ESPHOME_PASSWORD), the dashboard shows a blank screen. The SPA shell loads at `/`, but the frontend's entry script and lazy chunks return 401, so the app never boots.

`index.html` loads its bundle with a flat `src`, so `app.<hash>.js` and the numbered chunks resolve to the deploy root (`/app.<hash>.js`), not under `/assets/`; the auth allowlist only covered `/assets/`, so every top-level bundle 401'd. The original intent (allowlist comment: "Frontend assets are public so the login page can load before login") was only half implemented.

This allows GET/HEAD requests to top-level content-hashed filenames through `auth_middleware`. The hash segment is what makes it safe; no API or legacy route is content addressed, so `/devices`, `/json-config`, `/compile`, `/upload`, `/api/firmware/download` stay gated. The shared `HASHED_FILENAME_RE` is the same pattern the frontend serving uses for its immutable cache headers.

Verified against a real server with a password set: `/app.<hash>.js` now returns 200 without credentials while `/devices` and `/json-config` still return 401, and a nested `/device/app.<hash>.js` stays gated.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1560

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
