### PR TITLE
Generate a no-network stub when no Wi-Fi secrets exist

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -25,7 +25,12 @@ from ...helpers.device_yaml import (
     configuration_stem,
 )
 from ...helpers.event_bus import Event
-from ...helpers.secrets_state import SecretsContentError, validate_secrets_content
+from ...helpers.secrets_state import (
+    SecretsContentError,
+    read_secrets_yaml,
+    validate_secrets_content,
+    wifi_secrets_defined,
+)
 from ...helpers.storage import ShutdownCallback
 from ...models import (
     AddComponentResponse,
@@ -503,8 +508,27 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         ssid: str,
         psk: str,
     ) -> tuple[str, mutations_yaml.CreateYamlSource]:
+        # Read secrets only where the generator may emit !secret: skip
+        # file_content (user YAML as-is) and a literal ssid (inlines). The stub
+        # and a board template with no literal ssid qualify; a no-native-Wi-Fi
+        # board with no ssid also reads here but ignores the result (gating that
+        # out would need the board's Wi-Fi capability before the read).
+        wifi_secrets_available = True
+        if not file_content and not (board and ssid):
+            loop = asyncio.get_running_loop()
+            secrets = await loop.run_in_executor(
+                None, read_secrets_yaml, self._db.settings.config_dir
+            )
+            wifi_secrets_available = wifi_secrets_defined(secrets)
         return await mutations_yaml.yaml_content_for_create(
-            name, friendly, board, file_content, ssid, psk, catalog=self._db.components
+            name,
+            friendly,
+            board,
+            file_content,
+            ssid,
+            psk,
+            wifi_secrets_available=wifi_secrets_available,
+            catalog=self._db.components,
         )
 
     async def _validate_rewritten_yaml_or_raise(

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -40,6 +40,7 @@ async def yaml_content_for_create(
     ssid: str,
     psk: str,
     *,
+    wifi_secrets_available: bool = True,
     catalog: ComponentCatalog | None = None,
 ) -> tuple[str, CreateYamlSource]:
     """Pick the YAML body for ``devices/create`` based on the inputs."""
@@ -52,10 +53,21 @@ async def yaml_content_for_create(
             else None
         )
         return (
-            generate_device_yaml(name, friendly, board, ssid, psk, defaults=defaults),
+            generate_device_yaml(
+                name,
+                friendly,
+                board,
+                ssid,
+                psk,
+                wifi_secrets_available=wifi_secrets_available,
+                defaults=defaults,
+            ),
             "template",
         )
-    return generate_minimal_stub_yaml(name, friendly), "stub"
+    return (
+        generate_minimal_stub_yaml(name, friendly, wifi_secrets_available=wifi_secrets_available),
+        "stub",
+    )
 
 
 async def validate_rewritten_yaml_or_raise(

--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -58,6 +58,19 @@ _NO_NETWORK_TODO_LINES: tuple[str, ...] = (
     "",
 )
 
+# Emitted instead of the Wi-Fi block when no ``wifi_ssid`` / ``wifi_password``
+# secrets are defined (the user skipped Wi-Fi / uses Ethernet). The board may
+# have native Wi-Fi, so unlike ``_NO_NETWORK_TODO_LINES`` this doesn't claim
+# otherwise — it just points at adding a network. ``api:`` / ``ota:`` are
+# omitted because both require a ``network`` component to validate.
+_NO_WIFI_SECRETS_TODO_LINES: tuple[str, ...] = (
+    "# No Wi-Fi secrets are set, so this starter has no network yet.",
+    "# Add a ``wifi:`` block (with your credentials) or an ``ethernet:`` /",
+    "# ``openthread:`` block to suit your board, then add ``api:`` and",
+    "# ``ota:`` blocks once the network is ready.",
+    "",
+)
+
 
 def _has_native_wifi(
     *, platform: str, board: str | None = None, variant: str | None = None
@@ -88,6 +101,7 @@ def generate_device_yaml(
     ssid: str,
     psk: str,
     *,
+    wifi_secrets_available: bool = True,
     defaults: list[tuple[ComponentCatalogEntry, dict[str, Any]]] | None = None,
 ) -> str:
     """
@@ -161,37 +175,12 @@ def generate_device_yaml(
     connectivity = [c.value for c in board.hardware.connectivity] if board.hardware else []
     has_wifi = "wifi" in connectivity if connectivity else _infer_native_wifi(board)
 
-    if has_wifi:
-        # Home Assistant API — unique encryption key per device.
-        # Skipped on no-Wi-Fi boards because ``api:`` requires a
-        # ``network`` component (DEPENDENCIES=["network"]) and the
-        # wizard doesn't emit ``ethernet:`` / ``openthread:`` /
-        # ``host:`` for non-Wi-Fi boards. Validation would otherwise
-        # reject the generated config with
-        # "Component api requires component network." — see ``ota``
-        # below for the same reasoning.
-        api_key = base64.b64encode(secrets.token_bytes(32)).decode()
-        lines.append("api:")
-        lines.append("  encryption:")
-        lines.append(f'    key: "{api_key}"')
-        lines.append("")
-
-        # OTA — same network dependency as ``api:`` above.
-        lines.append("ota:")
-        lines.append("  - platform: esphome")
-        lines.append("")
-
-        lines.append("wifi:")
-        if ssid:
-            # An unquoted SSID like 'Home #2' truncates at the # comment
-            # marker; a password starting with an indicator char (*, !, &)
-            # fails to parse. Route raw user input through scalar-safe quoting.
-            lines.append(f"  ssid: {_safe_yaml_scalar(ssid)}")
-            lines.append(f"  password: {_safe_yaml_scalar(psk)}")
-        else:
-            lines.append("  ssid: !secret wifi_ssid")
-            lines.append("  password: !secret wifi_password")
-        lines.extend(_fallback_recovery_lines(friendly_name or name, platform))
+    # A literal ssid always inlines; a !secret reference needs the secrets to
+    # exist or ESPHome's config validation fails with "Secret not defined".
+    if has_wifi and not ssid and not wifi_secrets_available:
+        lines.extend(_NO_WIFI_SECRETS_TODO_LINES)
+    elif has_wifi:
+        lines.extend(_wifi_network_lines(ssid, psk, platform, friendly_name or name))
     else:
         # No native Wi-Fi → leave a TODO so the user knows what they
         # need to configure before adding ``api:`` / ``ota:``. Both
@@ -260,7 +249,9 @@ def _apply_default_components(
     return yaml_text
 
 
-def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
+def generate_minimal_stub_yaml(
+    name: str, friendly_name: str, *, wifi_secrets_available: bool = True
+) -> str:
     """
     Render a minimal ``esphome rename``-compatible stub config.
 
@@ -273,6 +264,12 @@ def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
     block without unwinding wizard-specific defaults like an
     auto-generated API encryption key.
 
+    When ``wifi_secrets_available`` is False (no ``wifi_ssid`` /
+    ``wifi_password`` in secrets.yaml) the stub omits the Wi-Fi
+    ``!secret`` block — and ``api:`` / ``ota:``, which need a
+    network — emitting a network TODO instead, so it still
+    validates.
+
     The platform defaults to ``esp32`` with ``board: esp32dev``
     because esp32 is the most common starter target and
     ``esp32dev`` is upstream-canonical (ships in
@@ -282,15 +279,19 @@ def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
     bind concern is at least called out in the file the user is
     about to edit.
     """
-    api_key = base64.b64encode(secrets.token_bytes(32)).decode()
-    recovery = "\n".join(_fallback_recovery_lines(friendly_name or name, "esp32"))
-    return (
+    header = (
         f"esphome:\n  name: {name}\n"
         f"  friendly_name: {_safe_yaml_scalar(friendly_name)}\n\n"
         "# Replace this with your actual platform if you aren't using ESP32.\n"
         "esp32:\n  board: esp32dev\n\n"
         "logger:\n\n"
-        "api:\n  encryption:\n"
+    )
+    if not wifi_secrets_available:
+        return header + "\n".join(_NO_WIFI_SECRETS_TODO_LINES)
+    api_key = base64.b64encode(secrets.token_bytes(32)).decode()
+    recovery = "\n".join(_fallback_recovery_lines(friendly_name or name, "esp32"))
+    return (
+        header + "api:\n  encryption:\n"
         f'    key: "{api_key}"\n\n'
         "ota:\n  - platform: esphome\n\n"
         "wifi:\n"
@@ -298,6 +299,37 @@ def generate_minimal_stub_yaml(name: str, friendly_name: str) -> str:
         "  password: !secret wifi_password\n"
         f"{recovery}"
     )
+
+
+def _wifi_network_lines(ssid: str, psk: str, platform: str, ap_label: str) -> list[str]:
+    """
+    Render the ``api:`` + ``ota:`` + ``wifi:`` network block for a Wi-Fi board.
+
+    A literal *ssid* inlines (scalar-safe quoted); an empty *ssid* falls back to
+    ``!secret`` references. ``api:`` / ``ota:`` are included here because both
+    need a ``network`` component, which the Wi-Fi block provides.
+    """
+    api_key = base64.b64encode(secrets.token_bytes(32)).decode()
+    lines = [
+        "api:",
+        "  encryption:",
+        f'    key: "{api_key}"',
+        "",
+        "ota:",
+        "  - platform: esphome",
+        "",
+        "wifi:",
+    ]
+    if ssid:
+        # An unquoted SSID like 'Home #2' truncates at the # comment marker; a
+        # password starting with an indicator char (*, !, &) fails to parse.
+        lines.append(f"  ssid: {_safe_yaml_scalar(ssid)}")
+        lines.append(f"  password: {_safe_yaml_scalar(psk)}")
+    else:
+        lines.append("  ssid: !secret wifi_ssid")
+        lines.append("  password: !secret wifi_password")
+    lines.extend(_fallback_recovery_lines(ap_label, platform))
+    return lines
 
 
 def _fallback_recovery_lines(label: str, platform: str) -> list[str]:

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -147,6 +147,26 @@ def is_wifi_unconfigured(secrets: dict | None) -> bool:
     return val.strip() in _UNCONFIGURED_WIFI_SSID_VALUES
 
 
+def wifi_secrets_defined(secrets: dict | None) -> bool:
+    """
+    Return True when a generated ``!secret`` Wi-Fi block would validate.
+
+    ``wifi_ssid`` must be a non-empty string (ESPHome's ``cv.ssid`` rejects an
+    empty SSID) and ``wifi_password`` a string — empty is allowed (open
+    networks), but ``null`` / non-string is rejected by ``cv.string_strict``, so
+    those count as undefined. A seeded placeholder still counts (non-empty and
+    validates), unlike :func:`is_wifi_unconfigured`.
+    """
+    if secrets is None:
+        return False
+    ssid = secrets.get("wifi_ssid")
+    return (
+        isinstance(ssid, str)
+        and ssid.strip() != ""
+        and isinstance(secrets.get("wifi_password"), str)
+    )
+
+
 def merge_secrets_file(src: Path, dest: Path) -> None:
     """
     Merge *src* secrets into *dest*, adding only keys *dest* lacks.

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -217,6 +217,9 @@ async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     about to edit.
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    # Wi-Fi secrets present (production bootstraps placeholders), so the stub
+    # emits the !secret wifi block.
+    (tmp_path / "secrets.yaml").write_text('wifi_ssid: "x"\nwifi_password: "y"\n', encoding="utf-8")
     boards = StubBoardLookups(ctrl)
     # Catalog returns a board for ``esp32dev`` to model the realistic
     # scenario flagged in review: many curated entries share that
@@ -233,12 +236,34 @@ async def test_create_device_emits_minimal_stub_when_no_board_or_file_content(
     assert "esp32:\n  board: esp32dev\n" in content
     assert "Replace this with your actual platform" in content
     assert "api:\n  encryption:\n    key:" in content
+    assert "  ssid: !secret wifi_ssid\n" in content
     assert ctrl._scanner.calls == [("scan",)]
     # Stub branch deliberately skips the catalog lookup so an
     # arbitrary entry sharing ``esp32dev`` doesn't get pinned to
     # this device's metadata before the user picks real hardware.
     pio_lookup.assert_not_called()
     variant_lookup.assert_not_called()
+
+
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers")
+async def test_create_device_minimal_stub_omits_wifi_without_secrets(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """No board / no file_content / no wifi secrets → no-network stub (no ``!secret``)."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    StubBoardLookups(ctrl)
+    # No secrets.yaml on disk → wifi_ssid/wifi_password undefined, so a
+    # generated !secret reference would not resolve. The stub must omit it.
+    assert not (tmp_path / "secrets.yaml").exists()
+
+    result = await ctrl.create_device(name="kitchen")
+
+    content = (tmp_path / result.configuration).read_text("utf-8")
+    assert "esp32:\n  board: esp32dev\n" in content
+    assert "!secret" not in content
+    assert "wifi:" not in content.splitlines()
+    assert "api:" not in content.splitlines()
+    assert "No Wi-Fi secrets are set" in content
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers")

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1158,6 +1158,48 @@ def test_generate_yaml_emits_explicit_wifi_credentials_when_provided() -> None:
     assert "  password: !secret wifi_password\n" in secret
 
 
+def test_generate_yaml_omits_wifi_when_board_has_wifi_but_no_secrets() -> None:
+    """No literal ssid and no wifi secrets → no ``!secret`` block, network TODO instead."""
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+
+    out = generate_device_yaml(
+        "kitchen", "Kitchen", board, ssid="", psk="", wifi_secrets_available=False
+    )
+
+    assert "!secret" not in out
+    # Line-anchored: the TODO comment mentions ``wifi:`` / ``api:`` in prose.
+    assert "wifi:" not in out.splitlines()
+    assert "api:" not in out.splitlines()
+    assert "ota:" not in out.splitlines()
+    assert "No Wi-Fi secrets are set" in out
+
+
+def test_generate_yaml_literal_ssid_inlines_regardless_of_secrets() -> None:
+    """A literal ssid still inlines even when wifi secrets are absent."""
+    board = _make_esp32_board(variant=Esp32Variant.ESP32)
+
+    out = generate_device_yaml(
+        "kitchen", "Kitchen", board, ssid="MyNet", psk="pw", wifi_secrets_available=False
+    )
+
+    assert "  ssid: MyNet\n" in out
+    assert "!secret" not in out
+    assert "No Wi-Fi secrets are set" not in out
+
+
+def test_generate_minimal_stub_yaml_omits_wifi_without_secrets() -> None:
+    """Stub with no wifi secrets drops wifi/api/ota and emits a network TODO."""
+    out = generate_minimal_stub_yaml("kitchen", "Kitchen Lamp", wifi_secrets_available=False)
+
+    assert "esphome:\n  name: kitchen\n  friendly_name: Kitchen Lamp\n" in out
+    assert "esp32:\n  board: esp32dev\n" in out
+    assert "!secret" not in out
+    assert "wifi:" not in out.splitlines()
+    assert "api:" not in out.splitlines()
+    assert "ota:" not in out.splitlines()
+    assert "No Wi-Fi secrets are set" in out
+
+
 def test_generate_yaml_secret_refs_resolve_through_esphome_loader(tmp_path: Path) -> None:
     """Empty ssid/psk emit !secret tags ESPHome's loader resolves from secrets.yaml.
 

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -25,9 +25,44 @@ from esphome_device_builder.helpers.secrets_state import (
     merge_secrets_file,
     read_secrets_yaml,
     validate_secrets_content,
+    wifi_secrets_defined,
     write_secret,
     write_secrets_locked,
 )
+
+
+def test_wifi_secrets_defined_requires_both_keys() -> None:
+    """Non-empty ssid + password key ⇒ True; missing either / None / empty ⇒ False."""
+    assert wifi_secrets_defined({"wifi_ssid": "x", "wifi_password": "y"}) is True
+    # Open network: an empty password is still a defined key.
+    assert wifi_secrets_defined({"wifi_ssid": "x", "wifi_password": ""}) is True
+    assert wifi_secrets_defined({"wifi_ssid": "x"}) is False
+    assert wifi_secrets_defined({"wifi_password": "y"}) is False
+    assert wifi_secrets_defined({}) is False
+    assert wifi_secrets_defined(None) is False
+
+
+def test_wifi_secrets_defined_false_for_empty_or_non_string_ssid() -> None:
+    """A present-but-empty / blank / non-string ssid would fail cv.ssid, so it's not defined."""
+    assert wifi_secrets_defined({"wifi_ssid": "", "wifi_password": "y"}) is False
+    assert wifi_secrets_defined({"wifi_ssid": "   ", "wifi_password": "y"}) is False
+    assert wifi_secrets_defined({"wifi_ssid": 42, "wifi_password": "y"}) is False
+
+
+def test_wifi_secrets_defined_false_for_null_or_non_string_password() -> None:
+    """A null / non-string password would fail cv.string_strict, so it's not defined."""
+    assert wifi_secrets_defined({"wifi_ssid": "x", "wifi_password": None}) is False
+    assert wifi_secrets_defined({"wifi_ssid": "x", "wifi_password": 12345678}) is False
+
+
+def test_wifi_secrets_defined_true_for_placeholder_values() -> None:
+    """Seeded placeholders still count as defined — the keys exist, so ``!secret`` resolves."""
+    assert (
+        wifi_secrets_defined(
+            {"wifi_ssid": PLACEHOLDER_WIFI_SSID, "wifi_password": PLACEHOLDER_WIFI_PASSWORD}
+        )
+        is True
+    )
 
 
 def test_unconfigured_when_secrets_is_none() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Creating a device failed for users without `wifi_ssid`/`wifi_password` in secrets.yaml (no Wi-Fi, e.g. an Ethernet board): the generators emitted `wifi: ssid: !secret wifi_ssid` unconditionally, and `esphome config` validation then raised "Secret 'wifi_ssid' not defined", so even an empty config couldn't be created.

Per the repo principle (never generate invalid configs; fix the generator), generation is now adaptive. When the Wi-Fi secrets aren't defined, the empty stub and the board template emit a network TODO instead of a broken `!secret` reference, dropping `wifi:`/`api:`/`ota:` (api and ota require a network component); when the secrets are present the `!secret` block is unchanged, so the common seeded onboarding is unaffected. A new `wifi_secrets_defined` helper checks for the keys, and the create flow reads secrets.yaml and passes the flag to the generators.

The companion frontend PR lets the wizard finish without Wi-Fi credentials.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1567

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend (branch fix-wizard-allow-no-wifi; wizard finishes without Wi-Fi)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
