### PR TITLE
Make psram mode/speed variant assertions skew-tolerant

### DIFF
--- a/tests/test_sync_components_psram.py
+++ b/tests/test_sync_components_psram.py
@@ -34,8 +34,10 @@ def test_mode_is_a_select_of_every_variant_mode() -> None:
     by_value = {o["value"]: o["variants"] for o in mode["options"]}
     assert set(by_value) == {"quad", "octal", "hex"}
     # Variants are lowercased to match the board catalog ``esphome.variant`` form.
-    assert by_value["octal"] == ["esp32s3"]
-    assert by_value["hex"] == ["esp32p4"]
+    # Membership, not equality: esphome adds octal/hex variants over time (e.g.
+    # esp32s31), and pinning the exact set would lockstep this repo to it.
+    assert "esp32s3" in by_value["octal"]
+    assert "esp32p4" in by_value["hex"]
     assert "esp32" in by_value["quad"] and "esp32s3" in by_value["quad"]
     # No single default is valid on every chip (P4 needs hex, not quad).
     assert "default_value" not in mode
@@ -49,8 +51,9 @@ def test_speed_unions_all_variant_speeds_ascending() -> None:
     values = list(by_value)
     assert {"40MHZ", "80MHZ", "120MHZ", "200MHZ"} <= set(values)
     assert values == sorted(values, key=lambda v: int(v[:-3]))
-    # 20MHZ is P4-only; 40MHZ covers the classic chips.
-    assert by_value["20MHZ"] == ["esp32p4"]
+    # 20MHZ is P4-only; 40MHZ covers the classic chips. Membership, not equality,
+    # so esphome adding speeds/variants (e.g. esp32s31's 250MHZ) can't lockstep us.
+    assert "esp32p4" in by_value["20MHZ"]
     assert "esp32" in by_value["40MHZ"]
     # P4's 40MHZ is invalid, so no cross-chip default is shipped.
     assert "default_value" not in speed

--- a/tests/test_sync_components_psram.py
+++ b/tests/test_sync_components_psram.py
@@ -34,8 +34,6 @@ def test_mode_is_a_select_of_every_variant_mode() -> None:
     by_value = {o["value"]: o["variants"] for o in mode["options"]}
     assert set(by_value) == {"quad", "octal", "hex"}
     # Variants are lowercased to match the board catalog ``esphome.variant`` form.
-    # Membership, not equality: esphome adds octal/hex variants over time (e.g.
-    # esp32s31), and pinning the exact set would lockstep this repo to it.
     assert "esp32s3" in by_value["octal"]
     assert "esp32p4" in by_value["hex"]
     assert "esp32" in by_value["quad"] and "esp32s3" in by_value["quad"]
@@ -51,8 +49,7 @@ def test_speed_unions_all_variant_speeds_ascending() -> None:
     values = list(by_value)
     assert {"40MHZ", "80MHZ", "120MHZ", "200MHZ"} <= set(values)
     assert values == sorted(values, key=lambda v: int(v[:-3]))
-    # 20MHZ is P4-only; 40MHZ covers the classic chips. Membership, not equality,
-    # so esphome adding speeds/variants (e.g. esp32s31's 250MHZ) can't lockstep us.
+    # 20MHZ is P4-only; 40MHZ covers the classic chips.
     assert "esp32p4" in by_value["20MHZ"]
     assert "esp32" in by_value["40MHZ"]
     # P4's 40MHZ is invalid, so no cross-chip default is shipped.


### PR DESCRIPTION
# What does this implement/fix?

`test_sync_components_psram.py` pinned the **exact** variant list per psram mode and speed — e.g. `assert by_value["octal"] == ["esp32s3"]` and `assert by_value["20MHZ"] == ["esp32p4"]`. Those lists are derived from the installed esphome's `psram` `CONFIG_SCHEMA`, so the moment esphome adds a psram variant they flip from equality to inequality and the assertion fails.

esphome/esphome#17192 adds octal PSRAM for ESP32-S31 and quad for ESP32-H4, which turns `by_value["octal"]` into `["esp32s3", "esp32s31"]` — breaking this repo's **downstream** test run against esphome `dev`, with no way for either side to go green first (the same lockstep that esphome/device-builder#1681 fixed for `has_native_wifi`).

Fix: assert **membership** (`"esp32s3" in by_value["octal"]`) instead of equality. The unioning logic stays covered (each mode/speed is still tagged with the variants that accept it) without pinning to esphome's exact, growing variant set. Verified the membership assertions hold against the currently-installed esphome.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [ ] The code change is tested and works locally. *(Verified the assertions against installed esphome by calling `_psram_config_entries()` directly; full pytest suite can't run in this env — `conftest` dep unavailable. CI runs it.)*
- [ ] Pre-commit hooks pass. *(ruff/codespell ran on commit)*
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md` (N/A).
