### PR TITLE
Make BOARD_PIN_KEYS a single source and complete the key set

### DIFF
--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -75,3 +75,21 @@ HA_INGRESS_DEFAULT_BIND_HOSTS = ("127.0.0.1", HA_SUPERVISOR_NETWORK_GATEWAY)
 # forward secrecy at the application layer, so there's no SSLContext
 # to manage.
 DEFAULT_REMOTE_BUILD_PORT = 6055
+
+
+# Long-form pin keys describing a board GPIO. Any other key in a pin mapping
+# names an I/O-expander provider whose value is the hub id. ``id`` is included
+# because expander pin schemas share this base, so a channel carrying an ``id``
+# must not have it taken for the provider key.
+BOARD_PIN_KEYS: frozenset[str] = frozenset(
+    {
+        "id",
+        "number",
+        "mode",
+        "inverted",
+        "allow_other_uses",
+        "ignore_strapping_warning",
+        "ignore_pin_validation_error",
+        "drive_strength",
+    }
+)

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -21,15 +21,6 @@ from .common import (
 _ = PinFeature  # suppress "imported but unused" — this is a re-export
 
 
-# Long-form pin sub-keys that describe a board GPIO. Any other key in a pin
-# mapping names an I/O-expander provider (``pcf8574``, ``mcp23xxx``, …) whose
-# value is a hub instance id and whose ``number`` is an expander channel, not a
-# board GPIO. Single source of truth for the sync + validation scripts.
-BOARD_PIN_KEYS: frozenset[str] = frozenset(
-    {"number", "mode", "inverted", "ignore_strapping_warning", "allow_other_uses", "drive_strength"}
-)
-
-
 class Connectivity(StrEnum):
     """Known connectivity types."""
 

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -64,6 +64,7 @@ from _catalog_split import (  # noqa: E402
 )
 from _esphome_version import assert_installed_esphome  # noqa: E402
 
+from esphome_device_builder.constants import BOARD_PIN_KEYS  # noqa: E402
 from esphome_device_builder.definitions import (  # noqa: E402
     build_board_catalog_from_manifests,
 )
@@ -78,7 +79,6 @@ from esphome_device_builder.models import (  # noqa: E402
     PinFeature,
     Platform,
 )
-from esphome_device_builder.models.boards import BOARD_PIN_KEYS  # noqa: E402
 
 _LOGGER = logging.getLogger("sync_boards")
 

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -46,7 +46,8 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
-from esphome_device_builder.models.boards import BOARD_PIN_KEYS, Esp32Variant  # noqa: E402
+from esphome_device_builder.constants import BOARD_PIN_KEYS  # noqa: E402
+from esphome_device_builder.models.boards import Esp32Variant  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -28,7 +28,14 @@ try:
 except ImportError:
     HAS_JSONSCHEMA = False
 
-DEFINITIONS_DIR = Path(__file__).resolve().parent.parent / "esphome_device_builder" / "definitions"
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Imported from the stdlib-only constants module so this script stays light.
+from esphome_device_builder.constants import BOARD_PIN_KEYS  # noqa: E402
+
+DEFINITIONS_DIR = _REPO_ROOT / "esphome_device_builder" / "definitions"
 SCHEMAS_DIR = DEFINITIONS_DIR / "schemas"
 COMPONENTS_INDEX_JSON = DEFINITIONS_DIR / "components.index.json"
 COMPONENTS_BODIES_DIR = DEFINITIONS_DIR / "components"
@@ -41,7 +48,8 @@ _FEATURED_EXCLUDED_CATEGORIES = {"core", "ota", "time", "update"}
 # ``core`` category — auto-pulled in place of wifi: when a board has onboard
 # wired/Thread networking. Runtime counterpart is
 # ``NETWORK_PROVIDER_COMPONENT_IDS`` in helpers/device_yaml/_generation.py;
-# keep both in sync when adding a provider (this script stays import-free).
+# keep both in sync when adding a provider (that module pulls the heavy helper
+# layer, so it's mirrored here rather than imported).
 _FEATURED_CATEGORY_EXCEPTIONS = {"ethernet"}
 
 # Required shape for featured-component ids: lowercase letters, digits, and
@@ -404,19 +412,9 @@ def _is_entity_base_universal(fkey: str, category: str | None) -> bool:
     return fkey == "name" and category in _HA_ENTITY_CATEGORIES
 
 
-# Long-form pin keys describing a board GPIO. A pin dict carrying any other key
-# sits on an I/O expander (``pcf8574``, ``mcp23xxx``, …): its ``number`` is an
-# expander channel, not a board GPIO, so it isn't checked against the board pins.
-# Mirror of ``esphome_device_builder.models.boards.BOARD_PIN_KEYS`` — kept inline
-# because this validator stays import-free (see top-of-file note); keep in sync.
-_LONG_FORM_PIN_KEYS = frozenset(
-    {"number", "mode", "inverted", "ignore_strapping_warning", "allow_other_uses", "drive_strength"}
-)
-
-
 def _is_expander_pin(raw: object) -> bool:
     """Whether *raw* is a long-form pin sitting on an I/O-expander hub."""
-    return isinstance(raw, dict) and bool(raw.keys() - _LONG_FORM_PIN_KEYS)
+    return isinstance(raw, dict) and bool(raw.keys() - BOARD_PIN_KEYS)
 
 
 def _validate_field_preset(

--- a/tests/test_sync_esphome_devices_extract.py
+++ b/tests/test_sync_esphome_devices_extract.py
@@ -15,9 +15,17 @@ synthesized ``pins[]`` block with orphan GPIO labels.
 from __future__ import annotations
 
 from script.sync_esphome_devices import (  # type: ignore[import-not-found]
+    _expander_keys,
     _extract_expander_hubs,
     _extract_featured_components,
 )
+
+
+def test_expander_keys_treats_board_pin_id_as_a_board_key() -> None:
+    """A pin-level ``id`` is a board-GPIO key; the provider is the hub key, not ``id``."""
+    assert _expander_keys({"pcf8574": "hub", "number": 0, "id": "relay1"}) == {"pcf8574"}
+    assert _expander_keys({"number": 5, "id": "btn", "ignore_pin_validation_error": True}) == set()
+
 
 # Minimal fake components index — only the keys the extractor reads
 # (``config_entries[*].key`` / ``type``). The pin entries make the

--- a/tests/test_validate_featured.py
+++ b/tests/test_validate_featured.py
@@ -10,9 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from esphome_device_builder.models.boards import BOARD_PIN_KEYS
 from script.validate_definitions import (  # type: ignore[import-not-found]
-    _LONG_FORM_PIN_KEYS,
     _build_components_index,
     _validate_featured,
     _validate_field_preset,
@@ -21,11 +19,6 @@ from script.validate_definitions import (  # type: ignore[import-not-found]
 # Co-locate with the rest of the catalog-heavy suite so we don't burn a
 # second xdist worker re-reading ``components.index.json``.
 pytestmark = pytest.mark.xdist_group("catalog")
-
-
-def test_long_form_pin_keys_match_canonical_board_pin_keys() -> None:
-    """The validator's import-free inline copy must not drift from ``BOARD_PIN_KEYS``."""
-    assert _LONG_FORM_PIN_KEYS == BOARD_PIN_KEYS
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to esphome/device-builder#1717 (now merged).

Two related changes to `BOARD_PIN_KEYS`, the set that drives I/O-expander provider detection (any long-form pin key *not* in this set names an expander provider whose value is the hub id):

1. **Single source of truth.** The set was defined in `models/boards.py` and mirrored inline in `script/validate_definitions.py` (the validator stays light, and importing `models.boards` pulls the mashumaro/orjson serialization stack via `models/common`). Move the definition into the dependency-free `constants` module and have every consumer read it from there: `sync_boards.py`, `sync_esphome_devices.py`, and the validator all import `constants.BOARD_PIN_KEYS`. The validator can do this without pulling the model layer because `constants` is stdlib-only. `models/boards.py` no longer defines or references the set (nothing in the model layer needs it), and the inline validator mirror plus its drift-guard test are gone.

2. **Complete the set against ESPHome's schema.** Checked against `~/esphome_3`: the board-GPIO long-form keys are the union of `gpio_base_schema` (`id`, `number`, `mode`, `inverted`, `allow_other_uses`) and the esp32 additions (`ignore_strapping_warning`, `drive_strength`, `ignore_pin_validation_error`). The set was missing `id` and `ignore_pin_validation_error`. `id` is the load-bearing one: expander pin schemas (`pcf8574`, etc.) extend the same `gpio_base_schema`, so a channel that also carries an `id` would otherwise have that `id` picked as the "provider" instead of `pcf8574`; a plain board pin with an `id` would be misclassified as an expander channel.

No remaining code imports `BOARD_PIN_KEYS` from `models.boards`, so dropping it there is safe (pre-release, no back-compat surface).

**Related issue or feature (if applicable):**

- follow-up to esphome/device-builder#1717
- companion frontend change (same set, `LONG_FORM_PIN_KEYS`): esphome/device-builder-frontend#1012

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1012

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
