### PR TITLE
Reacquire the re-enumerated port for flasher logs and validate the image

### DIFF
--- a/flasher/package.json
+++ b/flasher/package.json
@@ -8,7 +8,7 @@
     "build": "node build.mjs",
     "dev": "node build.mjs --serve",
     "typecheck": "tsc --noEmit",
-    "test": "node build.mjs && node test/handshake.test.mjs"
+    "test": "node build.mjs && node test/validate.test.mjs && node test/handshake.test.mjs"
   },
   "dependencies": {
     "esptool-js": "0.6.0"

--- a/flasher/src/image-magic.ts
+++ b/flasher/src/image-magic.ts
@@ -1,0 +1,27 @@
+// ESP32/ESP8266 firmware (and the bootloader a factory image starts with) carry
+// the ESP image magic byte at the bootloader offset.
+export const ESP_IMAGE_MAGIC = 0xe9;
+
+export interface FlashPart {
+  data: Uint8Array;
+  address: number;
+}
+
+// Reject anything that isn't an ESP image before the chip is erased. The magic
+// sits at byte 0 for ESP8266 and native-USB ESP32 parts (S3/C3/C6, bootloader
+// at 0x0); the original ESP32 / ESP32-S2 merged factory image pads 0x0-0xFFF
+// with 0xFF and places the bootloader (magic) at 0x1000. Returns an error
+// string, or null when it looks valid.
+export function validateEspImage(files: FlashPart[]): string | null {
+  const boot = files.find((f) => f.address === 0);
+  if (!boot) {
+    return "No image at offset 0x0; expected an ESP32/ESP8266 factory image.";
+  }
+  const hasMagic =
+    boot.data[0] === ESP_IMAGE_MAGIC ||
+    (boot.data.length > 0x1000 && boot.data[0x1000] === ESP_IMAGE_MAGIC);
+  if (!hasMagic) {
+    return "This does not look like ESP32/ESP8266 firmware (no 0xE9 image magic at 0x0 or 0x1000).";
+  }
+  return null;
+}

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -1,4 +1,5 @@
 import { ESPLoader, Transport } from "esptool-js";
+import { validateEspImage } from "./image-magic";
 import type {
   FirmwareMessage,
   OutboundMessage,
@@ -30,10 +31,6 @@ let streaming = false;
 let stopLogs = false;
 // Active log-stream reader, so the Stop button can cancel a blocked read().
 let logReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-
-// ESP32/ESP8266 firmware (and the bootloader a factory image starts with) begin
-// with the ESP image magic byte at offset 0.
-const ESP_IMAGE_MAGIC = 0xe9;
 
 // Native-USB chips (S3/C3/C6) re-enumerate on reset; wait this long for the
 // running firmware's port to reappear before giving up on logs.
@@ -258,20 +255,6 @@ async function flashFiles(
   writeProgress(100);
 }
 
-// Reject anything that isn't an ESP image before we erase the chip: the part at
-// offset 0 (factory bootloader, or the ESP8266 firmware) must carry the magic
-// byte. Returns an error string, or null when it looks valid.
-function validateEspImage(files: FileToFlash[]): string | null {
-  const boot = files.find((f) => f.address === 0);
-  if (!boot) {
-    return "No image at offset 0x0; expected an ESP32/ESP8266 factory image.";
-  }
-  if (boot.data.length < 1 || boot.data[0] !== ESP_IMAGE_MAGIC) {
-    return "This does not look like ESP32/ESP8266 firmware (missing 0xE9 image magic at 0x0).";
-  }
-  return null;
-}
-
 // Same USB device by vendor/product id; both ids must be present so two non-USB
 // ports don't match on undefined === undefined.
 function matchesDevice(a: SerialPortInfo, b: SerialPortInfo): boolean {
@@ -312,11 +295,10 @@ async function openLiveLogPort(
       try {
         await p.open({ baudRate: baud });
         return p;
-      } catch (err) {
-        const name = err instanceof DOMException ? err.name : "";
-        // NetworkError = still gone mid-re-enumeration: keep retrying. Anything
-        // else won't fix itself by waiting.
-        if (name !== "NetworkError") return null;
+      } catch {
+        // Unusable this round (still re-enumerating, or a transient open
+        // failure); fall through so the original handle is still tried before
+        // we retry the whole round.
       }
     }
     if (Date.now() >= deadline) return null;

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -267,41 +267,50 @@ function matchesDevice(a: SerialPortInfo, b: SerialPortInfo): boolean {
 }
 
 // Find and open the live port for the just-reset device. A native-USB chip
-// re-enumerates, so the flashing handle is dead; prefer a freshly-granted handle
-// for the same VID/PID (Chrome's re-enumerated port), falling back to the
-// original (UART bridges reopen in place). No re-prompt: every candidate is
-// already authorized. Returns an open port, or null if none came back in time.
+// re-enumerates, so the flashing handle is dead; prefer the genuinely new handle
+// (not present before the reset) so two identical boards don't cross logs, then
+// other VID/PID matches, then the original handle (UART bridges reopen in
+// place). No re-prompt: every candidate is already authorized. Returns the open
+// port, or null with the last error when none came back in time.
 async function openLiveLogPort(
   oldPort: SerialPort,
+  before: SerialPort[],
   baud: number,
   timeoutMs: number,
-): Promise<SerialPort | null> {
+): Promise<{ port: SerialPort | null; error?: string }> {
   const want = oldPort.getInfo();
+  const beforeSet = new Set(before);
   const deadline = Date.now() + timeoutMs;
+  let lastError = "";
   for (;;) {
-    if (stopLogs) return null; // user pressed Stop during the re-enumerate wait
+    if (stopLogs) return { port: null }; // user pressed Stop during the wait
     let granted: SerialPort[] = [];
     try {
       granted = await navigator.serial.getPorts();
-    } catch {
-      // getPorts can transiently reject mid-re-enumeration; retry below.
+    } catch (err) {
+      lastError = "getPorts failed: " + String(err);
     }
+    const matches = granted.filter(
+      (p) => p !== oldPort && matchesDevice(p.getInfo(), want),
+    );
     const candidates = [
-      ...granted.filter((p) => p !== oldPort && matchesDevice(p.getInfo(), want)),
+      ...matches.filter((p) => !beforeSet.has(p)), // the re-enumerated handle
+      ...matches.filter((p) => beforeSet.has(p)),
       oldPort,
     ];
     for (const p of candidates) {
-      if (p.readable) return p; // already open (reset race left it usable)
+      if (p.readable) return { port: p }; // already open (reset race left it usable)
       try {
         await p.open({ baudRate: baud });
-        return p;
-      } catch {
+        return { port: p };
+      } catch (err) {
         // Unusable this round (still re-enumerating, or a transient open
         // failure); fall through so the original handle is still tried before
         // we retry the whole round.
+        lastError = "open failed: " + String(err);
       }
     }
-    if (Date.now() >= deadline) return null;
+    if (Date.now() >= deadline) return { port: null, error: lastError || undefined };
     await sleep(200);
   }
 }
@@ -310,13 +319,21 @@ async function openLiveLogPort(
 // the boot end to end. Reads at 115200 (the ESPHome logger default); a board
 // whose logger uses a different baud (or whose USB id changes when running)
 // won't connect, which is surfaced rather than thrown.
-async function streamSerialLogs(oldPort: SerialPort): Promise<void> {
+async function streamSerialLogs(
+  oldPort: SerialPort,
+  before: SerialPort[],
+): Promise<void> {
   streaming = true;
   logbox.open = true;
   installBtn.textContent = "Stop logs";
   installBtn.disabled = false;
-  const port = await openLiveLogPort(oldPort, 115200, LOG_REOPEN_TIMEOUT_MS);
-  if (stopLogs) {
+  const { port, error } = await openLiveLogPort(
+    oldPort,
+    before,
+    115200,
+    LOG_REOPEN_TIMEOUT_MS,
+  );
+  if (stopLogs || !port || !port.readable) {
     if (port) {
       try {
         await port.close();
@@ -324,11 +341,13 @@ async function streamSerialLogs(oldPort: SerialPort): Promise<void> {
         // already closed
       }
     }
-    streaming = false;
-    return;
-  }
-  if (!port || !port.readable) {
-    log("[serial logs unavailable; the device did not re-enumerate in time]");
+    if (!stopLogs) {
+      log(
+        "[serial logs unavailable: " +
+          (error ?? "the device did not re-enumerate in time") +
+          "]",
+      );
+    }
     streaming = false;
     return;
   }
@@ -420,6 +439,14 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     await flashFiles(esploader, files, erase, setProgress, (detail) =>
       setState("installing", detail),
     );
+    // Snapshot authorized ports before the reset so the live-log re-acquire can
+    // tell the genuinely re-enumerated handle from an already-present board.
+    let portsBeforeReset: SerialPort[] = [];
+    try {
+      portsBeforeReset = await navigator.serial.getPorts();
+    } catch {
+      // tolerate; openLiveLogPort falls back to VID/PID matching
+    }
     await esploader.after(); // hard reset into the new firmware
     flashDone = true;
     setState(
@@ -434,7 +461,7 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     } catch {
       // already closed
     }
-    await streamSerialLogs(port);
+    await streamSerialLogs(port, portsBeforeReset);
   } catch (err) {
     setState("error", "Installation failed: " + String(err));
   } finally {

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -28,6 +28,16 @@ let busy = false;
 let flashDone = false;
 let streaming = false;
 let stopLogs = false;
+// Active log-stream reader, so the Stop button can cancel a blocked read().
+let logReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+// ESP32/ESP8266 firmware (and the bootloader a factory image starts with) begin
+// with the ESP image magic byte at offset 0.
+const ESP_IMAGE_MAGIC = 0xe9;
+
+// Native-USB chips (S3/C3/C6) re-enumerate on reset; wait this long for the
+// running firmware's port to reappear before giving up on logs.
+const LOG_REOPEN_TIMEOUT_MS = 8000;
 
 // --- UI -------------------------------------------------------------------
 
@@ -248,36 +258,139 @@ async function flashFiles(
   writeProgress(100);
 }
 
-async function resetDevice(transport: Transport): Promise<void> {
-  await transport.setRTS(true); // EN -> LOW
-  await sleep(100);
-  await transport.setRTS(false);
+// Reject anything that isn't an ESP image before we erase the chip: the part at
+// offset 0 (factory bootloader, or the ESP8266 firmware) must carry the magic
+// byte. Returns an error string, or null when it looks valid.
+function validateEspImage(files: FileToFlash[]): string | null {
+  const boot = files.find((f) => f.address === 0);
+  if (!boot) {
+    return "No image at offset 0x0; expected an ESP32/ESP8266 factory image.";
+  }
+  if (boot.data.length < 1 || boot.data[0] !== ESP_IMAGE_MAGIC) {
+    return "This does not look like ESP32/ESP8266 firmware (missing 0xE9 image magic at 0x0).";
+  }
+  return null;
+}
+
+// Same USB device by vendor/product id; both ids must be present so two non-USB
+// ports don't match on undefined === undefined.
+function matchesDevice(a: SerialPortInfo, b: SerialPortInfo): boolean {
+  return (
+    a.usbVendorId !== undefined &&
+    a.usbProductId !== undefined &&
+    a.usbVendorId === b.usbVendorId &&
+    a.usbProductId === b.usbProductId
+  );
+}
+
+// Find and open the live port for the just-reset device. A native-USB chip
+// re-enumerates, so the flashing handle is dead; prefer a freshly-granted handle
+// for the same VID/PID (Chrome's re-enumerated port), falling back to the
+// original (UART bridges reopen in place). No re-prompt: every candidate is
+// already authorized. Returns an open port, or null if none came back in time.
+async function openLiveLogPort(
+  oldPort: SerialPort,
+  baud: number,
+  timeoutMs: number,
+): Promise<SerialPort | null> {
+  const want = oldPort.getInfo();
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (stopLogs) return null; // user pressed Stop during the re-enumerate wait
+    let granted: SerialPort[] = [];
+    try {
+      granted = await navigator.serial.getPorts();
+    } catch {
+      // getPorts can transiently reject mid-re-enumeration; retry below.
+    }
+    const candidates = [
+      ...granted.filter((p) => p !== oldPort && matchesDevice(p.getInfo(), want)),
+      oldPort,
+    ];
+    for (const p of candidates) {
+      if (p.readable) return p; // already open (reset race left it usable)
+      try {
+        await p.open({ baudRate: baud });
+        return p;
+      } catch (err) {
+        const name = err instanceof DOMException ? err.name : "";
+        // NetworkError = still gone mid-re-enumeration: keep retrying. Anything
+        // else won't fix itself by waiting.
+        if (name !== "NetworkError") return null;
+      }
+    }
+    if (Date.now() >= deadline) return null;
+    await sleep(200);
+  }
 }
 
 // Stream the rebooted device's serial output into the log so a tester can watch
-// the boot over the same port that flashed it. Reads at the flash baud (115200,
-// the ESPHome logger default); a native-USB chip that re-enumerated on reset may
-// end the read early, which is surfaced rather than thrown.
-async function streamSerialLogs(transport: Transport): Promise<void> {
+// the boot end to end. Reads at 115200 (the ESPHome logger default); a board
+// whose logger uses a different baud (or whose USB id changes when running)
+// won't connect, which is surfaced rather than thrown.
+async function streamSerialLogs(oldPort: SerialPort): Promise<void> {
   streaming = true;
   logbox.open = true;
   installBtn.textContent = "Stop logs";
   installBtn.disabled = false;
-  const decoder = new TextDecoder();
+  const port = await openLiveLogPort(oldPort, 115200, LOG_REOPEN_TIMEOUT_MS);
+  if (stopLogs) {
+    if (port) {
+      try {
+        await port.close();
+      } catch {
+        // already closed
+      }
+    }
+    streaming = false;
+    return;
+  }
+  if (!port || !port.readable) {
+    log("[serial logs unavailable; the device did not re-enumerate in time]");
+    streaming = false;
+    return;
+  }
+  // Clear DTR/RTS so reopening the port doesn't reset the chip into the bootloader.
   try {
-    await transport.rawRead(
-      (chunk) => termWrite(decoder.decode(chunk, { stream: true })),
-      () => stopLogs,
-    );
+    await port.setSignals({ dataTerminalReady: false, requestToSend: false });
+  } catch {
+    // tolerate; the chip may already be in a fine state
+  }
+  const decoder = new TextDecoder();
+  const reader = port.readable.getReader();
+  logReader = reader;
+  try {
+    for (;;) {
+      if (stopLogs) break;
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) termWrite(decoder.decode(value, { stream: true }));
+    }
   } catch (err) {
-    log("[serial logs unavailable: " + String(err) + "]");
+    log("[serial logs ended: " + String(err) + "]");
   } finally {
+    logReader = null;
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released
+    }
+    try {
+      await port.close();
+    } catch {
+      // already closed
+    }
     streaming = false;
   }
 }
 
 async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
   if (busy) return;
+  const invalid = validateEspImage(files);
+  if (invalid) {
+    setState("error", invalid);
+    return;
+  }
   busy = true;
   installBtn.disabled = true;
   fileInput.disabled = true;
@@ -325,8 +438,7 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
     await flashFiles(esploader, files, erase, setProgress, (detail) =>
       setState("installing", detail),
     );
-    await esploader.after();
-    await resetDevice(transport);
+    await esploader.after(); // hard reset into the new firmware
     flashDone = true;
     setState(
       "done",
@@ -334,7 +446,13 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
         ? "Installed and rebooting. Live serial logs below; close this tab when finished."
         : "Installed and rebooting. Live serial logs below; press Stop logs when finished.",
     );
-    await streamSerialLogs(transport);
+    // Release the flashing handle before re-acquiring the live (re-enumerated) port.
+    try {
+      await transport.disconnect();
+    } catch {
+      // already closed
+    }
+    await streamSerialLogs(port);
   } catch (err) {
     setState("error", "Installation failed: " + String(err));
   } finally {
@@ -362,6 +480,7 @@ async function runFlash(files: FileToFlash[], erase: boolean): Promise<void> {
 installBtn.addEventListener("click", async () => {
   if (streaming) {
     stopLogs = true; // end the live-log read; the run's finally takes over
+    logReader?.cancel().catch(() => {}); // unblock a pending read() immediately
     return;
   }
   if (flashDone) {

--- a/flasher/test/validate.test.mjs
+++ b/flasher/test/validate.test.mjs
@@ -1,0 +1,56 @@
+// Unit test for the pure image-magic validator. esbuild transforms the TS
+// module to ESM in memory so it can be imported without the DOM-touching entry.
+import { Buffer } from "node:buffer";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import esbuild from "esbuild";
+
+const src = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "image-magic.ts");
+const built = await esbuild.build({
+  entryPoints: [src],
+  bundle: true,
+  format: "esm",
+  write: false,
+});
+const { validateEspImage } = await import(
+  "data:text/javascript;base64," + Buffer.from(built.outputFiles[0].text).toString("base64")
+);
+
+let ok = true;
+const check = (cond, msg) => {
+  if (cond) console.log("PASS:", msg);
+  else {
+    ok = false;
+    console.log("FAIL:", msg);
+  }
+};
+
+// ESP8266 / native-USB ESP32 (S3/C3/C6): magic at byte 0.
+check(
+  validateEspImage([{ address: 0, data: new Uint8Array([0xe9, 0, 0, 0]) }]) === null,
+  "accepts 0xE9 at byte 0",
+);
+
+// Original ESP32 / ESP32-S2 merged factory: 0xFF pad, bootloader magic at 0x1000.
+const esp32 = new Uint8Array(0x1001).fill(0xff);
+esp32[0x1000] = 0xe9;
+check(validateEspImage([{ address: 0, data: esp32 }]) === null, "accepts 0xE9 at 0x1000 (padded esp32)");
+
+// rp2040 .uf2 ("UF2\n") has no ESP magic at either offset.
+const uf2 = new Uint8Array([0x55, 0x46, 0x32, 0x0a]);
+check(validateEspImage([{ address: 0, data: uf2 }]) !== null, "rejects a uf2 image");
+
+// 0xFF-padded but no magic at 0x1000 either.
+check(
+  validateEspImage([{ address: 0, data: new Uint8Array(0x2000) }]) !== null,
+  "rejects an all-zero buffer",
+);
+
+// No part at offset 0.
+check(
+  validateEspImage([{ address: 0x10000, data: new Uint8Array([0xe9]) }]) !== null,
+  "rejects when no image at 0x0",
+);
+
+console.log(ok ? "\nALL PASS" : "\nFAILURES");
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
# What does this implement/fix?

Two fixes to the development USB flasher (`flasher/`), found testing on an ESP32-S3:

- **Serial logs never connected after a flash.** Native-USB chips (S3/C3/C6) drop their USB device on the post-flash `Hard resetting via RTS pin...`, so the flashing port handle is dead; the log read returned immediately with nothing. The flasher now re-acquires the running firmware's port via `navigator.serial.getPorts()` (matching VID/PID, falling back to the original handle for UART bridges) before streaming, reads it directly, and the **Stop logs** button cancels a blocked read.
- **No firmware validation.** A payload whose image at `0x0` lacks the `0xE9` ESP image magic is now rejected before the chip is erased, so a non-ESP file (e.g. an rp2040 `.uf2`) fails fast with a clear message instead of being blindly written.

Dev/test flasher only; the postMessage hand-off contract (`flasher/src/protocol.ts`) is unchanged.

**Related issue or feature (if applicable):**

- Part of esphome/backlog#151

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
