### PR TITLE
Restore legacy USERNAME and PASSWORD env vars as a deprecated fallback

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -70,6 +70,8 @@ On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/m
 
 When the dashboard is started with `--username`/`--password` (or `$ESPHOME_USERNAME`/`$ESPHOME_PASSWORD` env vars), every WebSocket connection on the public port must authenticate before any other command will be accepted.
 
+The legacy bare `$USERNAME`/`$PASSWORD` pair is still accepted as a deprecated fallback, so dashboards configured before the `ESPHOME_*` rename stay protected; it is adopted only when `$PASSWORD` is set and no newer source supplied credentials, and the dashboard logs a deprecation warning at startup. Rename to `$ESPHOME_USERNAME`/`$ESPHOME_PASSWORD`; the bare names will be removed in a future release.
+
 The handshake:
 
 1. Server sends `ServerInfoMessage` with `requires_auth: true`.

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-import os
 import signal
 import sys
 import threading
@@ -24,6 +23,7 @@ from .constants import (
     DEFAULT_REMOTE_BUILD_PORT,
     __version__,
 )
+from .helpers.credentials import resolve_credentials
 from .helpers.logging import activate_log_queue_handler
 from .helpers.startup_timing import StartupTimer
 
@@ -322,6 +322,8 @@ def main() -> None:
 
     _warn_deprecated_credential_flags(args)
 
+    _warn_legacy_credential_env(args)
+
     # ``--version`` / ``--help`` exit above before reaching this
     # point, so the lazy imports below are reachable only when the
     # user actually meant to run the dashboard. Gate on
