### PR TITLE
Surface the receiver's reject detail on download_artifacts failures

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -287,7 +287,8 @@ class ArtifactsDownloadSender:
     async def _send_reject(
         self, session: PeerLinkSession, job_id: str, reason: str, *, detail: str = ""
     ) -> None:
-        """Send a single ``artifacts_end{accepted: false, reason}`` and return.
+        """
+        Send a single ``artifacts_end{accepted: false, reason}`` and return.
 
         *detail* (capped) rides on the frame when given so the offloader can
         show the exact missing artefact path instead of just the coarse reason.

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -103,6 +103,10 @@ _REASON_JOB_NOT_COMPLETED = "job_not_completed"
 _REASON_BUILD_DIR_MISSING = "build_dir_missing"
 _REASON_PACK_FAILED = "pack_failed"
 
+# Cap the operator-facing reject ``detail`` (a build-server path / exception
+# message) so a pathological configuration string can't bloat the frame.
+_MAX_REJECT_DETAIL = 256
+
 
 # Required-field shape on the peer-controlled inbound frame.
 # ``parse_app_frame`` confirms the JSON parses to a dict, but
@@ -263,29 +267,39 @@ class ArtifactsDownloadSender:
                     firmware_job.configuration,
                     exc,
                 )
-                await self._send_reject(session, job_id, _REASON_BUILD_DIR_MISSING)
+                await self._send_reject(session, job_id, _REASON_BUILD_DIR_MISSING, detail=str(exc))
                 return
-            except Exception:
+            except Exception as exc:
                 _LOGGER.exception(
                     "download_artifacts from %s: pack failed for job %s (configuration=%r)",
                     session.dashboard_id,
                     job_id,
                     firmware_job.configuration,
                 )
-                await self._send_reject(session, job_id, _REASON_PACK_FAILED)
+                await self._send_reject(
+                    session, job_id, _REASON_PACK_FAILED, detail=f"{type(exc).__name__}: {exc}"
+                )
                 return
             await self._send_stream(session, job_id, packed)
         finally:
             self._inflight.pop(session.dashboard_id, None)
 
-    async def _send_reject(self, session: PeerLinkSession, job_id: str, reason: str) -> None:
-        """Send a single ``artifacts_end{accepted: false, reason}`` and return."""
+    async def _send_reject(
+        self, session: PeerLinkSession, job_id: str, reason: str, *, detail: str = ""
+    ) -> None:
+        """Send a single ``artifacts_end{accepted: false, reason}`` and return.
+
+        *detail* (capped) rides on the frame when given so the offloader can
+        show the exact missing artefact path instead of just the coarse reason.
+        """
         end: ArtifactsEndFrameData = {
             "type": "artifacts_end",
             "job_id": job_id,
             "accepted": False,
             "reason": reason,
         }
