### PR TITLE
Await peer-link client teardown before rebind respawn

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_shared.py
+++ b/esphome_device_builder/controllers/remote_build/_shared.py
@@ -12,6 +12,7 @@ Exposes:
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Callable, Iterable
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any
@@ -23,12 +24,16 @@ if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
     from ...helpers.event_bus import Event, EventType
 
+_LOGGER = logging.getLogger(__name__)
 
-async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
+
+async def drain_tasks(tasks: Iterable[asyncio.Task[Any]], *, log_exceptions: bool = False) -> None:
     """Cancel and await every task in *tasks*, swallowing exceptions.
 
-    Snapshots *tasks* to a list so the caller's post-drain
-    ``clear`` doesn't pull tasks out from under the gather.
+    With *log_exceptions*, a non-cancellation exception from a settled
+    task is logged at WARNING (still not propagated) instead of being
+    dropped silently. Snapshots *tasks* to a list so the caller's
+    post-drain ``clear`` doesn't pull tasks out from under the gather.
     Caller owns clearing the source collection.
     """
     tasks_list = list(tasks)
@@ -36,7 +41,14 @@ async def drain_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
         return
     for task in tasks_list:
         task.cancel()
-    await asyncio.gather(*tasks_list, return_exceptions=True)
+    results = await asyncio.gather(*tasks_list, return_exceptions=True)
+    if not log_exceptions:
+        return
+    for task, result in zip(tasks_list, results, strict=True):
+        # ``CancelledError`` is a ``BaseException`` (not ``Exception``),
+        # so the expected cancel outcome is skipped here.
+        if isinstance(result, Exception):
+            _LOGGER.warning("task %r failed during drain", task.get_name(), exc_info=result)
 
 
 class _RemoteBuildBase(TaskControllerBase):

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -239,13 +239,18 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
         )
 
     async def _refresh_identity_and_respawn_clients(self) -> None:
-        """Reload the identity snapshot and respawn every APPROVED peer-link client."""
+        """Reload the identity snapshot and respawn every APPROVED peer-link client.
+
+        Awaits each old client's teardown before respawning: rotation keeps the
+        ``dashboard_id`` and reconnects to the same receiver, so a late old
+        registration would supersede the fresh client (same race as rebind).
+        """
         await self._load_offloader_identities_async()
         for pin_sha256 in list(self.state.peer_link_clients):
             pairing = self.state.pairings.get(pin_sha256)
             if pairing is None or pairing.status is not PeerStatus.APPROVED:
                 continue
-            self._cancel_peer_link_client(pin_sha256)
+            await self._cancel_peer_link_client_and_wait(pin_sha256)
             self._spawn_peer_link_client(pairing)
 
     def _on_offloader_queue_status_changed(

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -328,9 +328,11 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
             self, pairing=pairing, new_hostname=new_hostname, new_port=new_port
         )
 
-    def _commit_endpoint_rebind(self, pairing: StoredPairing, *, hostname: str, port: int) -> None:
+    async def _commit_endpoint_rebind(
+        self, pairing: StoredPairing, *, hostname: str, port: int
+    ) -> None:
         """Mutate *pairing* to (*hostname*, *port*) and run the rebind epilogue."""
-        rebind.commit_endpoint_rebind(self, pairing, hostname=hostname, port=port)
+        await rebind.commit_endpoint_rebind(self, pairing, hostname=hostname, port=port)
 
     # ------------------------------------------------------------------
     # mDNS auto-rebind
@@ -599,6 +601,10 @@ class OffloaderController(_RemoteBuildBase):  # noqa: PLR0904
     def _cancel_peer_link_client(self, pin_sha256: str) -> None:
         """Cancel the peer-link client for *pin_sha256*. No-op if none running."""
         peer_link_lifecycle.cancel_peer_link_client(self, pin_sha256)
+
+    async def _cancel_peer_link_client_and_wait(self, pin_sha256: str) -> None:
+        """Cancel the peer-link client for *pin_sha256* and await its teardown."""
+        await peer_link_lifecycle.cancel_peer_link_client_and_wait(self, pin_sha256)
 
     def _sweep_stale_pairings_at_endpoint(
         self, hostname: str, port: int, *, keep_pin_sha256: str

--- a/esphome_device_builder/controllers/remote_build/pair_commands.py
+++ b/esphome_device_builder/controllers/remote_build/pair_commands.py
@@ -329,5 +329,5 @@ async def edit_pairing_endpoint(
                 error=result.transport_error,
             ),
         )
