### PR TITLE
Mark a device online from any reachability source, not just mDNS

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -231,7 +231,17 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             self.state.reachability.observe(name, source)
 
         current_source = self.state.state_source.get(name, ReachabilitySource.UNKNOWN)
-        if _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(current_source, 0):
+        # Online-wins: a positive reachability from any source brings a
+        # not-online device online, even one a higher-priority source owns
+        # (ping/MQTT reviving a device a stale mdns/mqtt OFFLINE owns). The
+        # priority gate still governs OFFLINE/downgrades so a low-priority
+        # flap can't drop a device a higher source confirmed online.
+        online_takeover = state == DeviceState.ONLINE and any(
+            d.state != DeviceState.ONLINE for d in devices
+        )
+        if not online_takeover and _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(
+            current_source, 0
+        ):
             return False
         # Dedupe must look at *every* matching device, not just the
         # first. Duplicate ``esphome.name`` entries (a config plus

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -210,8 +210,8 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         ``claim=True`` lets *source* take ownership even when the
         state is unchanged, blocking a lower-priority observation
         from later flipping the device back. The priority check
-        still applies — ``claim`` can't override a higher-priority
-        owner.
+        governs OFFLINE/downgrades; a positive ONLINE from any
+        source still revives a not-online device regardless of owner.
         """
         devices = self._get_devices_by_name(name)
         if not devices:
@@ -231,24 +231,23 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             self.state.reachability.observe(name, source)
 
         current_source = self.state.state_source.get(name, ReachabilitySource.UNKNOWN)
+        # Scan *every* matching device, not just the first. Duplicate
+        # ``esphome.name`` entries (a config plus a ``foo (1).yaml``
+        # copy, dashboard_import siblings) share the broadcast — if one
+        # sibling was rebuilt with state=UNKNOWN the first-match bail
+        # would leave it stale.
+        all_match = all(d.state == state for d in devices)
         # Online-wins: a positive reachability from any source brings a
         # not-online device online, even one a higher-priority source owns
         # (ping/MQTT reviving a device a stale mdns/mqtt OFFLINE owns). The
         # priority gate still governs OFFLINE/downgrades so a low-priority
         # flap can't drop a device a higher source confirmed online.
-        online_takeover = state == DeviceState.ONLINE and any(
-            d.state != DeviceState.ONLINE for d in devices
-        )
+        online_takeover = state == DeviceState.ONLINE and not all_match
         if not online_takeover and _SOURCE_PRIORITY.get(source, 0) < _SOURCE_PRIORITY.get(
             current_source, 0
         ):
             return False
-        # Dedupe must look at *every* matching device, not just the
-        # first. Duplicate ``esphome.name`` entries (a config plus
-        # a ``foo (1).yaml`` copy, dashboard_import siblings) share
-        # the broadcast — if one sibling was rebuilt with
-        # state=UNKNOWN the first-match bail would leave it stale.
-        if all(d.state == state for d in devices):
+        if all_match:
             if claim:
                 self.state.state_source[name] = source
             return False

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -203,7 +203,8 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         Record a state observation from *source*.
 
         Returns True iff the state was forwarded to the callback.
-        Sources below the current source's priority are ignored;
+        A source below the current source's priority is ignored,
+        except a positive ONLINE always revives a not-online device;
         observations where every matching device already carries
         *state* no-op.
 

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -173,17 +173,15 @@ class PingSource:
                 # primary for ICMP / OTA targeting.
                 monitor.apply_ip_addresses(device.name, cached)
                 continue
-            if monitor.state.dns_cache.has_cached_failure(device.address):
-                if device.ip_addresses:
-                    # The ``.local`` won't resolve, but a prior MQTT/DNS
-                    # observation left a known IP — ping that instead of
-                    # marking the device offline (mDNS-less devices).
-                    pingable.append(device)
-                    continue
-                # Don't hand the bare hostname to icmplib (it would
-                # hammer the system resolver every sweep). Apply
-                # OFFLINE under the ``ping`` source so a future
-                # successful resolve can flip the device back.
+            if monitor.state.dns_cache.has_cached_failure(device.address) and (
+                not device.ip_addresses
+            ):
+                # The ``.local`` won't resolve and we have no known IP.
+                # Don't hand the bare hostname to icmplib (it would hammer
+                # the system resolver every sweep). Apply OFFLINE under the
+                # ``ping`` source so a future successful resolve can flip
+                # the device back. A device with a known IP (e.g. from MQTT)
+                # falls through to ``pingable`` and is pinged at that IP.
                 monitor.apply(device.name, DeviceState.OFFLINE, "ping")
                 dns_failed.append(device)
                 continue

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -174,6 +174,12 @@ class PingSource:
                 monitor.apply_ip_addresses(device.name, cached)
                 continue
             if monitor.state.dns_cache.has_cached_failure(device.address):
+                if device.ip_addresses:
+                    # The ``.local`` won't resolve, but a prior MQTT/DNS
+                    # observation left a known IP — ping that instead of
+                    # marking the device offline (mDNS-less devices).
+                    pingable.append(device)
+                    continue
                 # Don't hand the bare hostname to icmplib (it would
                 # hammer the system resolver every sweep). Apply
                 # OFFLINE under the ``ping`` source so a future
@@ -189,6 +195,11 @@ class PingSource:
         monitor = self._monitor
         async with self._concurrency:
             addresses = await monitor.state.dns_cache.async_resolve(device.address)
+            if not addresses:
+                # mDNS-less devices: the ``.local`` won't resolve but a
+                # prior MQTT/DNS observation left a usable IP. Ping that so
+                # ping can confirm a device the network won't resolve.
+                addresses = list(device.ip_addresses)
             if not addresses:
                 monitor.apply(device.name, DeviceState.OFFLINE, "ping")
                 return

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -191,6 +191,61 @@ def test_apply_with_no_tracker_does_not_raise() -> None:
     monitor.apply("kitchen", DeviceState.ONLINE, "mdns")
 
 
+def test_lower_priority_online_revives_higher_priority_offline() -> None:
+    """A ping ONLINE brings online a device a higher-priority mqtt OFFLINE owns."""
+    devices = [_make_device(state=DeviceState.OFFLINE)]
+    monitor = _make_monitor(devices)
+    monitor.state.state_source["kitchen"] = "mqtt"
+
+    assert monitor.apply("kitchen", DeviceState.ONLINE, "ping") is True
+    assert devices[0].state is DeviceState.ONLINE
+    assert monitor.state.state_source["kitchen"] == "ping"
+
+
+def test_lower_priority_offline_does_not_drop_higher_priority_online() -> None:
+    """The gate still protects an mdns ONLINE from a ping OFFLINE flap."""
+    devices = [_make_device(state=DeviceState.ONLINE)]
+    monitor = _make_monitor(devices)
+    monitor.state.state_source["kitchen"] = "mdns"
+
+    assert monitor.apply("kitchen", DeviceState.OFFLINE, "ping") is False
+    assert devices[0].state is DeviceState.ONLINE
+    assert monitor.state.state_source["kitchen"] == "mdns"
+
+
+def test_select_ping_targets_keeps_device_with_known_ip_when_dns_failed() -> None:
+    """A cached DNS failure with a known IP pings the IP, not OFFLINE+dns_failed."""
+    devices = [_make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])]
+    monitor = _make_monitor(devices)
+    monitor.get_cached_addresses = lambda _a: None
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=True)
+
+    pingable, dns_failed = monitor._ping._select_ping_targets()
+
+    assert devices[0] in pingable
+    assert dns_failed == []
+    assert devices[0].state is DeviceState.OFFLINE
+
+
+async def test_resolve_and_ping_falls_back_to_known_ip() -> None:
+    """When the .local won't resolve, ping the MQTT/last-known IP and go ONLINE."""
+    devices = [_make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])]
+    monitor = _make_monitor(devices)
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=[])
+
+    fake_result = MagicMock()
+    fake_result.is_alive = True
+    fake_result.min_rtt = 1.0
+    with patch(
+        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
+        AsyncMock(return_value=fake_result),
+    ) as mock_ping:
+        await monitor._ping._resolve_and_ping(devices[0])
+
+    assert mock_ping.await_args.args[0] == "10.0.0.5"
+    assert devices[0].state is DeviceState.ONLINE
+
+
 async def test_ping_success_records_rtt_and_observation() -> None:
     """A successful ICMP probe captures ``min_rtt`` and stamps freshness."""
     devices = [_make_device()]

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -231,7 +231,8 @@ async def test_resolve_and_ping_falls_back_to_known_ip() -> None:
     """When the .local won't resolve, ping the MQTT/last-known IP and go ONLINE."""
     devices = [_make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])]
     monitor = _make_monitor(devices)
