### PR TITLE
Document deployment-mode network and auth boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,12 @@ secrets.yaml
 htmlcov/
 
 # Stray notes / screenshots dropped at the repo root during development.
-# The only root-level docs we track are README.md and CLAUDE.md.
+# The only root-level docs we track are README.md and CLAUDE.md
+# (AGENTS.md is a symlink to CLAUDE.md).
 /*.md
 !/README.md
 !/CLAUDE.md
+!/AGENTS.md
 /*.png
 
 # Stray top-level YAML must never be committed: a misplaced device config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,50 @@ against legacy behaviour before assuming the simpler version suffices.
   in `helpers/windows_build_paths` to relocate `CORE.data_dir` to
   `C:\esphb\<id8>` (clears `MAX_PATH` + spaces), so don't assume
   default-mode `<config>/.esphome` paths on Windows.
+- **Deployment modes also change the network & auth boundary; never
+  widen a bind or drop a credential source.** The on-disk table above is
+  only half the story; each mode also has a distinct trust posture, and
+  two advisories (GHSA-vv4j-m4vr-f3g6, GHSA-rrxg-g2pf-6hh4) came from
+  missing it. `docs/THREAT_MODEL.md` is the source of truth for the one
+  trust boundary; `docs/ARCHITECTURE.md` (ingress / host-network /
+  peer-guard) is the full narrative. The shapes:
+
+  | Mode | Bind | Auth |
+  |---|---|---|
+  | Standalone public (default / Docker) | `--host:--port` (`0.0.0.0:6052`) | password gate (`using_password`), WS in-band `auth` handshake, `--trusted-domains` Origin/Host allowlist |
+  | HA add-on ingress (default add-on) | `ingress_bind_hosts:ingress_port`, loopback + `172.30.32.1` only, NEVER `0.0.0.0` | none in-process by design; the supervisor authenticates upstream, and `ingress_peer_guard` restricts source peers to loopback / `172.30.32.2` |
+  | HA add-on public opt-in | public `6052`, `trusted=False, peer_guard=False` | none; requires both `DISABLE_HA_AUTHENTICATION` (`leave_front_door_open`) and a mapped port 6052 (`serve_public_unauthenticated`), Origin gate still active |
+
+  * **The ingress site is unauthenticated on purpose; its only boundary
+    is where it binds plus the peer guard.** The add-on runs host-network
+    for mDNS, so `0.0.0.0` would put the no-auth site on the LAN
+    (GHSA-vv4j-m4vr-f3g6, #1565). Two defenses, keep both:
+    `HA_INGRESS_DEFAULT_BIND_HOSTS` (`constants.py`) limits *where* it
+    listens; `ingress_peer_guard` (`helpers/auth.py`) limits *who* can
+    connect. `--ingress-host` may override the bind, but the peer guard
+    still restricts sources regardless. Never widen the ingress bind to
+    all interfaces.
+  * **Credential precedence** (`helpers/credentials.py:resolve_credentials`,
+    via `DashboardSettings.parse_args`): CLI `--username`/`--password`,
+    then `$ESPHOME_USERNAME` / `$ESPHOME_PASSWORD`, then the deprecated
+    bare `$USERNAME` / `$PASSWORD` (pair-only, gated on `$PASSWORD` so the
+    OS login `$USERNAME` is never read alone). Renaming or dropping a
+    credential source silently disabled auth for operators relying on it
+    (GHSA-rrxg-g2pf-6hh4); never remove a credential input without a
+    gated fallback and a loud deprecation. Auth resolution changes must
+    fail loud / closed, never silently open.
+  * **Mode plumbing:** `--ha-addon` sets `settings.on_ha_addon`;
+    esphome's `is_ha_addon()` is a *separate* signal (data-dir
+    resolution), not the flag. Mode branching is in `device_builder.py`
+    `run()`; the `front_door_open` / `serve_public_unauthenticated` /
+    `create_ingress_site` properties are in `controllers/config/
+    settings.py`. The add-on's own config (`host_network: true`,
+    `ingress: true`, `ingress_port: 0`, unmapped `6052`) lives in the
+    separate `esphome/home-assistant-addon` repo (metadata-only,
+    template-generated); the run script that passes `--ha-addon` is baked
+    into the `ghcr.io/esphome/esphome-hassio` image, not that repo. The
+    ingress-only-by-design decline is at `device_builder.py:419` (issue
+    #85).
 - **`config_hash` source of truth is `build_info.json`.** ESPHome writes
   `<storage.build_path>/build_info.json` after every successful compile
   *and* every `--only-generate` (the `write_cpp(config)` call runs before
@@ -607,6 +651,20 @@ When changing the sync script or catalog handling, watch for these:
   `tests/benchmarks/test_peer_link_noise_xx.py`:
   `pytest.param(_NEWLINE_PAYLOAD, 1000, id="newline_1k")`,
   `pytest.param(1024, id="1KiB")`. Bare ints / short slugs are fine.
+- **Binding the ingress site to `0.0.0.0` exposed it on the LAN.** The
+  HA-addon ingress site is unauthenticated by design; its only boundary
+  is its bind target plus `ingress_peer_guard`. The add-on runs
+  host-network for mDNS, so `0.0.0.0` reached every LAN device with no
+  credentials. Bind only `HA_INGRESS_DEFAULT_BIND_HOSTS` (loopback +
+  supervisor gateway) and keep the peer guard. (GHSA-vv4j-m4vr-f3g6,
+  #1565; see the network & auth boundary table above.)
+- **Renaming an auth env var silently disabled auth on upgrade.**
+  Dropping the bare `$USERNAME` / `$PASSWORD` fallback for `$ESPHOME_*`
+  left operators who set the old names with no credentials and no error;
+  `docker run -d` never surfaces the `WITHOUT AUTHENTICATION` banner.
+  Keep a gated deprecated fallback when moving a credential source, and
+  make auth resolution fail loud, not open. (GHSA-rrxg-g2pf-6hh4, fix
+  1.0.12.)
 
 ## Useful entry points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,9 @@ upstream-canonical reference for shared concerns (mDNS source dispatch,
 build-info hashes, StorageJSON layout, `CORE` lifecycle, `address_cache`
 semantics). Functional parity is essentially achieved as of 2026-05; the
 one intentional decline is the HA Supervisor `/auth` POST flow (our HA
-add-on path is ingress-only by design — issue #85, inline comment at
-`device_builder.py:419`). Before declaring a new feature complete, check
+add-on path is ingress-only by design; issue #85, in
+`device_builder.py`'s `_warn_front_door_open` / `front_door_open`
+block). Before declaring a new feature complete, check
 the open issue list filtered to "legacy parity".
 
 **Lessons about the comparison itself:** the legacy code is
@@ -446,8 +447,8 @@ against legacy behaviour before assuming the simpler version suffices.
     separate `esphome/home-assistant-addon` repo (metadata-only,
     template-generated); the run script that passes `--ha-addon` is baked
     into the `ghcr.io/esphome/esphome-hassio` image, not that repo. The
-    ingress-only-by-design decline is at `device_builder.py:419` (issue
-    #85).
+    ingress-only-by-design decline lives in `device_builder.py`'s
+    `_warn_front_door_open` / `front_door_open` block (issue #85).
 - **`config_hash` source of truth is `build_info.json`.** ESPHome writes
   `<storage.build_path>/build_info.json` after every successful compile
   *and* every `--only-generate` (the `write_cpp(config)` call runs before

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,8 +217,9 @@ build-info hashes, StorageJSON layout, `CORE` lifecycle, `address_cache`
 semantics). Functional parity is essentially achieved as of 2026-05; the
 one intentional decline is the HA Supervisor `/auth` POST flow (our HA
 add-on path is ingress-only by design; issue #85, in
-`device_builder.py`'s `_warn_front_door_open` / `front_door_open`
-block). Before declaring a new feature complete, check
+`device_builder.py`'s `_warn_front_door_open`, gated on the
+`DashboardSettings.front_door_open` property in
+`controllers/config/settings.py`). Before declaring a new feature complete, check
 the open issue list filtered to "legacy parity".
 
 **Lessons about the comparison itself:** the legacy code is
@@ -415,7 +416,7 @@ against legacy behaviour before assuming the simpler version suffices.
 
   | Mode | Bind | Auth |
   |---|---|---|
-  | Standalone public (default / Docker) | `--host:--port` (`0.0.0.0:6052`) | password gate (`using_password`), WS in-band `auth` handshake, `--trusted-domains` Origin/Host allowlist |
+  | Standalone public (default / Docker) | `--host:--port` (`0.0.0.0:6052`) | password gate + WS in-band `auth` handshake *only when* `using_password`; with no credentials it runs open and logs a `WITHOUT AUTHENTICATION` banner. `--trusted-domains` Origin/Host allowlist always applies |
   | HA add-on ingress (default add-on) | `ingress_bind_hosts:ingress_port`, loopback + `172.30.32.1` only, NEVER `0.0.0.0` | none in-process by design; the supervisor authenticates upstream, and `ingress_peer_guard` restricts source peers to loopback / `172.30.32.2` |
   | HA add-on public opt-in | public `6052`, `trusted=False, peer_guard=False` | none; requires both `DISABLE_HA_AUTHENTICATION` (`leave_front_door_open`) and a mapped port 6052 (`serve_public_unauthenticated`), Origin gate still active |
 
@@ -448,7 +449,8 @@ against legacy behaviour before assuming the simpler version suffices.
     template-generated); the run script that passes `--ha-addon` is baked
     into the `ghcr.io/esphome/esphome-hassio` image, not that repo. The
     ingress-only-by-design decline lives in `device_builder.py`'s
-    `_warn_front_door_open` / `front_door_open` block (issue #85).
+    `_warn_front_door_open`, gated on the `DashboardSettings.front_door_open`
+    property in `controllers/config/settings.py` (issue #85).
 - **`config_hash` source of truth is `build_info.json`.** ESPHome writes
   `<storage.build_path>/build_info.json` after every successful compile
   *and* every `--only-generate` (the `write_cpp(config)` call runs before


### PR DESCRIPTION
# What does this implement/fix?

Two recent advisories (GHSA-vv4j-m4vr-f3g6, GHSA-rrxg-g2pf-6hh4) both came from missing the per deployment mode network and auth boundary; the existing CLAUDE.md "Deployment modes" section only covers on-disk paths. This adds a network and auth boundary table next to it (standalone public, HA add-on ingress, add-on public opt-in), notes that the ingress site is unauthenticated by design and protected only by its bind target plus the peer guard, and records the credential precedence. It also adds two "Things that have bitten us before" entries for the two advisories, and cross references THREAT_MODEL.md and ARCHITECTURE.md.

An AGENTS.md symlink to CLAUDE.md is added so agent tooling that looks for AGENTS.md picks up the same notes. Docs only, no behaviour change.

**Related issue or feature (if applicable):**

- GHSA-vv4j-m4vr-f3g6
- GHSA-rrxg-g2pf-6hh4

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
