### PR TITLE
Disable version history instead of crashing on an unusable .git

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -191,8 +191,19 @@ class GitRepo:
                     self.config_dir,
                     toplevel,
                 )
+            elif (self.config_dir / ".git").exists():
+                # rev-parse found no work tree yet ``.git`` is present: an
+                # unusable git dir (a submodule / worktree pointer whose
+                # target isn't mounted, or a corrupt repo). Re-initialising
+                # over it fails, so disable rather than crash on init.
+                _LOGGER.info(
+                    "Config dir %s has a .git git can't use here (likely a submodule or "
+                    "worktree whose git dir isn't mounted); version history disabled",
+                    self.config_dir,
+                )
+                return
             self._init_repo()
-        except OSError as exc:
+        except (OSError, subprocess.CalledProcessError) as exc:
             _LOGGER.warning("Could not set up version-history git repo: %s", exc)
 
     def _discover_toplevel(self) -> Path | None:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -44,7 +44,7 @@ _LOGGER = logging.getLogger(__name__)
 # Resolved from the package itself so it survives this module being moved.
 _OWN_SOURCE_ROOT = Path(esphome_device_builder.__file__).resolve().parent
 
-# Errors a commit attempt raises for genuine git / environment reasons
+# Errors a git invocation raises for genuine git / environment reasons
 # (a failed ``git`` invocation, the binary vanishing) as opposed to a
 # programming bug. Callers swallow these as best-effort and let anything
 # else propagate so real bugs surface instead of being mislabelled.
@@ -203,7 +203,12 @@ class GitRepo:
                 )
                 return
             self._init_repo()
-        except (OSError, subprocess.CalledProcessError) as exc:
+        except GIT_COMMIT_ERRORS as exc:
+            # Leave the feature fully disabled, never half-enabled, so a
+            # failure after the adopt branch set ``enabled`` can't strand it.
+            self.enabled = False
+            self.toplevel = None
+            self.managed = False
             _LOGGER.warning("Could not set up version-history git repo: %s", exc)
 
     def _discover_toplevel(self) -> Path | None:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -201,15 +201,20 @@ class GitRepo:
                     "worktree whose git dir isn't mounted); version history disabled",
                     self.config_dir,
                 )
+                self._disable()
                 return
             self._init_repo()
         except GIT_COMMIT_ERRORS as exc:
-            # Leave the feature fully disabled, never half-enabled, so a
-            # failure after the adopt branch set ``enabled`` can't strand it.
-            self.enabled = False
-            self.toplevel = None
-            self.managed = False
+            # Never leave the repo half-enabled: a failure after the adopt
+            # branch set ``enabled`` would otherwise strand it.
+            self._disable()
             _LOGGER.warning("Could not set up version-history git repo: %s", exc)
+
+    def _disable(self) -> None:
+        """Reset to the fully-disabled state (no work tree adopted or created)."""
+        self.enabled = False
+        self.toplevel = None
+        self.managed = False
 
     def _discover_toplevel(self) -> Path | None:
         """Return the enclosing work tree's root, or ``None`` if there is none."""

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -74,6 +74,39 @@ def test_init_creates_repo_and_gitignore(tmp_path: Path) -> None:
     assert "Initialize version history" in _git(tmp_path, "log", "--format=%s")
 
 
+def test_unusable_git_pointer_disables_without_raising(tmp_path: Path) -> None:
+    """A ``.git`` pointing at a missing git dir (broken submodule) disables, not crash."""
+    # Mirrors a submodule whose parent ``.git/modules`` tree isn't mounted:
+    # ``git init`` over this pointer aborts with ``fatal: not a git repository``.
+    (tmp_path / ".git").write_text("gitdir: ./nonexistent/git/dir\n", encoding="utf-8")
+    repo = GitRepo(config_dir=tmp_path)
+
+    repo.discover_or_init()
+
+    assert not repo.enabled
+
+
+def test_init_failure_disables_without_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``git init`` that exits non-zero disables the feature instead of crashing."""
+    real_run = subprocess.run
+
+    def _fake(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "init" in cmd:
+            return subprocess.CompletedProcess(cmd, 128, "", "fatal: boom")
+        return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.version_history.git_repo.subprocess.run", _fake
+    )
+    repo = GitRepo(config_dir=tmp_path)
+
+    repo.discover_or_init()
+
+    assert not repo.enabled
+
+
 def test_adopts_existing_repo_without_touching_gitignore(tmp_path: Path) -> None:
     """A pre-existing work tree is adopted; the user's .gitignore is untouched."""
     _make_repo(tmp_path)

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -75,7 +75,7 @@ def test_init_creates_repo_and_gitignore(tmp_path: Path) -> None:
 
 
 def test_unusable_git_pointer_disables_without_raising(tmp_path: Path) -> None:
-    """A ``.git`` pointing at a missing git dir (broken submodule) disables, not crash."""
+    """A ``.git`` pointing at a missing git dir (broken submodule) disables rather than crashing."""
     # Mirrors a submodule whose parent ``.git/modules`` tree isn't mounted:
     # ``git init`` over this pointer aborts with ``fatal: not a git repository``.
     (tmp_path / ".git").write_text("gitdir: ./nonexistent/git/dir\n", encoding="utf-8")
@@ -84,6 +84,8 @@ def test_unusable_git_pointer_disables_without_raising(tmp_path: Path) -> None:
     repo.discover_or_init()
 
     assert not repo.enabled
+    assert repo.toplevel is None
+    assert not repo.managed
 
 
 def test_init_failure_disables_without_raising(
@@ -105,6 +107,29 @@ def test_init_failure_disables_without_raising(
     repo.discover_or_init()
 
     assert not repo.enabled
+    assert repo.toplevel is None
+    assert not repo.managed
+
+
+def test_failure_after_adopt_resets_to_fully_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A git failure after the adopt branch enabled the repo rolls state back to disabled."""
+    _make_repo(tmp_path)
+    repo = GitRepo(config_dir=tmp_path)
+
+    def _boom(_self: GitRepo) -> bool:
+        raise subprocess.CalledProcessError(1, ["git", "config"])
+
+    # ``_adopt_ownership`` runs after the adopt branch sets ``enabled``/``toplevel``;
+    # patch the class since ``GitRepo`` is slotted (no per-instance attributes).
+    monkeypatch.setattr(GitRepo, "_adopt_ownership", _boom)
+
+    repo.discover_or_init()
+
+    assert not repo.enabled
+    assert repo.toplevel is None
+    assert not repo.managed
 
 
 def test_adopts_existing_repo_without_touching_gitignore(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

When `/config` is bind-mounted from a git submodule, `/config/.git` is a pointer file (`gitdir: ...`) whose target lives in the parent repo's `.git/modules` tree; inside the container that tree is not mounted, so `git init /config` follows the pointer, finds nothing, and aborts. The resulting `GitCommandError` is a `CalledProcessError`, not an `OSError`, so it slipped past `discover_or_init`'s catch and crash-looped startup; the dashboard never came up.

This makes version history honor its documented "soft, optional" contract:

- Detect a `.git` that git can't use here (broken submodule or worktree pointer, corrupt repo) before attempting init, and disable cleanly with an INFO log.
- Broaden the setup catch to any git failure (`OSError` plus `subprocess.CalledProcessError`), matching the module's existing `GIT_COMMIT_ERRORS` pattern, so a startup git error disables the feature rather than taking down the server.

**Related issue or feature (if applicable):**

- Related: esphome/device-builder#1710

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