-    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=[])
+    # async_resolve returns None (not []) on resolution failure.
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=None)
 
     fake_result = MagicMock()
     fake_result.is_alive = True


### PR DESCRIPTION
# What does this implement/fix?

A device whose network blocks mDNS but answers ping and MQTT showed up as offline, so the log viewer's "On the network" option was disabled and the user had to fall back to Advanced, device IP. The reachability panel already showed ping and MQTT reachable; the signals were observed but never drove the overall state.

Two interacting causes in the device-state monitor:

1. The source-priority gate in `apply()` dropped a lower-priority source's update even when it was a positive ONLINE; once MQTT's offline timeout or a ping resolve-failure flipped the device offline and took ownership, the other source's ONLINE was rejected.
2. The ICMP sweep only resolved the mDNS `.local` hostname and never pinged the IP MQTT already delivered via `apply_ip`; with mDNS dead the hostname won't resolve, so the sweep stamped offline despite a known good IP.

This restores the legacy dashboard's behaviour (online from any reachability source):

- `apply()` now lets a positive reachability from any source bring a not-online device online; the gate still governs offline and downgrades so a flaky low-priority source can't drop a device a higher source confirmed online.
- The ping sweep falls back to the device's known IP addresses when its hostname won't resolve, so ping can verify an mDNS-less device.

No frontend change is needed; the frontend keys off `device.state` and flips online once the backend emits the state change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1577

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
