### PR TITLE
Make has_native_wifi agreement test skew-tolerant

### DIFF
--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1758,22 +1758,29 @@ def test_infer_native_wifi_routes_through_module_alias(
     ]
 
 
-def test_has_native_wifi_agrees_with_upstream_on_indexed_inputs() -> None:
-    """Our index-fed wifi inference matches esphome for the inputs the index covers.
+def test_has_native_wifi_logic_matches_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Our wifi inference LOGIC matches esphome, independent of catalog freshness.
 
-    Scoped to the variants / platforms in our committed index so it's robust on
-    the CI matrix (newer esphome adds inputs we don't yet know). For the inputs we
-    DO claim, we must agree with upstream's ``has_native_wifi`` — guards logic
-    drift the value-pinned ``test_has_native_wifi`` can't see.
+    Feeds ``_has_native_wifi`` the same no-wifi set esphome uses and iterates
+    esphome's own variant list, so this catches dispatch/logic drift without
+    coupling to the committed catalog's data. A data skew of up to one esphome
+    release is expected during rollout and is covered tolerantly by
+    ``test_index_within_installed_esphome``; comparing the inference against the
+    catalog's (possibly stale) data here would otherwise force a release lockstep
+    with esphome on every capability change.
     """
-    from esphome.components.wifi import has_native_wifi  # noqa: PLC0415
-
-    from esphome_device_builder.definitions import (  # noqa: PLC0415
-        load_platform_capabilities_index,
+    from esphome.components.esp32.const import VARIANTS  # noqa: PLC0415
+    from esphome.components.wifi import (  # noqa: PLC0415
+        NO_WIFI_VARIANTS,
+        has_native_wifi,
     )
 
-    caps = load_platform_capabilities_index()
-    for variant in caps.esp32_variants:
+    monkeypatch.setattr(
+        device_yaml._generation,
+        "_ESP32_NO_WIFI_VARIANTS",
+        frozenset(v.lower() for v in NO_WIFI_VARIANTS),
+    )
+    for variant in VARIANTS:
         assert device_yaml._has_native_wifi(platform="esp32", variant=variant) == has_native_wifi(
             platform="esp32", variant=variant
         )

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -1759,16 +1759,7 @@ def test_infer_native_wifi_routes_through_module_alias(
 
 
 def test_has_native_wifi_logic_matches_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Our wifi inference LOGIC matches esphome, independent of catalog freshness.
-
-    Feeds ``_has_native_wifi`` the same no-wifi set esphome uses and iterates
-    esphome's own variant list, so this catches dispatch/logic drift without
-    coupling to the committed catalog's data. A data skew of up to one esphome
-    release is expected during rollout and is covered tolerantly by
-    ``test_index_within_installed_esphome``; comparing the inference against the
-    catalog's (possibly stale) data here would otherwise force a release lockstep
-    with esphome on every capability change.
-    """
+    """Pin ``_has_native_wifi`` to esphome's inference over esphome's no-wifi set and variants."""
     from esphome.components.esp32.const import VARIANTS  # noqa: PLC0415
     from esphome.components.wifi import (  # noqa: PLC0415
         NO_WIFI_VARIANTS,


### PR DESCRIPTION
# What does this implement/fix?

`test_has_native_wifi_agrees_with_upstream_on_indexed_inputs` fed the committed catalog's `esp32_no_wifi_variants` into `_has_native_wifi` and asserted **exact per-variant** agreement with the installed esphome's `has_native_wifi`. That conflates the **inference logic** with **catalog data freshness**: a one-release data skew (expected during rollout) shows up as a "logic drift" failure.

This creates a **release lockstep** with esphome: an esphome PR that adds a no-Wi-Fi variant (e.g. esphome/esphome#17186 adding ESP32-H4/H21) fails this repo's downstream test, but the catalog can't be updated to match until esphome ships the change — and a manual catalog edit then fails *this* repo's CI against the not-yet-updated installed esphome. Neither side can go green first.

Fix: test the **logic** independent of catalog freshness — feed `_has_native_wifi` the same no-Wi-Fi set esphome uses and iterate esphome's own variant list. Catalog **data** freshness stays covered (tolerantly, within one release) by `test_index_within_installed_esphome`, and the value-pinned `test_loader_returns_known_platforms` still pins the committed data. The catalog continues to update via `script/sync_components.py` as usual.

**Related issue or feature (if applicable):**

- Unblocks esphome/esphome#17186 (and every future `NO_WIFI_VARIANTS` change) from the downstream lockstep.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [ ] The code change is tested and works locally. *(Verified the logic by inspection; could not run the suite in this environment — `blockbuster` test dep unavailable. CI runs it.)*
- [ ] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks). *(not run locally)*
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (N/A).