### PR TITLE
Honor ESPHOME_DATA_DIR for remote builds on an add-on receiver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,14 @@ against legacy behaviour before assuming the simpler version suffices.
   | HA addon (`is_ha_addon()` true) | `/data` | `/data/storage/<file>.json` | `/data/build/<name>/` |
   | `ESPHOME_DATA_DIR` env override | `$ESPHOME_DATA_DIR` | `$ESPHOME_DATA_DIR/storage/<file>.json` | `$ESPHOME_DATA_DIR/build/<name>/` |
 
+  The rows aren't independent: esphome's `CORE.data_dir` resolves
+  `is_ha_addon()` *before* `$ESPHOME_DATA_DIR`, so on an HA-addon host the
+  override is silently ignored unless `ESPHOME_IS_HA_ADDON` is also cleared —
+  which is why a remote-build receiver running as an addon would write
+  artefacts to `/data` instead of its per-build `ESPHOME_DATA_DIR` subtree, and
+  why `controllers/firmware/cli.py:compose_subprocess_env` drops the marker for
+  remote-build compile subprocesses.
+
   The HA-addon shape is dominant in production: YAML configs at
   `/config/esphome/` (HA's `/config` mount), every ESPHome artefact at
   `/data/` (the addon's per-instance volume). The split lets the addon

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -31,13 +31,17 @@ def compose_subprocess_env(job: FirmwareJob) -> dict[str, str]:
 
     Layers ``os.environ`` + :data:`ESPHOME_SUBPROCESS_ENV`, then
     for receiver-side remote-build jobs pins ``ESPHOME_DATA_DIR``
-    to the per-build subtree under ``CORE.data_dir`` so per-config
-    artefacts land in one ``(dashboard_id, device)``-keyed dir.
+    to the per-build subtree under ``CORE.data_dir`` and drops the
+    ``ESPHOME_IS_HA_ADDON`` marker so the override is honoured.
     """
     env = {**os.environ, **ESPHOME_SUBPROCESS_ENV}
     remote_build_path = parse_remote_build_path(job.configuration)
     if remote_build_path is not None:
         env["ESPHOME_DATA_DIR"] = str(remote_build_path.data_dir(Path(CORE.data_dir)))
+        # esphome's CORE.data_dir prefers is_ha_addon() over ESPHOME_DATA_DIR, so an
+        # add-on receiver would ignore the override, write artefacts to /data, and the
+        # download-read path couldn't find them; drop the marker so the child honours it.
+        env.pop("ESPHOME_IS_HA_ADDON", None)
     return env
 
 

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -38,9 +38,8 @@ def compose_subprocess_env(job: FirmwareJob) -> dict[str, str]:
     remote_build_path = parse_remote_build_path(job.configuration)
     if remote_build_path is not None:
         env["ESPHOME_DATA_DIR"] = str(remote_build_path.data_dir(Path(CORE.data_dir)))
-        # esphome's CORE.data_dir prefers is_ha_addon() over ESPHOME_DATA_DIR, so an
-        # add-on receiver would ignore the override, write artefacts to /data, and the
-        # download-read path couldn't find them; drop the marker so the child honours it.
+        # esphome's CORE.data_dir prefers is_ha_addon() over ESPHOME_DATA_DIR; an
+        # add-on receiver would write artefacts to /data and ignore the override.
         env.pop("ESPHOME_IS_HA_ADDON", None)
     return env
 

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -141,16 +141,7 @@ def test_remote_build_job_drops_ha_addon_marker(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A receiver-side remote-build job clears ``ESPHOME_IS_HA_ADDON`` for the child.
-
-    esphome's ``CORE.data_dir`` checks ``is_ha_addon()`` before
-    ``ESPHOME_DATA_DIR``, so on an add-on receiver the override
-    would be ignored and the compile would write to ``/data``
-    while the download-read path looks under the per-build
-    subtree — a silent ``build_dir_missing`` on every install.
-    Dropping the marker for remote-build subprocesses lets the
-    child honour the override.
-    """
+    """A remote-build job drops ``ESPHOME_IS_HA_ADDON`` so the child honours the override."""
     monkeypatch.setenv("ESPHOME_IS_HA_ADDON", "1")
     controller = firmware_controller_factory(with_settings=True)
     configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
@@ -163,12 +154,7 @@ def test_local_job_keeps_ha_addon_marker(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A local job leaves ``ESPHOME_IS_HA_ADDON`` untouched.
-
-    Local builds on the add-on must keep writing to ``/data``;
-    only remote-build subprocesses redirect, so the marker is
-    dropped only there.
-    """
+    """A local job leaves ``ESPHOME_IS_HA_ADDON`` untouched so local builds still target /data."""
     monkeypatch.setenv("ESPHOME_IS_HA_ADDON", "1")
     controller = firmware_controller_factory(with_settings=True)
     env = controller._compose_subprocess_env(_make_job(configuration="kitchen.yaml"))

--- a/tests/controllers/firmware/test_subprocess_env.py
+++ b/tests/controllers/firmware/test_subprocess_env.py
@@ -20,6 +20,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
 from esphome.core import CORE
 
 from esphome_device_builder.controllers.firmware.constants import (
@@ -134,6 +135,45 @@ def test_remote_build_clean_job_pins_data_dir_to_per_dashboard_esphome(
 
     expected = Path(CORE.data_dir) / ".remote_builds" / "a1b2c3d4" / ".esphome"
     assert env["ESPHOME_DATA_DIR"] == str(expected)
+
+
+def test_remote_build_job_drops_ha_addon_marker(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A receiver-side remote-build job clears ``ESPHOME_IS_HA_ADDON`` for the child.
+
+    esphome's ``CORE.data_dir`` checks ``is_ha_addon()`` before
+    ``ESPHOME_DATA_DIR``, so on an add-on receiver the override
+    would be ignored and the compile would write to ``/data``
+    while the download-read path looks under the per-build
+    subtree — a silent ``build_dir_missing`` on every install.
+    Dropping the marker for remote-build subprocesses lets the
+    child honour the override.
+    """
+    monkeypatch.setenv("ESPHOME_IS_HA_ADDON", "1")
+    controller = firmware_controller_factory(with_settings=True)
+    configuration = ".esphome/.remote_builds/a1b2c3d4/kitchen/kitchen.yaml"
+    env = controller._compose_subprocess_env(_make_job(configuration=configuration))
+
+    assert "ESPHOME_IS_HA_ADDON" not in env
+
+
+def test_local_job_keeps_ha_addon_marker(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local job leaves ``ESPHOME_IS_HA_ADDON`` untouched.
+
+    Local builds on the add-on must keep writing to ``/data``;
+    only remote-build subprocesses redirect, so the marker is
+    dropped only there.
+    """
+    monkeypatch.setenv("ESPHOME_IS_HA_ADDON", "1")
+    controller = firmware_controller_factory(with_settings=True)
+    env = controller._compose_subprocess_env(_make_job(configuration="kitchen.yaml"))
+
+    assert env["ESPHOME_IS_HA_ADDON"] == "1"
 
 
 def test_malformed_remote_build_path_falls_through_to_local(


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1580 (which surfaced the receiver's reject detail). The detailed
error pointed at the real cause: when the build server itself runs as an HA
add-on, the receiver compile ignored our per-build `ESPHOME_DATA_DIR` redirect.

esphome's `CORE.data_dir` checks `is_ha_addon()` before `ESPHOME_DATA_DIR`, so
on an add-on receiver the compile wrote artefacts to `/data` while the
download-read path looked under `<data_dir>/.remote_builds/<dir_id>/.esphome`;
the StorageJSON sidecar was never there, so `download_artifacts` failed with
`build_dir_missing` and every remote install/OTA/bin-download was blocked.

The compile child env now drops the `ESPHOME_IS_HA_ADDON` marker for
remote-build jobs so esphome honors the override; the firmware is byte-identical,
only the artefact location changes to where the download reads it.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1572

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