-    controller._commit_endpoint_rebind(pairing, hostname=clean_host, port=clean_port)
+    await controller._commit_endpoint_rebind(pairing, hostname=clean_host, port=clean_port)
     return controller._pairing_summary_for(pairing)

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -19,6 +19,7 @@ lookup) reach into a stable surface.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import TYPE_CHECKING
 
 from ...helpers.api import CommandError
@@ -78,6 +79,24 @@ def cancel_peer_link_client(controller: OffloaderController, pin_sha256: str) ->
     handle = controller.state.peer_link_clients.pop(pin_sha256, None)
     if handle is not None and not handle.task.done():
         handle.task.cancel()
+
+
+async def cancel_peer_link_client_and_wait(
+    controller: OffloaderController, pin_sha256: str
+) -> None:
+    """Cancel the peer-link client for *pin_sha256* and await its teardown.
+
+    The rebind respawn must let the old client's in-flight connect fully
+    unwind (its ``terminate`` sent, the receiver's ``dashboard_id`` slot
+    freed) before a new client connects; otherwise the late old
+    registration supersedes the fresh client and orphans it.
+    """
+    handle = controller.state.peer_link_clients.pop(pin_sha256, None)
+    if handle is None or handle.task.done():
+        return
+    handle.task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await handle.task
 
 
 def lookup_open_peer_link_client(

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -19,7 +19,6 @@ lookup) reach into a stable surface.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from typing import TYPE_CHECKING
 
 from ...helpers.api import CommandError
