### PR TITLE
Commit version history only on real YAML edits

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -64,9 +64,9 @@ class ScanChange(StrEnum):
     ADDED = "added"
     UPDATED = "updated"
     REMOVED = "removed"
-    # A forced re-read whose YAML bytes did not change (binary mtime,
+    # A forced re-read with no YAML cache-key change (binary mtime,
     # sidecar, StorageJSON). Distinct from UPDATED so consumers that only
-    # care about real YAML edits (version history) can skip it.
+    # care about on-disk YAML edits (version history) can skip it.
     RELOADED = "reloaded"
 
 

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -64,6 +64,10 @@ class ScanChange(StrEnum):
     ADDED = "added"
     UPDATED = "updated"
     REMOVED = "removed"
+    # A forced re-read whose YAML bytes did not change (binary mtime,
+    # sidecar, StorageJSON). Distinct from UPDATED so consumers that only
+    # care about real YAML edits (version history) can skip it.
+    RELOADED = "reloaded"
 
 
 # Callback invoked for every detected change. Receives the kind of
@@ -306,8 +310,8 @@ class DeviceScanner(WakeWorker[str]):
         reload.
 
         Returns True when the device exists and was re-read; False if
-        the file isn't tracked. Fires ``ScanChange.UPDATED`` on
-        success.
+        the file isn't tracked. Fires ``ScanChange.RELOADED`` on
+        success (the YAML itself is unchanged here).
         """
         async with self._lock:
             path = self._index.find_path_by_filename(filename)
@@ -342,7 +346,7 @@ class DeviceScanner(WakeWorker[str]):
             except OSError:
                 cache_key = previous_cache_key
             self._index.set(path, device, cache_key)
-            self._on_change(ScanChange.UPDATED, device)
+            self._on_change(ScanChange.RELOADED, device)
             return True
 
     # ------------------------------------------------------------------

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -16,12 +16,19 @@ _LOGGER = logging.getLogger(__name__)
 
 def on_scan_change(controller: DevicesController, kind: ScanChange, device: Device) -> None:
     """Forward scanner changes onto the event bus and fan out per-kind side effects."""
+    # UPDATED and RELOADED both refresh the client row via DEVICE_UPDATED;
+    # only UPDATED (a real on-disk YAML change) also fires DEVICE_YAML_UPDATED,
+    # so version history commits on edits but not on metadata reloads.
     event = {
         ScanChange.ADDED: EventType.DEVICE_ADDED,
         ScanChange.UPDATED: EventType.DEVICE_UPDATED,
+        ScanChange.RELOADED: EventType.DEVICE_UPDATED,
         ScanChange.REMOVED: EventType.DEVICE_REMOVED,
     }[kind]
-    controller._db.bus.fire(event, DeviceEventData(device=device))
+    payload = DeviceEventData(device=device)
+    controller._db.bus.fire(event, payload)
+    if kind is ScanChange.UPDATED:
+        controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, payload)
     if kind is ScanChange.ADDED:
         # ``probe_device`` short-circuits to the zeroconf cache
         # when present; otherwise it spawns a fire-and-forget
@@ -38,9 +45,9 @@ def on_scan_change(controller: DevicesController, kind: ScanChange, device: Devi
         # clients stop showing the adopt banner once the device is
         # configured. Idempotent: fires REMOVED only if a row existed.
         controller._on_importable_removed(device.name)
-    if kind in (ScanChange.UPDATED, ScanChange.REMOVED):
-        # YAML cache key changed; clear any prior failure
-        # marker so the next edit gets a fresh chance at
+    if kind in (ScanChange.UPDATED, ScanChange.RELOADED, ScanChange.REMOVED):
+        # YAML cache key changed (or a reload re-read it); clear any
+        # prior failure marker so the next edit gets a fresh chance at
         # ``--only-generate`` (and re-creating a deleted file
         # later doesn't inherit the old failure).
         controller.state.regenerate_failed.discard(device.configuration)

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -17,8 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 def on_scan_change(controller: DevicesController, kind: ScanChange, device: Device) -> None:
     """Forward scanner changes onto the event bus and fan out per-kind side effects."""
     # UPDATED and RELOADED both refresh the client row via DEVICE_UPDATED;
-    # only UPDATED (a real on-disk YAML change) also fires DEVICE_YAML_UPDATED,
-    # so version history commits on edits but not on metadata reloads.
+    # only UPDATED (the scanner saw the YAML's mtime/size/inode change) also
+    # fires DEVICE_YAML_UPDATED, so version history commits on edits but not
+    # on metadata reloads.
     event = {
         ScanChange.ADDED: EventType.DEVICE_ADDED,
         ScanChange.UPDATED: EventType.DEVICE_UPDATED,

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -54,7 +54,7 @@ _DEGRADED_THRESHOLD = 3
 # Catch-all commit message per scanner change kind (external edits).
 _EXTERNAL_MESSAGE: dict[EventType, str] = {
     EventType.DEVICE_ADDED: "Add {configuration}",
-    EventType.DEVICE_UPDATED: "Edit {configuration}",
+    EventType.DEVICE_YAML_UPDATED: "Edit {configuration}",
     EventType.DEVICE_REMOVED: "Delete {configuration}",
 }
 
@@ -96,10 +96,10 @@ class VersionHistoryController:
         if not self._repo.enabled:
             return
         _LOGGER.info("Version history active (git work tree: %s)", self._repo.toplevel)
-        # Catch-all for edits made outside the dashboard: the scanner
-        # fires these only on an actual disk cache-key change (mtime /
-        # size / inode), so runtime mDNS / ping state ticks don't reach
-        # us. Dashboard mutations have already committed by the time the
+        # Catch-all for edits made outside the dashboard. DEVICE_YAML_UPDATED
+        # fires only when a YAML's bytes changed on disk, so runtime mDNS /
+        # ping ticks and metadata reloads (which ride DEVICE_UPDATED) never
+        # reach us. Dashboard mutations have already committed by the time the
         # debounced flush runs, so those become no-ops here.
         for event_type in _EXTERNAL_MESSAGE:
             self._unsubs.append(self._db.bus.add_listener(event_type, self._on_disk_change))

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -97,10 +97,10 @@ class VersionHistoryController:
             return
         _LOGGER.info("Version history active (git work tree: %s)", self._repo.toplevel)
         # Catch-all for edits made outside the dashboard. DEVICE_YAML_UPDATED
-        # fires only when a YAML's bytes changed on disk, so runtime mDNS /
-        # ping ticks and metadata reloads (which ride DEVICE_UPDATED) never
-        # reach us. Dashboard mutations have already committed by the time the
-        # debounced flush runs, so those become no-ops here.
+        # fires only when the scanner detects a YAML change on disk (mtime/
+        # size/inode), so runtime mDNS / ping ticks and metadata reloads
+        # (which ride DEVICE_UPDATED) never reach us. Dashboard mutations have
+        # already committed by the debounced flush, so those become no-ops.
         for event_type in _EXTERNAL_MESSAGE:
             self._unsubs.append(self._db.bus.add_listener(event_type, self._on_disk_change))
 

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -190,6 +190,14 @@ async def _handle_version(_request: web.Request) -> web.Response:
 # and the test suite's pin-down assertion can reference it.
 _EXECUTOR_MAX_WORKERS = 64
 
+# Event types broadcast to every ``subscribe_events`` client. Two are held
+# back: ``DEVICE_REACHABILITY`` fires per-signal for every device (60+/min
+# under fleet load) and rides the per-device ``subscribe_reachability``
+# stream instead, and ``DEVICE_YAML_UPDATED`` is an internal version-history
+# signal (clients already get ``DEVICE_UPDATED`` for the row). Computed once.
+_INTERNAL_ONLY_EVENTS = frozenset({EventType.DEVICE_REACHABILITY, EventType.DEVICE_YAML_UPDATED})
+_BROADCAST_EVENT_TYPES = [et for et in EventType if et not in _INTERNAL_ONLY_EVENTS]
+
 
 class DeviceBuilder:
     """Core application singleton.
