### PR TITLE
Union referenced bus hubs into component dependencies

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2113,6 +2113,15 @@ def build_component_entry(
     if domain and stem not in dependencies and _references_own_hub(config_entries, stem):
         dependencies.append(stem)
 
+    # A device that cross-references a bus hub (``spi_id`` / ``i2c_id`` /
+    # ``uart_id``) needs that bus block to exist; ESPHome enforces it at config
+    # time but doesn't always list it in ``DEPENDENCIES`` (atm90e32, max6675,
+    # i2c touchscreens), so the schema index ships them bus-less and the
+    # frontend never prompts to add the bus. Union the referenced bus back in.
+    for bus in sorted(_referenced_buses(config_entries)):
+        if bus not in dependencies:
+            dependencies.append(bus)
+
     # Drop deps the chosen networking transport will auto-load. See
     # ``_implicit_dependencies``.
     implicit = _implicit_dependencies()
@@ -5173,6 +5182,19 @@ def _references_own_hub(config_entries: list[dict], stem: str) -> bool:
 
     _walk_catalog_entries(config_entries, visit)
     return found
+
+
+def _referenced_buses(config_entries: list[dict]) -> set[str]:
+    """Bus components (``i2c`` / ``spi`` / ``uart`` / ...) a config var cross-references via use_id."""
+    buses: set[str] = set()
+
+    def visit(entry: dict, _path: tuple[str, ...]) -> None:
+        ref = entry.get("references_component")
+        if ref is not None and _CATEGORY_OVERRIDES.get(ref) == "bus":
+            buses.add(ref)
+
+    _walk_catalog_entries(config_entries, visit)
+    return buses
 
 
 # Capability validators ESPHome wraps a pin field in when the pin must

--- a/tests/test_sync_components_hub_dependencies.py
+++ b/tests/test_sync_components_hub_dependencies.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from script.sync_components import (  # type: ignore[import-not-found]
     SchemaIndex,
+    _referenced_buses,
     _references_own_hub,
     build_component_entry,
 )
@@ -60,12 +61,41 @@ def test_existing_hub_dependency_not_duplicated() -> None:
     assert entry["dependencies"] == ["myhub"]
 
 
-def test_cross_component_refs_not_unioned() -> None:
-    """Only the entry's own hub is unioned — i2c/uart-style refs stay out."""
-    section = _section({"i2c_id": _use_id_var("i2c")})
+def test_non_bus_cross_component_ref_not_unioned() -> None:
+    """An optional sibling ref (output/power_supply/...) is never a hard dependency."""
+    section = _section({"output_id": _use_id_var("output")})
     entry = build_component_entry("myhub.button", section, SchemaIndex(), _UNUSED_SCHEMA_DIR, {})
     assert entry is not None
     assert entry["dependencies"] == []
+
+
+def test_bus_ref_gains_dependency() -> None:
+    """A bus use_id ref (spi/i2c/uart) ESPHome omits from DEPENDENCIES is unioned in."""
+    section = _section({"i2c_id": _use_id_var("i2c")})
+    entry = build_component_entry("myhub.button", section, SchemaIndex(), _UNUSED_SCHEMA_DIR, {})
+    assert entry is not None
+    assert entry["dependencies"] == ["i2c"]
+
+
+def test_referenced_buses_only_buses() -> None:
+    entries = [
+        {"key": "spi_id", "references_component": "spi"},
+        {"key": "output_id", "references_component": "output"},
+        {"key": "plain", "references_component": None},
+    ]
+    assert _referenced_buses(entries) == {"spi"}
+
+
+def test_referenced_buses_nested_and_deduped() -> None:
+    entries = [
+        {"key": "uart_id", "references_component": "uart"},
+        {
+            "key": "outer",
+            "references_component": None,
+            "config_entries": [{"key": "uart2_id", "references_component": "uart"}],
+        },
+    ]
+    assert _referenced_buses(entries) == {"uart"}
 
 
 def test_hub_build_not_unioned() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adding a component that rides a bus (for example an `atm90e32` button, or its `atm90e32` sensor hub) did not prompt to add the `spi` bus, so the config compiled to `Couldn't find any component that can be used for 'spi::SPIComponent'`. The catalog's `dependencies` is what drives the frontend's "add the bus" prompt, and most bus devices already list their bus there; but ESPHome doesn't always put the bus in a component's `DEPENDENCIES` (atm90e32, max6675, several i2c touchscreens rely on the device schema's `spi_id`/`i2c_id` ref plus a config-time check), so the schema index shipped about 30 of them bus-less.

The generator already unions a platform's own hub stem into `dependencies` when it's bound by a `use_id` ref instead of `DEPENDENCIES`; this applies the same idea to bus references. `_referenced_buses` collects any `references_component` whose category is `bus` (spi/i2c/uart/one_wire/modbus/canbus, via the existing `_CATEGORY_OVERRIDES` table) and unions it in. It is scoped to bus refs deliberately; optional sibling refs like `output_id` must not become hard dependencies.

The regenerated catalog is not in this PR; the nightly sync will pick it up. I verified locally that a regen adds only the bus dependency to the affected entries.

**Related issue or feature (if applicable):**

- n/a (reported in testing: adding an `atm90e32` button did not require `spi`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
