### PR TITLE
Resolve ESPHome substitutions in MQTT broker discovery

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -19,7 +19,12 @@ import yaml
 from esphome.core import EsphomeError
 
 from ..constants import SECRETS_FILENAME
-from ..helpers.device_yaml import load_device_yaml
+from ..helpers.device_yaml import (
+    _UNRESOLVED_SUBSTITUTION_RE,
+    _extract_resolved_substitutions,
+    _resolve_substitutions,
+    load_device_yaml,
+)
 from ..helpers.yaml import FastestSafeLoader, load_yaml_fast_then_esphome
 from ..models import Device
 from ._device_mqtt_monitor import (
@@ -32,6 +37,10 @@ from ._device_mqtt_monitor import (
 _LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 1883
+
+# ``mqtt:`` fields read into an MqttBrokerConfig, each resolved through
+# the same !secret + substitution pipeline.
+_BROKER_FIELDS = ("broker", "port", "username", "password")
 
 
 class DeviceMqttCoordinator:
@@ -232,9 +241,10 @@ def parse_mqtt_block(
 
     Returns ``None`` when the YAML has no ``mqtt:`` block, when the
     block has no resolvable ``broker:`` field, or when the YAML fails
-    to parse. ``!secret xyz`` references are resolved via *secrets_map*.
-    Reads literal contents only — ``packages:`` / ``!include`` go
-    through :func:`load_device_yaml` + ``_extract_broker_from_config``.
+    to parse. ``!secret xyz`` references and ``${var}`` / ``$var``
+    substitutions from the file's own ``substitutions:`` block are
+    resolved; a broker still carrying an unresolved token returns
+    ``None`` so the caller falls through to the package-aware slow path.
     """
     secrets_map = secrets_map or {}
     try:
@@ -251,30 +261,43 @@ def parse_mqtt_block(
     mqtt = data.get("mqtt")
     if not isinstance(mqtt, dict):
         return None
-    return _broker_from_block(
-        {
-            "broker": _resolve(mqtt.get("broker"), secrets_map),
-            "port": _resolve(mqtt.get("port"), secrets_map),
-            "username": _resolve(mqtt.get("username"), secrets_map),
-            "password": _resolve(mqtt.get("password"), secrets_map),
-        }
-    )
+    subs = _extract_resolved_substitutions(data)
+    return _broker_from_block(_resolve_broker_fields(mqtt, secrets_map, subs))
 
 
 def _extract_broker_from_config(config: dict | None) -> MqttBrokerConfig | None:
-    """Extract broker parameters from a fully-resolved ESPHome config."""
+    """Extract broker parameters from a fully-resolved ESPHome config.
+
+    ``load_device_yaml`` merges ``packages:`` / ``!include`` but skips the
+    substitution pass, so resolve ``${var}`` against the merged
+    ``substitutions:`` block here too.
+    """
     if not isinstance(config, dict):
         return None
     mqtt = config.get("mqtt")
     if not isinstance(mqtt, dict):
         return None
-    return _broker_from_block(mqtt)
+    subs = _extract_resolved_substitutions(config)
+    return _broker_from_block(_resolve_broker_fields(mqtt, {}, subs))
+
+
+def _resolve_broker_fields(
+    mqtt: dict, secrets_map: dict[str, Any], subs: dict[str, str]
+) -> dict[str, str | None]:
+    """Resolve each broker field through ``!secret`` then ``${var}`` substitution."""
+    return {
+        k: _resolve_substitutions(_resolve(mqtt.get(k), secrets_map), subs) for k in _BROKER_FIELDS
+    }
 
 
 def _broker_from_block(mqtt: dict) -> MqttBrokerConfig | None:
     """Build an :class:`MqttBrokerConfig` from a resolved ``mqtt:`` block."""
     host = mqtt.get("broker")
     if not host:
+        return None
+    # An unresolved ``${var}`` / ``$var`` token would otherwise become a
+    # bogus host and loop the monitor on DNS failure.
+    if isinstance(host, str) and _UNRESOLVED_SUBSTITUTION_RE.search(host):
         return None
     port_raw = mqtt.get("port")
     try:

--- a/esphome_device_builder/helpers/device_yaml/__init__.py
+++ b/esphome_device_builder/helpers/device_yaml/__init__.py
@@ -31,9 +31,12 @@ from ._loading import (
     load_device_yaml,
 )
 from ._parsing import (
+    _UNRESOLVED_SUBSTITUTION_RE,
     DEFAULT_API_PORT,
     EsphomeMeta,
+    _extract_resolved_substitutions,
     _parse_inline_value,
+    _resolve_substitutions,
     config_has_top_level_block,
     configuration_stem,
     detect_platform_from_yaml,
@@ -52,11 +55,14 @@ from ._parsing import (
 __all__ = [
     "DEFAULT_API_PORT",
     "NETWORK_PROVIDER_COMPONENT_IDS",
+    "_UNRESOLVED_SUBSTITUTION_RE",
     "EsphomeMeta",
     "StorageJSON",
+    "_extract_resolved_substitutions",
     "_has_native_wifi",
     "_infer_native_wifi",
     "_parse_inline_value",
+    "_resolve_substitutions",
     "board_provides_network",
     "board_requires_wifi",
     "compute_has_pending_changes",

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -93,11 +93,12 @@ def test_parse_mqtt_block_custom_port() -> None:
 
 
 def test_parse_mqtt_block_resolves_secrets() -> None:
-    yaml = "mqtt:\n  broker: !secret broker_host\n  password: !secret pw\n"
-    secrets = {"broker_host": "192.168.1.5", "pw": "topsecret"}
+    yaml = "mqtt:\n  broker: !secret broker_host\n  port: !secret port\n  password: !secret pw\n"
+    secrets = {"broker_host": "192.168.1.5", "port": "8883", "pw": "topsecret"}
     config = parse_mqtt_block(yaml, secrets)
     assert config is not None
     assert config.host == "192.168.1.5"
+    assert config.port == 8883
     assert config.password == "topsecret"
 
 
@@ -128,6 +129,41 @@ def test_parse_mqtt_block_ignores_unknown_tags() -> None:
 
 def test_parse_mqtt_block_invalid_yaml_returns_none() -> None:
     assert parse_mqtt_block("not: valid: yaml: at all") is None
+
+
+def test_parse_mqtt_block_resolves_substitutions() -> None:
+    yaml = (
+        "substitutions:\n  mqtt_host: 192.0.2.10\n  mqtt_user: bob\n  mqtt_port: '8883'\n"
+        "mqtt:\n  broker: ${mqtt_host}\n  port: ${mqtt_port}\n  username: $mqtt_user\n"
+    )
+    config = parse_mqtt_block(yaml)
+    assert config is not None
+    assert config.host == "192.0.2.10"
+    assert config.port == 8883
+    assert config.username == "bob"
+
+
+def test_parse_mqtt_block_unresolved_substitution_returns_none() -> None:
+    # No local substitutions block defines mqtt_host; the token must not
+    # become a host, so the caller falls through to the slow path.
+    yaml = "mqtt:\n  broker: ${mqtt_host}\n"
+    assert parse_mqtt_block(yaml) is None
+
+
+def test_parse_mqtt_block_resolves_port_substitution() -> None:
+    yaml = "substitutions:\n  mqtt_port: '8883'\nmqtt:\n  broker: 10.0.0.5\n  port: ${mqtt_port}\n"
+    config = parse_mqtt_block(yaml)
+    assert config is not None
+    assert config.port == 8883
+
+
+def test_parse_mqtt_block_unresolved_port_substitution_falls_back_to_default() -> None:
+    # An unresolved port token can't gate the monitor (only the host does),
+    # so it degrades to the default rather than raising.
+    yaml = "mqtt:\n  broker: 10.0.0.5\n  port: ${mqtt_port}\n"
+    config = parse_mqtt_block(yaml)
+    assert config is not None
+    assert config.port == 1883
 
 
 def test_mqtt_broker_config_key_groups_by_host_port() -> None:
@@ -402,6 +438,85 @@ async def test_coordinator_resolves_broker_pulled_in_via_packages(
     assert stub_monitor.instances[0].broker.host == "192.168.1.203"
 
 
+async def test_coordinator_resolves_broker_from_local_substitution(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Issue #1643: ${var} broker resolves from the file's own
+    # substitutions block in the fast path, without load_device_yaml.
+    def fail_loader(_path: Path) -> dict | None:
+        raise AssertionError("slow path must not run for a local substitution")
+
+    monkeypatch.setattr(coordinator_module, "load_device_yaml", fail_loader)
+    devices = [
+        _write_device(
+            tmp_path,
+            "alpha",
+            "substitutions:\n  mqtt_host: 192.0.2.10\nmqtt:\n  broker: ${mqtt_host}\n",
+        )
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert stub_monitor.instances[0].broker.host == "192.0.2.10"
+
+
+async def test_coordinator_resolves_port_from_substitution(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    mqtt_yaml = (
+        "substitutions:\n  mqtt_port: '8883'\nmqtt:\n  broker: 10.0.0.5\n  port: ${mqtt_port}\n"
+    )
+    devices = [_write_device(tmp_path, "alpha", mqtt_yaml)]
+    coord = _make_coordinator(tmp_path, devices)
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert stub_monitor.instances[0].broker.port == 8883
+
+
+async def test_coordinator_resolves_broker_substitution_via_package(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+) -> None:
+    (tmp_path / "common.yaml").write_text(
+        "substitutions:\n  mqtt_host: 192.168.1.77\nmqtt:\n  broker: ${mqtt_host}\n"
+    )
+    (tmp_path / "alpha.yaml").write_text(
+        "esphome:\n  name: alpha\npackages:\n  shared: !include common.yaml\n"
+    )
+    device = Device(
+        name="alpha",
+        friendly_name="alpha",
+        configuration="alpha.yaml",
+        uses_mqtt=True,
+    )
+    coord = _make_coordinator(tmp_path, [device])
+    await coord.reconcile()
+    assert coord.active_brokers == 1
+    assert stub_monitor.instances[0].broker.host == "192.168.1.77"
+
+
+async def test_coordinator_skips_unresolved_substitution(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # An undefined substitution must not start a monitor on the literal
+    # token; warn once instead of looping on DNS failure.
+    device = _write_device(tmp_path, "alpha", "mqtt:\n  broker: ${mqtt_host}\n")
+    coord = _make_coordinator(tmp_path, [device])
+
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("WARNING", logger=target):
+        await coord.reconcile()
+
+    assert coord.active_brokers == 0
+    warnings = [r for r in caplog.records if r.name == target and r.levelname == "WARNING"]
+    assert len(warnings) == 1
+
+
 async def test_coordinator_warns_once_per_unresolved_device(
     tmp_path: Path,
     stub_monitor: type[_RecordingMonitor],
@@ -605,6 +720,32 @@ def test_extract_broker_from_config_handles_invalid_port() -> None:
 
 def test_extract_broker_from_config_returns_none_when_broker_missing() -> None:
     assert _extract_broker_from_config({"mqtt": {"username": "u"}}) is None
+
+
+def test_extract_broker_from_config_resolves_substitutions() -> None:
+    # load_device_yaml merges packages but skips the substitution pass.
+    config = {
+        "substitutions": {"mqtt_host": "192.168.1.203", "mqtt_port": "8883"},
+        "mqtt": {"broker": "${mqtt_host}", "port": "${mqtt_port}"},
+    }
+    broker = _extract_broker_from_config(config)
+    assert broker is not None
+    assert broker.host == "192.168.1.203"
+    assert broker.port == 8883
+
+
+def test_extract_broker_from_config_unresolved_substitution_returns_none() -> None:
+    assert _extract_broker_from_config({"mqtt": {"broker": "${mqtt_host}"}}) is None
+
+
+def test_extract_broker_from_config_resolves_port_substitution() -> None:
+    config = {
+        "substitutions": {"mqtt_port": "8883"},
+        "mqtt": {"broker": "10.0.0.5", "port": "${mqtt_port}"},
+    }
+    broker = _extract_broker_from_config(config)
+    assert broker is not None
+    assert broker.port == 8883
 
 
 def test_extract_broker_from_config_reads_resolved_block() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Device Builder runs its dashboard side MQTT discovery by reading each device's `mqtt.broker` value straight from the YAML. The fast parser resolved `!secret` references but not ESPHome substitutions, so a config using `broker: ${mqtt_host}` started a monitor against the literal token `${mqtt_host}`, then looped forever on DNS failure.

This resolves `${var}` / `$var` substitutions from the file's own `substitutions:` block in both the fast parser and the slow path that expands packages. A broker that is still unresolved after both paths now starts no monitor and logs the existing once per device warning, instead of looping on DNS.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1643

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
