### PR TITLE
Don't adopt an enclosing git repo that ignores the config dir

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -177,7 +177,11 @@ class GitRepo:
             return
         try:
             toplevel = self._discover_toplevel()
-            if toplevel is not None and not _encloses_own_source(toplevel):
+            if (
+                toplevel is not None
+                and not _encloses_own_source(toplevel)
+                and not self._enclosing_repo_ignores_config_dir()
+            ):
                 self.toplevel = toplevel
                 self.enabled = True
                 self.managed = self._adopt_ownership()
@@ -185,10 +189,16 @@ class GitRepo:
                 _LOGGER.debug("Adopted existing git work tree at %s", toplevel)
                 return
             if toplevel is not None:
+                reason = (
+                    "is inside the Device Builder source checkout"
+                    if _encloses_own_source(toplevel)
+                    else "is ignored by the enclosing git repo"
+                )
                 _LOGGER.info(
-                    "Config dir %s is inside the Device Builder source checkout (%s); "
-                    "creating a config-local history repo instead of committing into it",
+                    "Config dir %s %s (%s); creating a config-local history repo "
+                    "instead of committing into it",
                     self.config_dir,
+                    reason,
                     toplevel,
                 )
             elif (git_entry := self.config_dir / ".git").is_symlink() or git_entry.exists():
@@ -231,6 +241,20 @@ class GitRepo:
             return None
         root = result.stdout.strip()
         return Path(root) if root else None
+
+    def _enclosing_repo_ignores_config_dir(self) -> bool:
+        """Whether the enclosing work tree ignores ``config_dir`` itself.
+
+        A ``/config`` inside an unrelated checkout that ``.gitignore``s it can
+        never track our YAML, so adopting would back up nothing while still
+        writing into that repo; init a config-local repo instead.
+        """
+        result = self._run(
+            ["check-ignore", "-q", str(self.config_dir)],
+            cwd=self.config_dir,
+            check=False,
+        )
+        return result.returncode == 0
 
     def _init_repo(self) -> None:
         """Create a fresh repo in ``config_dir`` and seed the existing configs.

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -241,6 +241,36 @@ def test_declines_to_adopt_own_source_checkout(
     assert (configs / ".git").is_dir()
 
 
+def test_declines_to_adopt_repo_that_ignores_config_dir(tmp_path: Path) -> None:
+    """A config dir gitignored by its enclosing repo gets a nested repo, not adoption.
+
+    Adopting an enclosing checkout that ``.gitignore``s the config dir backs up
+    nothing (git refuses the ignored YAML) while still writing our managed block
+    into that unrelated repo (#1718).
+    """
+    _make_repo(tmp_path)  # stands in for the unrelated esphome/esphome checkout
+    config = tmp_path / "config"
+    config.mkdir()
+    (tmp_path / ".gitignore").write_text("config/\n", encoding="utf-8")
+    _git(tmp_path, "add", ".gitignore")
+    _git(tmp_path, "commit", "-m", "ignore config")
+    (config / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    repo = GitRepo(config_dir=config)
+    repo.discover_or_init()
+
+    assert repo.enabled
+    assert repo.toplevel == config  # nested repo, not the enclosing one
+    assert (config / ".git").is_dir()
+    # The seed actually committed the config the adopted parent could never track.
+    assert "kitchen.yaml" in _git(config, "ls-files").split()
+    assert "Initialize version history" in _git(config, "log", "--format=%s")
+    # The unrelated parent repo was left untouched.
+    assert "ESPHome Device Builder" not in (tmp_path / ".git" / "info" / "exclude").read_text(
+        encoding="utf-8"
+    )
+
+
 def test_init_keeps_a_preexisting_gitignore(tmp_path: Path) -> None:
     """A .gitignore already sitting in a non-repo dir is committed, not overwritten."""
     (tmp_path / ".gitignore").write_text("user-rules/\n", encoding="utf-8")


### PR DESCRIPTION
# What does this implement/fix?

When the config dir sits inside an unrelated git checkout that gitignores it (e.g. an esphome/esphome clone with `config/` in its `.gitignore`), version history walked up, found the parent work tree, and adopted it. That repo can never track our YAML (git ignores the dir), so no backup is ever created; meanwhile we still wrote our managed block into the parent's `.git/info/exclude`, mutating an unrelated repo.

This declines to adopt an enclosing repo that ignores the config dir and creates a config-local repo instead, mirroring the existing decline path for the Device Builder source checkout. Detection is a single `git check-ignore` of the config dir; a non-ignored subdir (the normal `/config` case) still adopts as before.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1718

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
