### PR TITLE
Update the manifest for the Waveshare ESP32-S3-Zero board

### DIFF
--- a/esphome_device_builder/definitions/boards/waveshare_esp32_s3_zero/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/waveshare_esp32_s3_zero/manifest.yaml
@@ -1,8 +1,9 @@
 id: waveshare_esp32_s3_zero
 name: Waveshare ESP32-S3-Zero
-description: Waveshare ESP32-S3-Zero is a compact ESP32-S3 board in a Raspberry Pi Zero form factor with USB-C, 16 MB flash,
-  8 MB PSRAM, and castellated pads for direct soldering.
+description: Waveshare ESP32-S3-Zero is a compact (18x23.5mm) ESP32-S3 board with USB-C, 4 MB flash, 2 MB PSRAM and castellated pads for direct soldering.
 manufacturer: Waveshare
+images:
+- https://www.waveshare.com/w/upload/thumb/2/29/ESP32-S3-Zero.png/300px-ESP32-S3-Zero.png
 esphome:
   platform: esp32
   board: waveshare_esp32_s3_zero
@@ -16,18 +17,15 @@ hardware:
   - bluetooth
   - wifi
 tags:
+- esp32-s3
+- wifi
+- rgb-led
+- bluetooth
 - compact
 - usb-c
 docs_url: https://esphome.io/components/esp32.html
 product_url: https://www.waveshare.com/wiki/ESP32-S3-Zero
 pins:
-- gpio: 0
-  label: GPIO0
-  features:
-  - pwm
-  - strapping
-  available: null
-  notes: Strapping pin (boot mode select)
 - gpio: 1
   label: GPIO1
   features:
@@ -35,7 +33,7 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC1_CH0, Touch1
+  notes: ADC1_CH0, Touch1, I2S
 - gpio: 2
   label: GPIO2
   features:
@@ -43,7 +41,7 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC1_CH1, Touch2
+  notes: ADC1_CH1, Touch2, I2S
 - gpio: 3
   label: GPIO3
   features:
@@ -60,7 +58,7 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC1_CH3, Touch4
+  notes: ADC1_CH3, Touch4, I2S
 - gpio: 5
   label: GPIO5
   features:
@@ -68,7 +66,7 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC1_CH4, Touch5
+  notes: ADC1_CH4, Touch5, I2S
 - gpio: 6
   label: GPIO6
   features:
@@ -76,7 +74,7 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC1_CH5, Touch6
+  notes: ADC1_CH5, Touch6, I2S
 - gpio: 7
   label: GPIO7
   features:
@@ -84,7 +82,7 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC1_CH6, Touch7
+  notes: ADC1_CH6, Touch7, I2S
 - gpio: 8
   label: GPIO8
   features:
@@ -93,7 +91,7 @@ pins:
   - pwm
   - i2c_sda
   available: null
-  notes: ADC1_CH7, Touch8 — default I2C SDA
+  notes: ADC1_CH7, Touch8, I2S — default I2C SDA
 - gpio: 9
   label: GPIO9
   features:
@@ -102,39 +100,43 @@ pins:
   - pwm
   - i2c_scl
   available: null
-  notes: ADC1_CH8, Touch9 — default I2C SCL
+  notes: ADC1_CH8, Touch9, I2S — default I2C SCL
 - gpio: 10
   label: GPIO10
   features:
   - adc
   - touch
   - pwm
+  - spi_cs
   available: null
-  notes: ADC1_CH9, Touch10
+  notes: ADC1_CH9, Touch10 — default SPI CS
 - gpio: 11
   label: GPIO11
   features:
   - adc
   - touch
   - pwm
+  - spi_mosi
   available: null
-  notes: ADC2_CH0, Touch11
+  notes: ADC2_CH0, Touch11 — default SPI MOSI
 - gpio: 12
   label: GPIO12
   features:
   - adc
   - touch
   - pwm
+  - spi_clk
   available: null
-  notes: ADC2_CH1, Touch12
+  notes: ADC2_CH1, Touch12 — default SPI CLK
 - gpio: 13
   label: GPIO13
   features:
   - adc
   - touch
   - pwm
+  - spi_miso
   available: null
-  notes: ADC2_CH2, Touch13
+  notes: ADC2_CH2, Touch13 — default SPI MISO
 - gpio: 14
   label: GPIO14
   features:
@@ -142,76 +144,72 @@ pins:
   - touch
   - pwm
   available: null
-  notes: ADC2_CH3, Touch14
+  notes: ADC2_CH3, Touch14 — Solderpad on top
 - gpio: 15
   label: GPIO15
   features:
   - adc
