### PR TITLE
Harden esptool chip detection for classic ESP32, ESP8266, and new variants

### DIFF
--- a/esphome_device_builder/controllers/config/chip_detect.py
+++ b/esphome_device_builder/controllers/config/chip_detect.py
@@ -11,33 +11,45 @@ from contextlib import suppress
 from pathlib import Path
 
 from ...helpers.subprocess import run_subprocess_capture
+from ...models.boards import Esp32Variant
 
 _LOGGER = logging.getLogger(__name__)
 
-# Maps esptool's chip family string (lower-cased) to
-# ``(chip_family, variant, platform)``. ``chip_family`` matches a
-# ``WIZARD_BOARD_PLATFORMS.label`` value in the frontend so callers
-# can hand it straight to the board-picker filter; ``variant`` and
-# ``platform`` mirror ESPHome's own keys. Families not in this
-# table cause ``_chip_family_to_descriptor`` to return ``None``,
-# which the WS handler surfaces as ``_DETECT_UNKNOWN_CHIP``.
-#
+
+def _esp32_chip_family_map() -> dict[str, tuple[str, str, str]]:
+    """
+    Build the esptool-family → ``(chip_family, variant, platform)`` table.
+
+    Sourced from :class:`Esp32Variant` so a new ESP32 variant is
+    recognised by adding one enum member; keys mirror esptool's dashed
+    family string and ``chip_family`` the frontend filter label.
+    """
+    table: dict[str, tuple[str, str, str]] = {}
+    for v in Esp32Variant:
+        suffix = v.value[len("esp32") :]  # "" for classic, "s3"/"c61"/… otherwise
+        key = "esp32" if not suffix else f"esp32-{suffix}"
+        label = "ESP32" if not suffix else f"ESP32-{suffix.upper()}"
+        table[key] = (label, v.value, "esp32")
+    return table
+
+
 # esptool can only identify ESP chips. Non-ESP platforms (RP2040 /
 # RP2350, BK72xx, RTL87xx, LN882x, nRF52) need their own probe path;
-# they're not in this table.
+# they're not in this table. Families not in it cause
+# ``_chip_family_to_descriptor`` to return ``None``, which the WS
+# handler surfaces as ``_DETECT_UNKNOWN_CHIP``.
 _CHIP_FAMILY_MAP: dict[str, tuple[str, str, str]] = {
-    "esp32": ("ESP32", "esp32", "esp32"),
-    "esp32-s2": ("ESP32-S2", "esp32s2", "esp32"),
-    "esp32-s3": ("ESP32-S3", "esp32s3", "esp32"),
-    "esp32-c2": ("ESP32-C2", "esp32c2", "esp32"),
-    "esp32-c3": ("ESP32-C3", "esp32c3", "esp32"),
-    "esp32-c5": ("ESP32-C5", "esp32c5", "esp32"),
-    "esp32-c6": ("ESP32-C6", "esp32c6", "esp32"),
-    "esp32-c61": ("ESP32-C61", "esp32c61", "esp32"),
-    "esp32-h2": ("ESP32-H2", "esp32h2", "esp32"),
-    "esp32-p4": ("ESP32-P4", "esp32p4", "esp32"),
+    **_esp32_chip_family_map(),
     "esp8266": ("ESP8266", "", "esp8266"),
 }
+
+# esptool's ``get_chip_description()`` reports package-specific names
+# (``ESP32-D0WD``, ``ESP32-PICO-D4``, ``ESP8266EX``, ``ESP8285``) that
+# aren't bare family keys. These prefixes collapse the *classic* ESP32
+# SKUs to ``esp32``; sub-variants (s2/s3/c3/…) are dashed exact keys in
+# the map and never reach normalisation, so ``ESP32-S0WD`` (classic) maps
+# to ``esp32`` while ``ESP32-S31`` (a real variant) keeps its own key.
+_CLASSIC_ESP32_PREFIXES = ("esp32d", "esp32pico", "esp32u", "esp32s0")
 
 # ESP-IDF ``esp_app_desc_t`` lives at the start of every IDF app
 # image. With ESPHome's default partition layout the app partition
@@ -89,13 +101,26 @@ def _is_valid_port_name(port: str) -> bool:
 
 
 def _chip_family_to_descriptor(esptool_family: str) -> dict[str, str] | None:
-    """Map ``"ESP32-C3"`` → ``{chip_family, variant, platform}``."""
+    """Map ``"ESP32-C3"`` / ``"ESP32-D0WD"`` → ``{chip_family, variant, platform}``."""
     key = esptool_family.strip().lower()
     entry = _CHIP_FAMILY_MAP.get(key)
+    if entry is None:
+        normalized = _normalize_chip_family(key)
+        entry = _CHIP_FAMILY_MAP.get(normalized) if normalized else None
     if entry is None:
         return None
     family, variant, platform = entry
     return {"chip_family": family, "variant": variant, "platform": platform}
