### PR TITLE
Disable version history on a broken-symlink .git too

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -191,11 +191,15 @@ class GitRepo:
                     self.config_dir,
                     toplevel,
                 )
-            elif (self.config_dir / ".git").exists():
-                # rev-parse found no work tree yet ``.git`` is present: an
-                # unusable git dir (a submodule / worktree pointer whose
-                # target isn't mounted, or a corrupt repo). Re-initialising
-                # over it fails, so disable rather than crash on init.
+            elif (git_entry := self.config_dir / ".git").is_symlink() or git_entry.exists():
+                # rev-parse found no work tree yet ``.git`` is physically
+                # present: an unusable git dir (a submodule / worktree pointer
+                # file or symlink whose target isn't mounted, or a corrupt
+                # repo). ``is_symlink()`` catches a broken symlink that
+                # ``exists()`` misses; a valid symlink to a usable repo never
+                # reaches here (rev-parse would have found its work tree).
+                # Re-initialising over it fails, so disable rather than crash
+                # on init.
                 _LOGGER.info(
                     "Config dir %s has a .git git can't use here (likely a submodule or "
                     "worktree whose git dir isn't mounted); version history disabled",

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -74,11 +74,49 @@ def test_init_creates_repo_and_gitignore(tmp_path: Path) -> None:
     assert "Initialize version history" in _git(tmp_path, "log", "--format=%s")
 
 
-def test_unusable_git_pointer_disables_without_raising(tmp_path: Path) -> None:
-    """A ``.git`` pointing at a missing git dir (broken submodule) disables rather than crashing."""
-    # Mirrors a submodule whose parent ``.git/modules`` tree isn't mounted:
-    # ``git init`` over this pointer aborts with ``fatal: not a git repository``.
-    (tmp_path / ".git").write_text("gitdir: ./nonexistent/git/dir\n", encoding="utf-8")
+@pytest.mark.parametrize(
+    "pointer",
+    [
+        # The exact submodule pointer from #1710: a relative gitdir into the
+        # parent repo's ``.git/modules`` tree, which isn't mounted in the
+        # container, so it resolves to nothing.
+        "gitdir: ../../../.git/modules/vms/smarthome/esphome\n",
+        "gitdir: ./nonexistent/git/dir\n",
+        "gitdir: /nonexistent/.git/modules/x\n",
+    ],
+)
+def test_unusable_git_pointer_disables_without_raising(tmp_path: Path, pointer: str) -> None:
+    """A ``.git`` pointer at a missing git dir (broken submodule) disables rather than crashing."""
+    # ``git init`` over such a pointer aborts with ``fatal: not a git repository``.
+    (tmp_path / ".git").write_text(pointer, encoding="utf-8")
+    repo = GitRepo(config_dir=tmp_path)
+
+    repo.discover_or_init()
+
+    assert not repo.enabled
+    assert repo.toplevel is None
+    assert not repo.managed
+
+
+def test_unusable_git_pointer_to_empty_dir_disables(tmp_path: Path) -> None:
+    """A ``.git`` pointer whose target exists but is empty (partial mount) disables."""
+    empty = tmp_path / "empty-git-dir"
+    empty.mkdir()
+    (tmp_path / ".git").write_text(f"gitdir: {empty}\n", encoding="utf-8")
+    repo = GitRepo(config_dir=tmp_path)
+
+    repo.discover_or_init()
+
+    assert not repo.enabled
+    assert repo.toplevel is None
+    assert not repo.managed
+
+
+def test_broken_git_symlink_disables_without_initialising(tmp_path: Path) -> None:
+    """A broken-symlink ``.git`` disables instead of silently initialising a stray repo."""
+    # ``Path.exists()`` follows the dangling link and reports False; the guard
+    # must still treat the symlink as a present-but-unusable git entry.
+    (tmp_path / ".git").symlink_to(tmp_path / "missing-git-dir")
     repo = GitRepo(config_dir=tmp_path)
 
     repo.discover_or_init()


### PR DESCRIPTION
# What does this implement/fix?

Version history disables itself when `/config` has a `.git` git can't use here; #1649 already covers a submodule or worktree pointer file whose target git dir isn't mounted (the #1710 crash, since fixed and released in device-builder 1.0.14 and later). This closes the remaining hole: a broken symlink `.git` slipped past the `Path.exists()` check, which follows the dangling link and returns False, so it fell through to `git init` and enabled a stray repo instead of disabling. The guard now also treats a symlink as a present-but-unusable git entry, so every `.git` shape (pointer file, directory, symlink) is caught before init, independent of how `git init` happens to behave over it.

Adds regression tests pinning the real-world #1710 variants (the exact relative `gitdir:` pointer, an absolute missing pointer, a partial or empty mount) plus the newly covered broken symlink.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1710

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
