### PR TITLE
Retry version-history commits on a busy git index.lock

### DIFF
--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -141,11 +141,13 @@ class VersionHistoryController:
             return None
         async with self._lock:
             backoff = _LOCK_RETRY_BACKOFF
-            for attempt in range(_LOCK_RETRY_ATTEMPTS + 1):
+            attempts = 0
+            while True:
                 try:
                     sha = await self._in_executor(self._repo.commit_paths, paths, message)
                 except GitIndexLockBusyError:
-                    if attempt == _LOCK_RETRY_ATTEMPTS:
+                    attempts += 1
+                    if attempts > _LOCK_RETRY_ATTEMPTS:
                         self._note_commit_failure()
                         raise
                     await asyncio.sleep(backoff)
@@ -156,7 +158,6 @@ class VersionHistoryController:
                     raise
                 self._note_commit_success()
                 return sha
-        return None  # unreachable; the loop returns or raises
 
     def _note_commit_failure(self) -> None:
         """Count a git failure; flag degraded once they stop looking one-off."""

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -51,11 +51,8 @@ _DEBOUNCE_SECONDS = 2.0
 # one-off hiccup, which a future History pane can surface to the user.
 _DEGRADED_THRESHOLD = 3
 
-# A fresh index.lock means another writer (commonly a second dashboard
-# instance sharing one config-dir repo) is mid-commit; it releases within
-# milliseconds, so back off on the event loop and retry rather than drop
-# the edit or trip the degraded flag. The wait is async, so the executor
-# thread isn't held during it.
+# Bounded backoff for a fresh index.lock (a live concurrent writer); the
+# wait is awaited on the event loop, never inside the executor thread.
 _LOCK_RETRY_ATTEMPTS = 4
 _LOCK_RETRY_BACKOFF = 0.2  # seconds; doubled after each attempt
 

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError, api_command
 from ...models import ErrorCode, EventType
-from .git_repo import GIT_COMMIT_ERRORS, GitRepo
+from .git_repo import GIT_COMMIT_ERRORS, GitIndexLockBusyError, GitRepo
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -50,6 +50,14 @@ _DEBOUNCE_SECONDS = 2.0
 # — enough to tell a persistent breakage (corrupt repo, disk full) from a
 # one-off hiccup, which a future History pane can surface to the user.
 _DEGRADED_THRESHOLD = 3
