### PR TITLE
Honor variant gate in add_component required-check

### DIFF
--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -10,6 +10,7 @@ from ...models import AddComponentResponse, ErrorCode
 from .helpers import _apply_featured_presets, _drop_unconfigured_dependent_fields
 
 if TYPE_CHECKING:
+    from ...models import ConfigEntry
     from .controller import DevicesController
 
 
@@ -68,7 +69,7 @@ async def add_component(
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
     for entry in component.config_entries:
-        if entry.required and entry.key not in fields:
+        if entry.required and _entry_gate_active(entry, fields) and entry.key not in fields:
             msg = f"Missing required field: {entry.label or entry.key}"
             raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
@@ -92,3 +93,25 @@ async def add_component(
         )
 
     return AddComponentResponse(yaml=new_yaml)
+
+
+def _entry_gate_active(entry: ConfigEntry, fields: dict[str, Any]) -> bool:
+    """
+    Whether *entry*'s ``depends_on`` value gate is satisfied by *fields*.
+
+    Mirrors the frontend's ``isEntryVisible`` depends_on logic so the
+    required-check doesn't demand a variant-gated field whose gate is
+    inactive (e.g. ethernet's RMII-only ``clk`` when an SPI ``type`` is
+    selected). ``depends_on_component`` is a separate gate handled by
+    :func:`_drop_unconfigured_dependent_fields`.
+    """
+    if entry.depends_on is None:
+        return True
+    dep = fields.get(entry.depends_on)
+    if entry.depends_on_value is not None:
+        return dep == entry.depends_on_value
+    if entry.depends_on_value_not is not None:
+        return dep != entry.depends_on_value_not
+    if entry.depends_on_value_any is not None:
+        return dep in entry.depends_on_value_any
+    return True

--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -96,15 +96,7 @@ async def add_component(
 
 
 def _entry_gate_active(entry: ConfigEntry, fields: dict[str, Any]) -> bool:
-    """
-    Whether *entry*'s ``depends_on`` value gate is satisfied by *fields*.
-
-    Mirrors the frontend's ``isEntryVisible`` depends_on logic so the
-    required-check doesn't demand a variant-gated field whose gate is
-    inactive (e.g. ethernet's RMII-only ``clk`` when an SPI ``type`` is
-    selected). ``depends_on_component`` is a separate gate handled by
-    :func:`_drop_unconfigured_dependent_fields`.
-    """
+    """Whether *entry*'s ``depends_on`` value gate is satisfied by *fields*."""
     if entry.depends_on is None:
         return True
     dep = fields.get(entry.depends_on)

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -32,8 +32,10 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
+import esphome_device_builder.controllers.devices.add_component as add_component_mod
 import esphome_device_builder.controllers.devices.api_key as api_key_mod
 from esphome_device_builder.controllers._device_scanner import ScanChange
+from esphome_device_builder.controllers.devices.add_component import _entry_gate_active
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.build_size import BuildDirSignal, BuildSizeRefreshResult
 from esphome_device_builder.helpers.event_bus import Event
@@ -510,6 +512,116 @@ async def test_add_component_missing_required_field_raises(
             configuration="kitchen.yaml",
             component_id="dht",
             fields={"name": "Bedroom Temp"},
+        )
+    assert exc.value.code is ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.parametrize(
+    ("entry_kwargs", "fields", "expected"),
+    [
+        ({}, {}, True),
+        ({"depends_on": "type", "depends_on_value": "W5500"}, {"type": "W5500"}, True),
+        ({"depends_on": "type", "depends_on_value": "W5500"}, {"type": "LAN8720"}, False),
+        ({"depends_on": "type", "depends_on_value_not": "W5500"}, {"type": "LAN8720"}, True),
+        ({"depends_on": "type", "depends_on_value_not": "W5500"}, {"type": "W5500"}, False),
+        (
+            {"depends_on": "type", "depends_on_value_any": ["LAN8720", "DP83848"]},
+            {"type": "LAN8720"},
+            True,
+        ),
+        (
+            {"depends_on": "type", "depends_on_value_any": ["LAN8720", "DP83848"]},
+            {"type": "W5500"},
+            False,
+        ),
+        ({"depends_on": "type", "depends_on_value_any": ["LAN8720"]}, {}, False),
+    ],
+)
+def test_entry_gate_active(
+    entry_kwargs: dict[str, Any], fields: dict[str, Any], expected: bool
+) -> None:
+    """``_entry_gate_active`` mirrors the frontend's depends_on visibility gate."""
+    entry = ConfigEntry(key="clk", type=ConfigEntryType.NESTED, label="Clk", **entry_kwargs)
+    assert _entry_gate_active(entry, fields) is expected
+
+
+async def test_add_component_gated_inactive_required_field_not_demanded(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A required field whose variant gate is inactive is not demanded (issue #1579).
+
+    ethernet's ``clk`` is force-required but gated to RMII PHYs; with an
+    SPI ``type`` (W5500) selected, the backend must not reject the add
+    with ``Missing required field: Clk``.
+    """
+    controller = make_controller(tmp_path)
+    component = MagicMock()
+    component.id = "ethernet"
+    component.config_entries = [
+        ConfigEntry(key="type", type=ConfigEntryType.STRING, label="Type", required=True),
+        ConfigEntry(
+            key="clk",
+            type=ConfigEntryType.NESTED,
+            label="Clk",
+            required=True,
+            depends_on="type",
+            depends_on_value_any=["LAN8720", "DP83848"],
+        ),
+        ConfigEntry(
+            key="clk_pin",
+            type=ConfigEntryType.PIN,
+            label="Clk Pin",
+            required=True,
+            depends_on="type",
+            depends_on_value_any=["W5500"],
+        ),
+    ]
+    controller._db.components = MagicMock()
+    controller._db.components.get_component = AsyncMock(return_value=component)
+    monkeypatch.setattr(add_component_mod, "merge_component_yaml", lambda *a, **k: "merged: ok\n")
+
+    response = await controller.add_component(
+        configuration="kitchen.yaml",
+        component_id="ethernet",
+        fields={"type": "W5500", "clk_pin": "GPIO10"},
+        yaml="esphome:\n  name: kitchen\n",
+    )
+    assert response.yaml == "merged: ok\n"
+
+
+async def test_add_component_gated_active_required_field_demanded(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A required field whose variant gate IS active stays demanded (issue #1579).
+
+    With an RMII ``type`` selected, ``clk`` applies and a missing value
+    still raises ``Missing required field: Clk``.
+    """
+    controller = make_controller(tmp_path)
+    component = MagicMock()
+    component.id = "ethernet"
+    component.config_entries = [
+        ConfigEntry(key="type", type=ConfigEntryType.STRING, label="Type", required=True),
+        ConfigEntry(
+            key="clk",
+            type=ConfigEntryType.NESTED,
+            label="Clk",
+            required=True,
+            depends_on="type",
+            depends_on_value_any=["LAN8720", "DP83848"],
+        ),
+    ]
+    controller._db.components = MagicMock()
+    controller._db.components.get_component = AsyncMock(return_value=component)
+
+    with pytest.raises(CommandError, match="Missing required field: Clk") as exc:
+        await controller.add_component(
+            configuration="kitchen.yaml",
+            component_id="ethernet",
+            fields={"type": "LAN8720"},
+            yaml="esphome:\n  name: kitchen\n",
         )
     assert exc.value.code is ErrorCode.INVALID_ARGS
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -520,6 +520,7 @@ async def test_add_component_missing_required_field_raises(
     ("entry_kwargs", "fields", "expected"),
     [
         ({}, {}, True),
+        ({"depends_on": "type"}, {"type": "W5500"}, True),
         ({"depends_on": "type", "depends_on_value": "W5500"}, {"type": "W5500"}, True),
         ({"depends_on": "type", "depends_on_value": "W5500"}, {"type": "LAN8720"}, False),
         ({"depends_on": "type", "depends_on_value_not": "W5500"}, {"type": "LAN8720"}, True),
@@ -540,7 +541,7 @@ async def test_add_component_missing_required_field_raises(
 def test_entry_gate_active(
     entry_kwargs: dict[str, Any], fields: dict[str, Any], expected: bool
 ) -> None:
-    """``_entry_gate_active`` mirrors the frontend's depends_on visibility gate."""
+    """``_entry_gate_active`` evaluates each ``depends_on`` value predicate."""
     entry = ConfigEntry(key="clk", type=ConfigEntryType.NESTED, label="Clk", **entry_kwargs)
     assert _entry_gate_active(entry, fields) is expected
 
@@ -550,12 +551,7 @@ async def test_add_component_gated_inactive_required_field_not_demanded(
     make_controller: MakeControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A required field whose variant gate is inactive is not demanded (issue #1579).
-
-    ethernet's ``clk`` is force-required but gated to RMII PHYs; with an
-    SPI ``type`` (W5500) selected, the backend must not reject the add
-    with ``Missing required field: Clk``.
-    """
+    """A required field whose variant gate is inactive is not demanded."""
     controller = make_controller(tmp_path)
     component = MagicMock()
     component.id = "ethernet"
@@ -594,11 +590,7 @@ async def test_add_component_gated_inactive_required_field_not_demanded(
 async def test_add_component_gated_active_required_field_demanded(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    """A required field whose variant gate IS active stays demanded (issue #1579).
-
-    With an RMII ``type`` selected, ``clk`` applies and a missing value
-    still raises ``Missing required field: Clk``.
-    """
+    """A required field whose variant gate is active stays demanded."""
     controller = make_controller(tmp_path)
     component = MagicMock()
     component.id = "ethernet"


### PR DESCRIPTION
# What does this implement/fix?

Adding the ethernet component with an SPI chipset (e.g. `type: W5500`) was rejected
with `invalid_args: Missing required field: Clk`, even with every SPI field filled
and valid YAML. `clk` is the RMII-only clock group; it is force-marked required but
gated to RMII PHYs via `depends_on_value_any`, so it does not apply to SPI types.

The backend's required-field guard in `add_component` ignored the `depends_on` value
gate and demanded every required entry unconditionally. It now skips the guard for
entries whose `depends_on` / `depends_on_value` / `depends_on_value_not` /
`depends_on_value_any` gate is not satisfied by the submitted fields, mirroring the
frontend's `isEntryVisible` visibility check (the frontend already hides `clk` for
SPI types). This fixes both directions; clk_pin and the other SPI fields are
likewise not demanded for an RMII type.

This is the add-blocker half of the issue; the clock_speed split-field is a separate
catalog/sync fix coming in a follow-up PR.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1579

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
