### PR TITLE
Keep the flasher watchdog-reset config0 value an unsigned u32

### DIFF
--- a/flasher/src/reset.ts
+++ b/flasher/src/reset.ts
@@ -35,11 +35,12 @@ async function watchdogReset(loader: ESPLoader, transport: Transport): Promise<b
     // setSignals may fail; the WDT can still reset the chip.
   }
   // Sequence + magic value from esptool python's watchdog_reset(): unlock, set
-  // timeout, enable+arm, re-lock.
+  // timeout, enable+arm, re-lock. >>> 0 keeps config0 an unsigned u32
+  // (1 << 31 alone is negative in JS).
   try {
     await loader.writeReg(regs.wdtWProtect, RTC_CNTL_WDT_WKEY);
     await loader.writeReg(regs.wdtConfig1, 2000);
-    await loader.writeReg(regs.wdtConfig0, (1 << 31) | (5 << 28) | (1 << 8) | 2);
+    await loader.writeReg(regs.wdtConfig0, ((1 << 31) | (5 << 28) | (1 << 8) | 2) >>> 0);
     await loader.writeReg(regs.wdtWProtect, 0);
   } catch {
     // A writeReg can race the reset firing; the WDT has already done its job.


### PR DESCRIPTION
## What does this implement/fix?

`(1 << 31)` evaluates to a negative signed int32 in JavaScript, so the
`wdtConfig0` write in the flasher's `watchdogReset` (the
ESP32-S2/S3/C2/C3 RTC-WDT reset path) was passing a negative value where
the ROM expects the unsigned value. Masking with `>>> 0` keeps it an
unsigned u32 and documents why in the comment.

No behaviour change: `loader.writeReg` coerces to u32 on the wire either
way. Readability only, mirroring the same nit fixed in the dashboard's
copy (esphome/dashboard#923) and the canonical frontend source
(esphome/device-builder-frontend#912).

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`
