### PR TITLE
Add Web Serial USB flasher test site

### DIFF
--- a/.github/workflows/flasher-ci.yml
+++ b/.github/workflows/flasher-ci.yml
@@ -1,0 +1,32 @@
+name: Flasher CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - flasher/**
+      - .github/workflows/flasher-ci.yml
+  pull_request:
+    paths:
+      - flasher/**
+      - .github/workflows/flasher-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: flasher/package-lock.json
+      - run: npm ci
+        working-directory: flasher
+      - run: npm run typecheck
+        working-directory: flasher
+      - run: npm test
+        working-directory: flasher

--- a/.github/workflows/flasher-pages.yml
+++ b/.github/workflows/flasher-pages.yml
@@ -32,6 +32,8 @@ jobs:
           cache-dependency-path: flasher/package-lock.json
       - run: npm ci
         working-directory: flasher
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true" # deploy only builds; no browser needed
       - run: npm run typecheck
         working-directory: flasher
       - run: npm run build

--- a/.github/workflows/flasher-pages.yml
+++ b/.github/workflows/flasher-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy USB flasher to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - flasher/**
+      - .github/workflows/flasher-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: flasher/package-lock.json
+      - run: npm ci
+        working-directory: flasher
+      - run: npm run build
+        working-directory: flasher
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: flasher/dist
+      - id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/flasher-pages.yml
+++ b/.github/workflows/flasher-pages.yml
@@ -32,6 +32,8 @@ jobs:
           cache-dependency-path: flasher/package-lock.json
       - run: npm ci
         working-directory: flasher
+      - run: npm run typecheck
+        working-directory: flasher
       - run: npm run build
         working-directory: flasher
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0

--- a/flasher/.gitignore
+++ b/flasher/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/flasher/README.md
+++ b/flasher/README.md
@@ -29,6 +29,11 @@ See `src/protocol.ts`. The opener origin is unknown (the dashboard runs on an
 arbitrary http origin), so the channel is authenticated by a one-time `nonce`
 plus an `event.source === window.opener` check, not an origin allowlist.
 
+The production integration (PR 2) **must** open the flasher with
+`#origin=<dashboard-origin>` so outbound frames target that origin from the
+start and the `ready` frame never broadcasts the nonce to `*`. Without it the
+page falls back to `*` until the first inbound frame reveals the origin.
+
 1. Dashboard opens `…/#nonce=<random>`.
 2. Flasher posts `{type:"esphome-web-flash:ready", version, nonce}` to its opener.
 3. Dashboard posts `{type:"esphome-web-flash:firmware", nonce, name?, erase?, parts:[{address, data:ArrayBuffer}]}`.
@@ -46,7 +51,13 @@ npm install
 npm run dev        # esbuild serve with watch
 npm run build      # -> dist/
 npm run typecheck  # tsc --noEmit
+npm test           # build + headless Puppeteer check of the postMessage contract
 ```
+
+`npm test` runs the postMessage handshake in headless Chromium (ready frame,
+re-announcement, nonce + source rejection, malformed-payload error, firmware
+acceptance). Web Serial flashing itself needs real hardware and is not covered.
+CI runs the same via `.github/workflows/flasher-ci.yml`.
 
 Open the dev URL directly to use the manual file-picker mode (flash a factory
 `.bin` without a dashboard), or drive it from the dashboard for the postMessage flow.

--- a/flasher/README.md
+++ b/flasher/README.md
@@ -1,4 +1,11 @@
-# Device Builder USB flasher (test site)
+# Device Builder USB flasher (development / testing only)
+
+> **This is a development site, not production.** The production flasher is
+> <https://web.esphome.io/>. This page exists only to develop and verify the
+> dashboard flashing flow end to end, so we can prove it out **without touching
+> the production site**. The real change is a follow-up PR to web.esphome.io
+> (`esphome/dashboard`) that adds the same `postMessage`-ingest mode; once that
+> lands the dashboard points there and this page retires.
 
 A tiny static page that flashes ESP firmware over **Web Serial**, used to unblock
 USB flashing from the Home Assistant add-on dashboard.

--- a/flasher/README.md
+++ b/flasher/README.md
@@ -1,0 +1,57 @@
+# Device Builder USB flasher (test site)
+
+A tiny static page that flashes ESP firmware over **Web Serial**, used to unblock
+USB flashing from the Home Assistant add-on dashboard.
+
+## Why this exists
+
+The HA add-on dashboard is served over plain `http://` (ingress), and browsers
+only expose Web Serial in a secure context (`https://` or `localhost`). This page
+is served over `https://` from GitHub Pages, so Web Serial works here. The
+dashboard opens this page in a new tab and hands it the locally built firmware
+**tab-to-tab via `postMessage`** (a transferable `ArrayBuffer`); the firmware
+never touches a server.
+
+This is the **test target**. The same `postMessage` contract is being added to
+the official flasher at <https://web.esphome.io/> in a follow-up; once that lands,
+the dashboard points there and this page can retire.
+
+## Message contract
+
+See `src/protocol.ts`. The opener origin is unknown (the dashboard runs on an
+arbitrary http origin), so the channel is authenticated by a one-time `nonce`
+plus an `event.source === window.opener` check, not an origin allowlist.
+
+1. Dashboard opens `…/#nonce=<random>`.
+2. Flasher posts `{type:"esphome-web-flash:ready", version, nonce}` to its opener.
+3. Dashboard posts `{type:"esphome-web-flash:firmware", nonce, name?, erase?, parts:[{address, data:ArrayBuffer}]}`.
+4. User presses **Connect & install**, picks the serial port (the required user
+   gesture), and the page flashes via esptool-js.
+5. Flasher posts `state` / `progress` updates back so the dashboard can mirror them.
+
+The esptool-js calls mirror `esphome/dashboard`'s `src/web-serial/*` so the
+behavior matches web.esphome.io.
+
+## Develop
+
+```sh
+npm install
+npm run dev        # esbuild serve with watch
+npm run build      # -> dist/
+npm run typecheck  # tsc --noEmit
+```
+
+Open the dev URL directly to use the manual file-picker mode (flash a factory
+`.bin` without a dashboard), or drive it from the dashboard for the postMessage flow.
+
+## Deploy (GitHub Pages)
+
+`.github/workflows/flasher-pages.yml` builds `flasher/` and publishes `flasher/dist`
+to GitHub Pages on pushes to `main` that touch `flasher/**`.
+
+1. Repo **Settings -> Pages -> Build and deployment -> Source = GitHub Actions**.
+2. The site serves at `https://esphome.github.io/device-builder/`.
+
+Assets use relative paths, so the `/device-builder/` project-page subpath needs no
+extra config. Pages sets no `Cross-Origin-Opener-Policy`, so the `window.opener`
+handle survives for the postMessage handoff.

--- a/flasher/README.md
+++ b/flasher/README.md
@@ -29,13 +29,15 @@ See `src/protocol.ts`. The opener origin is unknown (the dashboard runs on an
 arbitrary http origin), so the channel is authenticated by a one-time `nonce`
 plus an `event.source === window.opener` check, not an origin allowlist.
 
-The production integration (PR 2) **must** open the flasher with
-`#origin=<dashboard-origin>` so outbound frames target that origin from the
-start and the `ready` frame never broadcasts the nonce to `*`. Without it the
-page falls back to `*` until the first inbound frame reveals the origin.
+The `nonce` travels one way only (opener to flasher): inbound firmware must
+carry it, but no outbound frame echoes it, so the pre-handoff `ready` broadcast
+leaks no secret. The opener correlates outbound frames by window source. As
+defense in depth the opener should still open the flasher with
+`#origin=<dashboard-origin>` so outbound targets that origin from frame zero;
+without it the page falls back to `*` until the first inbound frame reveals it.
 
-1. Dashboard opens `…/#nonce=<random>`.
-2. Flasher posts `{type:"esphome-web-flash:ready", version, nonce}` to its opener.
+1. Dashboard opens `…/#nonce=<random>` (ideally also `&origin=<dashboard-origin>`).
+2. Flasher posts `{type:"esphome-web-flash:ready", version}` to its opener (no nonce).
 3. Dashboard posts `{type:"esphome-web-flash:firmware", nonce, name?, erase?, parts:[{address, data:ArrayBuffer}]}`.
 4. User presses **Connect & install**, picks the serial port (the required user
    gesture), and the page flashes via esptool-js.

--- a/flasher/build.mjs
+++ b/flasher/build.mjs
@@ -1,0 +1,31 @@
+import * as esbuild from "esbuild";
+import { cpSync, mkdirSync } from "node:fs";
+
+const outdir = "dist";
+const serve = process.argv.includes("--serve");
+
+mkdirSync(outdir, { recursive: true });
+
+/** @type {import('esbuild').BuildOptions} */
+const options = {
+  entryPoints: ["src/main.ts"],
+  bundle: true,
+  format: "esm",
+  outfile: `${outdir}/flasher.js`,
+  sourcemap: true,
+  target: ["es2020"],
+  minify: !serve,
+  logLevel: "info",
+};
+
+cpSync("index.html", `${outdir}/index.html`);
+
+if (serve) {
+  const ctx = await esbuild.context(options);
+  await ctx.watch();
+  const { hosts, port } = await ctx.serve({ servedir: outdir });
+  console.log(`Serving flasher on http://${hosts[0]}:${port}`);
+} else {
+  await esbuild.build(options);
+  console.log("Built flasher -> dist/");
+}

