### PR TITLE
Add flash progress, live log, and exit cues to the dev flasher

### DIFF
--- a/flasher/index.html
+++ b/flasher/index.html
@@ -67,7 +67,7 @@
       #pct {
         font-size: 0.85rem;
         opacity: 0.8;
-        min-width: 3ch;
+        min-width: 4ch;
         font-variant-numeric: tabular-nums;
       }
       .spinner {

--- a/flasher/index.html
+++ b/flasher/index.html
@@ -45,7 +45,14 @@
       .status.installing { background: #ff980044; }
       .status.done { background: #4caf5044; }
       .status.error { background: #f4433644; }
+      #progress {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        margin: 1rem 0;
+      }
       #bar {
+        flex: 1;
         height: 0.5rem;
         border-radius: 0.25rem;
         background: #8884;
@@ -56,6 +63,28 @@
         width: 0%;
         background: #2196f3;
         transition: width 0.2s;
+      }
+      #pct {
+        font-size: 0.85rem;
+        opacity: 0.8;
+        min-width: 3ch;
+        font-variant-numeric: tabular-nums;
+      }
+      .spinner {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        margin-right: 0.5em;
+        border: 2px solid currentColor;
+        border-top-color: transparent;
+        border-radius: 50%;
+        vertical-align: -0.15em;
+        animation: spin 0.8s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
       button {
         margin-top: 1rem;
@@ -75,8 +104,13 @@
         margin-top: 1.5rem;
         font-size: 0.9rem;
       }
+      summary {
+        cursor: pointer;
+      }
       pre {
-        margin-top: 1rem;
+        margin-top: 0.5rem;
+        max-height: 18rem;
+        overflow: auto;
         font-size: 0.8rem;
         white-space: pre-wrap;
         opacity: 0.7;

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -26,6 +26,8 @@ let targetOrigin = params.get("origin") || "*";
 let firmware: FirmwareMessage | null = null;
 let busy = false;
 let flashDone = false;
+let streaming = false;
+let stopLogs = false;
 
 // --- UI -------------------------------------------------------------------
 
@@ -63,6 +65,11 @@ const installBtn = el<HTMLButtonElement>("install");
 const fileInput = el<HTMLInputElement>("file");
 const hintEl = el<HTMLParagraphElement>("hint");
 const logEl = el<HTMLPreElement>("log");
+const logbox = el<HTMLDetailsElement>("logbox");
+
+// CSI escapes (colour, cursor moves) in ESPHome's serial log; strip them so
+// the log shows plain text instead of raw control sequences.
+const ANSI_RE = /\[[\d;?]*[A-Za-z]/g;
 
 hintEl.textContent = opener
   ? "Plug the board into this computer over USB, then press Connect & install."
@@ -80,7 +87,7 @@ function termWrite(data: string): void {
   pending += data;
   let nl = pending.indexOf("\n");
   while (nl >= 0) {
-    log(pending.slice(0, nl).replace(/.*\r/, ""));
+    log(pending.slice(0, nl).replace(/.*\r/, "").replace(ANSI_RE, ""));
     pending = pending.slice(nl + 1);
     nl = pending.indexOf("\n");
   }
@@ -247,11 +254,38 @@ async function resetDevice(transport: Transport): Promise<void> {
   await transport.setRTS(false);
 }
 
+// Stream the rebooted device's serial output into the log so a tester can watch
+// the boot over the same port that flashed it. Reads at the flash baud (115200,
+// the ESPHome logger default); a native-USB chip that re-enumerated on reset may
+// end the read early, which is surfaced rather than thrown.
+async function streamSerialLogs(transport: Transport): Promise<void> {
+  streaming = true;
+  logbox.open = true;
+  installBtn.textContent = "Stop logs";
+  installBtn.disabled = false;
+  const decoder = new TextDecoder();
+  try {
+    await transport.rawRead(
+      (chunk) => termWrite(decoder.decode(chunk, { stream: true })),
+      () => stopLogs,
+    );
+  } catch (err) {
+    log("[serial logs unavailable: " + String(err) + "]");
+  } finally {
+    streaming = false;
+  }
+}
+
 async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
   if (busy) return;
   busy = true;
   installBtn.disabled = true;
   fileInput.disabled = true;
+  // Clear any stale bar/percent from a previous failed attempt.
+  stopLogs = false;
+  progressEl.hidden = true;
+  fillEl.style.width = "0%";
+  pctEl.textContent = "";
 
   let port: SerialPort;
   try {
@@ -293,11 +327,14 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     );
     await esploader.after();
     await resetDevice(transport);
+    flashDone = true;
     setState(
       "done",
-      "Installed. The device is rebooting. You can close this tab and return to the dashboard.",
+      opener
+        ? "Installed and rebooting. Live serial logs below; close this tab when finished."
+        : "Installed and rebooting. Live serial logs below; press Stop logs when finished.",
     );
-    flashDone = true;
+    await streamSerialLogs(transport);
   } catch (err) {
     setState("error", "Installation failed: " + String(err));
   } finally {
@@ -308,12 +345,25 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     }
     busy = false;
     fileInput.disabled = false;
-    installBtn.disabled = false;
-    if (flashDone) installBtn.textContent = "Close this tab";
+    // Only offer the self-close action when an opener exists; window.close() is
+    // blocked on a tab the user navigated to directly.
+    if (flashDone && opener) {
+      installBtn.textContent = "Close this tab";
+      installBtn.disabled = false;
+    } else if (flashDone) {
+      installBtn.textContent = "Done";
+      installBtn.disabled = true;
+    } else {
+      installBtn.disabled = false;
+    }
   }
 }
 
 installBtn.addEventListener("click", async () => {
+  if (streaming) {
+    stopLogs = true; // end the live-log read; the run's finally takes over
+    return;
+  }
   if (flashDone) {
     window.close();
     return;

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -25,6 +25,7 @@ let targetOrigin = params.get("origin") || "*";
 
 let firmware: FirmwareMessage | null = null;
 let busy = false;
+let flashDone = false;
 
 // --- UI -------------------------------------------------------------------
 
@@ -39,21 +40,25 @@ document.body.innerHTML = `
     </div>
     <p id="hint"></p>
     <div id="status" class="status idle">Waiting for firmware&hellip;</div>
-    <div id="bar" hidden><div id="fill"></div></div>
+    <div id="progress" hidden><div id="bar"><div id="fill"></div></div><span id="pct"></span></div>
     <button id="install" disabled>Connect &amp; install</button>
     <details id="manual">
       <summary>No firmware received? Flash a factory file manually</summary>
       <input id="file" type="file" accept=".bin" />
     </details>
-    <pre id="log"></pre>
+    <details id="logbox">
+      <summary>Show log</summary>
+      <pre id="log"></pre>
+    </details>
   </main>
 `;
 
 const el = <T extends HTMLElement>(id: string) =>
   document.getElementById(id) as T;
 const statusEl = el<HTMLDivElement>("status");
-const barEl = el<HTMLDivElement>("bar");
+const progressEl = el<HTMLDivElement>("progress");
 const fillEl = el<HTMLDivElement>("fill");
+const pctEl = el<HTMLSpanElement>("pct");
 const installBtn = el<HTMLButtonElement>("install");
 const fileInput = el<HTMLInputElement>("file");
 const hintEl = el<HTMLParagraphElement>("hint");
@@ -65,7 +70,34 @@ hintEl.textContent = opener
 
 function log(line: string): void {
   logEl.textContent += line + "\n";
+  logEl.scrollTop = logEl.scrollHeight;
 }
+
+// esptool-js streams its output here; a \r redraws the current line (progress),
+// so keep only what follows the last \r when flushing a completed line.
+let pending = "";
+function termWrite(data: string): void {
+  pending += data;
+  let nl = pending.indexOf("\n");
+  while (nl >= 0) {
+    log(pending.slice(0, nl).replace(/.*\r/, ""));
+    pending = pending.slice(nl + 1);
+    nl = pending.indexOf("\n");
+  }
+}
+
+const terminal = {
+  clean(): void {
+    logEl.textContent = "";
+    pending = "";
+  },
+  writeLine(data: string): void {
+    log(data);
+  },
+  write(data: string): void {
+    termWrite(data);
+  },
+};
 
 function post(msg: OutboundMessage): void {
   // targetOrigin narrows from '*' to the opener's real origin once known; see
@@ -74,14 +106,21 @@ function post(msg: OutboundMessage): void {
 }
 
 function setState(state: FlashState, detail: string): void {
-  statusEl.textContent = detail;
   statusEl.className = "status " + state;
+  statusEl.textContent = "";
+  if (state === "connecting" || state === "installing") {
+    const spin = document.createElement("span");
+    spin.className = "spinner";
+    statusEl.appendChild(spin);
+  }
+  statusEl.appendChild(document.createTextNode(detail));
   post({ type: "esphome-web-flash:state", state, detail });
 }
 
 function setProgress(pct: number): void {
-  barEl.hidden = false;
+  progressEl.hidden = false;
   fillEl.style.width = pct + "%";
+  pctEl.textContent = pct + "%";
   post({ type: "esphome-web-flash:progress", pct });
 }
 
@@ -127,6 +166,7 @@ window.addEventListener("message", (ev: MessageEvent) => {
     "connecting",
     `Firmware ready${firmware.name ? ": " + firmware.name : ""}. Press Connect & install.`,
   );
+  installBtn.focus();
 });
 
 // Re-announce until firmware arrives: a single 'ready' can race the opener
@@ -167,13 +207,16 @@ async function flashFiles(
   fileArray: FileToFlash[],
   erase: boolean,
   writeProgress: (pct: number) => void,
+  setPhase: (detail: string) => void,
 ): Promise<void> {
   if (erase) {
+    setPhase("Erasing flash… this can take a moment.");
     await esploader.eraseFlash();
   }
   let totalSize = 0;
   for (const f of fileArray) totalSize += f.data.length;
   let totalWritten = 0;
+  setPhase("Writing firmware… keep this tab visible.");
   writeProgress(0);
   await esploader.writeFlash({
     fileArray,
@@ -226,6 +269,7 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     transport,
     baudrate: 115200,
     enableTracing: false,
+    terminal,
   });
 
   try {
@@ -244,11 +288,16 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     }
     log("Detected chip: " + chipName);
 
-    setState("installing", "Installing… keep this tab visible.");
-    await flashFiles(esploader, files, erase, setProgress);
+    await flashFiles(esploader, files, erase, setProgress, (detail) =>
+      setState("installing", detail),
+    );
     await esploader.after();
     await resetDevice(transport);
-    setState("done", "Installed. The device is rebooting.");
+    setState(
+      "done",
+      "Installed. The device is rebooting. You can close this tab and return to the dashboard.",
+    );
+    flashDone = true;
   } catch (err) {
     setState("error", "Installation failed: " + String(err));
   } finally {
@@ -258,12 +307,17 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
       // already closed
     }
     busy = false;
-    installBtn.disabled = false;
     fileInput.disabled = false;
+    installBtn.disabled = false;
+    if (flashDone) installBtn.textContent = "Close this tab";
   }
 }
 
 installBtn.addEventListener("click", async () => {
+  if (flashDone) {
+    window.close();
+    return;
+  }
   if (firmware) {
     const files = firmware.parts.map((p) => ({
       data: new Uint8Array(p.data),


### PR DESCRIPTION
# What does this implement/fix?

Polishes the development USB flasher page (`flasher/`) so its flashing UX no longer looks frozen and gives the user a clear next step. Reported while testing the dashboard hand-off against the deployed dev flasher:

- **Looked frozen during erase.** A full-chip erase reports no progress, so "Installing…" sat silent. Added a spinner for the connect/erase/write phases and split the status into distinct **"Erasing flash…"** and **"Writing firmware…"** lines.
- **No visible esptool output.** esptool-js output now streams into a collapsible **"Show log"** section (carriage-return progress redraws collapse to one clean line each).
- **No percentage.** A live **%** now renders beside the progress bar.
- **Dead end on success.** After "Installed. The device is rebooting." the button becomes **"Close this tab"** and the status tells the user to return to the dashboard.

The `connecting` state now focuses the install button so Enter works.

This is the **dev/test flasher only** (deployed to GitHub Pages). The production target remains web.esphome.io, which already has all of this. The postMessage hand-off contract (`flasher/src/protocol.ts`) is unchanged.

**Related issue or feature (if applicable):**

- Part of esphome/backlog#151

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
