### PR TITLE
Guard sync_components against a mismatched installed ESPHome

### DIFF
--- a/script/_esphome_version.py
+++ b/script/_esphome_version.py
@@ -1,0 +1,46 @@
+"""Shared ESPHome-version guard for the catalog sync scripts.
+
+``sync_boards.py`` and ``sync_components.py`` both derive platform metadata
+from the *installed* ESPHome, so each must run against the version its output
+records, or it ships metadata from one ESPHome stamped with another's version.
+This centralizes the "installed == expected, else exit with install
+instructions" check both perform.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+
+
+def assert_installed_esphome(
+    expected: str,
+    *,
+    what: str,
+    normalize: Callable[[str], str] | None = None,
+    alt_fix: str | None = None,
+) -> None:
+    """
+    Exit unless the installed ESPHome matches *expected*.
+
+    *what* names the caller for the message; *normalize* (e.g. beta -> base) is
+    applied to both sides before comparing; *alt_fix* appends an extra
+    remediation line to the mismatch message.
+    """
+    canon = normalize or (lambda v: v)
+    install = f"    uv pip install 'esphome=={expected}'   # or: pip install 'esphome=={expected}'"
+    try:
+        from esphome.const import __version__ as installed
+    except ImportError:
+        raise SystemExit(
+            f"{what}: ESPHome is not importable in this interpreter ({sys.executable}).\n"
+            f"To fix, install it into the project venv and re-run:\n{install}"
+        ) from None
+    if canon(installed) != canon(expected):
+        msg = (
+            f"{what}: needs ESPHome {expected}, but {installed} is installed.\n"
+            f"To fix, install the matching version into this venv and re-run:\n{install}"
+        )
+        if alt_fix:
+            msg += f"\n{alt_fix}"
+        raise SystemExit(msg)

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -24,11 +24,11 @@ remain the human-editable source of truth; this script is the only
 thing that writes the three artefacts.
 
 Single-board mode (``BOARD_ID``) must run against the same ESPHome the
-rest of the committed catalog was generated against
-(``esphome_schema_version`` in ``components.index.json``), since it
-rebuilds the shared index from every board; it refuses on a mismatch. A
-full sync regenerates everything from the installed ESPHome and is
-internally consistent regardless, so it does not check.
+rest of the committed catalog was generated against (the
+``esphome_version`` a full sync stamps into ``boards.index.json``),
+since it rebuilds the shared index from every board; it refuses on a
+mismatch. A full sync regenerates everything from the installed ESPHome
+and re-stamps that version, so it does not check.
 
 Usage
 -----

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -61,6 +61,7 @@ from _catalog_split import (  # noqa: E402
     prepare_next_bodies_dir,
     swap_split_catalog_in,
 )
+from _esphome_version import assert_installed_esphome  # noqa: E402
 
 from esphome_device_builder.definitions import (  # noqa: E402
     build_board_catalog_from_manifests,
@@ -982,24 +983,15 @@ def _require_matching_esphome() -> None:
             f"sync_boards: could not read esphome_version from {_INDEX_FILE}.\n"
             f"To fix, regenerate the whole catalog first: python script/sync_boards.py"
         ) from None
-    try:
-        from esphome.const import __version__ as raw_installed
-    except ImportError:
-        raise SystemExit(
-            f"sync_boards: ESPHome is not importable in this interpreter ({sys.executable}).\n"
-            f"To fix, install it into the project venv and re-run:\n"
-            f"    uv pip install 'esphome=={expected}'   # or: pip install 'esphome=={expected}'"
-        ) from None
-    installed = _canonical_esphome_version(raw_installed)
-    if installed != expected:
-        raise SystemExit(
-            f"sync_boards: single-board mode needs ESPHome {expected} (the version "
-            f"boards.index.json was generated with), but {installed} is installed.\n"
-            f"To fix, install the matching version into this venv and re-run:\n"
-            f"    uv pip install 'esphome=={expected}'   # or: pip install 'esphome=={expected}'\n"
-            f"Or regenerate the whole catalog against your installed ESPHome instead:\n"
-            f"    python script/sync_boards.py"
-        )
+    assert_installed_esphome(
+        expected,
+        what="sync_boards single-board mode",
+        normalize=_canonical_esphome_version,
+        alt_fix=(
+            "Or regenerate the whole catalog against your installed ESPHome instead:\n"
+            "    python script/sync_boards.py"
+        ),
+    )
 
 
 def _emit_featured_components_index(boards: list[BoardCatalogEntry]) -> None:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -112,6 +112,7 @@ from _catalog_split import (  # noqa: E402
     prepare_next_bodies_dir,
     swap_split_catalog_in,
 )
+from _esphome_version import assert_installed_esphome  # noqa: E402
 
 from esphome_device_builder.controllers.components import (  # noqa: E402
     INTERNAL_COMPONENT_IDS as _INTERNAL_COMPONENT_IDS,
@@ -900,6 +901,12 @@ def main() -> int:
         include_prereleases=args.include_prereleases,
     )
     _LOGGER.info("Using ESPHome schema version: %s", version)
+
+    # Platform metadata (variants, board tables, wifi sets) is introspected from
+    # the installed ESPHome, but the schema bundle and the stamped
+    # esphome_schema_version come from *version*. They must be the same release
+    # or the catalog ships one ESPHome's metadata labelled as another's.
+    assert_installed_esphome(version, what="sync_components")
 
     schema_dir = ensure_schema(version)
     _LOGGER.info("Schema cached at: %s", schema_dir)

--- a/tests/test_esphome_version_guard.py
+++ b/tests/test_esphome_version_guard.py
@@ -1,0 +1,36 @@
+"""Pin the shared ESPHome-version guard used by both catalog sync scripts."""
+
+from __future__ import annotations
+
+import esphome.const
+import pytest
+
+from script._esphome_version import assert_installed_esphome
+
+
+def test_exact_match_passes(monkeypatch):
+    monkeypatch.setattr(esphome.const, "__version__", "2026.6.2")
+    assert_installed_esphome("2026.6.2", what="t")  # no raise
+
+
+def test_mismatch_raises_with_install_hint(monkeypatch):
+    monkeypatch.setattr(esphome.const, "__version__", "2026.4.3")
+    with pytest.raises(SystemExit, match=r"esphome==2026\.6\.2"):
+        assert_installed_esphome("2026.6.2", what="sync_components")
+
+
+def test_normalize_matches_beta_to_base(monkeypatch):
+    monkeypatch.setattr(esphome.const, "__version__", "2026.7.0b1")
+    assert_installed_esphome("2026.7.0", what="t", normalize=lambda v: v.split("b")[0])  # no raise
+
+
+def test_alt_fix_appended_on_mismatch(monkeypatch):
+    monkeypatch.setattr(esphome.const, "__version__", "1.0.0")
+    with pytest.raises(SystemExit, match="run a full sync instead"):
+        assert_installed_esphome("2.0.0", what="t", alt_fix="run a full sync instead")
+
+
+def test_not_importable_message(monkeypatch):
+    monkeypatch.delattr(esphome.const, "__version__")
+    with pytest.raises(SystemExit, match="not importable"):
+        assert_installed_esphome("2026.6.2", what="t")

--- a/tests/test_esphome_version_guard.py
+++ b/tests/test_esphome_version_guard.py
@@ -34,3 +34,18 @@ def test_not_importable_message(monkeypatch):
     monkeypatch.delattr(esphome.const, "__version__")
     with pytest.raises(SystemExit, match="not importable"):
         assert_installed_esphome("2026.6.2", what="t")
+
+
+def test_sync_components_main_requires_exact_match(monkeypatch):
+    # The guard runs before any schema fetch / esphome.components import, so a
+    # mismatch raises with no network. A base release does NOT satisfy a beta
+    # install here: components match exactly (unlike the board catalog), so this
+    # pins that main() wires the guard without a canonicalizing normalize.
+    # Imported lazily so the lightweight helper tests above don't pay the
+    # heavy sync_components import at collection.
+    from script import sync_components  # noqa: PLC0415
+
+    monkeypatch.setattr("sys.argv", ["sync_components.py", "--version", "2026.6.2"])
+    monkeypatch.setattr(esphome.const, "__version__", "2026.6.2b1")
+    with pytest.raises(SystemExit, match=r"needs ESPHome 2026\.6\.2"):
+        sync_components.main()


### PR DESCRIPTION
# What does this implement/fix?

`sync_components.py` derives platform metadata (variants, board tables, wifi sets) from the **installed** ESPHome, but stamps `esphome_schema_version` from the fetched `--version` tag, with nothing asserting the two agree. So running it against a mismatched esphome ships one release's metadata labelled as another's version.

This adds a shared `assert_installed_esphome()` (`script/_esphome_version.py`) and calls it right after the version resolves, before any `esphome.components` import. `sync_boards.py`'s existing single-board guard now routes through the same helper; the only difference is the match mode (the board catalog matches canonically since board tables are base-stable, components match exactly since the schema bundle is version-specific).

No CI job runs `sync_components.py` against a mismatched esphome (only `sync-component-catalog.yml`, which already installs `esphome==${version}`), so this surfaces contributor mistakes without touching automation.

**Related issue or feature (if applicable):**

- fixes #1654

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
