### PR TITLE
Stop asserting board image URLs in the catalog-consistency test

### DIFF
--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -108,6 +108,11 @@ def test_split_artefacts_match_manifests() -> None:
         if platform in esphome_filled or (platform == "esp8266" and not board.pins):
             expected.pop("pins", None)
             actual.pop("pins", None)
+        # Images are vendor-controlled URLs; a manifest image edit shouldn't fail
+        # this consistency check until the catalog regenerates. Reachability is
+        # validated separately by validate_definitions.py --check-images.
+        expected.pop("images", None)
+        actual.pop("images", None)
         assert expected == actual, (
             f"{board.id} is out of sync with its manifest. "
             "Run `python script/sync_boards.py` to regenerate."


### PR DESCRIPTION
# What does this implement/fix?

`test_boards_json.py::test_split_artefacts_match_manifests` compared the full `to_dict()` of each board manifest against the generated catalog, including the `images:` URLs. Those URLs are vendor-controlled and routinely edited in a manifest on their own (e.g. a vendor renamed a thumbnail), without immediately regenerating `boards.index.json` / `board_bodies/`. That turned a one-line manifest image fix into a red CI run on every open PR until the nightly catalog regen landed; it just happened after #1595 repointed the Olimex thumbnails.

Drop `images` from the comparison so an image-URL edit no longer trips the consistency check. Image reachability is validated separately (and on purpose) by the new `validate_definitions.py --check-images` (#1596), so coverage doesn't regress.

**Related issue or feature (if applicable):**

- n/a (unblocks CI after esphome/device-builder#1595)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) derives
the label from the ticked box and applies it automatically;
release-drafter uses the same label to slot this change into the
next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (where applicable).