+
+# A fresh index.lock means another writer (commonly a second dashboard
+# instance sharing one config-dir repo) is mid-commit; it releases within
+# milliseconds, so back off on the event loop and retry rather than drop
+# the edit or trip the degraded flag. The wait is async, so the executor
+# thread isn't held during it.
+_LOCK_RETRY_ATTEMPTS = 4
+_LOCK_RETRY_BACKOFF = 0.2  # seconds; doubled after each attempt
 
 # Catch-all commit message per scanner change kind (external edits).
 _EXTERNAL_MESSAGE: dict[EventType, str] = {
@@ -132,13 +140,23 @@ class VersionHistoryController:
         if not self._repo.enabled or not paths:
             return None
         async with self._lock:
-            try:
-                sha = await self._in_executor(self._repo.commit_paths, paths, message)
-            except GIT_COMMIT_ERRORS:
-                self._note_commit_failure()
-                raise
-            self._note_commit_success()
-            return sha
+            backoff = _LOCK_RETRY_BACKOFF
+            for attempt in range(_LOCK_RETRY_ATTEMPTS + 1):
+                try:
+                    sha = await self._in_executor(self._repo.commit_paths, paths, message)
+                except GitIndexLockBusyError:
+                    if attempt == _LOCK_RETRY_ATTEMPTS:
+                        self._note_commit_failure()
+                        raise
+                    await asyncio.sleep(backoff)
+                    backoff *= 2
+                    continue
+                except GIT_COMMIT_ERRORS:
+                    self._note_commit_failure()
+                    raise
+                self._note_commit_success()
+                return sha
+        return None  # unreachable; the loop returns or raises
 
     def _note_commit_failure(self) -> None:
         """Count a git failure; flag degraded once they stop looking one-off."""

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -132,10 +132,10 @@ class GitCommandError(subprocess.CalledProcessError):
 
 
 class GitIndexLockBusyError(GitCommandError):
-    """A *fresh* ``index.lock`` blocked the write — a live concurrent writer.
+    """A live concurrent writer holds the ``index.lock``; safe to retry.
 
-    Raised instead of waiting inside the executor thread, so the async
-    caller can back off on the event loop and retry the whole commit.
+    Raised so the async caller backs off on the event loop rather than
+    blocking the executor thread.
     """
 
 
@@ -463,17 +463,14 @@ class GitRepo:
         """
         Run a checked git write, handling index.lock contention.
 
-        A *stale* lock (a crashed prior run) is cleared and the write
-        retried at once. A *fresh* lock (a live concurrent writer, e.g.
-        another dashboard instance on the same repo) raises
-        :class:`GitIndexLockBusyError` so the async caller backs off on the
-        event loop instead of blocking this executor thread. Any other
-        failure propagates.
+        A stale lock is cleared and the write retried at once; a fresh
+        lock raises :class:`GitIndexLockBusyError` for the async caller to
+        back off and retry. Any other failure propagates.
         """
         try:
             self._run(args, check=True)
         except subprocess.CalledProcessError as exc:
-            if "index.lock" not in (exc.stderr or ""):
+            if not self._is_index_lock_error(exc):
                 raise
             if self._clear_stale_index_lock(exc):
                 self._run(args, check=True)  # cleared a stale lock; retry now
@@ -481,6 +478,11 @@ class GitRepo:
             raise GitIndexLockBusyError(
                 exc.returncode, exc.cmd, output=exc.output, stderr=exc.stderr
             ) from exc
+
+    @staticmethod
+    def _is_index_lock_error(exc: subprocess.CalledProcessError) -> bool:
+        """Whether *exc*'s stderr blames a contended ``index.lock``."""
+        return "index.lock" in (exc.stderr or "")
 
     def _clear_stale_index_lock(self, exc: subprocess.CalledProcessError) -> bool:
         """
@@ -490,7 +492,7 @@ class GitRepo:
         ``/config``) and age (:data:`_STALE_LOCK_SECONDS`), so a lock a
         live git is actively holding is never deleted out from under it.
         """
-        if not self.managed or "index.lock" not in (exc.stderr or ""):
+        if not self.managed or not self._is_index_lock_error(exc):
             return False
         lock = self._index_lock_path()
         if lock is None or not lock.exists():

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -131,6 +131,14 @@ class GitCommandError(subprocess.CalledProcessError):
         return f"{base}: {detail}" if detail else base
 
 
+class GitIndexLockBusyError(GitCommandError):
+    """A *fresh* ``index.lock`` blocked the write — a live concurrent writer.
+
+    Raised instead of waiting inside the executor thread, so the async
+    caller can back off on the event loop and retry the whole commit.
+    """
+
+
 @dataclass(slots=True)
 class CommitInfo:
     """One commit touching a file, as surfaced to the history UI."""
@@ -452,13 +460,27 @@ class GitRepo:
     # ------------------------------------------------------------------
 
     def _run_write(self, args: list[str]) -> None:
-        """Run a checked git write, clearing a *stale* index.lock and retrying once."""
+        """
+        Run a checked git write, handling index.lock contention.
+
+        A *stale* lock (a crashed prior run) is cleared and the write
+        retried at once. A *fresh* lock (a live concurrent writer, e.g.
+        another dashboard instance on the same repo) raises
+        :class:`GitIndexLockBusyError` so the async caller backs off on the
+        event loop instead of blocking this executor thread. Any other
+        failure propagates.
+        """
         try:
             self._run(args, check=True)
         except subprocess.CalledProcessError as exc:
-            if not self._clear_stale_index_lock(exc):
+            if "index.lock" not in (exc.stderr or ""):
                 raise
-            self._run(args, check=True)
+            if self._clear_stale_index_lock(exc):
+                self._run(args, check=True)  # cleared a stale lock; retry now
+                return
+            raise GitIndexLockBusyError(
+                exc.returncode, exc.cmd, output=exc.output, stderr=exc.stderr
+            ) from exc
 
     def _clear_stale_index_lock(self, exc: subprocess.CalledProcessError) -> bool:
         """

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -471,10 +471,13 @@ class GitRepo:
             if self._clear_stale_index_lock(exc):
                 self._run(args, check=True)  # cleared a stale lock; retry now
                 return
-            # Couldn't clear it: a live writer (the common case in an adopted
-            # shared repo, where we never touch the lock) or a rare
-            # stale-but-unremovable lock. Treat both as retryable; the latter
-            # just re-fails after the bounded backoff, never silently.
+            if not self._index_lock_is_fresh():
+                # Stale but unclearable (an adopted repo we won't touch, or a
+                # lock we couldn't unlink): it won't free itself, so surface
+                # the original failure instead of spinning on it.
+                raise
+            # A fresh lock is a live concurrent writer; tell the async caller
+            # to back off and retry.
             raise GitIndexLockBusyError(
                 exc.returncode, exc.cmd, output=exc.output, stderr=exc.stderr
             ) from exc
@@ -483,6 +486,21 @@ class GitRepo:
     def _is_index_lock_error(exc: subprocess.CalledProcessError) -> bool:
         """Whether *exc*'s stderr blames a contended ``index.lock``."""
         return "index.lock" in (exc.stderr or "")
+
+    def _index_lock_is_fresh(self) -> bool:
+        """Whether the index.lock is young enough that a live writer may hold it.
+
+        A vanished or unreadable lock counts as fresh (the retry resolves
+        it); one aged past :data:`_STALE_LOCK_SECONDS` won't free itself.
+        """
+        lock = self._index_lock_path()
+        if lock is None:
+            return True
+        try:
+            age = time.time() - lock.stat().st_mtime
+        except OSError:
+            return True
+        return age < _STALE_LOCK_SECONDS
 
     def _clear_stale_index_lock(self, exc: subprocess.CalledProcessError) -> bool:
         """

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -459,28 +459,35 @@ class GitRepo:
         """
         Run a checked git write, handling index.lock contention.
 
-        A stale lock is cleared and the write retried at once; a fresh
-        lock raises :class:`GitIndexLockBusyError` for the async caller to
-        back off and retry. Any other failure propagates.
+        A stale lock is cleared and the write retried in place (once); a
+        fresh lock raises :class:`GitIndexLockBusyError` for the async
+        caller to back off and retry. Any other failure propagates.
         """
-        try:
-            self._run(args, check=True)
-        except subprocess.CalledProcessError as exc:
-            if not self._is_index_lock_error(exc):
-                raise
-            if self._clear_stale_index_lock(exc):
-                self._run(args, check=True)  # cleared a stale lock; retry now
+        cleared_stale = False
+        while True:
+            try:
+                self._run(args, check=True)
+            except subprocess.CalledProcessError as exc:
+                if not self._is_index_lock_error(exc):
+                    raise
+                # Clear a stale lock once and retry in place; a re-collision
+                # after that (a fresh writer grabbed it) drops to the
+                # freshness check below and becomes a retryable busy.
+                if not cleared_stale and self._clear_stale_index_lock(exc):
+                    cleared_stale = True
+                    continue
+                if not self._index_lock_is_fresh():
+                    # Stale but unclearable (an adopted repo we won't touch, or
+                    # a lock we couldn't unlink): it won't free itself, so
+                    # surface the original failure instead of spinning on it.
+                    raise
+                # A fresh lock is a live concurrent writer; tell the async
+                # caller to back off and retry.
+                raise GitIndexLockBusyError(
+                    exc.returncode, exc.cmd, output=exc.output, stderr=exc.stderr
+                ) from exc
+            else:
                 return
-            if not self._index_lock_is_fresh():
-                # Stale but unclearable (an adopted repo we won't touch, or a
-                # lock we couldn't unlink): it won't free itself, so surface
-                # the original failure instead of spinning on it.
-                raise
-            # A fresh lock is a live concurrent writer; tell the async caller
-            # to back off and retry.
-            raise GitIndexLockBusyError(
-                exc.returncode, exc.cmd, output=exc.output, stderr=exc.stderr
-            ) from exc
 
     @staticmethod
     def _is_index_lock_error(exc: subprocess.CalledProcessError) -> bool:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -132,11 +132,7 @@ class GitCommandError(subprocess.CalledProcessError):
 
 
 class GitIndexLockBusyError(GitCommandError):
-    """A live concurrent writer holds the ``index.lock``; safe to retry.
-
-    Raised so the async caller backs off on the event loop rather than
-    blocking the executor thread.
-    """
+    """A live writer holds the ``index.lock``; the async caller should retry."""
 
 
 @dataclass(slots=True)
@@ -475,6 +471,10 @@ class GitRepo:
             if self._clear_stale_index_lock(exc):
                 self._run(args, check=True)  # cleared a stale lock; retry now
                 return
+            # Couldn't clear it: a live writer (the common case in an adopted
+            # shared repo, where we never touch the lock) or a rare
+            # stale-but-unremovable lock. Treat both as retryable; the latter
+            # just re-fails after the bounded backoff, never silently.
             raise GitIndexLockBusyError(
                 exc.returncode, exc.cmd, output=exc.output, stderr=exc.stderr
             ) from exc

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from esphome_device_builder.controllers.version_history import VersionHistoryController
+from esphome_device_builder.controllers.version_history import controller as vh_controller
+from esphome_device_builder.controllers.version_history.git_repo import GitIndexLockBusyError
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models import Device, DeviceEventData, ErrorCode, EventType
@@ -105,6 +107,58 @@ async def test_external_edit_committed_via_scanner_catch_all(
 
     versions = await controller.list_versions(configuration="kitchen.yaml")
     assert [v["message"] for v in versions] == ["Edit kitchen.yaml"]
+
+
+async def test_commit_retries_a_busy_index_lock_then_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live concurrent writer's lock is waited out on the loop, then the commit lands."""
+    monkeypatch.setattr(vh_controller, "_LOCK_RETRY_BACKOFF", 0.0)
+    sleeps: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(vh_controller.asyncio, "sleep", _fake_sleep)
+    controller = _make_controller(tmp_path)
+    calls = {"n": 0}
+
+    def _commit_paths(paths: list[Path], message: str) -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise GitIndexLockBusyError(128, ["git", "add"], stderr="...index.lock...")
+        return "deadbeef"
+
+    controller._repo = SimpleNamespace(enabled=True, commit_paths=_commit_paths)  # type: ignore[assignment]
+
+    assert await controller.commit([tmp_path / "kitchen.yaml"], "Edit") == "deadbeef"
+    assert calls["n"] == 3
+    assert len(sleeps) == 2  # one wait per retry
+    assert controller.degraded is False
+
+
+async def test_commit_gives_up_after_retries_on_persistent_busy_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lock that never clears propagates after the bounded retries and counts a failure."""
+    monkeypatch.setattr(vh_controller, "_LOCK_RETRY_BACKOFF", 0.0)
+
+    async def _fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(vh_controller.asyncio, "sleep", _fake_sleep)
+    controller = _make_controller(tmp_path)
+    calls = {"n": 0}
+
+    def _commit_paths(paths: list[Path], message: str) -> str:
+        calls["n"] += 1
+        raise GitIndexLockBusyError(128, ["git", "add"], stderr="...index.lock...")
+
+    controller._repo = SimpleNamespace(enabled=True, commit_paths=_commit_paths)  # type: ignore[assignment]
+
+    with pytest.raises(GitIndexLockBusyError):
+        await controller.commit([tmp_path / "kitchen.yaml"], "Edit")
+    assert calls["n"] == vh_controller._LOCK_RETRY_ATTEMPTS + 1
 
 
 async def test_external_edit_self_heals_stale_index_lock_after_restart(

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -606,8 +606,8 @@ def test_run_write_propagates_a_non_lock_error(
     assert calls["n"] == 1
 
 
-def test_commit_raises_when_stale_lock_cannot_be_removed(tmp_path: Path) -> None:
-    """If the stale lock can't be unlinked (e.g. it's a directory), the write still raises."""
+def test_commit_raises_busy_when_stale_lock_cannot_be_removed(tmp_path: Path) -> None:
+    """A stale lock we can't unlink (e.g. it's a directory) falls through to retryable busy."""
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
     yaml = tmp_path / "kitchen.yaml"
@@ -618,7 +618,7 @@ def test_commit_raises_when_stale_lock_cannot_be_removed(tmp_path: Path) -> None
     stamp = time.time() - 3600
     os.utime(lock_dir, (stamp, stamp))
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(git_repo_mod.GitIndexLockBusyError):
         repo.commit_paths([yaml], "Create kitchen.yaml")
     assert lock_dir.exists()
 

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -520,7 +520,7 @@ def test_commit_keeps_fresh_index_lock(tmp_path: Path) -> None:
 
 
 def test_adopted_repo_never_clears_index_lock(tmp_path: Path) -> None:
-    """An adopted work tree (user's ``/config``) is never auto-unlocked, even when stale."""
+    """An adopted work tree is never auto-unlocked; a stale lock there propagates as-is."""
     _make_repo(tmp_path)
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
@@ -528,6 +528,24 @@ def test_adopted_repo_never_clears_index_lock(tmp_path: Path) -> None:
     yaml = tmp_path / "kitchen.yaml"
     yaml.write_text("v1\n", encoding="utf-8")
     lock = _index_lock(tmp_path, age_seconds=3600)
+
+    # Stale (won't free itself) and unclearable (adopted) → the original
+    # failure surfaces, not a retryable busy signal.
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert not isinstance(excinfo.value, git_repo_mod.GitIndexLockBusyError)
+    assert lock.exists()
+
+
+def test_adopted_repo_fresh_lock_is_retryable_busy(tmp_path: Path) -> None:
+    """A live writer's fresh lock in an adopted repo is the retryable case (the PR's target)."""
+    _make_repo(tmp_path)
+    repo = GitRepo(config_dir=tmp_path)
+    repo.discover_or_init()
+    assert not repo.managed
+    yaml = tmp_path / "kitchen.yaml"
+    yaml.write_text("v1\n", encoding="utf-8")
+    lock = _index_lock(tmp_path, age_seconds=0)
 
     with pytest.raises(git_repo_mod.GitIndexLockBusyError):
         repo.commit_paths([yaml], "Create kitchen.yaml")
@@ -557,6 +575,7 @@ def test_run_write_raises_busy_on_a_fresh_lock(
     """A fresh lock (a live writer) becomes GitIndexLockBusyError for the async caller to retry."""
     repo = _bare_repo(tmp_path)
     monkeypatch.setattr(GitRepo, "_clear_stale_index_lock", lambda _self, _exc: False)
+    monkeypatch.setattr(GitRepo, "_index_lock_is_fresh", lambda _self: True)
     calls = {"n": 0}
 
     def _fake_run(_self: GitRepo, args: list[str], *, check: bool) -> object:
@@ -567,6 +586,26 @@ def test_run_write_raises_busy_on_a_fresh_lock(
     with pytest.raises(git_repo_mod.GitIndexLockBusyError):
         repo._run_write(["add", "--", "x"])
     assert calls["n"] == 1  # no in-thread retry; the wait belongs on the loop
+
+
+def test_run_write_propagates_a_stale_unclearable_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale lock that couldn't be cleared surfaces the original error, not a busy retry."""
+    repo = _bare_repo(tmp_path)
+    monkeypatch.setattr(GitRepo, "_clear_stale_index_lock", lambda _self, _exc: False)
+    monkeypatch.setattr(GitRepo, "_index_lock_is_fresh", lambda _self: False)
+    calls = {"n": 0}
+
+    def _fake_run(_self: GitRepo, args: list[str], *, check: bool) -> object:
+        calls["n"] += 1
+        raise _lock_error()
+
+    monkeypatch.setattr(GitRepo, "_run", _fake_run)
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        repo._run_write(["add", "--", "x"])
+    assert not isinstance(excinfo.value, git_repo_mod.GitIndexLockBusyError)
+    assert calls["n"] == 1
 
 
 def test_run_write_retries_in_place_after_clearing_a_stale_lock(
@@ -606,8 +645,29 @@ def test_run_write_propagates_a_non_lock_error(
     assert calls["n"] == 1
 
 
-def test_commit_raises_busy_when_stale_lock_cannot_be_removed(tmp_path: Path) -> None:
-    """A stale lock we can't unlink (e.g. it's a directory) falls through to retryable busy."""
+def test_index_lock_is_fresh_classifies_by_age(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unresolvable / vanished / young locks count as fresh; only an aged one is stale."""
+    repo = _bare_repo(tmp_path)
+    lock = tmp_path / "index.lock"
+
+    monkeypatch.setattr(GitRepo, "_index_lock_path", lambda _self: None)
+    assert repo._index_lock_is_fresh() is True  # can't resolve → retry resolves it
+
+    monkeypatch.setattr(GitRepo, "_index_lock_path", lambda _self: lock)
+    assert repo._index_lock_is_fresh() is True  # vanished (stat raises) → fresh
+
+    lock.write_text("", encoding="utf-8")
+    assert repo._index_lock_is_fresh() is True  # young → a live writer may hold it
+
+    stamp = time.time() - 3600
+    os.utime(lock, (stamp, stamp))
+    assert repo._index_lock_is_fresh() is False  # aged → won't free itself
+
+
+def test_commit_propagates_a_stale_lock_it_cannot_remove(tmp_path: Path) -> None:
+    """A stale lock we can't unlink (e.g. it's a directory) surfaces the original error."""
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
     yaml = tmp_path / "kitchen.yaml"
@@ -618,8 +678,10 @@ def test_commit_raises_busy_when_stale_lock_cannot_be_removed(tmp_path: Path) ->
     stamp = time.time() - 3600
     os.utime(lock_dir, (stamp, stamp))
 
-    with pytest.raises(git_repo_mod.GitIndexLockBusyError):
+    # Stale (won't free itself) and unclearable → not a retryable busy signal.
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
         repo.commit_paths([yaml], "Create kitchen.yaml")
+    assert not isinstance(excinfo.value, git_repo_mod.GitIndexLockBusyError)
     assert lock_dir.exists()
 
 

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from esphome_device_builder.controllers.version_history import git_repo as git_repo_mod
 from esphome_device_builder.controllers.version_history.git_repo import GitRepo
 
 _GIT = shutil.which("git") or "git"
@@ -506,14 +507,14 @@ def test_pre_marker_repo_is_backfilled_as_managed(tmp_path: Path) -> None:
 
 
 def test_commit_keeps_fresh_index_lock(tmp_path: Path) -> None:
-    """A young ``index.lock`` (a live git may hold it) is left alone; the write raises."""
+    """A young ``index.lock`` (a live git may hold it) is left alone; the write raises busy."""
     repo = GitRepo(config_dir=tmp_path)
     repo.discover_or_init()
     yaml = tmp_path / "kitchen.yaml"
     yaml.write_text("v1\n", encoding="utf-8")
     lock = _index_lock(tmp_path, age_seconds=0)
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(git_repo_mod.GitIndexLockBusyError):
         repo.commit_paths([yaml], "Create kitchen.yaml")
     assert lock.exists()
 
@@ -528,9 +529,81 @@ def test_adopted_repo_never_clears_index_lock(tmp_path: Path) -> None:
     yaml.write_text("v1\n", encoding="utf-8")
     lock = _index_lock(tmp_path, age_seconds=3600)
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(git_repo_mod.GitIndexLockBusyError):
         repo.commit_paths([yaml], "Create kitchen.yaml")
     assert lock.exists()
+
+
+def _lock_error() -> subprocess.CalledProcessError:
+    """Build a git failure whose stderr blames a live ``index.lock``."""
+    return subprocess.CalledProcessError(
+        128,
+        ["git", "add"],
+        stderr="fatal: Unable to create '.git/index.lock': File exists.",
+    )
+
+
+def _bare_repo(tmp_path: Path) -> GitRepo:
+    """Wire a GitRepo just enough to drive ``_run_write`` with a stubbed ``_run``."""
+    repo = GitRepo(config_dir=tmp_path)
+    repo.git_bin = "git"
+    repo.toplevel = tmp_path
+    return repo
+
+
+def test_run_write_raises_busy_on_a_fresh_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh lock (a live writer) becomes GitIndexLockBusyError for the async caller to retry."""
+    repo = _bare_repo(tmp_path)
+    monkeypatch.setattr(GitRepo, "_clear_stale_index_lock", lambda _self, _exc: False)
+    calls = {"n": 0}
+
+    def _fake_run(_self: GitRepo, args: list[str], *, check: bool) -> object:
+        calls["n"] += 1
+        raise _lock_error()
+
+    monkeypatch.setattr(GitRepo, "_run", _fake_run)
+    with pytest.raises(git_repo_mod.GitIndexLockBusyError):
+        repo._run_write(["add", "--", "x"])
+    assert calls["n"] == 1  # no in-thread retry; the wait belongs on the loop
+
+
+def test_run_write_retries_in_place_after_clearing_a_stale_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale lock is cleared and the write retried at once, no busy signal."""
+    repo = _bare_repo(tmp_path)
+    monkeypatch.setattr(GitRepo, "_clear_stale_index_lock", lambda _self, _exc: True)
+    calls = {"n": 0}
+
+    def _fake_run(_self: GitRepo, args: list[str], *, check: bool) -> object:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _lock_error()
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(GitRepo, "_run", _fake_run)
+    repo._run_write(["add", "--", "x"])
+    assert calls["n"] == 2
+
+
+def test_run_write_propagates_a_non_lock_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A git failure that isn't index.lock contention is not wrapped as busy."""
+    repo = _bare_repo(tmp_path)
+    calls = {"n": 0}
+
+    def _fake_run(_self: GitRepo, args: list[str], *, check: bool) -> object:
+        calls["n"] += 1
+        raise subprocess.CalledProcessError(1, ["git", "commit"], stderr="fatal: nothing to do")
+
+    monkeypatch.setattr(GitRepo, "_run", _fake_run)
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        repo._run_write(["commit"])
+    assert not isinstance(excinfo.value, git_repo_mod.GitIndexLockBusyError)
+    assert calls["n"] == 1
 
 
 def test_commit_raises_when_stale_lock_cannot_be_removed(tmp_path: Path) -> None:

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -627,6 +627,25 @@ def test_run_write_retries_in_place_after_clearing_a_stale_lock(
     assert calls["n"] == 2
 
 
+def test_run_write_reclassifies_a_post_clear_recollision_as_busy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh writer grabbing the lock right after a stale-clear is still retryable busy."""
+    repo = _bare_repo(tmp_path)
+    monkeypatch.setattr(GitRepo, "_clear_stale_index_lock", lambda _self, _exc: True)
+    monkeypatch.setattr(GitRepo, "_index_lock_is_fresh", lambda _self: True)
+    calls = {"n": 0}
+
+    def _fake_run(_self: GitRepo, args: list[str], *, check: bool) -> object:
+        calls["n"] += 1
+        raise _lock_error()  # the cleared lock is immediately re-taken
+
+    monkeypatch.setattr(GitRepo, "_run", _fake_run)
+    with pytest.raises(git_repo_mod.GitIndexLockBusyError):
+        repo._run_write(["add", "--", "x"])
+    assert calls["n"] == 2  # original attempt + one post-clear retry, then busy
+
+
 def test_run_write_propagates_a_non_lock_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When several dashboard instances share one config-dir git repo (a common HA setup: the prod, beta, and dev addons all running against one `/config/esphome`), a real external edit is detected by all of them at once and they collide on `.git/index.lock`. The loser raised, and because each collision counted as a commit failure, repeated collisions on the secondary instances would eventually trip the `degraded` flag.

A fresh (live) `index.lock` now raises a typed `GitIndexLockBusyError` from the synchronous git layer instead of failing outright. The async `commit()` catches it, backs off on the event loop, and retries the whole commit; the executor thread is not held during the wait. Whichever instance wins the lock commits the edit; the others retry, find nothing staged, and no-op cleanly. Stale-lock recovery (a crashed prior run) is unchanged.

This pairs with #1628, which removes the bulk of the contention by only committing on real YAML edits; this PR makes the genuine concurrent-edit case robust.

**Related issue or feature (if applicable):**

- N/A; reported from production logs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