@@ -465,9 +467,7 @@ def _format_version() -> str:
 
 def _validate_credentials(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     """Reject mismatched --username / --password (or env equivalents)."""
-    has_user = bool(args.username or os.getenv("ESPHOME_USERNAME"))
-    has_pass = bool(args.password or os.getenv("ESPHOME_PASSWORD"))
-    if has_user != has_pass:
+    if resolve_credentials(args.username, args.password).mismatch:
         parser.error(
             "--username and --password must both be set (or both unset). "
             "Use $ESPHOME_USERNAME / $ESPHOME_PASSWORD env vars as alternatives."
@@ -483,6 +483,23 @@ def _warn_deprecated_credential_flags(args: argparse.Namespace) -> None:
         "removed in a future release. Use $ESPHOME_USERNAME / "
         "$ESPHOME_PASSWORD env vars instead; command-line arguments are "
         "visible to every other local user via process listings."
+    )
+
+
+def _warn_legacy_credential_env(args: argparse.Namespace) -> None:
+    """Warn loudly when auth came from the deprecated bare $USERNAME / $PASSWORD."""
+    if not resolve_credentials(args.username, args.password).used_legacy:
+        return
+    banner = "=" * 70
+    logging.getLogger(_LOGGER_NAME).warning(
+        "\n%s\n"
+        " DEPRECATION: authenticating with the legacy $USERNAME / $PASSWORD\n"
+        " environment variables. Rename them to $ESPHOME_USERNAME /\n"
+        " $ESPHOME_PASSWORD; the bare names will stop working in a future\n"
+        " release.\n"
+        "%s",
+        banner,
+        banner,
     )
 
 

--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -21,6 +21,7 @@ from ...constants import (
 )
 from ...helpers.api import CommandError
 from ...helpers.auth import hash_password
+from ...helpers.credentials import resolve_credentials
 from ...helpers.network_interfaces import resolve_bind_host
 from ...helpers.secrets_state import migrate_placeholder_wifi_secrets
 from ...models import ErrorCode
@@ -101,19 +102,19 @@ class DashboardSettings:
         """Parse CLI arguments into settings."""
         self.on_ha_addon = getattr(args, "ha_addon", False)
         self.allow_public_port = getattr(args, "ha_addon_allow_public", False)
-        # Env-var fallback uses ``ESPHOME_*`` rather than the legacy
-        # dashboard's bare ``USERNAME`` / ``PASSWORD``: the bare names
-        # collide with login-shell / Windows system vars (``$USERNAME``
-        # is the OS user on both), which would silently promote the
-        # OS user to the dashboard username when only ``--password``
-        # / ``$ESPHOME_PASSWORD`` is set. Intentional divergence from
-        # ``esphome/dashboard/settings.py``.
-        username = getattr(args, "username", None) or os.getenv("ESPHOME_USERNAME") or ""
-        password = getattr(args, "password", None) or os.getenv("ESPHOME_PASSWORD") or ""
-        self.username = username
-        self.using_password = bool(username and password)
+        # Credentials resolve through ``resolve_credentials``: CLI flag, then
+        # ``$ESPHOME_*``, then the deprecated bare ``$USERNAME`` / ``$PASSWORD``
+        # pair (kept for back-compat with pre-rename dashboards, warned about at
+        # startup). The bare pair is adopted only when ``$PASSWORD`` is set, so
+        # the OS-provided ``$USERNAME`` is never read on its own.
+        resolved = resolve_credentials(
+            getattr(args, "username", "") or "",
+            getattr(args, "password", "") or "",
+        )
+        self.username = resolved.username
+        self.using_password = bool(resolved.username and resolved.password)
         if self.using_password:
-            self.password_hash = hash_password(password)
+            self.password_hash = hash_password(resolved.password)
         self.config_dir = Path(args.configuration)
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.absolute_config_dir = self.config_dir.resolve()

--- a/esphome_device_builder/helpers/credentials.py
+++ b/esphome_device_builder/helpers/credentials.py
@@ -41,7 +41,11 @@ def resolve_credentials(
     # configured legacy auth" signal. ``$USERNAME`` *is* the login user on
     # Linux/Windows, so it must never trigger the fallback or be read on its
     # own — doing so would silently promote the OS user to the dashboard
-    # username (the footgun the ESPHOME_* rename fixed).
+    # username (the footgun the ESPHOME_* rename fixed). On Windows
+    # ``$USERNAME`` is always populated, so the gate there reduces to
+    # "``$PASSWORD`` is set" and the adopted username is the OS login name;
+    # that fails safe (more locked down, and the deprecation banner fires),
+    # not open.
     if not username and not password and environ.get("PASSWORD"):
         username = environ.get("USERNAME", "")
         password = environ.get("PASSWORD", "")

--- a/esphome_device_builder/helpers/credentials.py
+++ b/esphome_device_builder/helpers/credentials.py
@@ -1,0 +1,54 @@
+"""Resolve dashboard auth credentials from CLI flags and environment vars."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ResolvedCredentials:
+    """Outcome of resolving the dashboard username/password across all sources."""
+
+    username: str
+    password: str
+    used_legacy: bool
+    mismatch: bool
+
+
+def resolve_credentials(
+    username_arg: str,
+    password_arg: str,
+    environ: Mapping[str, str] = os.environ,
+) -> ResolvedCredentials:
+    """
+    Resolve the dashboard credentials across flags, ``ESPHOME_*`` and legacy env.
+
+    Precedence per credential: CLI flag, then ``$ESPHOME_USERNAME`` /
+    ``$ESPHOME_PASSWORD``, then the deprecated bare ``$USERNAME`` /
+    ``$PASSWORD`` pair. The bare pair is adopted only when the new scheme
+    supplied nothing and ``$PASSWORD`` is set, so the OS-provided
+    ``$USERNAME`` is never read on its own (it would otherwise promote the
+    login-shell user to the dashboard username). ``mismatch`` is true when
+    exactly one half of the resolved pair is set.
+    """
+    username = username_arg or environ.get("ESPHOME_USERNAME", "")
+    password = password_arg or environ.get("ESPHOME_PASSWORD", "")
+    used_legacy = False
+    # Gate the legacy fallback on ``$PASSWORD`` specifically: it is not a
+    # standard OS/shell variable, so its presence is the deliberate "I
+    # configured legacy auth" signal. ``$USERNAME`` *is* the login user on
+    # Linux/Windows, so it must never trigger the fallback or be read on its
+    # own — doing so would silently promote the OS user to the dashboard
+    # username (the footgun the ESPHOME_* rename fixed).
+    if not username and not password and environ.get("PASSWORD"):
+        username = environ.get("USERNAME", "")
+        password = environ.get("PASSWORD", "")
+        used_legacy = bool(username and password)
+    return ResolvedCredentials(
+        username=username,
+        password=password,
+        used_legacy=used_legacy,
+        mismatch=bool(username) != bool(password),
+    )

--- a/tests/test_credentials_env.py
+++ b/tests/test_credentials_env.py
@@ -1,21 +1,19 @@
 """Tests for ``ESPHOME_USERNAME`` / ``ESPHOME_PASSWORD`` env-var handling.
 
-Two layers exercise the same precedence rules:
+Both layers share one resolver (``helpers.credentials.resolve_credentials``):
 
 * ``__main__._validate_credentials`` — the CLI-time mismatch guard
   that errors out before ``DashboardSettings`` is even built when
   one half of the credential pair is set without the other.
-* ``DashboardSettings.parse_args`` — the actual env-var lookup
-  that populates ``settings.username`` / ``settings.password_hash``.
+* ``DashboardSettings.parse_args`` — the actual lookup that
+  populates ``settings.username`` / ``settings.password_hash``.
 
-Both layers must:
-
-* Read ``$ESPHOME_USERNAME`` / ``$ESPHOME_PASSWORD`` as fallbacks
-  for ``--username`` / ``--password``.
-* Let CLI flags win over env vars.
-* **Ignore bare ``$USERNAME`` / ``$PASSWORD``** — those collide
-  with the OS user on Linux/Windows shells and are the regression
-  the rename fixes.
+Precedence per credential: ``--flag`` > ``$ESPHOME_*`` >
+deprecated bare ``$USERNAME`` / ``$PASSWORD`` pair. The bare pair is
+kept for back-compat with pre-rename dashboards (warned about at
+startup via ``_warn_legacy_credential_env``) but is adopted **only
+as a pair, gated on ``$PASSWORD``** — the OS-set ``$USERNAME`` is
+never read on its own.
 """
 
 from __future__ import annotations
@@ -30,8 +28,10 @@ import pytest
 from esphome_device_builder.__main__ import (
     _validate_credentials,
     _warn_deprecated_credential_flags,
+    _warn_legacy_credential_env,
 )
 from esphome_device_builder.controllers.config import DashboardSettings
+from esphome_device_builder.helpers.credentials import resolve_credentials
 
 
 def _ns(configuration: str, **kwargs: object) -> SimpleNamespace:
@@ -91,10 +91,9 @@ def _validate(env: dict[str, str], *, username: str = "", password: str = "") ->
         ({"ESPHOME_PASSWORD": "hunter2"}, "admin", ""),
         # Mix-and-match: env username + CLI password.
         ({"ESPHOME_USERNAME": "admin"}, "", "hunter2"),
-        # Bare ``USERNAME`` / ``PASSWORD`` together — the regression
-        # case. The login-shell-set vars must not satisfy either side
-        # of the both-or-neither check, so this lands on the "both
-        # unset" branch and starts unauthenticated.
+        # Bare ``USERNAME`` / ``PASSWORD`` together — adopted as a
+        # back-compat pair (both halves present), so it's a matched
+        # pair, not a mismatch.
         ({"USERNAME": "jesse", "PASSWORD": "shellsecret"}, "", ""),
     ],
 )
@@ -118,13 +117,17 @@ def test_validate_credentials_accepts(env: dict[str, str], username: str, passwo
         ({"ESPHOME_USERNAME": "admin"}, "", ""),
         ({"ESPHOME_PASSWORD": "hunter2"}, "", ""),
         # Bare ``USERNAME`` paired with a real ``--password`` must
-        # still error: the bare var doesn't count as a username, so
-        # only one half of the pair is actually set. Without this,
-        # the dashboard would silently start with ``username="jesse"``
-        # and whatever the operator typed for ``--password``.
+        # still error: the new scheme supplied a password, so the
+        # legacy pair is not adopted, and the bare ``$USERNAME`` is
+        # never read on its own — only one half is set.
         ({"USERNAME": "jesse"}, "", "hunter2"),
-        # Symmetric: bare ``PASSWORD`` + real ``--username``.
+        # Symmetric: bare ``PASSWORD`` + real ``--username``. The new
+        # scheme supplied a username, so the legacy pair isn't adopted.
         ({"PASSWORD": "shellsecret"}, "admin", ""),
+        # Legacy ``$PASSWORD`` with no ``$USERNAME`` (atypical — the
+        # getting-started guide sets both). Adopted as a pair, but the
+        # username half is empty, so it's a mismatch, not silent auth.
+        ({"PASSWORD": "shellsecret"}, "", ""),
     ],
 )
 def test_validate_credentials_rejects_mismatch(
@@ -281,23 +284,35 @@ def test_parse_args_mixes_env_username_with_cli_password(tmp_path: object) -> No
 
 
 # ---------------------------------------------------------------------------
-# DashboardSettings.parse_args — bare $USERNAME / $PASSWORD must be ignored
+# DashboardSettings.parse_args — legacy bare $USERNAME / $PASSWORD fallback
 # ---------------------------------------------------------------------------
 
 
-def test_parse_args_ignores_bare_username_and_password(tmp_path: object) -> None:
-    """Login-shell ``$USERNAME`` / ``$PASSWORD`` do not enable auth.
+def test_parse_args_adopts_legacy_bare_pair(tmp_path: object) -> None:
+    """A pre-rename ``$USERNAME`` + ``$PASSWORD`` pair keeps the dashboard protected.
 
-    The regression-fix this commit ships. Before the rename, this
-    env state would have silently produced ``using_password=True``
-    with ``username="jesse"`` — the OS user — and the operator's
-    ``--password`` not being set would have left the dashboard
-    requiring an unknowable password.
+    The back-compat path: an operator who set the legacy bare names
+    stays authenticated after upgrading into device-builder (warned
+    about separately via ``_warn_legacy_credential_env``).
     """
     settings = _parse(
         tmp_path,
         {"USERNAME": "jesse", "PASSWORD": "shellsecret"},
     )
+    assert settings.username == "jesse"
+    assert settings.using_password is True
+    assert settings.check_password("jesse", "shellsecret") is True
+
+
+def test_parse_args_ignores_bare_username_without_password(tmp_path: object) -> None:
+    """A lone OS-set ``$USERNAME`` (no ``$PASSWORD``) never enables auth.
+
+    The footgun the pair-gating avoids: ``$USERNAME`` is the login
+    user on Linux/Windows, so reading it on its own would promote the
+    OS user to the dashboard username. Gated on ``$PASSWORD``, this
+    starts unauthenticated.
+    """
+    settings = _parse(tmp_path, {"USERNAME": "jesse"})
     assert settings.username == ""
     assert settings.using_password is False
 
@@ -306,11 +321,12 @@ def test_parse_args_bare_username_does_not_satisfy_esphome_username(tmp_path: ob
     """Bare ``$USERNAME`` doesn't substitute for ``$ESPHOME_USERNAME``.
 
     ``$ESPHOME_PASSWORD`` is set, ``$USERNAME`` is set (e.g. by the
-    shell), but ``$ESPHOME_USERNAME`` is missing → the username side
-    is empty, the password side is set, ``using_password`` falls
-    back to False. The mismatch is real (and ``_validate_credentials``
-    would reject it before we got here) but ``parse_args`` itself
-    must also degrade safely if a caller bypasses the validator.
+    shell), but ``$ESPHOME_USERNAME`` is missing → the new scheme
+    supplied a password, so the legacy pair isn't adopted and the bare
+    ``$USERNAME`` is not read; the username side stays empty,
+    ``using_password`` falls back to False. ``_validate_credentials``
+    rejects this before we get here, but ``parse_args`` must also
+    degrade safely if a caller bypasses the validator.
     """
     settings = _parse(
         tmp_path,
@@ -343,3 +359,110 @@ def test_parse_args_no_credentials_disables_password(tmp_path: object) -> None:
     settings = _parse(tmp_path, {})
     assert settings.username == ""
     assert settings.using_password is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_credentials — precedence + legacy fallback (the shared resolver)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cli_flags_win_over_every_env() -> None:
+    """CLI flags beat both the new and legacy env vars."""
+    r = resolve_credentials(
+        "cli-user",
+        "cli-pass",
+        {
+            "ESPHOME_USERNAME": "env-user",
+            "ESPHOME_PASSWORD": "env-pass",
+            "USERNAME": "shell-user",
+            "PASSWORD": "shell-pass",
+        },
+    )
+    assert (r.username, r.password) == ("cli-user", "cli-pass")
+    assert r.used_legacy is False
+    assert r.mismatch is False
+
+
+def test_resolve_esphome_env_wins_over_legacy() -> None:
+    """``$ESPHOME_*`` beats the bare names; the legacy pair isn't adopted."""
+    r = resolve_credentials(
+        "",
+        "",
+        {
+            "ESPHOME_USERNAME": "admin",
+            "ESPHOME_PASSWORD": "hunter2",
+            "USERNAME": "shell-user",
+            "PASSWORD": "shell-pass",
+        },
+    )
+    assert (r.username, r.password) == ("admin", "hunter2")
+    assert r.used_legacy is False
+
+
+def test_resolve_adopts_legacy_pair() -> None:
+    """Bare ``$USERNAME`` + ``$PASSWORD`` with no new scheme → adopted pair."""
+    r = resolve_credentials("", "", {"USERNAME": "jesse", "PASSWORD": "shellsecret"})
+    assert (r.username, r.password) == ("jesse", "shellsecret")
+    assert r.used_legacy is True
+    assert r.mismatch is False
+
+
+def test_resolve_ignores_lone_bare_username() -> None:
+    """A lone OS-set ``$USERNAME`` (no ``$PASSWORD``) is never read."""
+    r = resolve_credentials("", "", {"USERNAME": "jesse"})
+    assert (r.username, r.password) == ("", "")
+    assert r.used_legacy is False
+    assert r.mismatch is False
+
+
+def test_resolve_lone_bare_password_is_mismatch() -> None:
+    """Bare ``$PASSWORD`` with no username resolves to a half-set mismatch."""
+    r = resolve_credentials("", "", {"PASSWORD": "shellsecret"})
+    assert r.used_legacy is False
+    assert r.mismatch is True
+
+
+def test_resolve_does_not_adopt_legacy_when_new_username_set() -> None:
+    """A new-scheme username present blocks legacy adoption (stays a mismatch)."""
+    r = resolve_credentials("", "", {"ESPHOME_USERNAME": "admin", "PASSWORD": "shellsecret"})
+    assert (r.username, r.password) == ("admin", "")
+    assert r.used_legacy is False
+    assert r.mismatch is True
+
+
+# ---------------------------------------------------------------------------
+# _warn_legacy_credential_env — loud banner only when the legacy pair is used
+# ---------------------------------------------------------------------------
+
+
+def test_warn_legacy_credential_env_fires_on_legacy_pair(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Adopting the bare pair logs a deprecation banner naming the new vars."""
+    args = argparse.Namespace(username="", password="")
+    with (
+        patch.dict(os.environ, {"USERNAME": "jesse", "PASSWORD": "shellsecret"}, clear=True),
+        caplog.at_level("WARNING", logger="esphome_device_builder"),
+    ):
+        _warn_legacy_credential_env(args)
+    msg = "\n".join(r.getMessage() for r in caplog.records)
+    assert "DEPRECATION" in msg
+    assert "$ESPHOME_USERNAME" in msg
+    assert "$ESPHOME_PASSWORD" in msg
+
+
+def test_warn_legacy_credential_env_silent_on_new_scheme(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No banner when the new ``$ESPHOME_*`` scheme supplies the credentials."""
+    args = argparse.Namespace(username="", password="")
+    with (
+        patch.dict(
+            os.environ,
+            {"ESPHOME_USERNAME": "admin", "ESPHOME_PASSWORD": "hunter2"},
+            clear=True,
+        ),
+        caplog.at_level("WARNING", logger="esphome_device_builder"),
+    ):
+        _warn_legacy_credential_env(args)
+    assert caplog.records == []


### PR DESCRIPTION
# What does this implement/fix?

Restores backward compatibility for the deprecated bare `USERNAME` and `PASSWORD` env vars. The `ESPHOME_*` rename in #265 dropped the old names, so a dashboard that was protected with `USERNAME` and `PASSWORD` lost its authentication on upgrade and started open to the network. The bare pair is accepted again as a deprecated fallback so previously protected instances stay protected; a loud deprecation warning at startup tells operators to rename them to `ESPHOME_USERNAME` and `ESPHOME_PASSWORD`. The fallback is gated on `PASSWORD` being set and is only adopted as a pair, so the OS provided `USERNAME` is never read on its own and the collision footgun that motivated #265 stays closed; a lone bare `PASSWORD` still fails loud as a credential mismatch rather than starting unauthenticated.

**Related issue or feature (if applicable):**

- closes GHSA-rrxg-g2pf-6hh4

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