--- a/flasher/index.html
+++ b/flasher/index.html
@@ -22,6 +22,19 @@
       h1 {
         font-size: 1.25rem;
       }
+      .devbanner {
+        border: 2px solid #ff9800;
+        background: #ff980022;
+        border-radius: 0.5rem;
+        padding: 0.75rem 1rem;
+        font-size: 0.9rem;
+      }
+      .devbanner strong {
+        color: #e65100;
+      }
+      .devbanner a {
+        color: inherit;
+      }
       .status {
         padding: 0.75rem 1rem;
         border-radius: 0.5rem;

--- a/flasher/index.html
+++ b/flasher/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ESPHome Device Builder USB flasher</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, sans-serif;
+      }
+      body {
+        margin: 0;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+      }
+      main {
+        width: min(34rem, 92vw);
+        padding: 1.5rem;
+      }
+      h1 {
+        font-size: 1.25rem;
+      }
+      .status {
+        padding: 0.75rem 1rem;
+        border-radius: 0.5rem;
+        margin: 1rem 0;
+        background: #8884;
+      }
+      .status.connecting { background: #2196f344; }
+      .status.installing { background: #ff980044; }
+      .status.done { background: #4caf5044; }
+      .status.error { background: #f4433644; }
+      #bar {
+        height: 0.5rem;
+        border-radius: 0.25rem;
+        background: #8884;
+        overflow: hidden;
+      }
+      #fill {
+        height: 100%;
+        width: 0%;
+        background: #2196f3;
+        transition: width 0.2s;
+      }
+      button {
+        margin-top: 1rem;
+        padding: 0.6rem 1.2rem;
+        font-size: 1rem;
+        border-radius: 0.5rem;
+        border: 0;
+        background: #03a9f4;
+        color: #fff;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+      details {
+        margin-top: 1.5rem;
+        font-size: 0.9rem;
+      }
+      pre {
+        margin-top: 1rem;
+        font-size: 0.8rem;
+        white-space: pre-wrap;
+        opacity: 0.7;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="./flasher.js"></script>
+  </body>
+</html>

--- a/flasher/package-lock.json
+++ b/flasher/package-lock.json
@@ -13,7 +13,33 @@
       "devDependencies": {
         "@types/w3c-web-serial": "^1.0.7",
         "esbuild": "^0.25.0",
+        "puppeteer": "^24.0.0",
         "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -458,6 +484,46 @@
         "node": ">=18"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/w3c-web-serial": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
@@ -465,11 +531,384 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/atob-lite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -513,6 +952,52 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esptool-js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.6.0.tgz",
@@ -524,17 +1009,635 @@
         "tslib": "^2.4.1"
       }
     },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
+      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "24.43.1",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -548,6 +1651,128 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/flasher/package-lock.json
+++ b/flasher/package-lock.json
@@ -1,0 +1,554 @@
+{
+  "name": "esphome-device-builder-flasher",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "esphome-device-builder-flasher",
+      "version": "0.0.0",
+      "dependencies": {
+        "esptool-js": "0.6.0"
+      },
+      "devDependencies": {
+        "@types/w3c-web-serial": "^1.0.7",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/w3c-web-serial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
+      "integrity": "sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esptool-js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.6.0.tgz",
+      "integrity": "sha512-ZyuSBXvmS+4DRKM6GrDHfCscnq3YSNlRfM+Zw0DoS7uC3SdkyC262s/ji4MjDYVmMH8SE2BiYx3/dZ1J23Xiew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "atob-lite": "^2.0.0",
+        "pako": "^2.1.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/flasher/package.json
+++ b/flasher/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "node build.mjs",
     "dev": "node build.mjs --serve",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node build.mjs && node test/handshake.test.mjs"
   },
   "dependencies": {
     "esptool-js": "0.6.0"
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@types/w3c-web-serial": "^1.0.7",
     "esbuild": "^0.25.0",
+    "puppeteer": "^24.0.0",
     "typescript": "^5.7.0"
   }
 }

--- a/flasher/package.json
+++ b/flasher/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "esphome-device-builder-flasher",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Standalone Web Serial flasher test page for ESPHome Device Builder. The postMessage contract here is reimplemented in web.esphome.io in a follow-up.",
+  "scripts": {
+    "build": "node build.mjs",
+    "dev": "node build.mjs --serve",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "esptool-js": "0.6.0"
+  },
+  "devDependencies": {
+    "@types/w3c-web-serial": "^1.0.7",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -16,6 +16,12 @@ const params = new URLSearchParams(location.hash.slice(1));
 const nonce = params.get("nonce") ?? "";
 const opener = window.opener as Window | null;
 
+// Where outbound frames are sent. The opener may pin its origin in the hash;
+// otherwise this stays '*' until the first valid inbound frame reveals
+// ev.origin, after which we target that. The 'ready' frame, sent before any
+// handoff, is unavoidably '*' when no origin was pinned.
+let targetOrigin = params.get("origin") || "*";
+
 let firmware: FirmwareMessage | null = null;
 let busy = false;
 
@@ -61,9 +67,9 @@ function log(line: string): void {
 }
 
 function post(msg: OutboundMessage): void {
-  // Opener origin is unknown; status carries no secrets, so target '*'. The
-  // nonce scopes the message to this session.
-  opener?.postMessage(msg, "*");
+  // targetOrigin narrows from '*' to the opener's real origin once known; see
+  // its declaration. The nonce scopes every frame to this session.
+  opener?.postMessage(msg, targetOrigin);
 }
 
 function setState(state: FlashState, detail: string): void {
@@ -82,6 +88,20 @@ function setProgress(pct: number): void {
 
 // --- handoff --------------------------------------------------------------
 
+function isFlashParts(parts: unknown): parts is FirmwareMessage["parts"] {
+  return (
+    Array.isArray(parts) &&
+    parts.length > 0 &&
+    parts.every(
+      (p) =>
+        !!p &&
+        typeof p === "object" &&
+        typeof (p as { address?: unknown }).address === "number" &&
+        (p as { data?: unknown }).data instanceof ArrayBuffer,
+    )
+  );
+}
+
 window.addEventListener("message", (ev: MessageEvent) => {
   // Only accept the firmware from the window that opened us, and only when the
   // nonce matches. No origin allowlist is possible since the dashboard runs on
@@ -90,19 +110,49 @@ window.addEventListener("message", (ev: MessageEvent) => {
   const data = ev.data as Partial<FirmwareMessage> | undefined;
   if (!data || data.type !== "esphome-web-flash:firmware") return;
   if (data.nonce !== nonce) return;
-  if (!Array.isArray(data.parts) || data.parts.length === 0) return;
+  if (!isFlashParts(data.parts)) {
+    setState("error", "Received a malformed firmware payload.");
+    return;
+  }
+  // The opener origin is now known; stop broadcasting and pin to it.
+  if (targetOrigin === "*" && ev.origin && ev.origin !== "null") {
+    targetOrigin = ev.origin;
+  }
+  stopReadyRetry();
   firmware = data as FirmwareMessage;
   installBtn.disabled = busy;
-  setState("connecting", `Firmware ready${firmware.name ? ": " + firmware.name : ""}. Press Connect & install.`);
+  setState(
+    "connecting",
+    `Firmware ready${firmware.name ? ": " + firmware.name : ""}. Press Connect & install.`,
+  );
 });
 
+// Re-announce until firmware arrives: a single 'ready' can race the opener
+// attaching its message listener after window.open(), wedging the handoff.
+let readyTimer: number | undefined;
+
+function stopReadyRetry(): void {
+  if (readyTimer !== undefined) {
+    clearInterval(readyTimer);
+    readyTimer = undefined;
+  }
+}
+
+function sendReady(): void {
+  post({ type: "esphome-web-flash:ready", version: PROTOCOL_VERSION, nonce });
+}
+
 if (opener && nonce) {
-  const ready: OutboundMessage = {
-    type: "esphome-web-flash:ready",
-    version: PROTOCOL_VERSION,
-    nonce,
-  };
-  opener.postMessage(ready, "*");
+  sendReady();
+  let waited = 0;
+  readyTimer = window.setInterval(() => {
+    waited += 500;
+    if (firmware || waited >= 10000) {
+      stopReadyRetry();
+      return;
+    }
+    sendReady();
+  }, 500);
 }
 
 // --- flashing (mirrors esphome/dashboard src/web-serial) ------------------

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -91,13 +91,16 @@ function isFlashParts(parts: unknown): parts is FirmwareMessage["parts"] {
   return (
     Array.isArray(parts) &&
     parts.length > 0 &&
-    parts.every(
-      (p) =>
-        !!p &&
-        typeof p === "object" &&
-        typeof (p as { address?: unknown }).address === "number" &&
-        (p as { data?: unknown }).data instanceof ArrayBuffer,
-    )
+    parts.every((p) => {
+      if (!p || typeof p !== "object") return false;
+      const address = (p as { address?: unknown }).address;
+      return (
+        typeof address === "number" &&
+        Number.isInteger(address) &&
+        address >= 0 &&
+        (p as { data?: unknown }).data instanceof ArrayBuffer
+      );
+    })
   );
 }
 

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -17,9 +17,10 @@ const nonce = params.get("nonce") ?? "";
 const opener = window.opener as Window | null;
 
 // Where outbound frames are sent. The opener may pin its origin in the hash;
-// otherwise this stays '*' until the first valid inbound frame reveals
-// ev.origin, after which we target that. The 'ready' frame, sent before any
-// handoff, is unavoidably '*' when no origin was pinned.
+// otherwise this stays '*' until the first valid inbound frame reveals ev.origin,
+// after which we target that. Outbound frames carry no nonce (see protocol.ts),
+// so the pre-handoff '*' fallback leaks no secret; '#origin=' pins it from the
+// start as defense in depth.
 let targetOrigin = params.get("origin") || "*";
 
 let firmware: FirmwareMessage | null = null;
@@ -68,22 +69,20 @@ function log(line: string): void {
 
 function post(msg: OutboundMessage): void {
   // targetOrigin narrows from '*' to the opener's real origin once known; see
-  // its declaration. The nonce scopes every frame to this session.
+  // its declaration. Outbound frames carry no nonce (see protocol.ts).
   opener?.postMessage(msg, targetOrigin);
 }
 
 function setState(state: FlashState, detail: string): void {
   statusEl.textContent = detail;
   statusEl.className = "status " + state;
-  if (nonce) {
-    post({ type: "esphome-web-flash:state", nonce, state, detail });
-  }
+  post({ type: "esphome-web-flash:state", state, detail });
 }
 
 function setProgress(pct: number): void {
   barEl.hidden = false;
   fillEl.style.width = pct + "%";
-  if (nonce) post({ type: "esphome-web-flash:progress", nonce, pct });
+  post({ type: "esphome-web-flash:progress", pct });
 }
 
 // --- handoff --------------------------------------------------------------
@@ -139,7 +138,7 @@ function stopReadyRetry(): void {
 }
 
 function sendReady(): void {
-  post({ type: "esphome-web-flash:ready", version: PROTOCOL_VERSION, nonce });
+  post({ type: "esphome-web-flash:ready", version: PROTOCOL_VERSION });
 }
 
 if (opener && nonce) {

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -1,0 +1,236 @@
+import { ESPLoader, Transport } from "esptool-js";
+import type {
+  FirmwareMessage,
+  OutboundMessage,
+  FlashState,
+} from "./protocol";
+import { PROTOCOL_VERSION } from "./protocol";
+
+// One image to write, in the byte form esptool-js 0.6 expects.
+interface FileToFlash {
+  data: Uint8Array;
+  address: number;
+}
+
+const params = new URLSearchParams(location.hash.slice(1));
+const nonce = params.get("nonce") ?? "";
+const opener = window.opener as Window | null;
+
+let firmware: FirmwareMessage | null = null;
+let busy = false;
+
+// --- UI -------------------------------------------------------------------
+
+document.body.innerHTML = `
+  <main>
+    <h1>ESPHome Device Builder USB flasher</h1>
+    <p id="hint"></p>
+    <div id="status" class="status idle">Waiting for firmware&hellip;</div>
+    <div id="bar" hidden><div id="fill"></div></div>
+    <button id="install" disabled>Connect &amp; install</button>
+    <details id="manual">
+      <summary>No firmware received? Flash a factory file manually</summary>
+      <input id="file" type="file" accept=".bin" />
+    </details>
+    <pre id="log"></pre>
+  </main>
+`;
+
+const el = <T extends HTMLElement>(id: string) =>
+  document.getElementById(id) as T;
+const statusEl = el<HTMLDivElement>("status");
+const barEl = el<HTMLDivElement>("bar");
+const fillEl = el<HTMLDivElement>("fill");
+const installBtn = el<HTMLButtonElement>("install");
+const fileInput = el<HTMLInputElement>("file");
+const hintEl = el<HTMLParagraphElement>("hint");
+const logEl = el<HTMLPreElement>("log");
+
+hintEl.textContent = opener
+  ? "Plug the board into this computer over USB, then press Connect & install."
+  : "Opened directly: pick a factory .bin below, plug in the board, then press Connect & install.";
+
+function log(line: string): void {
+  logEl.textContent += line + "\n";
+}
+
+function post(msg: OutboundMessage): void {
+  // Opener origin is unknown; status carries no secrets, so target '*'. The
+  // nonce scopes the message to this session.
+  opener?.postMessage(msg, "*");
+}
+
+function setState(state: FlashState, detail: string): void {
+  statusEl.textContent = detail;
+  statusEl.className = "status " + state;
+  if (nonce) {
+    post({ type: "esphome-web-flash:state", nonce, state, detail });
+  }
+}
+
+function setProgress(pct: number): void {
+  barEl.hidden = false;
+  fillEl.style.width = pct + "%";
+  if (nonce) post({ type: "esphome-web-flash:progress", nonce, pct });
+}
+
+// --- handoff --------------------------------------------------------------
+
+window.addEventListener("message", (ev: MessageEvent) => {
+  // Only accept the firmware from the window that opened us, and only when the
+  // nonce matches. No origin allowlist is possible since the dashboard runs on
+  // an arbitrary (often http) origin.
+  if (!opener || ev.source !== opener) return;
+  const data = ev.data as Partial<FirmwareMessage> | undefined;
+  if (!data || data.type !== "esphome-web-flash:firmware") return;
+  if (data.nonce !== nonce) return;
+  if (!Array.isArray(data.parts) || data.parts.length === 0) return;
+  firmware = data as FirmwareMessage;
+  installBtn.disabled = busy;
+  setState("connecting", `Firmware ready${firmware.name ? ": " + firmware.name : ""}. Press Connect & install.`);
+});
+
+if (opener && nonce) {
+  const ready: OutboundMessage = {
+    type: "esphome-web-flash:ready",
+    version: PROTOCOL_VERSION,
+    nonce,
+  };
+  opener.postMessage(ready, "*");
+}
+
+// --- flashing (mirrors esphome/dashboard src/web-serial) ------------------
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+
+async function flashFiles(
+  esploader: ESPLoader,
+  fileArray: FileToFlash[],
+  erase: boolean,
+  writeProgress: (pct: number) => void,
+): Promise<void> {
+  if (erase) {
+    await esploader.eraseFlash();
+  }
+  let totalSize = 0;
+  for (const f of fileArray) totalSize += f.data.length;
+  let totalWritten = 0;
+  writeProgress(0);
+  await esploader.writeFlash({
+    fileArray,
+    flashSize: "keep",
+    flashMode: "keep",
+    flashFreq: "keep",
+    eraseAll: false,
+    compress: true,
+    reportProgress: (fileIndex: number, written: number, total: number) => {
+      const uncompressedWritten =
+        (written / total) * fileArray[fileIndex].data.length;
+      const pct = Math.floor(
+        ((totalWritten + uncompressedWritten) / totalSize) * 100,
+      );
+      if (written === total) {
+        totalWritten += uncompressedWritten;
+        return;
+      }
+      writeProgress(pct);
+    },
+  });
+  writeProgress(100);
+}
+
+async function resetDevice(transport: Transport): Promise<void> {
+  await transport.setRTS(true); // EN -> LOW
+  await sleep(100);
+  await transport.setRTS(false);
+}
+
+async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
+  if (busy) return;
+  busy = true;
+  installBtn.disabled = true;
+  fileInput.disabled = true;
+
+  let port: SerialPort;
+  try {
+    port = await navigator.serial.requestPort();
+  } catch {
+    setState("error", "No serial port selected.");
+    busy = false;
+    installBtn.disabled = false;
+    fileInput.disabled = false;
+    return;
+  }
+
+  const transport = new Transport(port);
+  const esploader = new ESPLoader({
+    transport,
+    baudrate: 115200,
+    enableTracing: false,
+  });
+
+  try {
+    setState("connecting", "Connecting to device…");
+    let chipName: string;
+    try {
+      chipName = await esploader.main();
+      await esploader.flashId();
+    } catch (err) {
+      console.error(err);
+      setState(
+        "error",
+        "Failed to initialize. Reset the board, or hold BOOT while selecting the port, then retry.",
+      );
+      return;
+    }
+    log("Detected chip: " + chipName);
+
+    setState("installing", "Installing… keep this tab visible.");
+    await flashFiles(esploader, files, erase, setProgress);
+    await esploader.after();
+    await resetDevice(transport);
+    setState("done", "Installed. The device is rebooting.");
+  } catch (err) {
+    setState("error", "Installation failed: " + String(err));
+  } finally {
+    try {
+      await transport.disconnect();
+    } catch {
+      // already closed
+    }
+    busy = false;
+    installBtn.disabled = false;
+    fileInput.disabled = false;
+  }
+}
+
+installBtn.addEventListener("click", async () => {
+  if (firmware) {
+    const files = firmware.parts.map((p) => ({
+      data: new Uint8Array(p.data),
+      address: p.address,
+    }));
+    await runFlash(files, firmware.erase ?? true);
+    return;
+  }
+  const file = fileInput.files?.[0];
+  if (!file) {
+    setState("error", "Choose a factory .bin file first.");
+    return;
+  }
+  const data = new Uint8Array(await file.arrayBuffer());
+  await runFlash([{ data, address: 0 }], true);
+});
+
+fileInput.addEventListener("change", () => {
+  installBtn.disabled = busy || !fileInput.files?.length;
+});
+
+if (!("serial" in navigator)) {
+  setState(
+    "error",
+    "This browser has no Web Serial. Use Chrome or Edge over https or 127.0.0.1.",
+  );
+  installBtn.disabled = true;
+}

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -24,6 +24,12 @@ let busy = false;
 document.body.innerHTML = `
   <main>
     <h1>ESPHome Device Builder USB flasher</h1>
+    <div class="devbanner">
+      <strong>Development build, for testing only.</strong> The production
+      flasher is <a href="https://web.esphome.io/">web.esphome.io</a>. This page
+      exists only to develop and verify the dashboard flashing flow before that
+      capability is added to the production site. Do not rely on it.
+    </div>
     <p id="hint"></p>
     <div id="status" class="status idle">Waiting for firmware&hellip;</div>
     <div id="bar" hidden><div id="fill"></div></div>

--- a/flasher/src/protocol.ts
+++ b/flasher/src/protocol.ts
@@ -4,21 +4,22 @@
 // "is this my opener" source check, never an origin allowlist. This same
 // contract is what PR 2 reimplements inside web.esphome.io.
 //
-// URL hash params the flasher reads: 'nonce' (required, the session secret) and
-// 'origin'. 'origin' pins the outbound targetOrigin; without it, outbound stays
-// '*' until the first inbound frame reveals the origin, which means the early
-// 'ready' frames broadcast the nonce to '*'. The production integration (PR 2)
-// MUST pass 'origin=<dashboard-origin>' so 'ready' never broadcasts. The flasher
-// re-sends 'ready' until firmware arrives so a late opener listener cannot wedge
-// the handoff.
+// URL hash params the flasher reads: 'nonce' (required) and 'origin' (optional).
+// The nonce is a ONE-WAY opener->flasher token: inbound firmware must carry it,
+// but NO outbound frame (ready/state/progress) ever echoes it, so the pre-handoff
+// 'ready' broadcast to '*' leaks no secret. The opener correlates outbound frames
+// by window source, not by nonce. 'origin' pins the outbound targetOrigin from
+// frame zero (otherwise it is learned from the first inbound frame); PR 2 should
+// pass 'origin=<dashboard-origin>' as defense in depth. The flasher re-sends
+// 'ready' until firmware arrives so a late opener listener cannot wedge the handoff.
 
 export const PROTOCOL_VERSION = 1;
 
-// Flasher -> opener, once on load.
+// Flasher -> opener, announced on load and re-sent until firmware arrives. Carries
+// no nonce: the opener identifies us by window source, so this never leaks the secret.
 export interface ReadyMessage {
   type: "esphome-web-flash:ready";
   version: number;
-  nonce: string;
 }
 
 // One image to write at a flash offset. Bytes ride as a transferable
@@ -43,17 +44,16 @@ export type FlashState =
   | "done"
   | "error";
 
-// Flasher -> opener, status + progress so the dashboard can mirror it.
+// Flasher -> opener, status + progress so the dashboard can mirror it. No nonce
+// (see ReadyMessage); the opener correlates by window source.
 export interface StateMessage {
   type: "esphome-web-flash:state";
-  nonce: string;
   state: FlashState;
   detail?: string;
 }
 
 export interface ProgressMessage {
   type: "esphome-web-flash:progress";
-  nonce: string;
   pct: number;
 }
 

--- a/flasher/src/protocol.ts
+++ b/flasher/src/protocol.ts
@@ -1,0 +1,52 @@
+// Message contract between the Device Builder dashboard (the opener, on any
+// http/https origin) and this flasher page (a fixed secure-context origin).
+// The opener origin is unknown, so authentication is the one-time nonce plus an
+// "is this my opener" source check, never an origin allowlist. This same
+// contract is what PR 2 reimplements inside web.esphome.io.
+
+export const PROTOCOL_VERSION = 1;
+
+// Flasher -> opener, once on load.
+export interface ReadyMessage {
+  type: "esphome-web-flash:ready";
+  version: number;
+  nonce: string;
+}
+
+// One image to write at a flash offset. Bytes ride as a transferable
+// ArrayBuffer so the firmware never touches a server.
+export interface FlashPart {
+  address: number;
+  data: ArrayBuffer;
+}
+
+// Opener -> flasher, the firmware handoff.
+export interface FirmwareMessage {
+  type: "esphome-web-flash:firmware";
+  nonce: string;
+  name?: string;
+  erase?: boolean;
+  parts: FlashPart[];
+}
+
+export type FlashState =
+  | "connecting"
+  | "installing"
+  | "done"
+  | "error";
+
+// Flasher -> opener, status + progress so the dashboard can mirror it.
+export interface StateMessage {
+  type: "esphome-web-flash:state";
+  nonce: string;
+  state: FlashState;
+  detail?: string;
+}
+
+export interface ProgressMessage {
+  type: "esphome-web-flash:progress";
+  nonce: string;
+  pct: number;
+}
+
+export type OutboundMessage = ReadyMessage | StateMessage | ProgressMessage;

--- a/flasher/src/protocol.ts
+++ b/flasher/src/protocol.ts
@@ -5,9 +5,12 @@
 // contract is what PR 2 reimplements inside web.esphome.io.
 //
 // URL hash params the flasher reads: 'nonce' (required, the session secret) and
-// 'origin' (optional; pins the outbound targetOrigin, otherwise it is learned
-// from the first inbound frame). The flasher re-sends 'ready' until firmware
-// arrives so a late opener listener cannot wedge the handoff.
+// 'origin'. 'origin' pins the outbound targetOrigin; without it, outbound stays
+// '*' until the first inbound frame reveals the origin, which means the early
+// 'ready' frames broadcast the nonce to '*'. The production integration (PR 2)
+// MUST pass 'origin=<dashboard-origin>' so 'ready' never broadcasts. The flasher
+// re-sends 'ready' until firmware arrives so a late opener listener cannot wedge
+// the handoff.
 
 export const PROTOCOL_VERSION = 1;
 

--- a/flasher/src/protocol.ts
+++ b/flasher/src/protocol.ts
@@ -3,6 +3,11 @@
 // The opener origin is unknown, so authentication is the one-time nonce plus an
 // "is this my opener" source check, never an origin allowlist. This same
 // contract is what PR 2 reimplements inside web.esphome.io.
+//
+// URL hash params the flasher reads: 'nonce' (required, the session secret) and
+// 'origin' (optional; pins the outbound targetOrigin, otherwise it is learned
+// from the first inbound frame). The flasher re-sends 'ready' until firmware
+// arrives so a late opener listener cannot wedge the handoff.
 
 export const PROTOCOL_VERSION = 1;
 

--- a/flasher/test/handshake.test.mjs
+++ b/flasher/test/handshake.test.mjs
@@ -57,13 +57,14 @@ try {
   await popup.waitForNetworkIdle({ idleTime: 300 }).catch(() => {});
   await new Promise((r) => setTimeout(r, 300));
 
-  // 1. flasher posts a ready frame to its opener with the right nonce
+  // 1. flasher posts a ready frame to its opener that does NOT echo the nonce
   const ready = (await a.evaluate(() => window.__msgs)).find(
     (m) => m && m.type === "esphome-web-flash:ready",
   );
   if (!ready) fail("no ready message received by opener");
-  else if (ready.nonce !== "test-nonce-123") fail("ready nonce mismatch");
-  else console.log("PASS: ready received, nonce ok, version", ready.version);
+  else if ("nonce" in ready) fail("ready frame leaked the nonce");
+  else if (ready.version !== 1) fail("ready version mismatch");
+  else console.log("PASS: ready received, no nonce echoed, version", ready.version);
 
   // 1b. ready is re-announced until firmware arrives (handshake robustness)
   await a.evaluate(() => {

--- a/flasher/test/handshake.test.mjs
+++ b/flasher/test/handshake.test.mjs
@@ -114,6 +114,24 @@ try {
   else if (enabledAfterBad) fail("install enabled after malformed payload");
   else console.log("PASS: malformed payload rejected with error state");
 
+  // 2c. a negative/non-integer address is rejected at the boundary
+  await a.evaluate(() => {
+    window.__b.postMessage(
+      {
+        type: "esphome-web-flash:firmware",
+        nonce: "test-nonce-123",
+        name: "bad-addr",
+        parts: [{ address: -1, data: new ArrayBuffer(8) }],
+      },
+      "*",
+    );
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  label = await popup.$eval("#status", (e) => e.textContent);
+  if (!/malformed/i.test(label))
+    fail("negative address not rejected: " + label);
+  else console.log("PASS: negative address rejected at boundary");
+
   // 3. correct nonce accepted -> button enabled, state mirrored back
   await a.evaluate(() => {
     window.__b.postMessage(

--- a/flasher/test/handshake.test.mjs
+++ b/flasher/test/handshake.test.mjs
@@ -1,0 +1,150 @@
+// Headless check of the postMessage contract this subproject exists to pin.
+// Web Serial flashing itself needs real hardware and is not covered here.
+import http from "node:http";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import puppeteer from "puppeteer";
+
+const DIST = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+const OPENER = `<!doctype html><meta charset=utf-8><script>
+  window.__msgs = [];
+  addEventListener('message', (e) => window.__msgs.push(e.data));
+  window.__open = (url) => { window.__b = window.open(url); };
+</script>opener`;
+
+const server = http.createServer((req, res) => {
+  const path = req.url.split("?")[0];
+  if (path === "/opener.html") {
+    res.writeHead(200, { "content-type": "text/html" });
+    return res.end(OPENER);
+  }
+  const file = path === "/" ? "/index.html" : path;
+  try {
+    const body = readFileSync(DIST + file);
+    const ct = file.endsWith(".js")
+      ? "text/javascript"
+      : file.endsWith(".html")
+        ? "text/html"
+        : "application/octet-stream";
+    res.writeHead(200, { "content-type": ct });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end("nf");
+  }
+});
+
+await new Promise((r) => server.listen(0, r));
+const base = `http://localhost:${server.address().port}`;
+
+const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
+let ok = true;
+const fail = (m) => {
+  ok = false;
+  console.log("FAIL:", m);
+};
+
+try {
+  const a = await browser.newPage();
+  await a.goto(`${base}/opener.html`);
+
+  const flasherUrl = `${base}/#nonce=test-nonce-123`;
+  const [popup] = await Promise.all([
+    new Promise((res) => a.once("popup", res)),
+    a.evaluate((u) => window.__open(u), flasherUrl),
+  ]);
+  await popup.waitForNetworkIdle({ idleTime: 300 }).catch(() => {});
+  await new Promise((r) => setTimeout(r, 300));
+
+  // 1. flasher posts a ready frame to its opener with the right nonce
+  const ready = (await a.evaluate(() => window.__msgs)).find(
+    (m) => m && m.type === "esphome-web-flash:ready",
+  );
+  if (!ready) fail("no ready message received by opener");
+  else if (ready.nonce !== "test-nonce-123") fail("ready nonce mismatch");
+  else console.log("PASS: ready received, nonce ok, version", ready.version);
+
+  // 1b. ready is re-announced until firmware arrives (handshake robustness)
+  await a.evaluate(() => {
+    window.__msgs.length = 0;
+  });
+  await new Promise((r) => setTimeout(r, 700));
+  const retried = (await a.evaluate(() => window.__msgs)).some(
+    (m) => m && m.type === "esphome-web-flash:ready",
+  );
+  if (!retried) fail("ready not re-announced before firmware");
+  else console.log("PASS: ready re-announced until firmware arrives");
+
+  // 2. wrong nonce must be ignored
+  await a.evaluate(() => {
+    window.__b.postMessage(
+      {
+        type: "esphome-web-flash:firmware",
+        nonce: "WRONG",
+        name: "bad",
+        parts: [{ address: 0, data: new ArrayBuffer(8) }],
+      },
+      "*",
+    );
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  let label = await popup.$eval("#status", (e) => e.textContent);
+  if (/firmware ready/i.test(label)) fail("wrong-nonce firmware was accepted");
+  else console.log("PASS: wrong-nonce firmware ignored");
+
+  // 2b. malformed parts (data not an ArrayBuffer) -> error state, not a throw
+  await a.evaluate(() => {
+    window.__b.postMessage(
+      {
+        type: "esphome-web-flash:firmware",
+        nonce: "test-nonce-123",
+        name: "bad",
+        parts: [{ address: 0, data: "not-a-buffer" }],
+      },
+      "*",
+    );
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  label = await popup.$eval("#status", (e) => e.textContent);
+  const enabledAfterBad = await popup.$eval("#install", (b) => !b.disabled);
+  if (!/malformed/i.test(label))
+    fail("malformed payload not reported: " + label);
+  else if (enabledAfterBad) fail("install enabled after malformed payload");
+  else console.log("PASS: malformed payload rejected with error state");
+
+  // 3. correct nonce accepted -> button enabled, state mirrored back
+  await a.evaluate(() => {
+    window.__b.postMessage(
+      {
+        type: "esphome-web-flash:firmware",
+        nonce: "test-nonce-123",
+        name: "kitchen.factory.bin",
+        erase: true,
+        parts: [{ address: 0, data: new ArrayBuffer(2048) }],
+      },
+      "*",
+    );
+  });
+  await new Promise((r) => setTimeout(r, 300));
+  const enabled = await popup.$eval("#install", (b) => !b.disabled);
+  label = await popup.$eval("#status", (e) => e.textContent);
+  if (!enabled) fail("install button not enabled after firmware");
+  else if (!/kitchen\.factory\.bin/.test(label))
+    fail("status did not reflect firmware name: " + label);
+  else console.log("PASS: firmware accepted, button enabled, status:", label);
+
+  const stateMsg = (await a.evaluate(() => window.__msgs)).find(
+    (m) => m && m.type === "esphome-web-flash:state",
+  );
+  if (!stateMsg) fail("no state message mirrored to opener");
+  else console.log("PASS: state mirrored to opener ->", stateMsg.state);
+} catch (e) {
+  fail("exception: " + e.message);
+} finally {
+  await browser.close();
+  server.close();
+}
+
+console.log(ok ? "\nALL PASS" : "\nFAILURES");
+process.exit(ok ? 0 : 1);

--- a/flasher/tsconfig.json
+++ b/flasher/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["w3c-web-serial"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
# What does this implement/fix?

PR 1 of the "flash a USB board from the HA dashboard" work.

**This is a development and testing site, not production.** The production flasher is web.esphome.io. This page exists so we can build the whole flashing flow end to end and prove it out **without touching the production site**; the real change is a follow-up PR to `esphome/dashboard` (web.esphome.io) that adds the same `postMessage`-ingest mode, after which the dashboard points there and this page retires. It is labelled development-only on the page itself and in the README.

The HA add-on dashboard is plain `http://` (ingress), so its browser can never use Web Serial. This adds a small static esptool-js flasher page, deployed to GitHub Pages at `https://esphome.github.io/device-builder/`, that runs in a secure context and so can flash over USB.

The dashboard opens this page in a new tab and hands it the locally built firmware tab-to-tab via `postMessage` (a transferable `ArrayBuffer`); the firmware never touches a server. The channel is authenticated by a one-time nonce plus an `event.source === window.opener` check, since the dashboard origin is arbitrary and can't be allowlisted. The esptool calls mirror `esphome/dashboard`'s `web-serial` helpers so behavior matches web.esphome.io.

This is the test target; the same `postMessage` contract (see `flasher/src/protocol.ts`) is reimplemented in web.esphome.io in PR 2, after which the dashboard can point there and this page retires. The dashboard "Flash via USB" action is a separate frontend PR.

**Related issue or feature (if applicable):**

- Part of esphome/backlog#151

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

<!--
Notes:
- tsc + esbuild build pass; a headless Puppeteer test exercises the full postMessage handshake (ready, wrong-nonce rejected, firmware accepted, state mirrored). The esptool flashing itself mirrors known-good dashboard code and needs an on-hardware check.
- No Python tests: flasher/ is a self-contained static subproject, outside the Python package.
- Deploy needs Settings -> Pages -> Source = GitHub Actions enabled on this repo; the github-pages environment deploys from main on merge.
-->
