### PR TITLE
Materialise nested featured presets and flag preset fields

### DIFF
--- a/esphome_device_builder/controllers/components/_resolve.py
+++ b/esphome_device_builder/controllers/components/_resolve.py
@@ -14,6 +14,7 @@ from ...models import (
     ComponentCatalogIndexEntry,
     ComponentCategory,
     ConfigEntry,
+    ConfigEntryType,
     FeaturedComponent,
     FieldPreset,
 )
@@ -164,12 +165,38 @@ def _materialise_entry_with_preset(
     base = _materialise_entry(entry, target_platform, target_variant)
     if preset is None:
         return base
-    if preset.value is not None:
-        base.default_value = preset.value  # type: ignore[assignment]
-    base.locked = preset.locked
+    _apply_preset_value(base, preset.value, locked=preset.locked)
     if preset.suggestions is not None:
         base.suggestions = list(preset.suggestions)
     return base
+
+
+def _apply_preset_value(entry: ConfigEntry, value: object, *, locked: bool) -> None:
+    """Stamp *value* / *locked* onto *entry*, recursing a dict into a NESTED group's leaves."""
+    entry.from_preset = True
+    if (
+        entry.type == ConfigEntryType.NESTED
+        and not entry.multi_value
+        and isinstance(value, dict)
+        and entry.config_entries
+    ):
+        unmatched = value.keys() - {child.key for child in entry.config_entries}
+        if unmatched:
+            # A curated-manifest typo or a leaf renamed by an upstream re-sync;
+            # the value would otherwise vanish with no signal.
+            _LOGGER.debug(
+                "Featured preset for %r has keys with no matching child: %s",
+                entry.key,
+                sorted(unmatched),
+            )
+        for child in entry.config_entries:
+            if child.key in value:
+                _apply_preset_value(child, value[child.key], locked=locked)
+        entry.locked = locked
+        return
+    if value is not None:
+        entry.default_value = value  # type: ignore[assignment]
+    entry.locked = locked
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/models/common.py
+++ b/esphome_device_builder/models/common.py
@@ -496,6 +496,12 @@ class ConfigEntry(DashboardModel):
     locked: bool = False
     suggestions: list[ConfigPrimitive] | None = None
 
+    # True on entries that carry a board-side preset value (locked,
+    # suggestion, or plain value). Tells the add form to seed this field
+    # while leaving plain catalog defaults unseeded, so a featured add
+    # emits only the preset fields — matching the create-time auto-add.
+    from_preset: bool = False
+
     # === conditional visibility ===
     # `depends_on_value`, `depends_on_value_not` and
     # `depends_on_value_any` are mutually exclusive — set at most one.

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -26,6 +26,7 @@ import pytest
 
 from esphome_device_builder import definitions
 from esphome_device_builder.controllers.components import ComponentCatalog
+from esphome_device_builder.controllers.components._resolve import _apply_preset_value
 from esphome_device_builder.controllers.devices import DevicesController
 from esphome_device_builder.controllers.devices._state import DevicesState
 from esphome_device_builder.controllers.devices.helpers import (
@@ -40,7 +41,7 @@ from esphome_device_builder.definitions import (
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.yaml import generate_component_yaml
-from esphome_device_builder.models import ComponentCategory, ErrorCode
+from esphome_device_builder.models import ComponentCategory, ConfigEntry, ConfigEntryType, ErrorCode
 from esphome_device_builder.models.boards import FeaturedComponent
 from esphome_device_builder.models.common import FieldPreset
 
@@ -54,6 +55,48 @@ pytestmark = pytest.mark.xdist_group("catalog")
 # ---------------------------------------------------------------------------
 # Loader-level (pure unit tests, no catalog)
 # ---------------------------------------------------------------------------
+
+
+def test_apply_preset_value_recurses_nested_dict() -> None:
+    """A dict on a NESTED group lands on leaves; a pin entry keeps its dict verbatim."""
+    nested = ConfigEntry(
+        key="clk",
+        label="Clk",
+        type=ConfigEntryType.NESTED,
+        config_entries=[
+            ConfigEntry(key="pin", label="Pin", type=ConfigEntryType.PIN),
+            ConfigEntry(key="mode", label="Mode", type=ConfigEntryType.STRING),
+        ],
+    )
+    _apply_preset_value(nested, {"pin": "GPIO17", "mode": "CLK_OUT"}, locked=True)
+    assert nested.default_value is None
+    assert nested.from_preset is True
+    assert [(c.default_value, c.locked, c.from_preset) for c in nested.config_entries] == [
+        ("GPIO17", True, True),
+        ("CLK_OUT", True, True),
+    ]
+
+    pin = ConfigEntry(key="power_pin", label="Power Pin", type=ConfigEntryType.PIN)
+    _apply_preset_value(pin, {"number": "GPIO12"}, locked=True)
+    assert pin.default_value == {"number": "GPIO12"}
+    assert pin.from_preset is True
+
+
+def test_apply_preset_value_logs_unmatched_nested_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A preset dict key with no matching child is dropped but logged for diagnosis."""
+    nested = ConfigEntry(
+        key="clk",
+        label="Clk",
+        type=ConfigEntryType.NESTED,
+        config_entries=[ConfigEntry(key="pin", label="Pin", type=ConfigEntryType.PIN)],
+    )
+    with caplog.at_level("DEBUG"):
+        _apply_preset_value(nested, {"pin": "GPIO17", "pn": "typo"}, locked=True)
+    assert nested.config_entries[0].default_value == "GPIO17"
+    assert "no matching child" in caplog.text
+    assert "pn" in caplog.text
 
 
 def test_coerce_primitive_shorthand() -> None:
@@ -282,6 +325,23 @@ async def test_get_component_id_from_manifest_field(catalog: ComponentCatalog) -
     id_field = next(ce for ce in entry.config_entries if ce.key == "id")
     assert id_field.default_value == "button"
     assert id_field.locked is False
+
+
+async def test_get_component_nested_preset_reaches_leaves(catalog: ComponentCatalog) -> None:
+    """A dict preset on a NESTED group (esp32-poe-iso ``clk``) lands on its leaf children."""
+    entry = await catalog.get_component(component_id="featured.esp32-poe-iso.onboard_ethernet")
+    assert entry is not None
+    clk = next(ce for ce in entry.config_entries if ce.key == "clk")
+    pin = next(ce for ce in clk.config_entries if ce.key == "pin")
+    mode = next(ce for ce in clk.config_entries if ce.key == "mode")
+    assert (pin.default_value, pin.locked, pin.from_preset) == ("GPIO17", True, True)
+    assert (mode.default_value, mode.locked, mode.from_preset) == ("CLK_OUT", True, True)
+    # A ``pin``-typed group keeps its dict value verbatim (the pin renderer reads it).
+    power_pin = next(ce for ce in entry.config_entries if ce.key == "power_pin")
+    assert power_pin.default_value == {"number": "GPIO12", "ignore_strapping_warning": True}
+    # Plain catalog defaults stay unmarked so the add form doesn't seed them.
+    clock_speed = next(ce for ce in entry.config_entries if ce.key == "clock_speed")
+    assert clock_speed.from_preset is False
 
 
 async def test_get_component_name_from_manifest_field(


### PR DESCRIPTION
# What does this implement/fix?

Two fixes for featured-component materialisation, both surfaced by the OLIMEX
ESP32-PoE-ISO "Onboard Ethernet" featured component.

1. **Nested presets reach their leaves.** A dict-shaped preset on a NESTED group
   (e.g. `clk: {pin, mode}`) was stamped onto the parent entry's `default_value`,
   but the frontend seeds NESTED groups by their leaf children, so `clk.pin` /
   `clk.mode` rendered empty. `_apply_preset_value` now recurses a dict preset into
   the group's leaves, propagating `locked`. A `pin`-typed entry keeps its dict
   value verbatim (the pin renderer reads it), so `power_pin` is unchanged.

2. **Preset fields are flagged with `from_preset`.** Value-only presets are
   pervasive across the bundle catalog and are indistinguishable from plain catalog
   defaults once materialised. The new `ConfigEntry.from_preset` flag marks every
   preset-bearing entry, so the frontend can seed presets while leaving plain
   catalog defaults unseeded (companion frontend PR makes the featured add emit only
   the preset fields, matching the create-time auto-add and re-enabling Add).

`from_preset` defaults to `False` and is set only at featured-materialise time, so
the static catalog JSON is unaffected.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Frontend coordination

- [x] Companion frontend PR: esphome/device-builder-frontend#994

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