+        if detail:
+            end["detail"] = detail[:_MAX_REJECT_DETAIL]
         await session.send_app_frame(cast(dict[str, Any], end))
 
     async def _send_stream(

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
@@ -71,6 +71,11 @@ _ARTIFACTS_CHUNK_SCHEMA = frame_schema(
 
 _ARTIFACTS_END_SCHEMA = frame_schema({"job_id": str, "accepted": bool})
 
+# Mirror of the receiver-side reject-detail cap; re-applied here so a peer that
+# ignores its own cap can't make our error string / job log unbounded (the
+# session frame cap already bounds it, this is defense-in-depth).
+_MAX_REJECT_DETAIL = 256
+
 # Membership check on top of the str shape gate so a buggy
 # receiver sending status="unknown" is dropped at the wire layer
 # instead of fanning out a malformed bus event.
@@ -259,7 +264,9 @@ def dispatch_artifacts_end(client: PeerLinkClient, parsed: dict[str, Any]) -> No
         detail = parsed.get("detail")
         message = f"download_artifacts: receiver rejected ({reason})"
         if isinstance(detail, str) and detail:
-            message = f"{message}: {detail}"
+            # Re-cap on this side too: don't trust the peer to have honoured the
+            # sender's cap before echoing its detail into our error / job log.
+            message = f"{message}: {detail[:_MAX_REJECT_DETAIL]}"
         state.future.set_exception(DownloadArtifactsError(message, reason=str(reason)))
         return
     if state.assembler is None:

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
@@ -253,12 +253,14 @@ def dispatch_artifacts_end(client: PeerLinkClient, parsed: dict[str, Any]) -> No
         return
     if not wire["accepted"]:
         reason = parsed.get("reason", "unknown")
-        state.future.set_exception(
-            DownloadArtifactsError(
-                f"download_artifacts: receiver rejected ({reason})",
-                reason=str(reason),
-            )
-        )
+        # The receiver may include a ``detail`` (e.g. the exact missing artefact
+        # path) so the operator-facing error names the real problem rather than
+        # just the coarse reason code. ``reason`` still drives recovery policy.
+        detail = parsed.get("detail")
+        message = f"download_artifacts: receiver rejected ({reason})"
+        if isinstance(detail, str) and detail:
+            message = f"{message}: {detail}"
+        state.future.set_exception(DownloadArtifactsError(message, reason=str(reason)))
         return
     if state.assembler is None:
         state.future.set_exception(

--- a/esphome_device_builder/models/remote_build/wire_frames.py
+++ b/esphome_device_builder/models/remote_build/wire_frames.py
@@ -196,12 +196,17 @@ class ArtifactsEndFrameData(TypedDict):
     fires *instead of* any ``artifacts_start`` / ``artifacts_chunk``
     when the receiver refuses upfront (with a structured
     ``reason``). ``reason`` is ``NotRequired`` — omitted on accept.
+    ``detail`` is an optional human-readable elaboration on a
+    reject (e.g. the exact missing artefact path) the offloader
+    appends to its error; ``NotRequired`` and only set on
+    ``accepted=false``.
     """
 
     type: Literal["artifacts_end"]
     job_id: str
     accepted: bool
     reason: NotRequired[str]
+    detail: NotRequired[str]
 
 
 class CancelJobFrameData(TypedDict):

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -157,6 +157,8 @@ async def test_download_artifacts_unknown_job_rejected(
     assert payload["type"] == "artifacts_end"
     assert payload["accepted"] is False
     assert payload["reason"] == "unknown_job"
+    # Rejects without a specific elaboration omit the detail field entirely.
+    assert "detail" not in payload
     log_text = "\n".join(record.getMessage() for record in caplog.records)
     assert "missing" in log_text  # requested job_id
     assert "another" in log_text  # the receiver's known job_ids
@@ -238,11 +240,37 @@ async def test_download_artifacts_build_dir_missing_rejected(
     payload = _last_app_frame(session)
     assert payload["accepted"] is False
     assert payload["reason"] == "build_dir_missing"
+    # The reject frame now carries the FileNotFoundError detail so the offloader
+    # can surface the actual missing path, not just the coarse reason.
+    assert payload["detail"] == "StorageJSON sidecar missing for kitchen.yaml"
     # Receiver-side log carries the configuration + the
     # FileNotFoundError detail (the actual missing path).
     log_text = "\n".join(record.getMessage() for record in caplog.records)
     assert "kitchen.yaml" in log_text
     assert "StorageJSON sidecar missing" in log_text
+
+
+async def test_download_artifacts_reject_detail_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An overlong FileNotFoundError message is truncated on the reject frame."""
+
+    def _raise_long(_configuration: str) -> Any:
+        raise FileNotFoundError("x" * 1000)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.artifacts_download.pack_build_artifacts",
+        _raise_long,
+    )
+    sender = _make_sender(_make_firmware_with_job(configuration="kitchen.yaml"))
+    session = _make_session()
+
+    frame: DownloadArtifactsFrameData = {"type": "download_artifacts", "job_id": "remote-1"}
+    await sender.handle_download_artifacts(session, cast(dict[str, Any], frame))
+
+    payload = _last_app_frame(session)
+    assert payload["reason"] == "build_dir_missing"
+    assert len(payload["detail"]) == 256
 
 
 async def test_download_artifacts_pack_failed_rejected(
@@ -266,6 +294,7 @@ async def test_download_artifacts_pack_failed_rejected(
     payload = _last_app_frame(session)
     assert payload["accepted"] is False
     assert payload["reason"] == "pack_failed"
+    assert payload["detail"] == "RuntimeError: size cap"
 
 
 async def test_download_artifacts_happy_path_streams_start_chunk_end(

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -5398,6 +5398,30 @@ async def test_dispatch_artifacts_end_rejected_surfaces_detail(
     assert "/data/storage/x.json" in str(exc_info.value)
 
 
+async def test_dispatch_artifacts_end_rejected_caps_oversize_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversize peer-supplied detail is re-capped before it reaches the error."""
+    bus = EventBus()
+    client = _make_offloader_client(bus)
+    job_id = "dl-rejected-bigdetail"
+    fut: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+    client._artifacts_downloads[job_id] = _DownloadArtifactsState(future=fut)
+    frame = {
+        "type": "artifacts_end",
+        "job_id": job_id,
+        "accepted": False,
+        "reason": "build_dir_missing",
+        "detail": "x" * 1000,
+    }
+    async with _drive_session_with_frames(client, monkeypatch, [frame]):
+        with pytest.raises(DownloadArtifactsError) as exc_info:
+            await asyncio.wait_for(fut, timeout=2.0)
+
+    # The reason/prefix carry no "x", so the surviving detail is exactly the cap.
+    assert str(exc_info.value).count("x") == 256
+
+
 async def test_run_session_loops_drains_pending_artifacts_downloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -5367,6 +5367,35 @@ async def test_dispatch_artifacts_end_rejected_resolves_future_with_reason(
             await asyncio.wait_for(fut, timeout=2.0)
 
     assert exc_info.value.reason == "build_dir_missing"
+    # No detail on the frame -> the message is just the reason (backward compat
+    # with receivers that predate the detail field).
+    assert str(exc_info.value) == "download_artifacts: receiver rejected (build_dir_missing)"
+
+
+async def test_dispatch_artifacts_end_rejected_surfaces_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reject ``detail`` is appended to the error so the missing path is visible."""
+    bus = EventBus()
+    client = _make_offloader_client(bus)
+    job_id = "dl-rejected-detail"
+    fut: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+    client._artifacts_downloads[job_id] = _DownloadArtifactsState(future=fut)
+    frame = {
+        "type": "artifacts_end",
+        "job_id": job_id,
+        "accepted": False,
+        "reason": "build_dir_missing",
+        "detail": "StorageJSON sidecar missing for mhz19-co2.yaml: /data/storage/x.json",
+    }
+    async with _drive_session_with_frames(client, monkeypatch, [frame]):
+        with pytest.raises(DownloadArtifactsError) as exc_info:
+            await asyncio.wait_for(fut, timeout=2.0)
+
+    # Reason still drives recovery policy; the message now names the real cause.
+    assert exc_info.value.reason == "build_dir_missing"
+    assert "StorageJSON sidecar missing for mhz19-co2.yaml" in str(exc_info.value)
+    assert "/data/storage/x.json" in str(exc_info.value)
 
 
 async def test_run_session_loops_drains_pending_artifacts_downloads(


### PR DESCRIPTION
# What does this implement/fix?

A remote build that compiles successfully on the build server can still fail at the artifact-download step; the offloader showed only a coarse `download_artifacts: receiver rejected (build_dir_missing)`. The receiver already knows the exact cause (a `FileNotFoundError` naming the missing StorageJSON sidecar, firmware bin, or idedata path), but it only logged that on the build server; reporters rarely have that log, so the failure was undiagnosable from the offloader side (see #1572).

This threads the receiver's specific reject text through an optional `detail` field on the `artifacts_end` reject frame, so the offloader's error and the job log name the real cause end to end; e.g. `receiver rejected (build_dir_missing): StorageJSON sidecar missing for mhz19-co2.yaml: <path>`. The detail is length-capped, rides outside the validated frame schema so older peers simply omit it, and the `reason` code is unchanged so recovery policy and error-code mapping stay the same. This makes the underlying path-mismatch cause visible for follow-up.

**Related issue or feature (if applicable):**

- relates to #1572

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