@@ -675,19 +683,6 @@ class DeviceBuilder:
             # massive backlog.
             controls.push_or_terminate(event.event_type.value, serialized)
 
-        # ``DEVICE_REACHABILITY`` is intentionally excluded — it fires
-        # on every per-signal observation (every mDNS announce, every
-        # ping success, every MQTT discover response) for *every*
-        # configured device, which would push 60+ events/min/device
-        # at every connected client. The drawer's per-device
-        # subscription is the only consumer; broadcasting these
-        # would defeat the point of having a per-device stream and
-        # could trip the bounded queue's backpressure terminator
-        # under fleet load.
-        # DEVICE_YAML_UPDATED is an internal version-history signal; clients
-        # already get DEVICE_UPDATED for the row, so it stays off the wire.
-        _internal_only = (EventType.DEVICE_REACHABILITY, EventType.DEVICE_YAML_UPDATED)
-        broadcast_event_types = [et for et in EventType if et not in _internal_only]
         # Hold a presence reference for the lifetime of the stream so
         # idle-time ICMP discovery resumes the moment a client
         # subscribes and pauses again on disconnect. The 0→1
@@ -699,7 +694,7 @@ class DeviceBuilder:
                 client=client,
                 message_id=message_id,
                 bus=self.bus,
-                event_types=broadcast_event_types,
+                event_types=_BROADCAST_EVENT_TYPES,
                 handle_event=_handle_event,
                 send_initial=_send_initial,
             )

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -684,7 +684,10 @@ class DeviceBuilder:
         # would defeat the point of having a per-device stream and
         # could trip the bounded queue's backpressure terminator
         # under fleet load.
