### PR TITLE
Raise instead of assert for empty libretiny families

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -6683,7 +6683,8 @@ def _libretiny_families() -> tuple[str, ...]:
     from esphome.components.libretiny.const import FAMILY_COMPONENT
 
     families = tuple(sorted(set(FAMILY_COMPONENT.values())))
-    assert families, "esphome FAMILY_COMPONENT yielded no libretiny families"
+    if not families:
+        raise RuntimeError("esphome FAMILY_COMPONENT yielded no libretiny families")
     return families
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1697. The empty-`FAMILY_COMPONENT` guard in `_libretiny_families` was an `assert`, which `python -O` / `PYTHONOPTIMIZE` compiles out; under an optimized interpreter the guard silently disappears and an empty expansion re-leaks libretiny components onto every platform, the exact failure the sync should fail loud on. Raise a `RuntimeError` unconditionally instead, matching the eager-import guard right above it.

No behaviour change for a normal interpreter; the happy path still returns the three families.

**Related issue or feature (if applicable):**

- follow-up to #1697 (Kōan review suggestion)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