+  - touch
   - pwm
   available: null
-  notes: ADC2_CH4
+  notes: ADC2_CH4, Touch12, UART1 RX — Solderpad on top
 - gpio: 16
   label: GPIO16
   features:
   - adc
   - pwm
   available: null
-  notes: ADC2_CH5
+  notes: ADC2_CH5, UART1 TX — Solderpad on top
 - gpio: 17
   label: GPIO17
   features:
   - adc
   - pwm
   available: null
-  notes: ADC2_CH6
+  notes: ADC2_CH6 — Solderpad on bottom
 - gpio: 18
   label: GPIO18
   features:
   - adc
   - pwm
   available: null
-  notes: ADC2_CH7
+  notes: ADC2_CH7 — Solderpad on bottom
 - gpio: 19
   label: GPIO19
   features:
   - adc
   - pwm
   - usb_dm
-  available: null
-  notes: ADC2_CH8, USB D- (USB-OTG)
+  available: false
+  notes: Not available
 - gpio: 20
   label: GPIO20
   features:
   - adc
   - pwm
   - usb_dp
-  available: null
-  notes: ADC2_CH9, USB D+ (USB-OTG)
+  available: false
+  notes: Not available
 - gpio: 21
   label: GPIO21
-  features:
-  - pwm
-  available: null
+  available: false
+  notes: Not available
 - gpio: 22
   label: GPIO22
-  features:
-  - pwm
-  available: null
+  available: false
+  notes: Not available
 - gpio: 23
   label: GPIO23
-  features:
-  - pwm
-  available: null
+  available: false
+  notes: Not available
 - gpio: 24
   label: GPIO24
-  features:
-  - pwm
-  available: null
+  available: false
+  notes: Not available
 - gpio: 25
   label: GPIO25
-  features:
-  - pwm
-  available: null
+  available: false
+  notes: Not available
 - gpio: 26
   label: GPIO26
   available: false
@@ -249,62 +247,53 @@ pins:
   notes: SPI Flash — do not use
 - gpio: 33
   label: GPIO33
-  features:
-  - pwm
-  available: null
+  available: false
 - gpio: 34
   label: GPIO34
-  features:
-  - pwm
-  - spi_cs
-  available: null
-  notes: Default SPI2 CS
+  available: false
+  notes: Not available
 - gpio: 35
   label: GPIO35
-  features:
-  - pwm
-  - spi_mosi
-  available: null
-  notes: Default SPI2 MOSI
+  available: false
+  notes: Not available
 - gpio: 36
   label: GPIO36
-  features:
-  - pwm
-  - spi_clk
-  available: null
-  notes: Default SPI2 CLK
+  available: false
+  notes: Not available
 - gpio: 37
   label: GPIO37
-  features:
-  - pwm
-  - spi_miso
-  available: null
-  notes: Default SPI2 MISO
+  available: false
+  notes: Not available
 - gpio: 38
   label: GPIO38
   features:
-  - pwm
-  available: null
+  - rgb_led
+  occupied_by: WS2812 RGB LED
+  notes: Onboard RGB LED (WS2812) — Solderpad on bottom
 - gpio: 39
   label: GPIO39
   features:
   - pwm
   available: null
+  notes:  Solderpad on bottom
 - gpio: 40
   label: GPIO40
   features:
   - pwm
   available: null
+  notes:  Solderpad on bottom
 - gpio: 41
   label: GPIO41
   features:
   - pwm
   available: null
+  notes:  Solderpad on bottom
 - gpio: 42
   label: GPIO42
   features:
   - pwm
   available: null
+  notes:  Solderpad on bottom
 - gpio: 43
   label: GPIO43
   features:
@@ -325,22 +314,15 @@ pins:
   - pwm
   - strapping
   available: null
-  notes: Strapping pin (VDD_SPI voltage select)
+  notes: Strapping pin (VDD_SPI voltage select) — Solderpad on bottom
 - gpio: 46
   label: GPIO46
-  features:
-  - pwm
-  - strapping
-  available: null
-  notes: Strapping pin (boot mode)
+  available: false
+  notes: Not available
 - gpio: 47
   label: GPIO47
-  features:
-  - pwm
-  available: null
+  available: false
 - gpio: 48
   label: GPIO48
-  features:
-  - pwm
-  available: null
-  notes: Commonly used for onboard RGB LED (WS2812)
+  available: false
+  notes: Not available


### PR DESCRIPTION
# What does this implement/fix?

Update the manifest for the Waveshare ESP32-S3-Zero board

**Related issue or feature (if applicable):**

none

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [ ] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
