### PR TITLE
Document protocol extensibility and add version/deviceName fields

### DIFF
--- a/flasher/src/protocol.ts
+++ b/flasher/src/protocol.ts
@@ -12,6 +12,16 @@
 // frame zero (otherwise it is learned from the first inbound frame); PR 2 should
 // pass 'origin=<dashboard-origin>' as defense in depth. The flasher re-sends
 // 'ready' until firmware arrives so a late opener listener cannot wedge the handoff.
+//
+// EXTENDING THE PROTOCOL: keep changes additive. New optional fields and new
+// message types stay forward- and backward-compatible because every receiver
+// reads only the fields it knows and ignores unknown message types, and senders
+// default absent fields. That is how 'deviceName' was added without a bump.
+// Both sides exchange PROTOCOL_VERSION (ReadyMessage.version from the flasher,
+// FirmwareMessage.version from the opener); a peer that sees a higher version
+// than it speaks should proceed with its known subset (and may warn). Bump
+// PROTOCOL_VERSION only for a BREAKING change, and branch on the peer's version
+// at that point; additive changes never bump it.
 
 export const PROTOCOL_VERSION = 1;
 
@@ -33,7 +43,13 @@ export interface FlashPart {
 export interface FirmwareMessage {
   type: "esphome-web-flash:firmware";
   nonce: string;
+  // The opener's protocol version, so the flasher can branch on it for a future
+  // breaking change. Absent means v1.
+  version?: number;
   name?: string;
+  // The device's friendly name, so the flasher window and tab title identify
+  // which device they're for.
+  deviceName?: string;
   erase?: boolean;
   parts: FlashPart[];
 }


### PR DESCRIPTION
# What does this implement/fix?

Documents the postMessage flash protocol's extensibility contract in `flasher/src/protocol.ts` and adds the two optional `FirmwareMessage` fields the dashboard already sends.

The contract is intentionally additive: new optional fields and new message types stay forward- and backward-compatible because every receiver reads only the fields it knows and ignores unknown message types, and senders default absent fields (that's how `deviceName` was added without a bump). Both sides exchange `PROTOCOL_VERSION` (`ReadyMessage.version` from the flasher, `FirmwareMessage.version` from the opener); a peer seeing a higher version than it speaks proceeds with its known subset. `PROTOCOL_VERSION` is bumped only for a breaking change, and that's where you branch on the peer's version.

Adds `FirmwareMessage.version` (the opener's protocol version) and `FirmwareMessage.deviceName` (so the flasher window and tab title identify the device). Both are optional; receivers that don't read them are unaffected.

**Related issue or feature (if applicable):**

- Part of esphome/backlog#151

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
