### PR TITLE
Harden the dev flasher's postMessage receiver

### DIFF
--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -117,7 +117,14 @@ const terminal = {
 function post(msg: OutboundMessage): void {
   // targetOrigin narrows from '*' to the opener's real origin once known; see
   // its declaration. Outbound frames carry no nonce (see protocol.ts).
-  opener?.postMessage(msg, targetOrigin);
+  try {
+    opener?.postMessage(msg, targetOrigin);
+  } catch {
+    // A malformed origin= hash param (e.g. origin=null) makes postMessage throw,
+    // which would wedge the ready handshake before the retry interval is set up.
+    targetOrigin = "*";
+    opener?.postMessage(msg, "*");
+  }
 }
 
 function setState(state: FlashState, detail: string): void {
@@ -167,6 +174,9 @@ window.addEventListener("message", (ev: MessageEvent) => {
   if (!data || data.type !== "esphome-web-flash:firmware") return;
   if (data.nonce !== nonce) return;
   if (!isFlashParts(data.parts)) {
+    // The opener has attached and sent — stop re-announcing ready even though
+    // the payload is unusable, mirroring the accepted path below.
+    stopReadyRetry();
     setState("error", "Received a malformed firmware payload.");
     return;
   }
@@ -504,7 +514,7 @@ installBtn.addEventListener("click", async () => {
       data: new Uint8Array(p.data),
       address: p.address,
     }));
-    await runFlash(files, firmware.erase ?? true);
+    await runFlash(files, firmware.erase !== false);
     return;
   }
   const file = fileInput.files?.[0];

--- a/flasher/src/main.ts
+++ b/flasher/src/main.ts
@@ -119,11 +119,19 @@ function post(msg: OutboundMessage): void {
   // its declaration. Outbound frames carry no nonce (see protocol.ts).
   try {
     opener?.postMessage(msg, targetOrigin);
-  } catch {
+  } catch (err) {
     // A malformed origin= hash param (e.g. origin=null) makes postMessage throw,
-    // which would wedge the ready handshake before the retry interval is set up.
+    // which would wedge the ready handshake. Fall back to '*' so frames keep
+    // flowing; outbound frames carry no nonce (see protocol.ts), so the broader
+    // audience leaks nothing. Log rather than swallow so an unrelated failure
+    // (not just a bad origin) is still visible.
+    console.error("Flasher postMessage failed; falling back to '*':", err);
     targetOrigin = "*";
-    opener?.postMessage(msg, "*");
+    try {
+      opener?.postMessage(msg, "*");
+    } catch (err2) {
+      console.error("Flasher postMessage failed after origin fallback:", err2);
+    }
   }
 }
 
@@ -174,7 +182,7 @@ window.addEventListener("message", (ev: MessageEvent) => {
   if (!data || data.type !== "esphome-web-flash:firmware") return;
   if (data.nonce !== nonce) return;
   if (!isFlashParts(data.parts)) {
-    // The opener has attached and sent — stop re-announcing ready even though
+    // The opener has attached and sent, so stop re-announcing ready even though
     // the payload is unusable, mirroring the accepted path below.
     stopReadyRetry();
     setState("error", "Received a malformed firmware payload.");

--- a/flasher/test/handshake.test.mjs
+++ b/flasher/test/handshake.test.mjs
@@ -114,6 +114,18 @@ try {
   else if (enabledAfterBad) fail("install enabled after malformed payload");
   else console.log("PASS: malformed payload rejected with error state");
 
+  // 2b-ii. ...and the malformed payload stops the ready re-announce: the opener
+  // has clearly attached, so it must not keep receiving ready frames.
+  await a.evaluate(() => {
+    window.__msgs.length = 0;
+  });
+  await new Promise((r) => setTimeout(r, 700));
+  const readyAfterBad = (await a.evaluate(() => window.__msgs)).some(
+    (m) => m && m.type === "esphome-web-flash:ready",
+  );
+  if (readyAfterBad) fail("ready still re-announced after malformed payload");
+  else console.log("PASS: ready retry stopped after malformed payload");
+
   // 2c. a negative/non-integer address is rejected at the boundary
   await a.evaluate(() => {
     window.__b.postMessage(
@@ -131,6 +143,26 @@ try {
   if (!/malformed/i.test(label))
     fail("negative address not rejected: " + label);
   else console.log("PASS: negative address rejected at boundary");
+
+  // 2d. a malformed origin= hash param must not wedge the ready handshake:
+  // postMessage to a bad targetOrigin throws, and the receiver falls back to '*'.
+  {
+    const c = await browser.newPage();
+    await c.goto(`${base}/opener.html`);
+    const [pop2] = await Promise.all([
+      new Promise((res) => c.once("popup", res)),
+      c.evaluate((u) => window.__open(u), `${base}/#nonce=n2&origin=null`),
+    ]);
+    await pop2.waitForNetworkIdle({ idleTime: 300 }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 300));
+    const ready2 = (await c.evaluate(() => window.__msgs)).find(
+      (m) => m && m.type === "esphome-web-flash:ready",
+    );
+    if (!ready2) fail("ready not received when origin= hash param is malformed");
+    else console.log("PASS: malformed origin falls back to '*', ready still sent");
+    await pop2.close();
+    await c.close();
+  }
 
   // 3. correct nonce accepted -> button enabled, state mirrored back
   await a.evaluate(() => {


### PR DESCRIPTION
# What does this implement/fix?

Three receiver-side hardening fixes for the dev flasher's postMessage handler (`flasher/src/main.ts`), for parity with the web.esphome.io receiver review (esphome/dashboard#923) that shares the same contract. The device-builder-frontend sender (`src/util/usb-flasher.ts`) is unaffected; these are receiver concerns.

- **`post()` no longer throws on a malformed origin.** `targetOrigin` comes from the hash `origin` param, so a value like `origin=null` becomes `"null"` and the first synchronous `post()` threw before the ready-retry interval was set up, wedging the handshake. `post()` now wraps `postMessage` in try/catch, falls back to `"*"`, and pins `targetOrigin = "*"` so subsequent frames keep flowing.
- **A malformed payload stops the ready re-announce.** The `isFlashParts` failure branch set the error state and returned before `stopReadyRetry()`, so the opener kept receiving `ready` frames for up to 10s even though it had clearly attached and sent. It now calls `stopReadyRetry()` on that path, mirroring the accepted path.
- **`erase` is coerced explicitly.** `firmware.erase ?? true` only defaults on null/undefined, so a non-boolean `erase` (e.g. the string `"false"`) read as truthy. Changed to `firmware.erase !== false`, so erase stays the safe default unless the opener explicitly sent boolean `false`.

The puppeteer harness (`flasher/test/handshake.test.mjs`) gains assertions for the first two: a malformed `origin=null` still yields a `ready` frame, and a malformed payload stops the `ready` re-announce. The erase path only runs at flash time against real hardware, so it stays code-only (consistent with the harness's existing scope). I confirmed both new assertions go red when their fix is reverted.

**Related issue or feature (if applicable):**

- Fixes #1607

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-dashboard-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