-        broadcast_event_types = [et for et in EventType if et is not EventType.DEVICE_REACHABILITY]
+        # DEVICE_YAML_UPDATED is an internal version-history signal; clients
+        # already get DEVICE_UPDATED for the row, so it stays off the wire.
+        _internal_only = (EventType.DEVICE_REACHABILITY, EventType.DEVICE_YAML_UPDATED)
+        broadcast_event_types = [et for et in EventType if et not in _internal_only]
         # Hold a presence reference for the lifetime of the stream so
         # idle-time ICMP discovery resumes the moment a client
         # subscribes and pauses again on disconnect. The 0→1

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -63,9 +63,9 @@ class EventType(StrEnum):
     DEVICE_ADDED = "device_added"
     DEVICE_REMOVED = "device_removed"
     DEVICE_UPDATED = "device_updated"
-    # Fires only when a device's YAML file changed on disk (an external
-    # edit), unlike DEVICE_UPDATED which also rides every runtime tick and
-    # metadata reload. Internal-only; not broadcast to clients.
+    # Fires when the scanner detects a device's YAML change on disk
+    # (mtime/size/inode), unlike DEVICE_UPDATED which also rides runtime
+    # ticks and metadata reloads. Internal-only; not broadcast to clients.
     DEVICE_YAML_UPDATED = "device_yaml_updated"
 
     # Device online/offline state change

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -63,6 +63,10 @@ class EventType(StrEnum):
     DEVICE_ADDED = "device_added"
     DEVICE_REMOVED = "device_removed"
     DEVICE_UPDATED = "device_updated"