@@ -95,8 +94,12 @@ async def cancel_peer_link_client_and_wait(
     if handle is None or handle.task.done():
         return
     handle.task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await handle.task
+    # ``asyncio.wait`` rather than ``await handle.task``: it absorbs the
+    # task's own outcome (cancellation or any teardown exception) without
+    # adopting it, but still propagates a cancellation of *this* task — so
+    # shutdown isn't swallowed and a settling-task error can't abort the
+    # caller's respawn.
+    await asyncio.wait({handle.task})
 
 
 def lookup_open_peer_link_client(

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from ...helpers.api import CommandError
 from ...models import ErrorCode, PeerStatus, StoredPairing
 from ._models import PeerLinkClientHandle
+from ._shared import drain_tasks
 from .peer_link_client import PeerLinkClient
 
 if TYPE_CHECKING:
@@ -93,13 +94,11 @@ async def cancel_peer_link_client_and_wait(
     handle = controller.state.peer_link_clients.pop(pin_sha256, None)
     if handle is None or handle.task.done():
         return
-    handle.task.cancel()
-    # ``asyncio.wait`` rather than ``await handle.task``: it absorbs the
-    # task's own outcome (cancellation or any teardown exception) without
-    # adopting it, but still propagates a cancellation of *this* task — so
-    # shutdown isn't swallowed and a settling-task error can't abort the
-    # caller's respawn.
-    await asyncio.wait({handle.task})
+    # ``drain_tasks`` cancels + awaits and retrieves the outcome via
+    # ``gather(return_exceptions=True)``: a teardown exception is absorbed
+    # (not "never retrieved") and can't abort the caller's respawn, while a
+    # cancellation of *this* task still propagates. Same idiom as ``stop()``.
+    await drain_tasks((handle.task,))
 
 
 def lookup_open_peer_link_client(

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -95,10 +95,10 @@ async def cancel_peer_link_client_and_wait(
     if handle is None or handle.task.done():
         return
     # ``drain_tasks`` cancels + awaits and retrieves the outcome via
-    # ``gather(return_exceptions=True)``: a teardown exception is absorbed
-    # (not "never retrieved") and can't abort the caller's respawn, while a
-    # cancellation of *this* task still propagates. Same idiom as ``stop()``.
-    await drain_tasks((handle.task,))
+    # ``gather(return_exceptions=True)``: a teardown exception is logged and
+    # absorbed (not "never retrieved") so it can't abort the caller's respawn,
+    # while a cancellation of *this* task still propagates.
+    await drain_tasks((handle.task,), log_exceptions=True)
 
 
 def lookup_open_peer_link_client(

--- a/esphome_device_builder/controllers/remote_build/rebind.py
+++ b/esphome_device_builder/controllers/remote_build/rebind.py
@@ -87,7 +87,7 @@ async def probe_pairing_endpoint(
     return RebindProbeResult(RebindProbeOutcome.OK)
 
 
-def commit_endpoint_rebind(
+async def commit_endpoint_rebind(
     controller: OffloaderController, pairing: StoredPairing, *, hostname: str, port: int
 ) -> None:
     """Mutate *pairing* to (*hostname*, *port*) and run the rebind epilogue.
@@ -99,19 +99,20 @@ def commit_endpoint_rebind(
     pairing.receiver_hostname = hostname
     pairing.receiver_port = port
     controller._schedule_pairings_save()
-    _respawn_peer_link_at_new_endpoint(controller, pairing)
+    await _respawn_peer_link_at_new_endpoint(controller, pairing)
     controller.state.rebind_probe_until.pop(pairing.pin_sha256, None)
 
 
-def _respawn_peer_link_at_new_endpoint(
+async def _respawn_peer_link_at_new_endpoint(
     controller: OffloaderController, pairing: StoredPairing
 ) -> None:
     """Cancel + respawn the peer-link client and fire the rebind event.
 
-    The caller has already mutated *pairing*'s
-    hostname/port; this is the shared epilogue.
+    Awaits the old client's teardown first (see
+    :func:`peer_link_lifecycle.cancel_peer_link_client_and_wait`). The
+    caller has already mutated *pairing*'s hostname/port.
     """
-    controller._cancel_peer_link_client(pairing.pin_sha256)
+    await controller._cancel_peer_link_client_and_wait(pairing.pin_sha256)
     controller._spawn_peer_link_client(pairing)
     _fire_offloader_pair_endpoint_rebound(
         controller,
@@ -212,7 +213,7 @@ async def probe_and_rebind_endpoint(
             # Updated callbacks doesn't re-fire the probe
             # against state that's already moved on.
             return
-        controller._commit_endpoint_rebind(pairing, hostname=new_hostname, port=new_port)
+        await controller._commit_endpoint_rebind(pairing, hostname=new_hostname, port=new_port)
         _LOGGER.info("rebound pairing %s to %s:%d", pin, new_hostname, new_port)
 
 

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import os
 import secrets as _secrets
 from pathlib import Path
@@ -41,6 +42,7 @@ from esphome_device_builder.controllers.remote_build._mdns import (
     peer_from_service_info,
 )
 from esphome_device_builder.controllers.remote_build._models import PeerLinkClientHandle
+from esphome_device_builder.controllers.remote_build._shared import drain_tasks
 from esphome_device_builder.controllers.remote_build._storage_codecs import (
     decode_pairings,
     encode_pairings,
@@ -473,6 +475,58 @@ async def test_cancel_peer_link_client_and_wait_propagates_caller_cancellation(
 
     child.cancel()
     await asyncio.gather(child, return_exceptions=True)
+
+
+async def test_drain_tasks_logs_exception_when_requested(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``log_exceptions=True`` logs a non-cancel teardown failure and absorbs it."""
+
+    async def _bad_teardown() -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise RuntimeError("terminate send failed") from None
+
+    task = asyncio.create_task(_bad_teardown(), name="bad-teardown")
+    await asyncio.sleep(0)
+    with caplog.at_level(logging.WARNING):
+        await drain_tasks((task,), log_exceptions=True)
+    assert any(
+        "bad-teardown" in rec.getMessage() and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )
+
+
+async def test_drain_tasks_does_not_log_plain_cancellation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A clean cancellation isn't logged even with ``log_exceptions=True``."""
+
+    async def _park() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(_park(), name="parked")
+    await asyncio.sleep(0)
+    with caplog.at_level(logging.WARNING):
+        await drain_tasks((task,), log_exceptions=True)
+    assert not any("parked" in rec.getMessage() for rec in caplog.records)
+
+
+async def test_drain_tasks_silent_by_default(caplog: pytest.LogCaptureFixture) -> None:
+    """Without the flag, a teardown failure is swallowed without logging."""
+
+    async def _bad_teardown() -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise RuntimeError("boom") from None
+
+    task = asyncio.create_task(_bad_teardown(), name="silent-boom")
+    await asyncio.sleep(0)
+    with caplog.at_level(logging.WARNING):
+        await drain_tasks((task,))
+    assert not any("silent-boom" in rec.getMessage() for rec in caplog.records)
 
 
 async def test_rebind_respawn_awaits_old_client_before_spawn(tmp_path: Path) -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -40,6 +40,7 @@ from esphome_device_builder.controllers.remote_build._mdns import (
     decode_txt_value,
     peer_from_service_info,
 )
+from esphome_device_builder.controllers.remote_build._models import PeerLinkClientHandle
 from esphome_device_builder.controllers.remote_build._storage_codecs import (
     decode_pairings,
     encode_pairings,
@@ -351,8 +352,8 @@ def _patch_probe_internals(
     """Stub the probe's three external calls and seed an optional cooldown.
 
     Every probe test mocks the same three surfaces:
-    ``_cancel_peer_link_client`` (assert called or not),
-    ``_spawn_peer_link_client`` (same), and
+    ``_cancel_peer_link_client_and_wait`` (assert called or
+    not), ``_spawn_peer_link_client`` (same), and
     ``peer_link_preview_pair`` (return the observed pin or
     raise). Tests that pin "the cooldown is preserved on
     failure" also seed ``_rebind_probe_until[pin]`` before
@@ -362,12 +363,13 @@ def _patch_probe_internals(
     Returns ``(cancel_mock, spawn_mock)`` so the caller can do
     ``cancel.assert_called_once_with(pin)`` on the success
     path or ``cancel.assert_not_called()`` on every failure
-    path. Pass exactly one of *preview_return* /
+    path. The rebind respawn awaits the cancel, so the mock is
+    an ``AsyncMock``. Pass exactly one of *preview_return* /
     *preview_side_effect*.
     """
-    cancel = MagicMock()
+    cancel = AsyncMock()
     spawn = MagicMock()
-    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)
+    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client_and_wait", cancel)
     monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", spawn)
     if preview_side_effect is not None:
         monkeypatch.setattr(
@@ -414,6 +416,57 @@ async def test_rebind_probe_match_mutates_pairing_and_fires_event(
     # Successful rebind clears the cooldown so a future move
     # gets probed immediately rather than waiting out the window.
     assert pin not in controller.offloader.state.rebind_probe_until
+
+
+async def test_cancel_peer_link_client_and_wait_awaits_teardown(tmp_path: Path) -> None:
+    """The awaiting cancel cancels the client task and waits for it to finish."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing()
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    running = asyncio.Event()
+
+    async def _park() -> None:
+        running.set()
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(_park())
+    await running.wait()
+    controller.offloader.state.peer_link_clients[pin] = PeerLinkClientHandle(
+        client=MagicMock(), task=task
+    )
+
+    await controller.offloader._cancel_peer_link_client_and_wait(pin)
+
+    assert task.done()
+    assert pin not in controller.offloader.state.peer_link_clients
+
+
+async def test_rebind_respawn_awaits_old_client_before_spawn(tmp_path: Path) -> None:
+    """Respawn waits for the old client to tear down before spawning the new one."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing(receiver_hostname="new.local", receiver_port=7000)
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    running = asyncio.Event()
+
+    async def _park() -> None:
+        running.set()
+        await asyncio.sleep(3600)
+
+    old_task = asyncio.create_task(_park())
+    await running.wait()
+    controller.offloader.state.peer_link_clients[pin] = PeerLinkClientHandle(
+        client=MagicMock(), task=old_task
+    )
+
+    old_done_at_spawn: list[bool] = []
+    controller.offloader._spawn_peer_link_client = lambda _p: old_done_at_spawn.append(  # type: ignore[method-assign]
+        old_task.done()
+    )
+
+    await rb_rebind._respawn_peer_link_at_new_endpoint(controller.offloader, pairing)
+
+    assert old_done_at_spawn == [True]
+    assert old_task.cancelled()
 
 
 async def test_rebind_probe_pin_mismatch_does_not_mutate(
@@ -920,9 +973,9 @@ async def test_edit_pairing_endpoint_raises_not_found_when_pairing_replaced_mid_
         return pin
 
     monkeypatch.setattr(rb_rebind, "peer_link_preview_pair", _replace_during_preview)
-    cancel = MagicMock()
+    cancel = AsyncMock()
     spawn = MagicMock()
-    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)
+    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client_and_wait", cancel)
     monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", spawn)
 
     with pytest.raises(CommandError) as exc_info:
@@ -989,9 +1042,9 @@ async def test_edit_pairing_endpoint_status_changed_mid_probe_raises_preconditio
         return pin
 
     monkeypatch.setattr(rb_rebind, "peer_link_preview_pair", _flip_status_during_preview)
-    cancel = MagicMock()
+    cancel = AsyncMock()
     spawn = MagicMock()
-    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)
+    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client_and_wait", cancel)
     monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", spawn)
 
     with pytest.raises(CommandError) as exc_info:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -441,6 +441,40 @@ async def test_cancel_peer_link_client_and_wait_awaits_teardown(tmp_path: Path) 
     assert pin not in controller.offloader.state.peer_link_clients
 
 
+async def test_cancel_peer_link_client_and_wait_propagates_caller_cancellation(
+    tmp_path: Path,
+) -> None:
+    """A cancel of the calling task isn't swallowed by the teardown wait."""
+    pin = "a" * 64
+    pairing = _valid_stored_pairing()
+    controller = _make_paired_offloader_controller(config_dir=tmp_path, pairing=pairing)
+    child_cancelled = asyncio.Event()
+
+    async def _stubborn() -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            # Swallow the first cancel so the helper stays parked in its
+            # ``asyncio.wait`` while we cancel the calling task.
+            child_cancelled.set()
+            await asyncio.sleep(3600)
+
+    child = asyncio.create_task(_stubborn())
+    await asyncio.sleep(0)
+    controller.offloader.state.peer_link_clients[pin] = PeerLinkClientHandle(
+        client=MagicMock(), task=child
+    )
+
+    outer = asyncio.create_task(controller.offloader._cancel_peer_link_client_and_wait(pin))
+    await child_cancelled.wait()
+    outer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+    child.cancel()
+    await asyncio.gather(child, return_exceptions=True)
+
+
 async def test_rebind_respawn_awaits_old_client_before_spawn(tmp_path: Path) -> None:
     """Respawn waits for the old client to tear down before spawning the new one."""
     pin = "a" * 64

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -2010,16 +2010,18 @@ async def test_identity_rotation_refreshes_snapshot_and_respawns_approved_client
     controller.offloader.state.pairings["b" * 64] = pending
     controller.offloader.state.peer_link_clients["a" * 64] = MagicMock()
     controller.offloader.state.peer_link_clients["b" * 64] = MagicMock()
-    cancel = MagicMock()
+    cancel = AsyncMock()
     spawn = MagicMock()
-    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client", cancel)
+    monkeypatch.setattr(controller.offloader, "_cancel_peer_link_client_and_wait", cancel)
     monkeypatch.setattr(controller.offloader, "_spawn_peer_link_client", spawn)
 
     rotated = await controller.offloader._db.peer_link_identity_store.async_rotate()
     await controller.offloader._refresh_identity_and_respawn_clients()
 
     assert controller.offloader.state.offloader_peer_link_priv == rotated.private_bytes
-    cancel.assert_called_once_with("a" * 64)
+    # Awaits teardown before respawn (same supersede race as rebind: rotation
+    # keeps the dashboard_id and reconnects to the same receiver).
+    cancel.assert_awaited_once_with("a" * 64)
     spawn.assert_called_once_with(approved)
 
 


### PR DESCRIPTION
# What does this implement/fix?

A paired build server that restarts under a changed mDNS hostname could stay DISCONNECTED until the dashboard process itself was restarted.

On a restart the receiver re-announced under a different `.local` name (same machine, same IP), which fired an endpoint rebind. The rebind cancelled the old peer-link client and immediately spawned a new one without awaiting the old task; the old client's in-flight connect to the prior endpoint then completed a few milliseconds later, and since every peer-link client shares the offloader's single `dashboard_id`, the receiver superseded the freshly-spawned client and orphaned it for good (the orphan flag is one-shot).

The fix awaits the old client's teardown before spawning the replacement, so the old connection is fully gone (its terminate sent, the receiver's `dashboard_id` slot freed) before the new client connects; the new client is then the only registrant and stays connected.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
