### PR TITLE
Refresh deployed version after a flash so Update Available clears

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,12 +409,20 @@ against legacy behaviour before assuming the simpler version suffices.
   `apply_api_encryption` both lean on the empty-string-means-plaintext
   distinction; a nullable boolean would lose it.
 - **Optimistic post-flash sync** in
-  `DevicesController._sync_deployed_hash_after_flash` pre-pins
-  `deployed_config_hash = expected_config_hash` after a successful
-  UPLOAD/INSTALL via `DeviceStateMonitor.apply_config_hash`, so the dot
-  clears immediately instead of waiting on the rebooted device's mDNS
-  announce. If the OTA silently failed, the next real announce pushes the
-  truth back through the same callback.
+  `DevicesController._sync_deployed_state_after_flash` pre-pins both
+  `deployed_config_hash = expected_config_hash` *and*
+  `deployed_version = StorageJSON.esphome_version` after a successful
+  UPLOAD/INSTALL via `DeviceStateMonitor.apply_config_hash` /
+  `apply_version`, so the dot and the "update available" badge clear
+  immediately instead of waiting on the rebooted device's mDNS announce.
+  A real announce later overwrites either through the same callback. mDNS
+  is dark in some deployments (Docker-bridge), so `refresh_after_job`
+  also arms a `loop.call_later` timer (`_schedule_version_reprobe`,
+  tracked in `_reprobe_timers`, cancelled in `stop()`) that ~60s later
+  forces one Native-API version probe via `request_version_reprobe` —
+  the only signal of a rollback / failed boot where the announce never
+  arrives. The forced probe still honours `_is_due`'s `priority_for !=
+  MDNS` guard, so a device already seen over mDNS is skipped.
 - **Two mDNS paths with different OFFLINE semantics:**
   - **Browser callback** (`_on_service_state_change`) — passively
     subscribed to `_esphomelib._tcp.local.`. Trust mDNS **both

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -293,6 +293,11 @@ class DeviceScanner(WakeWorker[str]):
         """
         return self._index.get_by_name(name)
 
+    def get_by_configuration(self, configuration: str) -> Device | None:
+        """Return the configured device for YAML filename *configuration*, or ``None``."""
+        path = self._index.find_path_by_filename(configuration)
+        return self._index.by_path.get(path) if path is not None else None
+
     async def scan(self) -> None:
         """Refresh the device cache from disk, emitting per-file change events."""
         async with self._lock:

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -157,7 +157,8 @@ class ApiInfoSource:
         )
 
     def _select_targets(self) -> list[Device]:
-        """Due devices that are off cooldown — the probe candidates for this sweep.
+        """
+        Due devices that are off cooldown — the probe candidates for this sweep.
 
         A forced re-probe ignores cooldown: it's a deliberate one-shot request.
         """
@@ -187,8 +188,12 @@ class ApiInfoSource:
 
     async def _fetch(self, device: Device) -> None:
         monitor = self._monitor
-        # One-shot: a forced re-probe is consumed by this attempt, so a device
-        # with no reachable API isn't probed every sweep forever.
+        # One-shot, consumed up front — before the dial / key-resolve
+        # early-returns below — so a device we can't even reach (no address,
+        # unresolvable Noise key) isn't force-probed every sweep, since a
+        # forced probe bypasses cooldown. The trade-off is deliberate: that
+        # device's post-flash rollback check is skipped, but it can't be
+        # API-verified anyway.
         forced = device.name in self._force_reprobe
         self._force_reprobe.discard(device.name)
         addresses = self._candidate_addresses(device)

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -189,6 +189,7 @@ class ApiInfoSource:
         monitor = self._monitor
         # One-shot: a forced re-probe is consumed by this attempt, so a device
         # with no reachable API isn't probed every sweep forever.
+        forced = device.name in self._force_reprobe
         self._force_reprobe.discard(device.name)
         addresses = self._candidate_addresses(device)
         if not addresses:
@@ -231,6 +232,13 @@ class ApiInfoSource:
         filled_mac = monitor.apply_mac_address(device.name, info.get("mac_address", ""))
         filled_version = monitor.apply_version(device.name, info.get("esphome_version", ""))
         if filled_mac or filled_version:
+            return
+        # A forced re-probe that connected (``info`` truthy) but changed
+        # nothing confirmed the existing version — a success, not a miss, so
+        # don't cool it down. The normal path still cools down here: it was
+        # due *because* a field was missing, so "nothing newly filled" is a
+        # real miss to retry later.
+        if forced and info:
             return
         self._record_failure(device)
 

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -59,11 +59,19 @@ class ApiInfoSource:
         self._wake = asyncio.Event()
         # name -> monotonic deadline before which we won't retry a fetch.
         self._cooldown: dict[str, float] = {}
+        # Device names to probe once even though they already have mac+version
+        # (post-flash version verification); cleared after one probe attempt.
+        self._force_reprobe: set[str] = set()
         # One-shot latch for the systemic WARNING; re-arms once the count of
         # distinct devices stuck failing drops back below the threshold.
         self._warned_systemic = False
         if monitor._presence is not None:
             monitor._presence.add_subscriber_callback(self._wake.set)
+
+    def request_reprobe(self, name: str) -> None:
+        """Force one probe of *name* on the next sweep, ignoring the mac+version guard."""
+        self._force_reprobe.add(name)
+        self._wake.set()
 
     async def run(self) -> None:
         # ``find_spec`` resolves without importing, so ``aioesphomeapi``
@@ -97,6 +105,7 @@ class ApiInfoSource:
         # not a fleet sweep — serialising keeps it unobtrusive.
         live = {device.name for device in self._monitor._get_devices()}
         self._cooldown = {name: t for name, t in self._cooldown.items() if name in live}
+        self._force_reprobe &= live
         # Cap probes per sweep so an mDNS-dark fleet where every probe runs
         # the full subprocess timeout doesn't churn out back-to-back
         # interpreter spawns for minutes. The overflow rolls to the next
@@ -130,25 +139,34 @@ class ApiInfoSource:
         Report whether *device* needs an API probe, ignoring cooldown.
 
         Due means: online, exposes a Native API, not owned by the mDNS source
-        (so the ``_esphomelib._tcp`` TXT records aren't arriving), still missing
-        a field, and reachable by IP.
+        (so the ``_esphomelib._tcp`` TXT records aren't arriving), reachable by
+        IP, and either still missing a field or flagged for a forced re-probe
+        (post-flash version verification, which probes even when both fields
+        are already filled).
         """
         monitor = self._monitor
         return (
             device.state is DeviceState.ONLINE
             and device.api_enabled
             and monitor.priority_for(device.name) != ReachabilitySource.MDNS
-            and not (device.mac_address and device.deployed_version)
+            and (
+                device.name in self._force_reprobe
+                or not (device.mac_address and device.deployed_version)
+            )
             and bool(self._candidate_addresses(device))
         )
 
     def _select_targets(self) -> list[Device]:
-        """Due devices that are off cooldown — the probe candidates for this sweep."""
+        """Due devices that are off cooldown — the probe candidates for this sweep.
+
+        A forced re-probe ignores cooldown: it's a deliberate one-shot request.
+        """
         now = time.monotonic()
         return [
             device
             for device in self._monitor._get_devices()
-            if self._is_due(device) and self._cooldown.get(device.name, 0.0) <= now
+            if self._is_due(device)
+            and (device.name in self._force_reprobe or self._cooldown.get(device.name, 0.0) <= now)
         ]
 
     @staticmethod
@@ -169,6 +187,9 @@ class ApiInfoSource:
 
     async def _fetch(self, device: Device) -> None:
         monitor = self._monitor
+        # One-shot: a forced re-probe is consumed by this attempt, so a device
+        # with no reachable API isn't probed every sweep forever.
+        self._force_reprobe.discard(device.name)
         addresses = self._candidate_addresses(device)
         if not addresses:
             # select→fetch TOCTOU: an mDNS/ping callback emptied the address

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -349,6 +349,10 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._on_ip_change(name, primary, addresses)
         return True
 
+    def request_version_reprobe(self, name: str) -> None:
+        """Force one Native-API version probe of *name*, ignoring the mac+version guard."""
+        self._api_info.request_reprobe(name)
+
     def apply_version(self, name: str, version: str) -> bool:
         """Record a firmware version observation; True iff forwarded."""
         if not version or self._on_version_change is None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1120,8 +1120,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _persist_expected_config_hash(self, configuration: str) -> None:
         await firmware_sync.persist_expected_config_hash(self, configuration)
 
-    def _sync_deployed_hash_after_flash(self, configuration: str) -> None:
-        firmware_sync.sync_deployed_hash_after_flash(self, configuration)
+    async def _sync_deployed_state_after_flash(self, configuration: str) -> None:
+        await firmware_sync.sync_deployed_state_after_flash(self, configuration)
+
+    async def _reprobe_version_after_flash(self, configuration: str) -> None:
+        await firmware_sync.reprobe_version_after_flash(self, configuration)
 
     def _persist_build_size(self, configuration: str, result: BuildSizeRefreshResult) -> None:
         """Merge a fresh build-size triple into the metadata store."""

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -115,6 +115,10 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # Unsubscribe handle for the firmware-job-completion listener
         # wired up in start(); held so stop() can detach cleanly.
         self._unsub_job_completed: Any = None
+        # Pending post-flash version re-probe timers, keyed on
+        # configuration so a re-flash cancels its predecessor; cancelled
+        # en masse in stop().
+        self._reprobe_timers: dict[str, asyncio.TimerHandle] = {}
 
         # Constructed before the scanner so the first
         # ``_resolve_device_metadata`` reads off the store.
@@ -266,6 +270,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         if self._unsub_job_completed is not None:
             self._unsub_job_completed()
             self._unsub_job_completed = None
+        self._cancel_reprobe_timers()
         await self._scanner.stop()
         await self._build_size.stop()
         await self._mqtt_coordinator.stop()
@@ -1123,8 +1128,14 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     async def _sync_deployed_state_after_flash(self, configuration: str) -> None:
         await firmware_sync.sync_deployed_state_after_flash(self, configuration)
 
-    async def _reprobe_version_after_flash(self, configuration: str) -> None:
-        await firmware_sync.reprobe_version_after_flash(self, configuration)
+    def _schedule_version_reprobe(self, configuration: str) -> None:
+        firmware_sync.schedule_version_reprobe(self, configuration)
+
+    def _cancel_reprobe_timers(self) -> None:
+        """Cancel any pending post-flash re-probe timers."""
+        for handle in self._reprobe_timers.values():
+            handle.cancel()
+        self._reprobe_timers.clear()
 
     def _persist_build_size(self, configuration: str, result: BuildSizeRefreshResult) -> None:
         """Merge a fresh build-size triple into the metadata store."""

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -170,10 +170,7 @@ async def sync_deployed_state_after_flash(
     the "update available" badge without waiting on an mDNS announce —
     one that never arrives in mDNS-dark deployments (Docker-bridge).
     """
-    device = next(
-        (d for d in controller._scanner.devices if d.configuration == configuration),
-        None,
-    )
+    device = controller._scanner.get_by_configuration(configuration)
     if device is None:
         return
     if device.expected_config_hash:
@@ -190,10 +187,7 @@ async def reprobe_version_after_flash(controller: DevicesController, configurati
     way to catch a rollback / failed boot when mDNS can't reach us.
     """
     await asyncio.sleep(_POST_FLASH_VERSION_REPROBE_DELAY)
-    device = next(
-        (d for d in controller._scanner.devices if d.configuration == configuration),
-        None,
-    )
+    device = controller._scanner.get_by_configuration(configuration)
     if device is not None:
         controller._state_monitor.request_version_reprobe(device.name)
 

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -115,9 +115,7 @@ async def refresh_after_job(
     await controller._scanner.reload(configuration)
     if flashed:
         await controller._sync_deployed_state_after_flash(configuration)
-        controller._db.create_background_task(
-            controller._reprobe_version_after_flash(configuration)
-        )
+        controller._schedule_version_reprobe(configuration)
     # A real compile moves the build-size cache's freshness
     # pair (build-dir mtime + ``build_info.json`` mtime); the
     # worker short-circuits when the pair didn't actually move
@@ -180,16 +178,23 @@ async def sync_deployed_state_after_flash(
         controller._state_monitor.apply_version(device.name, version)
 
 
-async def reprobe_version_after_flash(controller: DevicesController, configuration: str) -> None:
-    """Re-probe the device's running version over the Native API after a flash.
+def schedule_version_reprobe(controller: DevicesController, configuration: str) -> None:
+    """Arm a one-shot Native-API version re-probe ~60s after a flash.
 
-    Confirms the optimistic pin once the device has rebooted — the only
-    way to catch a rollback / failed boot when mDNS can't reach us.
+    The delay lets the device reboot into the new image before we
+    connect; the re-probe then confirms the optimistically-pinned
+    version (and catches a rollback) where mDNS can't reach us.
+    Re-arming for the same configuration cancels the prior timer so a
+    rapid re-flash doesn't stack probes; the handle is tracked on the
+    controller so ``stop`` can cancel anything still pending.
     """
-    await asyncio.sleep(_POST_FLASH_VERSION_REPROBE_DELAY)
-    device = controller._scanner.get_by_configuration(configuration)
-    if device is not None:
-        controller._state_monitor.request_version_reprobe(device.name)
+    existing = controller._reprobe_timers.pop(configuration, None)
+    if existing is not None:
+        existing.cancel()
+    loop = asyncio.get_running_loop()
+    controller._reprobe_timers[configuration] = loop.call_later(
+        _POST_FLASH_VERSION_REPROBE_DELAY, _fire_version_reprobe, controller, configuration
+    )
 
 
 async def migrate_metadata_then_scan(
@@ -207,6 +212,19 @@ async def migrate_metadata_then_scan(
             new_configuration,
         )
     await controller._scanner.scan()
+
+
+def _fire_version_reprobe(controller: DevicesController, configuration: str) -> None:
+    """Timer callback: ask the monitor to verify the device's running version.
+
+    A no-op if the device vanished in the interim. The request still
+    honours the monitor's ``priority_for != MDNS`` guard, so a device
+    already seen over mDNS by now is skipped rather than probed.
+    """
+    controller._reprobe_timers.pop(configuration, None)
+    device = controller._scanner.get_by_configuration(configuration)
+    if device is not None:
+        controller._state_monitor.request_version_reprobe(device.name)
 
 
 def _read_compiled_esphome_version(configuration: str) -> str:

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from esphome.storage_json import StorageJSON
 
 from ...helpers.config_hash import compute_yaml_config_hash
 from ...helpers.event_bus import Event
 from ...helpers.remote_build_layout import (
     parse_from_configuration as parse_remote_build_path,
 )
+from ...helpers.storage_path import resolve_storage_path
 from ...models import JobLifecycleData, JobStatus, JobType
 
 if TYPE_CHECKING:
     from .controller import DevicesController
 
 _LOGGER = logging.getLogger(__name__)
+
+# Delay before the post-flash Native-API version re-probe so the device
+# has time to reboot into the new image before we connect.
+_POST_FLASH_VERSION_REPROBE_DELAY = 60
 
 
 def on_job_completed(controller: DevicesController, event: Event[JobLifecycleData]) -> None:
@@ -96,17 +104,20 @@ async def refresh_after_job(
 
     Always reloads after the optional hash recompute so the
     mtime side of ``has_pending_changes`` flips. When *flashed*,
-    optimistically pins ``deployed_config_hash = expected`` so
-    the dot clears immediately rather than waiting on the
-    rebooted device's mDNS announce; if the OTA actually failed
-    silently, ``_on_config_hash_change`` pushes the real value
-    back on the next announce.
+    optimistically pins ``deployed_config_hash`` + ``deployed_version``
+    so the dot and the "update available" badge clear immediately
+    rather than waiting on the rebooted device's mDNS announce, then
+    schedules a delayed Native-API re-probe to confirm the running
+    version (the only signal of a rollback when mDNS can't reach us).
     """
     if recompute_hash:
         await controller._persist_expected_config_hash(configuration)
     await controller._scanner.reload(configuration)
     if flashed:
-        controller._sync_deployed_hash_after_flash(configuration)
+        await controller._sync_deployed_state_after_flash(configuration)
+        controller._db.create_background_task(
+            controller._reprobe_version_after_flash(configuration)
+        )
     # A real compile moves the build-size cache's freshness
     # pair (build-dir mtime + ``build_info.json`` mtime); the
     # worker short-circuits when the pair didn't actually move
@@ -143,24 +154,48 @@ async def persist_expected_config_hash(controller: DevicesController, configurat
     _LOGGER.debug("Stored expected_config_hash for %s: %s", configuration, new_hash)
 
 
-def sync_deployed_hash_after_flash(controller: DevicesController, configuration: str) -> None:
+async def sync_deployed_state_after_flash(
+    controller: DevicesController, configuration: str
+) -> None:
     """
-    Optimistically align ``deployed_config_hash`` with the just-flashed image.
+    Optimistically align ``deployed_config_hash`` + ``deployed_version`` with the flash.
 
-    Driving the update through ``apply_config_hash`` lets the
-    existing ``_on_config_hash_change`` callback handle the
-    device-field write + ``DEVICE_UPDATED`` event, and seeds
-    the monitor's per-name cache so the rebooted device's
-    matching announce deduplicates instead of firing a
-    redundant event.
+    A successful flash means the freshly-compiled binary is on the
+    device, so its ``expected_config_hash`` and
+    ``StorageJSON.esphome_version`` describe what the device now runs.
+    Driving both through ``apply_config_hash`` / ``apply_version`` lets
+    the existing ``_on_*_change`` callbacks write the fields, fire
+    ``DEVICE_UPDATED``, and seed the monitor's cache so the rebooted
+    device's matching announce deduplicates. Clears the orange dot and
+    the "update available" badge without waiting on an mDNS announce —
+    one that never arrives in mDNS-dark deployments (Docker-bridge).
     """
     device = next(
         (d for d in controller._scanner.devices if d.configuration == configuration),
         None,
     )
-    if device is None or not device.expected_config_hash:
+    if device is None:
         return
-    controller._state_monitor.apply_config_hash(device.name, device.expected_config_hash)
+    if device.expected_config_hash:
+        controller._state_monitor.apply_config_hash(device.name, device.expected_config_hash)
+    version = await asyncio.to_thread(_read_compiled_esphome_version, configuration)
+    if version:
+        controller._state_monitor.apply_version(device.name, version)
+
+
+async def reprobe_version_after_flash(controller: DevicesController, configuration: str) -> None:
+    """Re-probe the device's running version over the Native API after a flash.
+
+    Confirms the optimistic pin once the device has rebooted — the only
+    way to catch a rollback / failed boot when mDNS can't reach us.
+    """
+    await asyncio.sleep(_POST_FLASH_VERSION_REPROBE_DELAY)
+    device = next(
+        (d for d in controller._scanner.devices if d.configuration == configuration),
+        None,
+    )
+    if device is not None:
+        controller._state_monitor.request_version_reprobe(device.name)
 
 
 async def migrate_metadata_then_scan(
@@ -178,3 +213,11 @@ async def migrate_metadata_then_scan(
             new_configuration,
         )
     await controller._scanner.scan()
+
+
+def _read_compiled_esphome_version(configuration: str) -> str:
+    """Read ``esphome_version`` from the device's StorageJSON; ``""`` on miss."""
+    storage = StorageJSON.load(resolve_storage_path(configuration))
+    if storage is None or not storage.esphome_version:
+        return ""
+    return str(storage.esphome_version)

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -179,7 +179,8 @@ async def sync_deployed_state_after_flash(
 
 
 def schedule_version_reprobe(controller: DevicesController, configuration: str) -> None:
-    """Arm a one-shot Native-API version re-probe ~60s after a flash.
+    """
+    Arm a one-shot Native-API version re-probe ~60s after a flash.
 
     The delay lets the device reboot into the new image before we
     connect; the re-probe then confirms the optimistically-pinned
@@ -215,7 +216,8 @@ async def migrate_metadata_then_scan(
 
 
 def _fire_version_reprobe(controller: DevicesController, configuration: str) -> None:
-    """Timer callback: ask the monitor to verify the device's running version.
+    """
+    Timer callback: ask the monitor to verify the device's running version.
 
     A no-op if the device vanished in the interim. The request still
     honours the monitor's ``priority_for != MDNS`` guard, so a device

--- a/tests/_recording_scanner.py
+++ b/tests/_recording_scanner.py
@@ -80,3 +80,11 @@ class RecordingScanner:
         # Fresh list snapshot — mirrors production semantics so
         # callers can iterate / mutate without poisoning the index.
         return list(self._devices_by_name.get(name, []))
+
+    def get_by_configuration(self, configuration: str) -> object | None:
+        # A read accessor like ``devices`` / ``by_path`` — not recorded in
+        # ``calls`` (those track side-effecting / awaitable operations).
+        return next(
+            (d for d in self.devices if getattr(d, "configuration", None) == configuration),
+            None,
+        )

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -359,11 +359,15 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
     db = MagicMock()
     db.settings.config_dir = tmp_path
     db.settings.rel_path = lambda c: tmp_path / c
+    # The flashed branch schedules the post-flash re-probe; close the coro
+    # so it doesn't leak (no device seeded, so the state sync is a no-op).
+    db.create_background_task.side_effect = lambda coro: coro.close()
 
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
     controller._scanner = RecordingScanner()
     controller._build_size = MagicMock()
+    controller._state_monitor = MagicMock()
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=False, flashed=True)
 
@@ -372,16 +376,20 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
 
 
 # ----------------------------------------------------------------------
-# DevicesController._sync_deployed_hash_after_flash
+# DevicesController._sync_deployed_state_after_flash
 #
-# Drives the orange-dot-clears-after-OTA fix. The reloaded device
-# inherits ``deployed_config_hash`` from the previous in-memory
-# snapshot — typically the now-stale pre-flash mDNS value — so without
-# this sync ``has_pending_changes`` reads ``expected != deployed`` and
-# the user sees a still-orange dot until the rebooted device's mDNS
-# announce propagates (seconds at best, "never" if the rebroadcast
-# gets dropped on the wire).
+# Drives the badges-clear-after-OTA fix. The reloaded device inherits
+# ``deployed_config_hash`` / ``deployed_version`` from the previous
+# in-memory snapshot — typically the now-stale pre-flash values — so
+# without this sync ``has_pending_changes`` and ``update_available``
+# read stale and the user sees a still-orange dot / "update available"
+# until the rebooted device's mDNS announce propagates (seconds at
+# best, "never" in mDNS-dark deployments like the Docker bridge).
 # ----------------------------------------------------------------------
+
+_VERSION_READ = (
+    "esphome_device_builder.controllers.devices.firmware_sync._read_compiled_esphome_version"
+)
 
 
 def _flush_controller(device: Device) -> tuple[Any, list[Any]]:
@@ -396,24 +404,29 @@ def _flush_controller(device: Device) -> tuple[Any, list[Any]]:
     scanner.get_by_name = lambda name: [device] if device.name == name else []
 
     state_monitor = MagicMock()
-    # Drive the same de-dup behaviour real ``apply_config_hash`` has —
-    # if the scan device's name matches and the hash differs from the
-    # cached value, fire the controller's ``_on_config_hash_change``
-    # callback so the assertion can verify the device fields flipped.
-    cache: dict[str, str] = {}
+    # Drive the same de-dup behaviour the real ``apply_*`` methods have —
+    # if the scan device's name matches and the value differs from the
+    # cached one, fire the controller's ``_on_*_change`` callback so the
+    # assertion can verify the device fields flipped.
+    hash_cache: dict[str, str] = {}
+    version_cache: dict[str, str] = {}
 
-    def _apply(name: str, config_hash: str) -> bool:
-        if not config_hash:
+    def _apply_hash(name: str, config_hash: str) -> bool:
+        if not config_hash or hash_cache.get(name) == config_hash:
             return False
-        if cache.get(name) == config_hash:
-            return False
-        cache[name] = config_hash
-        # Mirror what ``DeviceStateMonitor`` does — fire the callback
-        # the controller registered when wiring up the monitor.
+        hash_cache[name] = config_hash
         controller._on_config_hash_change(name, config_hash)
         return True
 
-    state_monitor.apply_config_hash.side_effect = _apply
+    def _apply_version(name: str, version: str) -> bool:
+        if not version or version_cache.get(name) == version:
+            return False
+        version_cache[name] = version
+        controller._on_version_change(name, version)
+        return True
+
+    state_monitor.apply_config_hash.side_effect = _apply_hash
+    state_monitor.apply_version.side_effect = _apply_version
 
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
@@ -431,68 +444,141 @@ def _flush_controller(device: Device) -> tuple[Any, list[Any]]:
     return controller, fired
 
 
-async def test_sync_after_flash_pins_deployed_hash_and_clears_pending() -> None:
-    """Post-flash sync flips deployed → expected and emits ``DEVICE_UPDATED``."""
+async def test_sync_after_flash_pins_hash_and_version(monkeypatch: Any) -> None:
+    """Post-flash sync flips both deployed hash + version and clears both badges."""
+    monkeypatch.setattr(_VERSION_READ, lambda _cfg: "2026.6.2")
     device = _device(
         expected_config_hash="aaaa1111",
         deployed_config_hash="bbbb2222",  # stale pre-flash mDNS value
+        deployed_version="2024.6.4",  # stale pre-flash version
+        current_version="2026.6.2",
+        has_pending_changes=True,
+        update_available=True,
+    )
+    controller, fired = _flush_controller(device)
+
+    await controller._sync_deployed_state_after_flash("kitchen.yaml")
+
+    assert device.deployed_config_hash == "aaaa1111"
+    assert device.has_pending_changes is False
+    assert device.deployed_version == "2026.6.2"
+    assert device.update_available is False
+    # One DEVICE_UPDATED per pin, via the existing _on_*_change callbacks.
+    assert [t for t, _p in fired] == [EventType.DEVICE_UPDATED, EventType.DEVICE_UPDATED]
+
+
+async def test_sync_after_flash_no_expected_hash_pins_version_only(monkeypatch: Any) -> None:
+    """Without ``expected_config_hash`` the hash pin is skipped; the version still pins."""
+    monkeypatch.setattr(_VERSION_READ, lambda _cfg: "2026.6.2")
+    device = _device(
+        expected_config_hash="",
+        deployed_config_hash="bbbb2222",
+        deployed_version="2024.6.4",
+        current_version="2026.6.2",
+    )
+    controller, fired = _flush_controller(device)
+
+    await controller._sync_deployed_state_after_flash("kitchen.yaml")
+
+    assert device.deployed_config_hash == "bbbb2222"  # untouched
+    assert device.deployed_version == "2026.6.2"
+    assert [t for t, _p in fired] == [EventType.DEVICE_UPDATED]
+
+
+async def test_sync_after_flash_no_compiled_version_pins_hash_only(monkeypatch: Any) -> None:
+    """Without a StorageJSON version the version pin is skipped; the hash still pins."""
+    monkeypatch.setattr(_VERSION_READ, lambda _cfg: "")
+    device = _device(
+        expected_config_hash="aaaa1111",
+        deployed_config_hash="bbbb2222",
+        deployed_version="2024.6.4",
         has_pending_changes=True,
     )
     controller, fired = _flush_controller(device)
 
-    controller._sync_deployed_hash_after_flash("kitchen.yaml")
+    await controller._sync_deployed_state_after_flash("kitchen.yaml")
 
     assert device.deployed_config_hash == "aaaa1111"
     assert device.has_pending_changes is False
-    # Exactly one DEVICE_UPDATED — the optimistic apply_config_hash
-    # path fires it via the existing _on_config_hash_change callback,
-    # not in addition to a separate fire from the sync helper.
+    assert device.deployed_version == "2024.6.4"  # untouched
     assert [t for t, _p in fired] == [EventType.DEVICE_UPDATED]
 
 
-async def test_sync_after_flash_no_expected_hash_is_noop() -> None:
-    """Without ``expected_config_hash`` we have nothing to pin — fall back to mtime."""
-    device = _device(
-        expected_config_hash="",
-        deployed_config_hash="bbbb2222",
-    )
-    controller, fired = _flush_controller(device)
-
-    controller._sync_deployed_hash_after_flash("kitchen.yaml")
-
-    # deployed_config_hash isn't touched — the mtime side of
-    # compute_has_pending_changes will catch the post-flash state on
-    # the next scanner reload.
-    assert device.deployed_config_hash == "bbbb2222"
-    assert fired == []
-
-
-async def test_sync_after_flash_already_in_sync_is_noop() -> None:
-    """Already-matching hashes skip both the cache write and the event."""
+async def test_sync_after_flash_already_in_sync_is_noop(monkeypatch: Any) -> None:
+    """Already-matching hash + version skip both the cache write and the event."""
+    monkeypatch.setattr(_VERSION_READ, lambda _cfg: "2026.6.2")
     device = _device(
         expected_config_hash="aaaa1111",
         deployed_config_hash="aaaa1111",
+        deployed_version="2026.6.2",
+        current_version="2026.6.2",
         has_pending_changes=False,
     )
     controller, fired = _flush_controller(device)
 
-    controller._sync_deployed_hash_after_flash("kitchen.yaml")
+    await controller._sync_deployed_state_after_flash("kitchen.yaml")
 
-    # apply_config_hash is still called (it's the integration point),
-    # but its de-dup short-circuits — no callback, no event, no churn.
+    # The apply_* methods are still called (they're the integration point),
+    # but their de-dup short-circuits — no callback, no event, no churn.
     assert fired == []
 
 
-async def test_sync_after_flash_unknown_configuration_is_noop() -> None:
+async def test_sync_after_flash_unknown_configuration_is_noop(monkeypatch: Any) -> None:
     """Configuration not in the scanner's device list — silently skip."""
+    monkeypatch.setattr(_VERSION_READ, lambda _cfg: "2026.6.2")
     device = _device(
         configuration="livingroom.yaml",
         expected_config_hash="aaaa1111",
         deployed_config_hash="bbbb2222",
+        deployed_version="2024.6.4",
     )
     controller, fired = _flush_controller(device)
 
-    controller._sync_deployed_hash_after_flash("kitchen.yaml")
+    await controller._sync_deployed_state_after_flash("kitchen.yaml")
 
     assert device.deployed_config_hash == "bbbb2222"  # unchanged
+    assert device.deployed_version == "2024.6.4"  # unchanged
     assert fired == []
+
+
+# ----------------------------------------------------------------------
+# DevicesController._reprobe_version_after_flash
+#
+# A successful flash optimistically pins the version, but in an mDNS-dark
+# deployment the dashboard can't see a rollback / failed boot. A one-shot
+# Native-API re-probe scheduled after the device reboots confirms (or
+# corrects) the running version.
+# ----------------------------------------------------------------------
+
+
+async def test_reprobe_after_flash_requests_version_reprobe(monkeypatch: Any) -> None:
+    """After the delay, the device's name is handed to the monitor's re-probe."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.firmware_sync._POST_FLASH_VERSION_REPROBE_DELAY",
+        0,
+    )
+    device = _device()
+    controller = DevicesController.__new__(DevicesController)
+    controller._scanner = MagicMock()
+    controller._scanner.devices = [device]
+    controller._state_monitor = MagicMock()
+
+    await controller._reprobe_version_after_flash("kitchen.yaml")
+
+    controller._state_monitor.request_version_reprobe.assert_called_once_with(device.name)
+
+
+async def test_reprobe_after_flash_unknown_configuration_is_noop(monkeypatch: Any) -> None:
+    """No matching device → nothing to re-probe."""
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.devices.firmware_sync._POST_FLASH_VERSION_REPROBE_DELAY",
+        0,
+    )
+    controller = DevicesController.__new__(DevicesController)
+    controller._scanner = MagicMock()
+    controller._scanner.devices = []
+    controller._state_monitor = MagicMock()
+
+    await controller._reprobe_version_after_flash("kitchen.yaml")
+
+    controller._state_monitor.request_version_reprobe.assert_not_called()

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -402,6 +402,7 @@ def _flush_controller(device: Device) -> tuple[Any, list[Any]]:
     scanner = MagicMock()
     scanner.devices = [device]
     scanner.get_by_name = lambda name: [device] if device.name == name else []
+    scanner.get_by_configuration = lambda cfg: device if device.configuration == cfg else None
 
     state_monitor = MagicMock()
     # Drive the same de-dup behaviour the real ``apply_*`` methods have —
@@ -560,7 +561,9 @@ async def test_reprobe_after_flash_requests_version_reprobe(monkeypatch: Any) ->
     device = _device()
     controller = DevicesController.__new__(DevicesController)
     controller._scanner = MagicMock()
-    controller._scanner.devices = [device]
+    controller._scanner.get_by_configuration = lambda cfg: (
+        device if device.configuration == cfg else None
+    )
     controller._state_monitor = MagicMock()
 
     await controller._reprobe_version_after_flash("kitchen.yaml")
@@ -576,7 +579,7 @@ async def test_reprobe_after_flash_unknown_configuration_is_noop(monkeypatch: An
     )
     controller = DevicesController.__new__(DevicesController)
     controller._scanner = MagicMock()
-    controller._scanner.devices = []
+    controller._scanner.get_by_configuration = lambda _cfg: None
     controller._state_monitor = MagicMock()
 
     await controller._reprobe_version_after_flash("kitchen.yaml")

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -29,12 +29,14 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+from esphome.core import CORE
+
 from esphome_device_builder.controllers._device_scanner import (
     DeviceFileMetadata,
     DeviceScanner,
     ScanChange,
 )
-from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices import DevicesController, firmware_sync
 from esphome_device_builder.controllers.devices._metadata_store import DeviceMetadataStore
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import (
@@ -45,6 +47,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 from tests._recording_scanner import RecordingScanner
+from tests._storage_fixtures import write_storage_json
 from tests.conftest import make_device
 
 
@@ -585,3 +588,46 @@ async def test_reprobe_after_flash_unknown_configuration_is_noop(monkeypatch: An
     await controller._reprobe_version_after_flash("kitchen.yaml")
 
     controller._state_monitor.request_version_reprobe.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# Helpers: _read_compiled_esphome_version + DeviceScanner.get_by_configuration
+# ----------------------------------------------------------------------
+
+
+def test_read_compiled_esphome_version_reads_storage(tmp_path: Path, monkeypatch: Any) -> None:
+    """The version is read off the device's StorageJSON sidecar."""
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "___sentinel___.yaml")
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"esphome_version": "2026.6.2"})
+    assert firmware_sync._read_compiled_esphome_version("kitchen.yaml") == "2026.6.2"
+
+
+def test_read_compiled_esphome_version_missing_storage_is_empty(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """No sidecar (never compiled / wiped) → empty string, never raise."""
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "___sentinel___.yaml")
+    assert firmware_sync._read_compiled_esphome_version("ghost.yaml") == ""
+
+
+def test_read_compiled_esphome_version_blank_version_is_empty(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """A sidecar with no esphome_version → empty string."""
+    monkeypatch.setattr(CORE, "config_path", tmp_path / "___sentinel___.yaml")
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"esphome_version": None})
+    assert firmware_sync._read_compiled_esphome_version("kitchen.yaml") == ""
+
+
+def test_scanner_get_by_configuration(tmp_path: Path) -> None:
+    """The indexed lookup returns the device for a tracked filename, else ``None``."""
+    scanner = DeviceScanner(
+        config_dir=tmp_path,
+        get_metadata=lambda _config_dir, _filename: DeviceFileMetadata(board_id="", ip=""),
+        on_change=lambda _kind, _device: None,
+    )
+    device = _device()
+    scanner._index.set(tmp_path / "kitchen.yaml", device, (0, 0, 0.0, 0))
+
+    assert scanner.get_by_configuration("kitchen.yaml") is device
+    assert scanner.get_by_configuration("ghost.yaml") is None

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -24,6 +24,7 @@ Three pieces are covered:
 
 from __future__ import annotations
 
+import asyncio
 import tempfile as _tempfile
 from pathlib import Path
 from typing import Any
@@ -362,20 +363,20 @@ async def test_refresh_after_upload_skips_hash_compute(tmp_path: Path, monkeypat
     db = MagicMock()
     db.settings.config_dir = tmp_path
     db.settings.rel_path = lambda c: tmp_path / c
-    # The flashed branch schedules the post-flash re-probe; close the coro
-    # so it doesn't leak (no device seeded, so the state sync is a no-op).
-    db.create_background_task.side_effect = lambda coro: coro.close()
 
     controller = DevicesController.__new__(DevicesController)
     controller._db = db
     controller._scanner = RecordingScanner()
     controller._build_size = MagicMock()
     controller._state_monitor = MagicMock()
+    # The flashed branch arms a post-flash re-probe timer.
+    controller._reprobe_timers = {}
 
     await controller._refresh_after_firmware_job("kitchen.yaml", recompute_hash=False, flashed=True)
 
     assert compute_calls == []
     assert controller._scanner.calls == [("reload", "kitchen.yaml")]
+    controller._cancel_reprobe_timers()
 
 
 # ----------------------------------------------------------------------
@@ -546,48 +547,79 @@ async def test_sync_after_flash_unknown_configuration_is_noop(monkeypatch: Any) 
 
 
 # ----------------------------------------------------------------------
-# DevicesController._reprobe_version_after_flash
+# Post-flash version re-probe timer
 #
 # A successful flash optimistically pins the version, but in an mDNS-dark
 # deployment the dashboard can't see a rollback / failed boot. A one-shot
-# Native-API re-probe scheduled after the device reboots confirms (or
-# corrects) the running version.
+# Native-API re-probe armed ~60s after the device reboots confirms (or
+# corrects) the running version. Scheduled via ``loop.call_later`` and
+# tracked so ``stop`` can cancel anything still pending.
 # ----------------------------------------------------------------------
 
+_DELAY = (
+    "esphome_device_builder.controllers.devices.firmware_sync._POST_FLASH_VERSION_REPROBE_DELAY"
+)
 
-async def test_reprobe_after_flash_requests_version_reprobe(monkeypatch: Any) -> None:
-    """After the delay, the device's name is handed to the monitor's re-probe."""
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.firmware_sync._POST_FLASH_VERSION_REPROBE_DELAY",
-        0,
-    )
-    device = _device()
+
+def _reprobe_controller(device: Device | None) -> Any:
+    """Build a bare controller wired for the re-probe timer path."""
     controller = DevicesController.__new__(DevicesController)
+    controller._reprobe_timers = {}
     controller._scanner = MagicMock()
     controller._scanner.get_by_configuration = lambda cfg: (
-        device if device.configuration == cfg else None
+        device if device is not None and device.configuration == cfg else None
     )
     controller._state_monitor = MagicMock()
+    return controller
 
-    await controller._reprobe_version_after_flash("kitchen.yaml")
+
+async def test_schedule_version_reprobe_fires_and_requests(monkeypatch: Any) -> None:
+    """When the timer fires, the device's name is handed to the monitor's re-probe."""
+    monkeypatch.setattr(_DELAY, 0)
+    device = _device()
+    controller = _reprobe_controller(device)
+
+    controller._schedule_version_reprobe("kitchen.yaml")
+    await asyncio.sleep(0.01)  # let the call_later(0) timer fire
 
     controller._state_monitor.request_version_reprobe.assert_called_once_with(device.name)
+    assert controller._reprobe_timers == {}  # consumed
 
 
-async def test_reprobe_after_flash_unknown_configuration_is_noop(monkeypatch: Any) -> None:
-    """No matching device → nothing to re-probe."""
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.devices.firmware_sync._POST_FLASH_VERSION_REPROBE_DELAY",
-        0,
-    )
-    controller = DevicesController.__new__(DevicesController)
-    controller._scanner = MagicMock()
-    controller._scanner.get_by_configuration = lambda _cfg: None
-    controller._state_monitor = MagicMock()
+async def test_fire_version_reprobe_unknown_configuration_is_noop() -> None:
+    """No matching device when the timer fires → nothing to re-probe."""
+    controller = _reprobe_controller(None)
 
-    await controller._reprobe_version_after_flash("kitchen.yaml")
+    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml")
 
     controller._state_monitor.request_version_reprobe.assert_not_called()
+
+
+async def test_schedule_version_reprobe_reschedule_cancels_previous(monkeypatch: Any) -> None:
+    """Re-arming for the same configuration cancels the prior pending timer."""
+    monkeypatch.setattr(_DELAY, 60)  # long enough that neither fires during the test
+    controller = _reprobe_controller(_device())
+
+    controller._schedule_version_reprobe("kitchen.yaml")
+    first = controller._reprobe_timers["kitchen.yaml"]
+    controller._schedule_version_reprobe("kitchen.yaml")
+
+    assert first.cancelled()
+    assert controller._reprobe_timers["kitchen.yaml"] is not first
+    controller._cancel_reprobe_timers()
+
+
+async def test_cancel_reprobe_timers_cancels_pending(monkeypatch: Any) -> None:
+    """``stop`` cancels any armed-but-unfired re-probe timers."""
+    monkeypatch.setattr(_DELAY, 60)
+    controller = _reprobe_controller(_device())
+
+    controller._schedule_version_reprobe("kitchen.yaml")
+    handle = controller._reprobe_timers["kitchen.yaml"]
+    controller._cancel_reprobe_timers()
+
+    assert handle.cancelled()
+    assert controller._reprobe_timers == {}
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -793,6 +793,22 @@ async def test_forced_reprobe_probes_then_clears_itself() -> None:
     assert src._select_targets() == []  # consumed → no longer due
 
 
+async def test_forced_reprobe_confirming_existing_version_is_not_a_failure() -> None:
+    """A forced probe that connected and confirmed the version isn't cooled down."""
+    device = _online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.2")
+    monitor, _ = make_state_monitor_with_callbacks([device])
+    src = monitor._api_info
+    src.request_reprobe("kitchen")
+    src._run_worker = AsyncMock(  # type: ignore[method-assign]
+        return_value={"mac_address": "94c9601f8cf1", "esphome_version": "2026.6.2"}
+    )
+
+    await src._fetch(device)
+
+    # Nothing newly filled, but the connect succeeded — no cooldown.
+    assert "kitchen" not in src._cooldown
+
+
 async def test_sweep_prunes_force_reprobe_for_dead_devices() -> None:
     """A force flag for a device that's no longer present is dropped on the next sweep."""
     device = _online_api_device()

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -15,6 +15,7 @@ import asyncio
 import io
 import json
 import logging
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -747,3 +748,59 @@ def test_log_task_exit_logs_crash(caplog: Any) -> None:
     with caplog.at_level(logging.ERROR):
         DeviceStateMonitor._log_api_info_task_exit(task)
     assert "API info fallback loop crashed" in caplog.text
+
+
+# ----------------------------------------------------------------------
+# Forced re-probe — request_reprobe (post-flash version verification)
+# ----------------------------------------------------------------------
+
+
+def test_request_reprobe_makes_filled_device_due() -> None:
+    """A forced re-probe overrides the mac+version guard that would skip the device."""
+    device = _online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")
+    monitor, _ = make_state_monitor_with_callbacks([device])
+    src = monitor._api_info
+    assert src._select_targets() == []  # both fields present → normally skipped
+    src.request_reprobe("kitchen")
+    assert [d.name for d in src._select_targets()] == ["kitchen"]
+
+
+def test_request_reprobe_bypasses_cooldown() -> None:
+    """A forced re-probe is deliberate — it ignores the per-device failure cooldown."""
+    device = _online_api_device()
+    monitor, _ = make_state_monitor_with_callbacks([device])
+    src = monitor._api_info
+    src._cooldown["kitchen"] = time.monotonic() + 600
+    assert src._select_targets() == []  # parked on cooldown
+    src.request_reprobe("kitchen")
+    assert [d.name for d in src._select_targets()] == ["kitchen"]
+
+
+async def test_forced_reprobe_probes_then_clears_itself() -> None:
+    """The forced probe runs even with both fields set, then the flag is consumed."""
+    device = _online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")
+    monitor, _ = make_state_monitor_with_callbacks([device])
+    src = monitor._api_info
+    src.request_reprobe("kitchen")
+    src._run_worker = AsyncMock(  # type: ignore[method-assign]
+        return_value={"esphome_version": "2026.6.2"}
+    )
+
+    await src._fetch(device)
+
+    assert device.deployed_version == "2026.6.2"
+    assert "kitchen" not in src._force_reprobe  # one-shot
+    assert src._select_targets() == []  # consumed → no longer due
+
+
+async def test_sweep_prunes_force_reprobe_for_dead_devices() -> None:
+    """A force flag for a device that's no longer present is dropped on the next sweep."""
+    device = _online_api_device()
+    monitor, _ = make_state_monitor_with_callbacks([device])
+    src = monitor._api_info
+    src.request_reprobe("ghost")  # not a live device
+    src._fetch = AsyncMock()  # type: ignore[method-assign]
+
+    await src._sweep()
+
+    assert "ghost" not in src._force_reprobe

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -804,3 +804,11 @@ async def test_sweep_prunes_force_reprobe_for_dead_devices() -> None:
     await src._sweep()
 
     assert "ghost" not in src._force_reprobe
+
+
+def test_monitor_request_version_reprobe_forwards_to_api_info() -> None:
+    """The monitor facade forwards a version re-probe request to the API source."""
+    device = _online_api_device()
+    monitor, _ = make_state_monitor_with_callbacks([device])
+    monitor.request_version_reprobe("kitchen")
+    assert "kitchen" in monitor._api_info._force_reprobe


### PR DESCRIPTION
# What does this implement/fix?

After a successful install or upload the dashboard pinned only the config hash, so the orange dot cleared but the deployed version stayed at its pre-update value; the device row kept showing the old version and an Update Available badge that never cleared even though the device was running the new build. This is permanent in deployments where mDNS cannot reach the dashboard (Docker Desktop on macOS is the textbook case), since deployed_version only ever updates from an mDNS announce or a Native API probe that stops once a version is already present.

This pins deployed_version from StorageJSON at flash time alongside the config hash, so both badges clear immediately. A successful flash means the new binary is on the device, so the compiled version is what it now runs; to catch a rollback or failed boot where mDNS can't tell us, it also schedules a one-shot Native API re-probe 60s after the flash, which confirms or corrects the running version.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1630

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