+    # Fires only when a device's YAML file changed on disk (an external
+    # edit), unlike DEVICE_UPDATED which also rides every runtime tick and
+    # metadata reload. Internal-only; not broadcast to clients.
+    DEVICE_YAML_UPDATED = "device_yaml_updated"
 
     # Device online/offline state change
     DEVICE_STATE_CHANGED = "device_state_changed"

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -960,6 +960,43 @@ def test_on_scan_change_updated_clears_regenerate_failed_marker(
     assert "kitchen.yaml" not in controller.state.regenerate_failed
 
 
+def test_on_scan_change_updated_fires_yaml_updated(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
+) -> None:
+    """A real YAML edit fires DEVICE_UPDATED for clients and DEVICE_YAML_UPDATED for history."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+    device = _device("kitchen")
+    captured = capture_devices_events(
+        controller, EventType.DEVICE_UPDATED, EventType.DEVICE_YAML_UPDATED
+    )
+
+    controller._on_scan_change(ScanChange.UPDATED, device)
+
+    assert [e.event_type for e in captured] == [
+        EventType.DEVICE_UPDATED,
+        EventType.DEVICE_YAML_UPDATED,
+    ]
+
+
+def test_on_scan_change_reloaded_skips_yaml_updated(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+    capture_devices_events: CaptureDevicesEventsFactory,
+) -> None:
+    """A metadata reload refreshes the row but never commits to version history."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+    device = _device("kitchen")
+    captured = capture_devices_events(
+        controller, EventType.DEVICE_UPDATED, EventType.DEVICE_YAML_UPDATED
+    )
+
+    controller._on_scan_change(ScanChange.RELOADED, device)
+
+    assert [e.event_type for e in captured] == [EventType.DEVICE_UPDATED]
+
+
 def test_on_scan_change_removed_revisits_importables(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -58,8 +58,8 @@ def _device(name: str = "kitchen", **overrides: Any) -> Device:
 # ----------------------------------------------------------------------
 
 
-async def test_reload_rereads_state_and_fires_updated(tmp_path: Path) -> None:
-    """Reload re-runs the loader and fires ``UPDATED`` so listeners refresh."""
+async def test_reload_rereads_state_and_fires_reloaded(tmp_path: Path) -> None:
+    """Reload re-runs the loader and fires ``RELOADED`` so listeners refresh."""
     yaml_path = tmp_path / "kitchen.yaml"
     yaml_path.write_text("esphome:\n  name: kitchen\n")
 
@@ -80,7 +80,7 @@ async def test_reload_rereads_state_and_fires_updated(tmp_path: Path) -> None:
 
     assert await scanner.reload("kitchen.yaml") is True
     assert scanner.by_path[yaml_path] is refreshed
-    assert changes == [(ScanChange.UPDATED, refreshed)]
+    assert changes == [(ScanChange.RELOADED, refreshed)]
 
 
 async def test_reload_unknown_filename_is_noop(tmp_path: Path) -> None:

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -88,7 +88,7 @@ async def test_disabled_when_no_git(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 async def test_external_edit_committed_via_scanner_catch_all(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A scanner DEVICE_UPDATED commits the externally-edited YAML (debounced)."""
+    """A scanner DEVICE_YAML_UPDATED commits the externally-edited YAML (debounced)."""
     monkeypatch.setattr(
         "esphome_device_builder.controllers.version_history.controller._DEBOUNCE_SECONDS",
         0.0,
@@ -98,7 +98,7 @@ async def test_external_edit_committed_via_scanner_catch_all(
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
 
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
-    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     # Let the debounced flush task run.
     assert controller._flush_task is not None
     await controller._flush_task
@@ -133,7 +133,7 @@ async def test_external_edit_self_heals_stale_index_lock_after_restart(
 
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
-    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     assert controller._flush_task is not None
     await controller._flush_task
 
@@ -160,7 +160,7 @@ async def test_dashboard_commit_makes_catch_all_a_noop(
     await controller.record_configuration("kitchen.yaml", "Edit kitchen.yaml via editor")
     # Scanner then fires for the same on-disk change.
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
-    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     assert controller._flush_task is not None
     await controller._flush_task
 
@@ -196,12 +196,12 @@ async def test_flush_picks_up_edit_arriving_during_commit(
             injected = True
             # Simulate b.yaml being edited externally mid-flush.
             device = Device(name="b", friendly_name="b", configuration="b.yaml")
-            controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+            controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
         return result
 
     monkeypatch.setattr(controller, "record_configuration", _wrapper)
     device = Device(name="a", friendly_name="a", configuration="a.yaml")
-    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     assert controller._flush_task is not None
     await controller._flush_task
 
@@ -318,7 +318,7 @@ async def test_stop_detaches_listeners_and_flushes_pending(
     await controller.start()
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
-    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     assert controller._flush_task is not None
 
     await controller.stop()
@@ -327,7 +327,7 @@ async def test_stop_detaches_listeners_and_flushes_pending(
     # The queued edit was flushed on shutdown rather than lost.
     assert await controller.list_versions(configuration="kitchen.yaml")
     # A post-stop event must not reach the (now detached) listener.
-    controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+    controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     assert not controller._pending
 
 
@@ -419,7 +419,7 @@ async def test_flush_task_failure_is_surfaced(
     monkeypatch.setattr(controller, "_flush_pending", _boom)
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
     with caplog.at_level(logging.WARNING):
-        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
         task = controller._flush_task
         assert task is not None
         with suppress(RuntimeError):
@@ -473,7 +473,7 @@ async def test_catch_all_flush_survives_a_failing_config(
     monkeypatch.setattr(controller, "record_configuration", _maybe_fail)
     for name in ("bad.yaml", "good.yaml"):
         device = Device(name=name, friendly_name=name, configuration=name)
-        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
     assert controller._flush_task is not None
     await controller._flush_task
 
@@ -537,7 +537,7 @@ async def test_catch_all_programming_bug_propagates_to_done_callback(
     monkeypatch.setattr(controller, "record_configuration", _bug)
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
     with caplog.at_level(logging.WARNING):
-        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
         task = controller._flush_task
         assert task is not None
         with suppress(AttributeError):
@@ -592,7 +592,7 @@ async def test_catch_all_warns_on_real_commit_failure(
     )
     device = Device(name="kitchen", friendly_name="Kitchen", configuration="kitchen.yaml")
     with caplog.at_level(logging.WARNING):
-        controller._db.bus.fire(EventType.DEVICE_UPDATED, DeviceEventData(device=device))
+        controller._db.bus.fire(EventType.DEVICE_YAML_UPDATED, DeviceEventData(device=device))
         assert controller._flush_task is not None
         await controller._flush_task
 

--- a/tests/test_device_scanner_branches.py
+++ b/tests/test_device_scanner_branches.py
@@ -168,9 +168,9 @@ async def test_reload_swallows_oserror_on_post_load_stat(tmp_path: Path) -> None
         ok = await scanner.reload("kitchen.yaml")
 
     assert ok is True
-    # UPDATED still fired with the freshly-loaded Device.
+    # RELOADED still fired with the freshly-loaded Device.
     assert [(kind, dev.friendly_name) for kind, dev in events] == [
-        (ScanChange.UPDATED, "Kitchen Renamed")
+        (ScanChange.RELOADED, "Kitchen Renamed")
     ]
 
 

--- a/tests/test_device_scanner_request.py
+++ b/tests/test_device_scanner_request.py
@@ -71,7 +71,7 @@ async def test_request_drains_one_file(tmp_path: Path) -> None:
         finally:
             await scanner.stop()
 
-    assert [(kind, dev.name) for kind, dev in events] == [(ScanChange.UPDATED, "kitchen")]
+    assert [(kind, dev.name) for kind, dev in events] == [(ScanChange.RELOADED, "kitchen")]
 
 
 async def test_request_coalesces_duplicate_filenames(tmp_path: Path) -> None:
@@ -142,7 +142,7 @@ async def test_request_before_start_drains_on_start(tmp_path: Path) -> None:
         finally:
             await scanner.stop()
 
-    assert [(kind, dev.name) for kind, dev in events] == [(ScanChange.UPDATED, "kitchen")]
+    assert [(kind, dev.name) for kind, dev in events] == [(ScanChange.RELOADED, "kitchen")]
 
 
 async def test_start_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_mdns_version.py
+++ b/tests/test_mdns_version.py
@@ -112,6 +112,9 @@ async def test_on_version_change_updates_device_fires_event_and_persists(
     # current_version is "2026.5.0" too, so update_available should be False.
     assert device.update_available is False
     assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
+    # A runtime mDNS tick must not look like a YAML edit, or version history
+    # would commit (and contend for the git index) on every announce.
+    assert not any(e.event_type == EventType.DEVICE_YAML_UPDATED for e in captured)
     # Persisted to the store (deployed_version is a STORE_FIELDS member).
     assert controller._metadata_store.get(device.configuration) == {"deployed_version": "2026.5.0"}
 


### PR DESCRIPTION
# What does this implement/fix?

The version history catch-all listened to `DEVICE_UPDATED`, which also fires on every mDNS runtime tick (version, config_hash, ip, mac, api_encryption) and on every post-flash scanner reload. None of those change the YAML, but each one queued a debounced git commit; the commit was a content no-op yet still grabbed the repo's `index.lock`, so a quiet device kept triggering pointless git work on every announce.

This adds a `DEVICE_YAML_UPDATED` event that fires only when the scanner sees a device's YAML change on disk, and splits the forced metadata re-read into `ScanChange.RELOADED`. Clients still get `DEVICE_UPDATED` for both cases; only a real edit fires `DEVICE_YAML_UPDATED`, which is now what version history commits on. The new event is internal, so it stays off the client broadcast.

**Related issue or feature (if applicable):**

- N/A; reported from production logs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