+
+
+def _normalize_chip_family(key: str) -> str | None:
+    """Collapse a package-specific esptool name to its bare family key."""
+    nodash = key.replace("-", "")
+    if nodash.startswith("esp82"):  # esp8266 / esp8285 share esphome's esp8266
+        return "esp8266"
+    if nodash.startswith(_CLASSIC_ESP32_PREFIXES):
+        return "esp32"
+    return None
 
 
 def _parse_project_name(blob: bytes) -> str | None:

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -54,12 +54,15 @@ class Esp32Variant(StrEnum):
     ESP32 = "esp32"
     ESP32S2 = "esp32s2"
     ESP32S3 = "esp32s3"
+    ESP32S31 = "esp32s31"
     ESP32C2 = "esp32c2"
     ESP32C3 = "esp32c3"
     ESP32C5 = "esp32c5"
     ESP32C6 = "esp32c6"
     ESP32C61 = "esp32c61"
     ESP32H2 = "esp32h2"
+    ESP32H4 = "esp32h4"
+    ESP32H21 = "esp32h21"
     ESP32P4 = "esp32p4"
 
 

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -1310,6 +1310,60 @@ def test_chip_family_to_descriptor_maps_esp8266() -> None:
     }
 
 
+def test_chip_family_to_descriptor_maps_classic_esp32_packages() -> None:
+    """Esptool's package-specific classic names collapse to esp32."""
+    for name in ("ESP32-D0WD-V3", "ESP32-D0WDQ6", "ESP32-PICO-D4", "ESP32-U4WDH"):
+        assert _chip_family_to_descriptor(name) == {
+            "chip_family": "ESP32",
+            "variant": "esp32",
+            "platform": "esp32",
+        }
+
+
+def test_chip_family_to_descriptor_maps_esp8266_and_esp8285_packages() -> None:
+    for name in ("ESP8266EX", "ESP8285"):
+        assert _chip_family_to_descriptor(name) == {
+            "chip_family": "ESP8266",
+            "variant": "",
+            "platform": "esp8266",
+        }
+
+
+def test_chip_family_to_descriptor_keeps_s0wd_classic_not_s_variant() -> None:
+    """ESP32-S0WD is a classic SKU, not a sub-variant — must map to esp32."""
+    assert _chip_family_to_descriptor("ESP32-S0WD") == {
+        "chip_family": "ESP32",
+        "variant": "esp32",
+        "platform": "esp32",
+    }
+
+
+def test_chip_family_to_descriptor_recognizes_new_variants() -> None:
+    """S31/H4/H21 are real esphome variants now in the catalog enum."""
+    assert _chip_family_to_descriptor("ESP32-S31") == {
+        "chip_family": "ESP32-S31",
+        "variant": "esp32s31",
+        "platform": "esp32",
+    }
+    assert _chip_family_to_descriptor("ESP32-H21")["variant"] == "esp32h21"
+
+
+def test_parse_chip_family_line_classic_from_chip_type_line() -> None:
+    """The ``Chip type:`` line alone identifies a classic ESP32 (no rescue)."""
+    output = "Chip type:          ESP32-D0WD-V3 (revision v3.1)\n"
+    assert _parse_chip_family_line(output) == {
+        "chip_family": "ESP32",
+        "variant": "esp32",
+        "platform": "esp32",
+    }
+
+
+def test_parse_chip_family_line_keeps_s3_off_classic() -> None:
+    """An ESP32-S3 package must stay on the S3 variant, not collapse to esp32."""
+    output = "Chip type:          ESP32-S3 (QFN56) (revision v0.2)\n"
+    assert _parse_chip_family_line(output)["variant"] == "esp32s3"
+
+
 def test_parse_project_name_returns_project_name_when_magic_matches() -> None:
     blob = _app_descriptor_blob("starter-kit")
     assert _parse_project_name(blob) == "starter-kit"


### PR DESCRIPTION
# What does this implement/fix?

The server-side `config/detect_chip` fallback matched esptool's family string by exact lookup, so package-specific descriptions (ESP32-D0WD, ESP8266EX, ESP8285) only resolved through the later CHIP_NAME line and could miss the chip entirely.

`_chip_family_to_descriptor` now collapses the classic ESP32 SKUs and the esp82 family to their bare key, while distinct sub-variants stay exact, so ESP32-S0WD maps to esp32 but ESP32-S31 keeps its own key (never mis-read as S3). The chip-family table is derived from `Esp32Variant` so a new variant is one enum member, and the enum gains the esphome-defined S31, H4, and H21.

Companion to the frontend fix where the same bug was user-facing on the WebSerial path.

**Related issue or feature (if applicable):**

Reported via the dashboard; no tracking issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#914

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
