### PR TITLE
Descend cv.typed_schema branches in the sync schema walker

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -4560,6 +4560,15 @@ def _walk_schema_keys(
             return
         candidate = _unwrap_schema_to_dict(node)
         if candidate is None:
+            # A ``cv.typed_schema`` is a closure, not a ``vol.*`` wrapper, so
+            # ``_unwrap_schema_to_dict`` can't peel it. Descend each per-type
+            # branch at the same path (typed variants flatten in YAML and add
+            # no path segment) so the collectors reach variant-only fields
+            # like ethernet's ``clock_speed``.
+            branches = _typed_branch_schemas(node)
+            if branches is not None:
+                for branch in branches.values():
+                    walk(branch, path, depth + 1)
             return
         if id(candidate) in visited:
             return
@@ -4956,6 +4965,21 @@ def _collect_refined_types(  # noqa: C901
     return out
 
 
+def _closure_nonlocals(func: Any) -> dict[str, Any]:
+    """Map *func*'s closure freevar names to values, ``{}`` for a non-closure.
+
+    Reads ``__code__.co_freevars`` / ``__closure__`` directly instead of
+    ``inspect.getclosurevars``, whose global/builtin name analysis dominates the
+    schema walk. Raises ``ValueError`` on an unbound cell (as ``getclosurevars``
+    does); callers suppress it.
+    """
+    code = getattr(func, "__code__", None)
+    closure = getattr(func, "__closure__", None)
+    if code is None or not closure:
+        return {}
+    return {name: cell.cell_contents for name, cell in zip(code.co_freevars, closure, strict=True)}
+
+
 def _typed_closure_default(node: Any) -> tuple[tuple[str, Any] | None, dict[str, Any]]:
     """Read a ``cv.typed_schema`` validator's ``(typed_key, default)`` + its closure vars.
 
@@ -4967,7 +4991,7 @@ def _typed_closure_default(node: Any) -> tuple[tuple[str, Any] | None, dict[str,
     if not (callable(node) and getattr(node, "__closure__", None)):
         return None, {}
     try:
-        nonlocals = inspect.getclosurevars(node).nonlocals
+        nonlocals = _closure_nonlocals(node)
     except (TypeError, ValueError):
         return None, {}
     default = nonlocals.get("default_schema_option")
@@ -4976,12 +5000,15 @@ def _typed_closure_default(node: Any) -> tuple[tuple[str, Any] | None, dict[str,
     return None, nonlocals
 
 
-def _typed_default_of(node: Any) -> tuple[str, Any] | None:
-    """Return ``(typed_key, default_type)`` for a ``cv.typed_schema`` reachable from *node*.
+def _search_validator_graph[ProbeResult](
+    node: Any, probe: Callable[[Any], ProbeResult | None]
+) -> ProbeResult | None:
+    """Return the first non-None ``probe(current)`` across the validator graph from *node*.
 
-    ``cv.All(cv.ensure_list(...))`` buries the typed validator two
-    closures deep (``spi``), so descend ``.validators`` / ``.schema`` /
-    closure cells. ``None`` when no reachable typed_schema has a default.
+    Walks the union of each node's closure freevars, ``.validators`` tuple, and
+    ``.schema`` attribute — the nesting ``cv.All`` / ``cv.ensure_list`` /
+    ``cv.typed_schema`` use to bury validators — deduping by ``id`` so a cyclic
+    schema terminates.
     """
     seen: set[int] = set()
     stack: list[Any] = [node]
@@ -4990,10 +5017,12 @@ def _typed_default_of(node: Any) -> tuple[str, Any] | None:
         if id(current) in seen:
             continue
         seen.add(id(current))
-        found, nonlocals = _typed_closure_default(current)
-        if found is not None:
-            return found
-        stack.extend(nonlocals.values())
+        result = probe(current)
+        if result is not None:
+            return result
+        if callable(current) and getattr(current, "__closure__", None):
+            with contextlib.suppress(TypeError, ValueError):
+                stack.extend(_closure_nonlocals(current).values())
         inner = getattr(current, "validators", None)
         if isinstance(inner, (list, tuple)):
             stack.extend(inner)
@@ -5001,6 +5030,35 @@ def _typed_default_of(node: Any) -> tuple[str, Any] | None:
         if schema is not None and schema is not current:
             stack.append(schema)
     return None
+
+
+def _typed_branch_schemas(node: Any) -> dict[str, Any] | None:
+    """Return a reachable ``cv.typed_schema``'s per-type branch sub-schemas, or None.
+
+    Reads the ``schemas`` freevar — the ``{type_name: sub_schema}`` dict
+    ``cv.typed_schema(schemas, ...)`` captures — off the first reachable
+    typed_schema closure.
+    """
+
+    def _branches(current: Any) -> dict[str, Any] | None:
+        if not (callable(current) and getattr(current, "__closure__", None)):
+            return None
+        try:
+            schemas = _closure_nonlocals(current).get("schemas")
+        except (TypeError, ValueError):
+            return None
+        return schemas if isinstance(schemas, dict) and schemas else None
+
+    return _search_validator_graph(node, _branches)
+
+
+def _typed_default_of(node: Any) -> tuple[str, Any] | None:
+    """Return ``(typed_key, default_type)`` for a ``cv.typed_schema`` reachable from *node*.
+
+    ``cv.All(cv.ensure_list(...))`` buries the typed validator two closures deep
+    (``spi``); ``None`` when no reachable typed_schema has a default.
+    """
+    return _search_validator_graph(node, lambda current: _typed_closure_default(current)[0])
 
 
 def _collect_typed_defaults(manifest: Any) -> dict[tuple[str, ...], Any]:
@@ -5910,7 +5968,7 @@ def _platform_set(node: Any) -> frozenset[str] | None:
     """
     if callable(node) and getattr(node, "__closure__", None):
         try:
-            nonlocals = inspect.getclosurevars(node).nonlocals
+            nonlocals = _closure_nonlocals(node)
         except (TypeError, ValueError):
             nonlocals = {}
         platforms = nonlocals.get("platforms")
@@ -6028,7 +6086,7 @@ def _required_group_from_validator(node: Any) -> dict[str, Any] | None:
     if kind is None:
         return None
     try:
-        nonlocals = inspect.getclosurevars(node).nonlocals
+        nonlocals = _closure_nonlocals(node)
     except (TypeError, ValueError):
         return None
     keys = nonlocals.get("keys")

--- a/tests/test_sync_components_unit_extraction.py
+++ b/tests/test_sync_components_unit_extraction.py
@@ -15,6 +15,7 @@ warning fires for the cases we've already curated as follow-ups.
 from __future__ import annotations
 
 import logging
+import types
 
 import pytest
 
@@ -24,6 +25,7 @@ from script.sync_components import (  # type: ignore[import-not-found]
     _enumerate_platform_manifests,
     _extract_validator_units,
     _present_non_introspectable_units,
+    _walk_schema_keys,
 )
 
 
@@ -325,6 +327,34 @@ def test_missing_non_introspectable_validator_warns(caplog) -> None:
     assert "temperature_delta" in caplog.text
     assert "temperature_delta" not in present
     assert {"data_size", "temperature"} <= present.keys()
+
+
+def test_walk_descends_typed_schema_branches(cv) -> None:
+    """``_walk_schema_keys`` visits fields inside ``cv.typed_schema`` branches."""
+    typed = cv.typed_schema(
+        {
+            "W5500": cv.Schema({cv.Optional("clock_speed", default="26.67MHz"): cv.frequency}),
+            "LAN8720": cv.Schema({cv.Optional("phy_addr", default=0): cv.int_}),
+        },
+        upper=True,
+    )
+    keys: set[str] = set()
+    _walk_schema_keys(typed, lambda _k, key_name, _v, _path: keys.add(key_name))
+    assert {"clock_speed", "phy_addr"} <= keys
+
+
+def test_collect_refined_types_descends_typed_schema(cv) -> None:
+    """A ``cv.frequency`` field inside a typed_schema branch refines to ``float_with_unit``."""
+    typed = cv.typed_schema(
+        {"W5500": cv.Schema({cv.Optional("clock_speed", default="26.67MHz"): cv.frequency})},
+        upper=True,
+    )
+    manifest = types.SimpleNamespace(config_schema=typed)
+    refined = _collect_refined_types(manifest)
+    clock_speed = refined.get(("clock_speed",))
+    assert clock_speed is not None
+    assert clock_speed.type == "float_with_unit"
+    assert clock_speed.unit_options is not None and "MHz" in clock_speed.unit_options
 
 
 def test_audit_silent_when_no_mismatches(caplog) -> None:


### PR DESCRIPTION
> **Note:** the regenerated catalog has been dropped from this PR — it is a
> pure sync-script fix. The nightly catalog sync will pick up the refined
> `ethernet.clock_speed` (and the other typed_schema variant fields) on its
> next run.

# What does this implement/fix?

Second half of issue #1579: the ethernet clock-speed field rendered as a plain
number, so typing `10` emitted `clock_speed: 10` (no unit) and `10Mhz` was
rejected "Must be a number".

ESPHome's ethernet `CONFIG_SCHEMA` is a `cv.typed_schema` union, and the
live-introspection collectors walk `manifest.config_schema` via
`_walk_schema_keys`, whose `_unwrap_schema_to_dict` cannot peel a typed_schema
closure. Per-variant fields were therefore never refined, so `clock_speed` (a
`cv.frequency` SplitDefault) shipped as a bare `integer` with no units or default.

The walker now descends each typed_schema branch (reading the closure's `schemas`
freevar, the same closure-inspection pattern `_typed_closure_default` already
uses). Regenerated the catalog at esphome 2026.6.1 (the version the committed
catalog already targets). `ethernet.clock_speed` is now `float_with_unit` with the
Hz-family unit picker and a `26.67MHz` esp32 default (resolved from
`platform_defaults` per target chip), so the editor shows an MHz dropdown and
emits `10MHz`.

The same descent corrects the other `cv.typed_schema` components, where
variant-only fields previously fell back to `string`/`integer`. They now get their
real metadata re-derived from the live schema: `float` `setup_priority` /
`sorting_weight`, `lambda` fields, `float_with_unit` temperatures, integer ranges,
and SPI pin features the prebuilt bundle alone did not carry. No component was
added or removed and the schema version is unchanged. (Regenerated at esphome
2026.6.1 with a refreshed docs-index cache, so component `image_url`s stay intact.)

Opened as **draft** for the human catalog review. The add-blocker half of #1579
("Missing required field: Clk") is fixed separately in #1586.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1579

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerated via `script/sync_components.py`).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.


