### PR TITLE
Harden config-dir check-ignore and trim docstrings

### DIFF
--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -243,14 +243,10 @@ class GitRepo:
         return Path(root) if root else None
 
     def _enclosing_repo_ignores_config_dir(self) -> bool:
-        """Whether the enclosing work tree ignores ``config_dir`` itself.
-
-        A ``/config`` inside an unrelated checkout that ``.gitignore``s it can
-        never track our YAML, so adopting would back up nothing while still
-        writing into that repo; init a config-local repo instead.
-        """
+        """Whether the enclosing work tree ignores ``config_dir`` itself."""
         result = self._run(
-            ["check-ignore", "-q", str(self.config_dir)],
+            # ``--`` so a config_dir starting with ``-`` isn't read as an option.
+            ["check-ignore", "-q", "--", str(self.config_dir)],
             cwd=self.config_dir,
             check=False,
         )

--- a/tests/controllers/version_history/test_git_repo.py
+++ b/tests/controllers/version_history/test_git_repo.py
@@ -242,12 +242,7 @@ def test_declines_to_adopt_own_source_checkout(
 
 
 def test_declines_to_adopt_repo_that_ignores_config_dir(tmp_path: Path) -> None:
-    """A config dir gitignored by its enclosing repo gets a nested repo, not adoption.
-
-    Adopting an enclosing checkout that ``.gitignore``s the config dir backs up
-    nothing (git refuses the ignored YAML) while still writing our managed block
-    into that unrelated repo (#1718).
-    """
+    """A config dir gitignored by its enclosing repo gets a nested repo, not adoption."""
     _make_repo(tmp_path)  # stands in for the unrelated esphome/esphome checkout
     config = tmp_path / "config"
     config.mkdir()


### PR DESCRIPTION
# What does this implement/fix?

Addresses a late Copilot review on #1720 (it landed seconds after merge). Two small things in the version-history git adoption code; no behaviour change for normal config dirs.

Pass `--` to `git check-ignore` in `_enclosing_repo_ignores_config_dir` so a `config_dir` whose path begins with `-` is read as a path rather than an option. Trim the helper docstring and the new test's docstring to terse contracts per the repo style (drop the rationale block and the issue-number cross-reference; the why lives in #1720 and its commit).

**Related issue or feature (if applicable):**

- Follow-up to #1720

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
