### PR TITLE
Honor a startup stop signal whose SystemExit was swallowed

### DIFF
--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -391,7 +391,15 @@ def _serve_until_stop(device_builder: DeviceBuilder) -> None:
     try/finally — so a half-started controller's teardown can surface a
     non-``CancelledError`` that escapes ``run_app``. With a stop pending
     that's a clean exit; a crash with no stop pending propagates.
+
+    The pre-serve check covers a stop signal whose ``SystemExit(0)`` was
+    swallowed (signals raised inside an import-machinery weakref callback are
+    ignored by CPython): ``_stop_requested`` is still set, so honour it here
+    rather than serving forever.
     """
+    if _stop_requested:
+        logging.getLogger(_LOGGER_NAME).info("Stop signal received during startup; exiting")
+        return
     try:
         device_builder.run()
     except Exception:

--- a/esphome_device_builder/__main__.py
+++ b/esphome_device_builder/__main__.py
@@ -391,12 +391,8 @@ def _serve_until_stop(device_builder: DeviceBuilder) -> None:
     try/finally — so a half-started controller's teardown can surface a
     non-``CancelledError`` that escapes ``run_app``. With a stop pending
     that's a clean exit; a crash with no stop pending propagates.
-
-    The pre-serve check covers a stop signal whose ``SystemExit(0)`` was
-    swallowed (signals raised inside an import-machinery weakref callback are
-    ignored by CPython): ``_stop_requested`` is still set, so honour it here
-    rather than serving forever.
     """
+    # Honour a startup stop whose SystemExit was swallowed (e.g. in a weakref callback).
     if _stop_requested:
         logging.getLogger(_LOGGER_NAME).info("Stop signal received during startup; exiting")
         return

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -74,6 +74,16 @@ def test_serve_until_stop_returns_on_clean_run(monkeypatch: pytest.MonkeyPatch) 
     main_module._serve_until_stop(builder)  # type: ignore[arg-type]
 
 
+def test_serve_until_stop_skips_run_when_stop_already_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop swallowed during startup is honoured before serving (``run`` is skipped)."""
+    monkeypatch.setattr(main_module, "_stop_requested", True)
+    ran: list[bool] = []
+    main_module._serve_until_stop(SimpleNamespace(run=lambda: ran.append(True)))  # type: ignore[arg-type]
+    assert ran == []
+
+
 def test_serve_until_stop_swallows_error_when_stop_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`test_sigterm_during_startup_exits_zero` flakes on CI: "dashboard did not exit within 30s of SIGTERM". The child transcript shows the cause:

```
Exception ignored while calling weakref callback <function _get_module_lock.<locals>.cb ...>:
  File ".../__main__.py", line 131, in _exit_cleanly_on_signal
    raise SystemExit(0) from None
SystemExit: 0
```

The SIGTERM landed while Python was running an importlib module-lock weakref callback (during `main()`'s lazy imports). CPython ignores exceptions raised in weakref callbacks, so the handler's `raise SystemExit(0)` was swallowed; `_stop_requested` was set, but nothing acted on it, so startup completed and the dashboard served forever.

The handler always sets `_stop_requested` reliably (a plain assignment, never swallowed); only the `SystemExit` raise is best-effort. This adds a pre-serve check at the top of `_serve_until_stop`: if a stop is already pending, log and return before serving. That recovers the swallowed case at a deterministic checkpoint (the swallow window is the import phase, which finishes before `_serve_until_stop` runs). The signal handler is unchanged and stays log-free.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
