### PR TITLE
Gate clearing secrets.yaml behind an allow_wipe confirm

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -117,7 +117,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `devices/list_archived` | — | `[{configuration, name, friendly_name, comment}]` | List archived devices for the dashboard's archived-devices dialog. |
 | `devices/delete_archived` | `{configuration}` | — | Permanently delete an archived YAML and its sidecars. The companion to `unarchive` for "I really don't want this back". |
 | `devices/get_config` | `{configuration}` | `string` | Read device YAML config |
-| `devices/update_config` | `{configuration, content}` | — | Write device YAML config |
+| `devices/update_config` | `{configuration, content, allow_wipe?}` | — | Write device YAML config; `allow_wipe` confirms clearing secrets.yaml |
 | `devices/add_component` | `{configuration, component_id, fields?, sub_entities?, yaml?}` | `AddComponentResponse` | Add component to device config. Optional `yaml` is the editor's unsaved draft — merge into it and return the result **without** persisting (the editor saves it, like `automations/upsert`); omit to merge the on-disk YAML and persist. |
 | `devices/import` | `{name, project_name?, package_import_url?, ...}` | `dict` | Import/adopt discovered device |
 | `devices/ignore` | `{name, ignore?}` | — | Toggle device visibility |

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -650,15 +650,25 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found") from err
 
     @api_command("devices/update_config")
-    async def update_config(self, *, configuration: str, content: str, **kwargs: Any) -> None:
-        """Write device config YAML."""
-        if not content.strip():
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                f"refusing to write empty content to {configuration!r} to prevent "
-                "accidental data loss; use the delete action to remove a file",
-            )
+    async def update_config(
+        self, *, configuration: str, content: str, allow_wipe: bool = False, **kwargs: Any
+    ) -> None:
+        """
+        Write device config YAML.
+
+        ``allow_wipe`` permits clearing secrets.yaml to empty; without it an
+        empty secrets save is refused. An empty device YAML is always refused.
+        """
+        if not isinstance(allow_wipe, bool):
+            raise CommandError(ErrorCode.INVALID_ARGS, "allow_wipe must be a boolean")
+        is_empty = not content.strip()
         if is_secrets_file(configuration):
+            if is_empty and not allow_wipe:
+                raise CommandError(
+                    ErrorCode.INVALID_ARGS,
+                    "refusing to clear all secrets from secrets.yaml without "
+                    "confirmation; pass allow_wipe to confirm",
+                )
             try:
                 validate_secrets_content(content, self._db.settings.rel_path(configuration))
             except SecretsContentError as err:
@@ -674,6 +684,12 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
                     configuration, content, message=f"Edit {configuration}"
                 )
             return
+        if is_empty:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                f"refusing to write empty content to {configuration!r} to prevent "
+                "accidental data loss; use the delete action to remove a file",
+            )
         await self._persist_yaml_mutation(configuration, content, message=f"Edit {configuration}")
 
     async def apply_restored_yaml(

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -257,10 +257,11 @@ async def test_update_config_writes_before_requesting_reload(
     assert yaml_path.read_text(encoding="utf-8") == new_content
 
 
-async def test_update_config_refuses_empty_content(
-    tmp_path: Path, make_controller: MakeControllerFactory
+@pytest.mark.parametrize("content", ["", "  \n\t\n"])
+async def test_update_config_refuses_blank_secrets_without_allow_wipe(
+    tmp_path: Path, make_controller: MakeControllerFactory, content: str
 ) -> None:
-    """Empty content raises ``INVALID_ARGS``; file and side effects untouched."""
+    """Clearing secrets.yaml without ``allow_wipe`` raises ``INVALID_ARGS``; file untouched."""
     controller = make_controller(tmp_path)
     regenerated = _stub_regenerate(controller)
     target = tmp_path / "secrets.yaml"
@@ -268,7 +269,7 @@ async def test_update_config_refuses_empty_content(
     target.write_text(original, encoding="utf-8")
 
     with pytest.raises(CommandError) as excinfo:
-        await controller.update_config(configuration="secrets.yaml", content="")
+        await controller.update_config(configuration="secrets.yaml", content=content)
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
     assert target.read_text(encoding="utf-8") == original
@@ -276,23 +277,57 @@ async def test_update_config_refuses_empty_content(
     assert controller._scanner.calls == []
 
 
-async def test_update_config_refuses_whitespace_only_content(
+@pytest.mark.parametrize("content", ["", "   \n\n"])
+async def test_update_config_wipes_secrets_with_allow_wipe(
+    tmp_path: Path, make_controller: MakeControllerFactory, content: str
+) -> None:
+    """``allow_wipe=True`` clears secrets.yaml (the confirmed destructive save)."""
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    target = tmp_path / "secrets.yaml"
+    target.write_text("wifi_password: hunter2\n", encoding="utf-8")
+
+    await controller.update_config(configuration="secrets.yaml", content=content, allow_wipe=True)
+
+    assert target.read_text(encoding="utf-8") == content
+
+
+async def test_update_config_refuses_empty_device_yaml_even_with_allow_wipe(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """Whitespace-only content raises ``INVALID_ARGS``; file and side effects untouched."""
+    """``allow_wipe`` is secrets-scoped; an empty device YAML is still refused."""
     controller = make_controller(tmp_path)
     regenerated = _stub_regenerate(controller)
-    target = tmp_path / "secrets.yaml"
-    original = "wifi_password: hunter2\n"
+    target = tmp_path / "kitchen.yaml"
+    original = "esphome:\n  name: kitchen\n"
     target.write_text(original, encoding="utf-8")
 
     with pytest.raises(CommandError) as excinfo:
-        await controller.update_config(configuration="secrets.yaml", content="  \n\t\n")
+        await controller.update_config(configuration="kitchen.yaml", content="", allow_wipe=True)
 
     assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "delete action" in excinfo.value.message
     assert target.read_text(encoding="utf-8") == original
     assert regenerated == []
     assert controller._scanner.calls == []
+
+
+async def test_update_config_rejects_non_bool_allow_wipe(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A non-boolean ``allow_wipe`` is rejected with ``INVALID_ARGS``."""
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+
+    with pytest.raises(CommandError) as excinfo:
+        await controller.update_config(
+            configuration="secrets.yaml",
+            content="",
+            allow_wipe="yes",  # type: ignore[arg-type]
+        )
+
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert "allow_wipe" in excinfo.value.message
 
 
 async def test_update_config_writes_valid_secrets_yaml(


### PR DESCRIPTION
# What does this implement/fix?

Removing the last secret saved an empty secrets.yaml, which the empty-content guard refused with "use the delete action to remove a file"; that advice is impossible since secrets.yaml is a singleton file, not a device.

The guard is intentional (it stops you wiping every secret by accident), so this keeps it but makes the wipe confirmable. `devices/update_config` gains `allow_wipe`; an empty secrets.yaml is accepted only when `allow_wipe` is passed, otherwise it returns a secrets-specific message. Device YAML is unchanged; `allow_wipe` is scoped to secrets. The frontend gates `allow_wipe` behind a destructive confirm dialog (companion PR below).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1568

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend (branch fix-clear-last-secret; gates allow_wipe behind a destructive confirm dialog)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
