### PR TITLE
Don't gate device adoption on a cold remote-package validate

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -594,6 +594,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         action: str,
         on_failure: ErrorCode = ErrorCode.INVALID_ARGS,
         on_error_cleanup: Callable[[], None] | None = None,
+        tolerate_unavailable: bool = False,
+        timeout: float | None = None,
     ) -> None:
         await mutations_yaml.validate_rewritten_yaml_or_raise(
             self._db.editor,
@@ -602,6 +604,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             action=action,
             on_failure=on_failure,
             on_error_cleanup=on_error_cleanup,
+            tolerate_unavailable=tolerate_unavailable,
+            timeout=timeout,
         )
 
     @api_command("devices/delete")

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -88,7 +88,7 @@ async def import_device(
     # half-import. The generated config carries a ``github://`` package
     # ref whose cold fetch can outlast a full validate, so the adopt
     # path tolerates a validator timeout (keeps the file) and uses a
-    # short budget — the fast pre-network YAML-syntax check still runs.
+    # short budget; the fast pre-network YAML-syntax check still runs.
     def _read() -> str:
         return path.read_text(encoding="utf-8")
 

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -82,13 +82,10 @@ async def import_device(
         msg = f"Configuration {configuration} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
 
-    # Validate the freshly-written YAML before announcing it; on a
-    # genuine validation failure the cleanup callback unlinks the file
-    # so a retry doesn't trip ``FileExistsError`` on a leftover
-    # half-import. The generated config carries a ``github://`` package
-    # ref whose cold fetch can outlast a full validate, so the adopt
-    # path tolerates a validator timeout (keeps the file) and uses a
-    # short budget; the fast pre-network YAML-syntax check still runs.
+    # Validate the freshly-written YAML; on a genuine failure the cleanup
+    # callback unlinks it so a retry doesn't trip ``FileExistsError``. Adopt
+    # tolerates a validator timeout on a short budget: the config's
+    # ``github://`` fetch can outlast a full validate.
     def _read() -> str:
         return path.read_text(encoding="utf-8")
 

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -21,6 +21,7 @@ from ...models import (
     ImportableDeviceAddedData,
     ImportableDeviceRemovedData,
 )
+from ..editor import _IMPORT_VALIDATE_TIMEOUT
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -81,10 +82,13 @@ async def import_device(
         msg = f"Configuration {configuration} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
 
-    # Validate the freshly-written YAML before announcing it; on
-    # any failure the cleanup callback unlinks the file so a
-    # retry doesn't trip ``FileExistsError`` on a leftover
-    # half-import.
+    # Validate the freshly-written YAML before announcing it; on a
+    # genuine validation failure the cleanup callback unlinks the file
+    # so a retry doesn't trip ``FileExistsError`` on a leftover
+    # half-import. The generated config carries a ``github://`` package
+    # ref whose cold fetch can outlast a full validate, so the adopt
+    # path tolerates a validator timeout (keeps the file) and uses a
+    # short budget — the fast pre-network YAML-syntax check still runs.
     def _read() -> str:
         return path.read_text(encoding="utf-8")
 
@@ -97,7 +101,12 @@ async def import_device(
         await loop.run_in_executor(None, _cleanup)
         raise
     await controller._validate_rewritten_yaml_or_raise(
-        configuration, content, action="import", on_error_cleanup=_cleanup
+        configuration,
+        content,
+        action="import",
+        on_error_cleanup=_cleanup,
+        tolerate_unavailable=True,
+        timeout=_IMPORT_VALIDATE_TIMEOUT,
     )
 
     await controller._commit_history(configuration, f"Import {configuration}")

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -21,7 +21,7 @@ from ...models import (
     ImportableDeviceAddedData,
     ImportableDeviceRemovedData,
 )
-from ..editor import _IMPORT_VALIDATE_TIMEOUT
+from ..editor import IMPORT_VALIDATE_TIMEOUT
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -103,7 +103,7 @@ async def import_device(
         action="import",
         on_error_cleanup=_cleanup,
         tolerate_unavailable=True,
-        timeout=_IMPORT_VALIDATE_TIMEOUT,
+        timeout=IMPORT_VALIDATE_TIMEOUT,
     )
 
     await controller._commit_history(configuration, f"Import {configuration}")

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -131,9 +131,7 @@ async def validate_rewritten_yaml_or_raise(
         except TimeoutError:
             if not tolerate_unavailable:
                 raise
-            # Expected on adopt: the imported config's cold ``github://``
-            # fetch outran the budget. Keep the file; compile/install
-            # surfaces any real error later.
+            # Expected on adopt: the cold ``github://`` fetch outran the budget.
             _LOGGER.info(
                 "Validation of %s for %s timed out; keeping file, deferring to compile/install",
                 configuration,
@@ -144,11 +142,8 @@ async def validate_rewritten_yaml_or_raise(
         except (ValidatorUnavailableError, BrokenPipeError):
             if not tolerate_unavailable:
                 raise
-            # Abnormal: the validator subprocess died / wedged. A generic
-            # RuntimeError (a bug in the validate path) is deliberately not
-            # caught here, so it surfaces instead of masquerading as success.
-            # WARNING because an always-down validator is operationally
-            # significant, not a routine timeout.
+            # Subprocess down (a generic RuntimeError still propagates); WARNING
+            # since an always-down validator is operationally significant.
             _LOGGER.warning(
                 "Validator subprocess unavailable during %s of %s; keeping file unvalidated",
                 action,

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -101,6 +101,8 @@ async def validate_rewritten_yaml_or_raise(
     action: str,
     on_failure: ErrorCode = ErrorCode.INVALID_ARGS,
     on_error_cleanup: Callable[[], None] | None = None,
+    tolerate_unavailable: bool = False,
+    timeout: float | None = None,
 ) -> None:
     """
     Schema-validate *content* via the editor; raise if invalid.
@@ -111,12 +113,37 @@ async def validate_rewritten_yaml_or_raise(
     generators. *on_error_cleanup* runs in a finally on any
     non-success path so callers that wrote the YAML before
     validating can roll back.
+
+    *tolerate_unavailable* treats a validator timeout / subprocess
+    failure as success (file kept, no cleanup): the adopt path uses it
+    so a cold ``github://`` package fetch can't gate adoption. Genuine
+    YAML/schema errors still raise. *timeout* overrides the validator's
+    round-trip budget.
     """
     if editor is None:
         return
+    validate_kwargs: dict[str, object] = {}
+    if timeout is not None:
+        validate_kwargs["timeout"] = timeout
     succeeded = False
     try:
-        result = await editor.validate_yaml(configuration=configuration, content=content)
+        try:
+            result = await editor.validate_yaml(
+                configuration=configuration, content=content, **validate_kwargs
+            )
+        except (TimeoutError, RuntimeError, BrokenPipeError):
+            if not tolerate_unavailable:
+                raise
+            # Validator wedged or the remote-package fetch ran long;
+            # keep the written file and let compile/install surface any
+            # real error later.
+            _LOGGER.info(
+                "Validator unavailable during %s of %s; keeping file unvalidated",
+                action,
+                configuration,
+            )
+            succeeded = True
+            return
         errors = [
             *(err.get("message", "") for err in result.get("yaml_errors", [])),
             *(err.get("message", "") for err in result.get("validation_errors", [])),

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -13,6 +13,7 @@ from ...helpers.device_yaml import (
     generate_minimal_stub_yaml,
 )
 from ...models import ErrorCode
+from ..editor import ValidatorUnavailableError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -141,11 +142,12 @@ async def validate_rewritten_yaml_or_raise(
             )
             succeeded = True
             return
-        except (RuntimeError, BrokenPipeError):
+        except (ValidatorUnavailableError, BrokenPipeError):
             if not tolerate_unavailable:
                 raise
-            # Abnormal: the validator subprocess died / wedged (mirrors the
-            # set ``validate_yaml`` itself treats as subprocess failure).
+            # Abnormal: the validator subprocess died / wedged. A generic
+            # RuntimeError (a bug in the validate path) is deliberately not
+            # caught here, so it surfaces instead of masquerading as success.
             # WARNING because an always-down validator is operationally
             # significant, not a routine timeout.
             _LOGGER.warning(

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -128,14 +128,28 @@ async def validate_rewritten_yaml_or_raise(
             result = await editor.validate_yaml(
                 configuration=configuration, content=content, timeout=timeout
             )
-        except (TimeoutError, RuntimeError, BrokenPipeError):
+        except TimeoutError:
             if not tolerate_unavailable:
                 raise
-            # Validator wedged or the remote-package fetch ran long;
-            # keep the written file and let compile/install surface any
-            # real error later.
+            # Expected on adopt: the imported config's cold ``github://``
+            # fetch outran the budget. Keep the file; compile/install
+            # surfaces any real error later.
             _LOGGER.info(
-                "Validator unavailable during %s of %s; keeping file unvalidated",
+                "Validation of %s for %s timed out; keeping file, deferring to compile/install",
+                configuration,
+                action,
+            )
+            succeeded = True
+            return
+        except (RuntimeError, BrokenPipeError):
+            if not tolerate_unavailable:
+                raise
+            # Abnormal: the validator subprocess died / wedged (mirrors the
+            # set ``validate_yaml`` itself treats as subprocess failure).
+            # WARNING because an always-down validator is operationally
+            # significant, not a routine timeout.
+            _LOGGER.warning(
+                "Validator subprocess unavailable during %s of %s; keeping file unvalidated",
                 action,
                 configuration,
             )

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -115,9 +115,8 @@ async def validate_rewritten_yaml_or_raise(
     non-success path so callers that wrote the YAML before
     validating can roll back.
 
-    *tolerate_unavailable* treats a validator timeout / subprocess
-    failure as success (file kept, no cleanup): the adopt path uses it
-    so a cold ``github://`` package fetch can't gate adoption. Genuine
+    *tolerate_unavailable* treats validator unavailability (timeout /
+    subprocess failure) as success: file kept, no cleanup; genuine
     YAML/schema errors still raise. *timeout* overrides the validator's
     round-trip budget.
     """

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -122,14 +122,11 @@ async def validate_rewritten_yaml_or_raise(
     """
     if editor is None:
         return
-    validate_kwargs: dict[str, object] = {}
-    if timeout is not None:
-        validate_kwargs["timeout"] = timeout
     succeeded = False
     try:
         try:
             result = await editor.validate_yaml(
-                configuration=configuration, content=content, **validate_kwargs
+                configuration=configuration, content=content, timeout=timeout
             )
         except (TimeoutError, RuntimeError, BrokenPipeError):
             if not tolerate_unavailable:

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -29,10 +29,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 _STARTUP_TIMEOUT = 15.0
 _VALIDATE_TIMEOUT = 30.0
-# Short budget for the adopt path: a generator YAML-syntax error surfaces at
-# parse (well under a second), before esphome's network packages pass. An
-# imported config triggers a cold ``github://`` package fetch; that fetch is
-# abandoned rather than blocking adoption, and compile/install runs it later.
+# Short budget for adopt: a YAML-syntax error surfaces at parse (sub-second,
+# pre-network); the cold ``github://`` package fetch is abandoned, not awaited.
 _IMPORT_VALIDATE_TIMEOUT = 8.0
 # Linter and save both call ``validate_yaml`` on identical
 # content (typing-stops → linter at 600 ms → user clicks save).
@@ -305,8 +303,7 @@ class EditorController:
         internal-only; a WS client always gets the default.
         """
         if client is not None:
-            # ``timeout`` is an internal knob; ignore any value a WS
-            # client supplied so the wire contract stays fixed.
+            # ``timeout`` is internal-only; ignore a WS client's value.
             timeout = None
         if timeout is None:
             timeout = _VALIDATE_TIMEOUT
@@ -329,19 +326,16 @@ class EditorController:
             if cached is not None and cached.is_fresh_for(content_hash):
                 return cached.result
             try:
-                # Spawn / warm the subprocess outside the round-trip budget:
-                # a cold start has its own ``_STARTUP_TIMEOUT`` and counting it
-                # against a short import timeout would skip the fast pre-network
-                # YAML parse before the budget runs out.
+                # Warm the subprocess outside the budget so a cold start
+                # (own ``_STARTUP_TIMEOUT``) doesn't eat a short import timeout.
                 await self._ensure_subprocess(session)
                 result = await asyncio.wait_for(
                     self._validate_locked(session, configuration, content),
                     timeout=timeout,
                 )
             except (TimeoutError, ValidatorUnavailableError, BrokenPipeError):
-                # Subprocess wedged or died — kill it so the next call respawns.
-                # A generic RuntimeError (a bug in the validate path) propagates
-                # without being mistaken for subprocess unavailability.
+                # Subprocess wedged or died, kill it so the next call respawns;
+                # a generic RuntimeError (a real bug) propagates instead.
                 await self._terminate_subprocess(session)
                 raise
             session.cached = _CachedValidation(

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 _STARTUP_TIMEOUT = 15.0
 _VALIDATE_TIMEOUT = 30.0
+# Short budget for the adopt path: a generator YAML-syntax error surfaces at
+# parse (well under a second), before esphome's network packages pass. The
+# cold ``github://`` package fetch an imported config triggers is abandoned
+# rather than blocking adoption; compile/install fetches it later.
+_IMPORT_VALIDATE_TIMEOUT = 8.0
 # Linter and save both call ``validate_yaml`` on identical
 # content (typing-stops → linter at 600 ms → user clicks save).
 # Cache covers that hand-off; longer would risk staleness for
@@ -273,6 +278,7 @@ class EditorController:
         *,
         configuration: str,
         content: str,
+        timeout: float = _VALIDATE_TIMEOUT,
         client: Any = None,
         message_id: str = "",
         **kwargs: Any,
@@ -288,6 +294,9 @@ class EditorController:
         Results are cached per session by content hash for
         ``_VALIDATE_CACHE_TTL`` seconds; the linter and the
         save-time re-validate hit the same content back-to-back.
+
+        ``timeout`` bounds the round-trip; the import path passes a short
+        budget so adoption isn't gated on a cold remote-package fetch.
         """
         session = self._sessions.setdefault(
             configuration, _EditorSession(configuration=configuration)
@@ -310,7 +319,7 @@ class EditorController:
             try:
                 result = await asyncio.wait_for(
                     self._validate_locked(session, configuration, content),
-                    timeout=_VALIDATE_TIMEOUT,
+                    timeout=timeout,
                 )
             except (TimeoutError, RuntimeError, BrokenPipeError):
                 # Subprocess wedged or died — kill it so the next call respawns.

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -278,7 +278,7 @@ class EditorController:
         *,
         configuration: str,
         content: str,
-        timeout: float = _VALIDATE_TIMEOUT,
+        timeout: float | None = None,
         client: Any = None,
         message_id: str = "",
         **kwargs: Any,
@@ -298,6 +298,8 @@ class EditorController:
         ``timeout`` bounds the round-trip; the import path passes a short
         budget so adoption isn't gated on a cold remote-package fetch.
         """
+        if timeout is None:
+            timeout = _VALIDATE_TIMEOUT
         session = self._sessions.setdefault(
             configuration, _EditorSession(configuration=configuration)
         )

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -30,9 +30,9 @@ _LOGGER = logging.getLogger(__name__)
 _STARTUP_TIMEOUT = 15.0
 _VALIDATE_TIMEOUT = 30.0
 # Short budget for the adopt path: a generator YAML-syntax error surfaces at
-# parse (well under a second), before esphome's network packages pass. The
-# cold ``github://`` package fetch an imported config triggers is abandoned
-# rather than blocking adoption; compile/install fetches it later.
+# parse (well under a second), before esphome's network packages pass. An
+# imported config triggers a cold ``github://`` package fetch; that fetch is
+# abandoned rather than blocking adoption, and compile/install runs it later.
 _IMPORT_VALIDATE_TIMEOUT = 8.0
 # Linter and save both call ``validate_yaml`` on identical
 # content (typing-stops → linter at 600 ms → user clicks save).
@@ -295,9 +295,15 @@ class EditorController:
         ``_VALIDATE_CACHE_TTL`` seconds; the linter and the
         save-time re-validate hit the same content back-to-back.
 
-        ``timeout`` bounds the round-trip; the import path passes a short
-        budget so adoption isn't gated on a cold remote-package fetch.
+        ``timeout`` bounds the validate round-trip (not subprocess
+        startup); it is internal-only — the import path passes a short
+        budget so adoption isn't gated on a cold remote-package fetch,
+        while a WS client always gets the default.
         """
+        if client is not None:
+            # ``timeout`` is an internal knob; ignore any value a WS
+            # client supplied so the wire contract stays fixed.
+            timeout = None
         if timeout is None:
             timeout = _VALIDATE_TIMEOUT
         session = self._sessions.setdefault(
@@ -319,6 +325,11 @@ class EditorController:
             if cached is not None and cached.is_fresh_for(content_hash):
                 return cached.result
             try:
+                # Spawn / warm the subprocess outside the round-trip budget:
+                # a cold start has its own ``_STARTUP_TIMEOUT`` and counting it
+                # against a short import timeout would skip the fast pre-network
+                # YAML parse before the budget runs out.
+                await self._ensure_subprocess(session)
                 result = await asyncio.wait_for(
                     self._validate_locked(session, configuration, content),
                     timeout=timeout,
@@ -338,10 +349,10 @@ class EditorController:
         """
         Run a single validation round-trip against `session`'s subprocess.
 
-        Caller must hold ``session.lock``; the stdin/stdout protocol is stateful
-        and any interleaving would corrupt subsequent responses.
+        Caller must hold ``session.lock`` and have brought the subprocess up
+        via ``_ensure_subprocess``; the stdin/stdout protocol is stateful and
+        any interleaving would corrupt subsequent responses.
         """
-        await self._ensure_subprocess(session)
         proc = session.proc
         assert proc is not None and proc.stdin is not None and proc.stdout is not None
 

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -50,11 +50,7 @@ _REAP_INTERVAL = 60.0
 
 
 class ValidatorUnavailableError(RuntimeError):
-    """The validator subprocess couldn't be reached (failed to start / closed its pipe).
-
-    A narrow signal callers can tolerate, distinct from a generic
-    ``RuntimeError`` raised by an actual bug in the validate path.
-    """
+    """Validator subprocess couldn't be reached (failed to start / closed its pipe)."""
 
 
 @dataclass
@@ -305,10 +301,8 @@ class EditorController:
         ``_VALIDATE_CACHE_TTL`` seconds; the linter and the
         save-time re-validate hit the same content back-to-back.
 
-        ``timeout`` bounds the validate round-trip (not subprocess
-        startup); it is internal-only — the import path passes a short
-        budget so adoption isn't gated on a cold remote-package fetch,
-        while a WS client always gets the default.
+        ``timeout`` bounds the round-trip (not subprocess startup) and is
+        internal-only; a WS client always gets the default.
         """
         if client is not None:
             # ``timeout`` is an internal knob; ignore any value a WS

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -49,6 +49,14 @@ _IDLE_SUBPROCESS_TIMEOUT = 600.0
 _REAP_INTERVAL = 60.0
 
 
+class ValidatorUnavailableError(RuntimeError):
+    """The validator subprocess couldn't be reached (failed to start / closed its pipe).
+
+    A narrow signal callers can tolerate, distinct from a generic
+    ``RuntimeError`` raised by an actual bug in the validate path.
+    """
+
+
 @dataclass
 class _CachedValidation:
     """Snapshot of a validate_yaml result, with the inputs needed to reuse it."""
@@ -161,7 +169,9 @@ class EditorController:
             await asyncio.wait_for(session.proc.stdout.readline(), timeout=_STARTUP_TIMEOUT)
         except TimeoutError as err:
             await self._terminate_subprocess(session)
-            raise RuntimeError("esphome vscode subprocess did not start in time") from err
+            raise ValidatorUnavailableError(
+                "esphome vscode subprocess did not start in time"
+            ) from err
 
     async def _terminate_subprocess(self, session: _EditorSession) -> None:
         """Terminate the session's subprocess."""
@@ -334,8 +344,10 @@ class EditorController:
                     self._validate_locked(session, configuration, content),
                     timeout=timeout,
                 )
-            except (TimeoutError, RuntimeError, BrokenPipeError):
+            except (TimeoutError, ValidatorUnavailableError, BrokenPipeError):
                 # Subprocess wedged or died — kill it so the next call respawns.
+                # A generic RuntimeError (a bug in the validate path) propagates
+                # without being mistaken for subprocess unavailability.
                 await self._terminate_subprocess(session)
                 raise
             session.cached = _CachedValidation(
@@ -363,7 +375,7 @@ class EditorController:
         while True:
             line = await proc.stdout.readline()
             if not line:
-                raise RuntimeError("esphome vscode subprocess closed stdout")
+                raise ValidatorUnavailableError("esphome vscode subprocess closed stdout")
             try:
                 # The subprocess emits one UTF-8 JSON object per line;
                 # orjson decodes bytes directly so no .decode() round-trip.

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -31,7 +31,7 @@ _STARTUP_TIMEOUT = 15.0
 _VALIDATE_TIMEOUT = 30.0
 # Short budget for adopt: a YAML-syntax error surfaces at parse (sub-second,
 # pre-network); the cold ``github://`` package fetch is abandoned, not awaited.
-_IMPORT_VALIDATE_TIMEOUT = 8.0
+IMPORT_VALIDATE_TIMEOUT = 8.0
 # Linter and save both call ``validate_yaml`` on identical
 # content (typing-stops → linter at 600 ms → user clicks save).
 # Cache covers that hand-off; longer would risk staleness for
@@ -325,6 +325,7 @@ class EditorController:
             cached = session.cached
             if cached is not None and cached.is_fresh_for(content_hash):
                 return cached.result
+            ok = False
             try:
                 # Warm the subprocess outside the budget so a cold start
                 # (own ``_STARTUP_TIMEOUT``) doesn't eat a short import timeout.
@@ -333,11 +334,14 @@ class EditorController:
                     self._validate_locked(session, configuration, content),
                     timeout=timeout,
                 )
-            except (TimeoutError, ValidatorUnavailableError, BrokenPipeError):
-                # Subprocess wedged or died, kill it so the next call respawns;
-                # a generic RuntimeError (a real bug) propagates instead.
-                await self._terminate_subprocess(session)
-                raise
+                ok = True
+            finally:
+                # Any failure (timeout, subprocess loss, a bug, cancellation)
+                # can leave the stateful stdin/stdout protocol mid-message;
+                # kill it so the next call respawns clean. The exception (typed
+                # for callers) propagates unchanged.
+                if not ok:
+                    await self._terminate_subprocess(session)
             session.cached = _CachedValidation(
                 content_hash=content_hash, result=result, at=time.monotonic()
             )

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -483,7 +483,7 @@ async def test_import_device_validates_with_short_timeout(
     make_controller: MakeControllerFactory,
 ) -> None:
     """Adopt passes the short import budget so it isn't gated on a cold fetch."""
-    from esphome_device_builder.controllers.editor import _IMPORT_VALIDATE_TIMEOUT  # noqa: PLC0415
+    from esphome_device_builder.controllers.editor import IMPORT_VALIDATE_TIMEOUT  # noqa: PLC0415
 
     monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
@@ -497,7 +497,7 @@ async def test_import_device_validates_with_short_timeout(
         package_import_url="github://x",
     )
 
-    assert validate.await_args.kwargs["timeout"] == _IMPORT_VALIDATE_TIMEOUT
+    assert validate.await_args.kwargs["timeout"] == IMPORT_VALIDATE_TIMEOUT
 
 
 async def test_import_device_skips_validation_when_editor_unavailable(

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.editor import ValidatorUnavailableError
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import AdoptableDevice, DeviceState, ErrorCode, EventType
 
@@ -425,7 +426,11 @@ async def test_import_device_preserves_original_error_when_cleanup_fails(
 
 @pytest.mark.parametrize(
     "exc",
-    [TimeoutError("subprocess wedged"), RuntimeError("closed stdout"), BrokenPipeError()],
+    [
+        TimeoutError("subprocess wedged"),
+        ValidatorUnavailableError("closed stdout"),
+        BrokenPipeError(),
+    ],
 )
 async def test_import_device_keeps_yaml_when_validator_unavailable(
     tmp_path: Path,
@@ -454,6 +459,33 @@ async def test_import_device_keeps_yaml_when_validator_unavailable(
     assert result == {"configuration": "kitchen.yaml"}
     assert (tmp_path / "kitchen.yaml").exists()
     assert ctrl._scanner.calls == [("scan",)]
+
+
+async def test_import_device_propagates_generic_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A generic RuntimeError (a bug, not subprocess loss) is not swallowed by adopt.
+
+    Tolerance is scoped to ``ValidatorUnavailableError`` / timeouts; an
+    unexpected RuntimeError must surface (and roll the YAML back) rather
+    than commit an unvalidated config as success.
+    """
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    ctrl._db.editor.validate_yaml = AsyncMock(side_effect=RuntimeError("unexpected bug"))
+
+    with pytest.raises(RuntimeError, match="unexpected bug"):
+        await ctrl.import_device(
+            name="kitchen",
+            project_name="x",
+            package_import_url="github://x",
+        )
+
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == []
 
 
 async def test_import_device_validates_with_short_timeout(

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -438,13 +438,7 @@ async def test_import_device_keeps_yaml_when_validator_unavailable(
     make_controller: MakeControllerFactory,
     exc: Exception,
 ) -> None:
-    """A validator timeout / subprocess error keeps the file and proceeds.
-
-    The adopt path tolerates an unavailable validator: an imported
-    config's ``github://`` package fetch can outlast the validate
-    budget, and that fetch happens again at compile/install. The file
-    stays, adoption completes, and the scan runs.
-    """
+    """Adopt tolerates an unavailable validator: file kept, adoption completes, scan runs."""
     monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
@@ -466,12 +460,7 @@ async def test_import_device_propagates_generic_runtime_error(
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
 ) -> None:
-    """A generic RuntimeError (a bug, not subprocess loss) is not swallowed by adopt.
-
-    Tolerance is scoped to ``ValidatorUnavailableError`` / timeouts; an
-    unexpected RuntimeError must surface (and roll the YAML back) rather
-    than commit an unvalidated config as success.
-    """
+    """A generic RuntimeError (a bug, not subprocess loss) propagates and rolls the YAML back."""
     monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -423,36 +423,60 @@ async def test_import_device_preserves_original_error_when_cleanup_fails(
     assert "required key not provided: a platform" in excinfo.value.message
 
 
-async def test_import_device_rolls_back_on_validator_subprocess_error(
+@pytest.mark.parametrize(
+    "exc",
+    [TimeoutError("subprocess wedged"), RuntimeError("closed stdout"), BrokenPipeError()],
+)
+async def test_import_device_keeps_yaml_when_validator_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_controller: MakeControllerFactory,
+    exc: Exception,
 ) -> None:
-    """A non-CommandError failure from the validator still rolls the YAML back.
+    """A validator timeout / subprocess error keeps the file and proceeds.
 
-    The validator subprocess can raise ``TimeoutError`` /
-    ``RuntimeError`` / ``BrokenPipeError`` (or even an
-    ``OSError`` from the post-write read) without going through
-    ``CommandError``. Without a broad ``except`` the rollback
-    would skip and the half-imported YAML would stick around,
-    tripping ``FileExistsError`` on every retry — exactly the
-    foot-gun this PR is meant to prevent.
+    The adopt path tolerates an unavailable validator: an imported
+    config's ``github://`` package fetch can outlast the validate
+    budget, and that fetch happens again at compile/install. The file
+    stays, adoption completes, and the scan runs.
     """
     monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
-    ctrl._db.editor.validate_yaml = AsyncMock(side_effect=TimeoutError("subprocess wedged"))
+    ctrl._db.editor.validate_yaml = AsyncMock(side_effect=exc)
 
-    with pytest.raises(TimeoutError):
-        await ctrl.import_device(
-            name="kitchen",
-            project_name="x",
-            package_import_url="github://x",
-        )
+    result = await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x",
+    )
 
-    # YAML must be unlinked even though the failure wasn't a CommandError.
-    assert not (tmp_path / "kitchen.yaml").exists()
-    assert ctrl._scanner.calls == []
+    assert result == {"configuration": "kitchen.yaml"}
+    assert (tmp_path / "kitchen.yaml").exists()
+    assert ctrl._scanner.calls == [("scan",)]
+
+
+async def test_import_device_validates_with_short_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Adopt passes the short import budget so it isn't gated on a cold fetch."""
+    from esphome_device_builder.controllers.editor import _IMPORT_VALIDATE_TIMEOUT  # noqa: PLC0415
+
+    monkeypatch.setattr("esphome.components.dashboard_import.import_config", _import_config_stub())
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    validate = AsyncMock(return_value={"yaml_errors": [], "validation_errors": []})
+    ctrl._db.editor.validate_yaml = validate
+
+    await ctrl.import_device(
+        name="kitchen",
+        project_name="x",
+        package_import_url="github://x",
+    )
+
+    assert validate.await_args.kwargs["timeout"] == _IMPORT_VALIDATE_TIMEOUT
 
 
 async def test_import_device_skips_validation_when_editor_unavailable(

--- a/tests/controllers/devices/test_mutations_yaml.py
+++ b/tests/controllers/devices/test_mutations_yaml.py
@@ -1,0 +1,53 @@
+"""Tests for ``validate_rewritten_yaml_or_raise``'s tolerate / strict paths."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from esphome_device_builder.controllers.devices import mutations_yaml
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [TimeoutError(), RuntimeError("subprocess died"), BrokenPipeError()],
+)
+async def test_strict_path_propagates_validator_failure_and_cleans_up(exc: Exception) -> None:
+    """Default (strict) callers re-raise a validator timeout / subprocess error and roll back."""
+    editor = MagicMock()
+    editor.validate_yaml = AsyncMock(side_effect=exc)
+    cleanup = Mock()
+
+    with pytest.raises(type(exc)):
+        await mutations_yaml.validate_rewritten_yaml_or_raise(
+            editor,
+            "kitchen.yaml",
+            "esphome:\n",
+            action="rename",
+            on_error_cleanup=cleanup,
+        )
+
+    cleanup.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [TimeoutError(), RuntimeError("subprocess died"), BrokenPipeError()],
+)
+async def test_tolerate_path_keeps_file_on_validator_failure(exc: Exception) -> None:
+    """``tolerate_unavailable`` swallows the failure: no raise, no cleanup."""
+    editor = MagicMock()
+    editor.validate_yaml = AsyncMock(side_effect=exc)
+    cleanup = Mock()
+
+    await mutations_yaml.validate_rewritten_yaml_or_raise(
+        editor,
+        "kitchen.yaml",
+        "esphome:\n",
+        action="import",
+        on_error_cleanup=cleanup,
+        tolerate_unavailable=True,
+    )
+
+    cleanup.assert_not_called()

--- a/tests/controllers/devices/test_mutations_yaml.py
+++ b/tests/controllers/devices/test_mutations_yaml.py
@@ -7,11 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 
 from esphome_device_builder.controllers.devices import mutations_yaml
+from esphome_device_builder.controllers.editor import ValidatorUnavailableError
 
 
 @pytest.mark.parametrize(
     "exc",
-    [TimeoutError(), RuntimeError("subprocess died"), BrokenPipeError()],
+    [TimeoutError(), ValidatorUnavailableError("subprocess died"), BrokenPipeError()],
 )
 async def test_strict_path_propagates_validator_failure_and_cleans_up(exc: Exception) -> None:
     """Default (strict) callers re-raise a validator timeout / subprocess error and roll back."""
@@ -33,7 +34,7 @@ async def test_strict_path_propagates_validator_failure_and_cleans_up(exc: Excep
 
 @pytest.mark.parametrize(
     "exc",
-    [TimeoutError(), RuntimeError("subprocess died"), BrokenPipeError()],
+    [TimeoutError(), ValidatorUnavailableError("subprocess died"), BrokenPipeError()],
 )
 async def test_tolerate_path_keeps_file_on_validator_failure(exc: Exception) -> None:
     """``tolerate_unavailable`` swallows the failure: no raise, no cleanup."""
@@ -51,3 +52,22 @@ async def test_tolerate_path_keeps_file_on_validator_failure(exc: Exception) -> 
     )
 
     cleanup.assert_not_called()
+
+
+async def test_tolerate_path_still_propagates_generic_runtime_error() -> None:
+    """A generic RuntimeError isn't subprocess-unavailability; it surfaces even when tolerating."""
+    editor = MagicMock()
+    editor.validate_yaml = AsyncMock(side_effect=RuntimeError("unexpected bug"))
+    cleanup = Mock()
+
+    with pytest.raises(RuntimeError, match="unexpected bug"):
+        await mutations_yaml.validate_rewritten_yaml_or_raise(
+            editor,
+            "kitchen.yaml",
+            "esphome:\n",
+            action="import",
+            on_error_cleanup=cleanup,
+            tolerate_unavailable=True,
+        )
+
+    cleanup.assert_called_once()

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -793,10 +793,14 @@ async def test_validate_yaml_terminates_session_on_validator_unavailable(
     terminated.assert_awaited_once()
 
 
-async def test_validate_yaml_propagates_generic_runtime_error_without_teardown(
+async def test_validate_yaml_propagates_generic_runtime_error_and_tears_down(
     tmp_path: Path,
 ) -> None:
-    """A generic ``RuntimeError`` (a bug, not subprocess loss) propagates, no teardown."""
+    """A generic ``RuntimeError`` propagates by type, but the subprocess is still torn down.
+
+    The round-trip may have left the stateful protocol mid-message, so a bug
+    must not strand a desynced subprocess for the next validate to misread.
+    """
     controller = _make_controller(tmp_path)
 
     async def _raise_runtime(*_args: Any, **_kwargs: Any) -> dict:
@@ -810,7 +814,7 @@ async def test_validate_yaml_propagates_generic_runtime_error_without_teardown(
     with pytest.raises(RuntimeError, match="unexpected bug"):
         await controller.validate_yaml(configuration="kitchen.yaml", content="")
 
-    terminated.assert_not_awaited()
+    terminated.assert_awaited_once()
 
 
 async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -816,11 +816,7 @@ async def test_validate_yaml_propagates_generic_runtime_error_without_teardown(
 async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Subprocess startup runs before the timeout budget, which wraps only the round-trip.
-
-    Guards the adopt path: a cold start (its own ``_STARTUP_TIMEOUT``)
-    must not eat a short import budget before the YAML is parsed.
-    """
+    """Subprocess startup runs before the timeout budget, which wraps only the round-trip."""
     controller = _make_controller(tmp_path)
     events: list[str] = []
 

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -40,6 +40,7 @@ import pytest
 from esphome_device_builder.controllers import editor as editor_module
 from esphome_device_builder.controllers.editor import (
     _IDLE_SUBPROCESS_TIMEOUT,
+    _VALIDATE_TIMEOUT,
     EditorController,
     _EditorSession,
 )
@@ -726,6 +727,7 @@ async def test_validate_yaml_creates_session_and_delegates(
         return {"yaml_errors": [], "validation_errors": []}
 
     controller._validate_locked = _fake_validate  # type: ignore[method-assign]
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
 
     result = await controller.validate_yaml(configuration="kitchen.yaml", content="esphome:\n")
 
@@ -749,6 +751,7 @@ async def test_validate_yaml_terminates_session_on_timeout(
         return {}
 
     controller._validate_locked = _hangs  # type: ignore[method-assign]
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
 
     async def _raise_timeout(awaitable: Any, *_args: Any, **_kwargs: Any) -> None:
         if hasattr(awaitable, "close"):
@@ -779,6 +782,7 @@ async def test_validate_yaml_terminates_session_on_runtime_error(
         raise RuntimeError("subprocess closed stdout")
 
     controller._validate_locked = _raise_runtime  # type: ignore[method-assign]
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
     terminated = AsyncMock()
     controller._terminate_subprocess = terminated  # type: ignore[method-assign]
 
@@ -786,6 +790,73 @@ async def test_validate_yaml_terminates_session_on_runtime_error(
         await controller.validate_yaml(configuration="kitchen.yaml", content="")
 
     terminated.assert_awaited_once()
+
+
+async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subprocess startup runs before the timeout budget, which wraps only the round-trip.
+
+    Guards the adopt path: a cold start (its own ``_STARTUP_TIMEOUT``)
+    must not eat a short import budget before the YAML is parsed.
+    """
+    controller = _make_controller(tmp_path)
+    events: list[str] = []
+
+    async def _ensure(_session: _EditorSession) -> None:
+        events.append("ensure")
+
+    async def _locked(*_args: Any, **_kwargs: Any) -> dict:
+        events.append("validate")
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._ensure_subprocess = _ensure  # type: ignore[method-assign]
+    controller._validate_locked = _locked  # type: ignore[method-assign]
+
+    captured: dict[str, float] = {}
+    real_wait_for = asyncio.wait_for
+
+    async def _wait_for(awaitable: Any, *, timeout: float) -> Any:
+        events.append("wait_for")
+        captured["timeout"] = timeout
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr("esphome_device_builder.controllers.editor.asyncio.wait_for", _wait_for)
+
+    await controller.validate_yaml(configuration="kitchen.yaml", content="", timeout=0.5)
+
+    # Startup happened before the budgeted wait_for, which wrapped only the round-trip.
+    assert events == ["ensure", "wait_for", "validate"]
+    assert captured["timeout"] == 0.5
+
+
+async def test_validate_yaml_ignores_client_supplied_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``timeout`` is internal-only: a WS client can't tune its validate budget."""
+    controller = _make_controller(tmp_path)
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+
+    async def _locked(*_args: Any, **_kwargs: Any) -> dict:
+        return {"yaml_errors": [], "validation_errors": []}
+
+    controller._validate_locked = _locked  # type: ignore[method-assign]
+
+    captured: dict[str, float] = {}
+    real_wait_for = asyncio.wait_for
+
+    async def _wait_for(awaitable: Any, *, timeout: float) -> Any:
+        captured["timeout"] = timeout
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr("esphome_device_builder.controllers.editor.asyncio.wait_for", _wait_for)
+
+    # A WS-dispatched call carries ``client``; the supplied short timeout is dropped.
+    await controller.validate_yaml(
+        configuration="kitchen.yaml", content="", timeout=0.001, client=object()
+    )
+
+    assert captured["timeout"] == _VALIDATE_TIMEOUT
 
 
 # ---------------------------------------------------------------------------
@@ -808,6 +879,7 @@ async def test_validate_yaml_caches_result_for_repeated_content(tmp_path: Path) 
         return {"yaml_errors": [], "validation_errors": []}
 
     controller._validate_locked = _record  # type: ignore[method-assign]
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
 
     first = await controller.validate_yaml(
         configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"
@@ -830,6 +902,7 @@ async def test_validate_yaml_cache_misses_on_different_content(tmp_path: Path) -
         return {"yaml_errors": [], "validation_errors": []}
 
     controller._validate_locked = _record  # type: ignore[method-assign]
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
 
     await controller.validate_yaml(
         configuration="kitchen.yaml", content="esphome:\n  name: kitchen\n"

--- a/tests/test_editor_controller.py
+++ b/tests/test_editor_controller.py
@@ -42,6 +42,7 @@ from esphome_device_builder.controllers.editor import (
     _IDLE_SUBPROCESS_TIMEOUT,
     _VALIDATE_TIMEOUT,
     EditorController,
+    ValidatorUnavailableError,
     _EditorSession,
 )
 from esphome_device_builder.helpers.json import dumps
@@ -772,24 +773,44 @@ async def test_validate_yaml_terminates_session_on_timeout(
     terminated.assert_awaited_once()
 
 
-async def test_validate_yaml_terminates_session_on_runtime_error(
+async def test_validate_yaml_terminates_session_on_validator_unavailable(
     tmp_path: Path,
 ) -> None:
-    """``_validate_locked`` raising ``RuntimeError`` (subprocess died) → teardown + re-raise."""
+    """``_validate_locked`` raising ``ValidatorUnavailableError`` → teardown + re-raise."""
+    controller = _make_controller(tmp_path)
+
+    async def _raise_unavailable(*_args: Any, **_kwargs: Any) -> dict:
+        raise ValidatorUnavailableError("subprocess closed stdout")
+
+    controller._validate_locked = _raise_unavailable  # type: ignore[method-assign]
+    controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
+    terminated = AsyncMock()
+    controller._terminate_subprocess = terminated  # type: ignore[method-assign]
+
+    with pytest.raises(ValidatorUnavailableError, match="closed stdout"):
+        await controller.validate_yaml(configuration="kitchen.yaml", content="")
+
+    terminated.assert_awaited_once()
+
+
+async def test_validate_yaml_propagates_generic_runtime_error_without_teardown(
+    tmp_path: Path,
+) -> None:
+    """A generic ``RuntimeError`` (a bug, not subprocess loss) propagates, no teardown."""
     controller = _make_controller(tmp_path)
 
     async def _raise_runtime(*_args: Any, **_kwargs: Any) -> dict:
-        raise RuntimeError("subprocess closed stdout")
+        raise RuntimeError("unexpected bug")
 
     controller._validate_locked = _raise_runtime  # type: ignore[method-assign]
     controller._ensure_subprocess = AsyncMock()  # type: ignore[method-assign]
     terminated = AsyncMock()
     controller._terminate_subprocess = terminated  # type: ignore[method-assign]
 
-    with pytest.raises(RuntimeError, match="closed stdout"):
+    with pytest.raises(RuntimeError, match="unexpected bug"):
         await controller.validate_yaml(configuration="kitchen.yaml", content="")
 
-    terminated.assert_awaited_once()
+    terminated.assert_not_awaited()
 
 
 async def test_validate_yaml_warms_subprocess_outside_round_trip_budget(


### PR DESCRIPTION
# What does this implement/fix?

"Take Control" wrote the imported YAML, then validated it before returning. The generated config carries a `github://` package whose cold fetch outlasts the 30s validate timeout, so adoption failed; the file was left on disk just long enough that a second click hit `FileExistsError` and reported "already exists".

The adopt path now tolerates a validator timeout or subprocess error (keeps the file, proceeds) and runs validation with a short budget. The fast pre-network YAML-syntax check still runs, so a real generator bug is still caught; the remote package fetch is deferred to compile/install where there is proper job progress. Rename, edit, and create keep strict validation.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1644

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
