### PR TITLE
Repoint dead Olimex board thumbnails to current URLs

### DIFF
--- a/esphome_device_builder/definitions/boards/esp32-evb/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/esp32-evb/manifest.yaml
@@ -4,7 +4,7 @@ description: Olimex ESP32-EVB evaluation board with ESP32-WROOM, Ethernet (LAN87
   and UEXT connector. Industrial-grade board for automation.
 manufacturer: OLIMEX
 images:
-- https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB/images/thumbs/350x/ESP32-EVB-01.jpg
+- https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB/images/thumbs/310x230/ESP32-EVB-1.jpg
 esphome:
   platform: esp32
   board: esp32-evb

--- a/esphome_device_builder/definitions/boards/esp32-gateway/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/esp32-gateway/manifest.yaml
@@ -4,7 +4,7 @@ description: Olimex ESP32-GATEWAY with ESP32-WROOM, Ethernet (LAN8710A), and mic
   for bridging Wi-Fi and wired networks in home automation.
 manufacturer: OLIMEX
 images:
-- https://www.olimex.com/Products/IoT/ESP32/ESP32-GATEWAY/images/thumbs/350x/ESP32-GATEWAY-03.jpg
+- https://www.olimex.com/Products/IoT/ESP32/ESP32-GATEWAY/images/thumbs/310x230/ESP32-GATEWAY-1.jpg
 esphome:
   platform: esp32
   board: esp32-gateway

--- a/esphome_device_builder/definitions/boards/esp32-poe-iso/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/esp32-poe-iso/manifest.yaml
@@ -4,7 +4,7 @@ description: Olimex ESP32-POE-ISO with ESP32-WROOM, Ethernet with galvanically i
   microSD slot. No separate power supply needed.
 manufacturer: OLIMEX
 images:
-- https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO/images/thumbs/350x/ESP32-POE-ISO-02.jpg
+- https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO/images/thumbs/310x230/ESP32-POE-ISO-1.jpg
 esphome:
   platform: esp32
   board: esp32-poe-iso


### PR DESCRIPTION
# What does this implement/fix?

The board picker showed a broken-image icon for the three curated Olimex ESP32 boards (`esp32-evb`, `esp32-gateway`, `esp32-poe-iso`). Their `images:` URLs hotlinked Olimex `thumbs/350x/…-0N.jpg` paths that now return HTTP 404; Olimex renamed the thumbnails (unpadded names under `thumbs/310x230/`).

This repoints the three manifests at the live URLs (verified `200 image/jpeg` for all three). The PR touches the source manifests only; the generated board catalog (`boards.index.json` + the `board_bodies/esp32-*.json`) is left to the nightly catalog-sync to regenerate after merge.

A follow-up PR adds a scheduled image-reachability check so a future vendor 404 fails a CI run instead of silently shipping a broken thumbnail.

**Related issue or feature (if applicable):**

- Fixes esphome/device-builder#1593

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (where applicable).

