### PR TITLE
Fold list-valued locked pins into the bundle pin-conflict check

### DIFF
--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -45,6 +45,7 @@ import logging
 import re
 import shutil
 import sys
+from collections.abc import Iterator
 from dataclasses import replace
 from functools import cache
 from operator import attrgetter
@@ -79,6 +80,7 @@ from esphome_device_builder.models import (  # noqa: E402
     Esp32Variant,
     FeaturedBundle,
     FeaturedComponent,
+    FieldPreset,
     PinFeature,
     Platform,
 )
@@ -928,18 +930,36 @@ def _has_pin_conflict(components: list[FeaturedComponent]) -> bool:
     ``allow_other_uses``; a single plain usage of a shared pin fails validation.
     Mirror that: a board GPIO used by more than one locked pin is a conflict
     unless all of those usages allow it. Namespaced expander channels are string
-    tokens, not board GPIOs, so they're ignored.
+    tokens, not board GPIOs, so they're ignored. List-valued pins (octal SPI
+    ``data_pins``) are folded in from the raw fields — ``locked_pins`` only holds
+    one canonical pin per key, so it drops them.
     """
     usages: dict[int, list[bool]] = {}
     for fc in components:
         for key, gpio in fc.locked_pins.items():
-            if not isinstance(gpio, int):
-                continue
-            preset = fc.fields.get(key)
-            value = preset.value if preset is not None else None
-            allows = isinstance(value, dict) and bool(value.get("allow_other_uses"))
-            usages.setdefault(gpio, []).append(allows)
+            if isinstance(gpio, int):
+                usages.setdefault(gpio, []).append(_pin_allows_reuse(fc.fields.get(key)))
+        for gpio in _list_pin_gpios(fc):
+            usages.setdefault(gpio, []).append(False)
     return any(len(uses) > 1 and not all(uses) for uses in usages.values())
+
+
+def _pin_allows_reuse(preset: FieldPreset | None) -> bool:
+    """Whether a locked pin preset opts into ``allow_other_uses`` (long-form pins only)."""
+    value = preset.value if preset is not None else None
+    return isinstance(value, dict) and bool(value.get("allow_other_uses"))
+
+
+def _list_pin_gpios(fc: FeaturedComponent) -> Iterator[int]:
+    """Yield each board GPIO a featured component locks via a list-valued pin field."""
+    for key in _component_pin_keys(fc.component_id):
+        preset = fc.fields.get(key)
+        if preset is None or not preset.locked or not isinstance(preset.value, list):
+            continue
+        for item in preset.value:
+            gpio = _canonical_gpio(item)
+            if gpio is not None:
+                yield gpio
 
 
 def build_catalog() -> BoardCatalogResponse:

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -80,7 +80,6 @@ from esphome_device_builder.models import (  # noqa: E402
     Esp32Variant,
     FeaturedBundle,
     FeaturedComponent,
-    FieldPreset,
     PinFeature,
     Platform,
 )
@@ -938,20 +937,22 @@ def _has_pin_conflict(components: list[FeaturedComponent]) -> bool:
     for fc in components:
         for key, gpio in fc.locked_pins.items():
             if isinstance(gpio, int):
-                usages.setdefault(gpio, []).append(_pin_allows_reuse(fc.fields.get(key)))
-        for gpio in _list_pin_gpios(fc):
-            usages.setdefault(gpio, []).append(False)
+                preset = fc.fields.get(key)
+                usages.setdefault(gpio, []).append(
+                    _pin_allows_reuse(preset.value if preset is not None else None)
+                )
+        for gpio, allows in _list_pin_gpios(fc):
+            usages.setdefault(gpio, []).append(allows)
     return any(len(uses) > 1 and not all(uses) for uses in usages.values())
 
 
-def _pin_allows_reuse(preset: FieldPreset | None) -> bool:
-    """Whether a locked pin preset opts into ``allow_other_uses`` (long-form pins only)."""
-    value = preset.value if preset is not None else None
+def _pin_allows_reuse(value: Any) -> bool:
+    """Whether a pin value opts into ``allow_other_uses`` (long-form pin mappings only)."""
     return isinstance(value, dict) and bool(value.get("allow_other_uses"))
 
 
-def _list_pin_gpios(fc: FeaturedComponent) -> Iterator[int]:
-    """Yield each board GPIO a featured component locks via a list-valued pin field."""
+def _list_pin_gpios(fc: FeaturedComponent) -> Iterator[tuple[int, bool]]:
+    """Yield each ``(board GPIO, allow_other_uses)`` a component locks via a list pin field."""
     for key in _component_pin_keys(fc.component_id):
         preset = fc.fields.get(key)
         if preset is None or not preset.locked or not isinstance(preset.value, list):
@@ -959,7 +960,7 @@ def _list_pin_gpios(fc: FeaturedComponent) -> Iterator[int]:
         for item in preset.value:
             gpio = _canonical_gpio(item)
             if gpio is not None:
-                yield gpio
+                yield gpio, _pin_allows_reuse(item)
 
 
 def build_catalog() -> BoardCatalogResponse:

--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -432,6 +432,24 @@ def test_has_pin_conflict_folds_in_list_valued_pins() -> None:
     )
     assert _has_pin_conflict([spi, no_clash]) is False
 
+    # A list item that opts into allow_other_uses isn't a conflict when the
+    # colliding usage also allows it (tracked per item, not hardcoded False).
+    spi_shared = FeaturedComponent(
+        id="bus",
+        component_id="spi",
+        fields={
+            "data_pins": FieldPreset(value=[{"number": 7, "allow_other_uses": True}], locked=True)
+        },
+        locked_pins={},
+    )
+    clash_shared = FeaturedComponent(
+        id="relay",
+        component_id="switch.gpio",
+        fields={"pin": FieldPreset(value={"number": 7, "allow_other_uses": True}, locked=True)},
+        locked_pins={"pin": 7},
+    )
+    assert _has_pin_conflict([spi_shared, clash_shared]) is False
+
 
 def test_omit_default_preserves_meaningful_falsy() -> None:
     """``locked=True`` / falsy non-default ``value`` survive the strip."""

--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -55,6 +55,7 @@ from script.sync_boards import (
     _backfill_rp2040_mcu,
     _backfill_rp2040_wifi,
     _consolidate_full_setup_bundles,
+    _has_pin_conflict,
     _stamp_featured_locked_pins,
 )
 
@@ -403,6 +404,33 @@ def test_synthesize_full_setup_bundle_skips_pin_conflict() -> None:
     ]
     _consolidate_full_setup_bundles([conflict_covered])
     assert [b.id for b in conflict_covered.featured_bundles] == ["all_setup", "a_setup"]
+
+
+def test_has_pin_conflict_folds_in_list_valued_pins() -> None:
+    """A board GPIO claimed by a list-valued pin (octal SPI ``data_pins``) is detected."""
+    # ``locked_pins`` holds one canonical pin per key, so an octal ``data_pins``
+    # list never lands there; the detector must read the raw fields to see it.
+    spi = FeaturedComponent(
+        id="bus",
+        component_id="spi",
+        fields={"data_pins": FieldPreset(value=[6, 7, 15], locked=True)},
+        locked_pins={},
+    )
+    clash = FeaturedComponent(
+        id="relay",
+        component_id="switch.gpio",
+        fields={"pin": FieldPreset(value=7, locked=True)},
+        locked_pins={"pin": 7},
+    )
+    assert _has_pin_conflict([spi, clash]) is True
+
+    no_clash = FeaturedComponent(
+        id="relay",
+        component_id="switch.gpio",
+        fields={"pin": FieldPreset(value=21, locked=True)},
+        locked_pins={"pin": 21},
+    )
+    assert _has_pin_conflict([spi, no_clash]) is False
 
 
 def test_omit_default_preserves_meaningful_falsy() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`_stamp_featured_locked_pins` runs each locked pin through `_canonical_pin` -> `_canonical_gpio`, which returns `None` for a list, so an octal SPI `data_pins` list never lands in `FeaturedComponent.locked_pins`. `_has_pin_conflict` reads only `locked_pins`, so those GPIOs were invisible to it: a `data_pins` GPIO colliding with another featured component's locked pin would go undetected, and `_consolidate_full_setup_bundles` would emit a single combined "(full setup)" bundle that fails ESPHome validation, the same "never ship an invalid config" class the bus-lift PR fixes on the other side.

`_has_pin_conflict` now folds in list-valued locked pin fields read straight from the raw fields (via the component's pin keys), so every board GPIO a list pin occupies participates in conflict detection. The scalar `locked_pins` path is unchanged.

No board hits this today (all consolidate to one clean bundle), so it's a latent-bug guard; regenerating the catalog produces no diff. Added a regression test where an octal `data_pins` GPIO collides with a switch's locked pin.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1735

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
