### PR TITLE
Skip the default Wi-Fi block on adopt when shared secrets are absent

### DIFF
--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from esphome import const
 from esphome.storage_json import ignored_devices_storage_path
@@ -13,6 +13,7 @@ from esphome.storage_json import ignored_devices_storage_path
 from ...helpers.api import CommandError
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.lazy_module import async_import_module
+from ...helpers.secrets_state import read_secrets_yaml, wifi_secrets_defined
 from ...models import (
     AdoptableDevice,
     DeviceState,
@@ -27,6 +28,11 @@ if TYPE_CHECKING:
     from .controller import DevicesController
 
 _LOGGER = logging.getLogger(__name__)
+
+# import_config only special-cases ``network == CONF_WIFI``, so any other
+# value suppresses its default `!secret wifi_ssid` block; "" reads as
+# "scaffold no network block". Revisit if upstream gains an explicit flag.
+_NO_DEFAULT_WIFI_BLOCK: Final = ""
 
 
 async def import_device(
@@ -59,6 +65,16 @@ async def import_device(
     )
     network = adoptable.network if adoptable and adoptable.network else const.CONF_WIFI
     loop = asyncio.get_running_loop()
+    if network == const.CONF_WIFI:
+        secrets = await loop.run_in_executor(
+            None, read_secrets_yaml, controller._db.settings.config_dir
+        )
+        if not wifi_secrets_defined(secrets):
+            # No wifi_ssid/wifi_password in secrets.yaml; import_config would
+            # otherwise append a `!secret wifi_ssid` block that fails validation
+            # (#1742). Skip it so adoption lands a config the user can complete
+            # in the editor (e.g. their own wifi.networks).
+            network = _NO_DEFAULT_WIFI_BLOCK
     # ``esphome.components.dashboard_import`` pulls in ~14 MB of
     # upstream code; load it through ``async_import_module`` so
     # the first adoption pays the cost on the dedicated import

--- a/tests/controllers/devices/test_import.py
+++ b/tests/controllers/devices/test_import.py
@@ -43,6 +43,20 @@ def _seed_import_state(controller: DevicesController) -> None:
     controller.state.import_result = {}
 
 
+def _write_wifi_secrets(config_dir: Path, *, standard: bool = True) -> None:
+    """Seed ``secrets.yaml``; *standard* writes ``wifi_ssid`` / ``wifi_password``.
+
+    When False, only a custom-named key is written so ``wifi_secrets_defined``
+    reports the shared secrets as absent (the #1742 scenario).
+    """
+    body = (
+        "wifi_ssid: my-network\nwifi_password: hunter2\n"
+        if standard
+        else "wifi_0_ssid: my-network\nwifi_0_key: hunter2\n"
+    )
+    (config_dir / "secrets.yaml").write_text(body, encoding="utf-8")
+
+
 def _import_config_stub(
     captured: dict[str, Any] | None = None,
 ) -> Callable[..., None]:
@@ -94,6 +108,7 @@ async def test_import_device_invokes_import_config_and_returns_path(
     )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     _seed_import_state(ctrl)
+    _write_wifi_secrets(tmp_path)
 
     result = await ctrl.import_device(
         name="kitchen-1a2b3c",
@@ -252,11 +267,83 @@ async def test_import_device_falls_back_to_wifi_for_old_factory_firmware(
         network="",  # field absent / empty in TXT
         ignored=False,
     )
+    _write_wifi_secrets(tmp_path)
 
     await ctrl.import_device(
         name="legacy-bulb",
         project_name="vendor.old",
         package_import_url="github://vendor/old.yaml",
+    )
+
+    assert captured["args"][5] == "wifi"
+
+
+async def test_import_device_suppresses_default_wifi_when_secrets_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """No ``wifi_ssid`` secret → don't append the default ``!secret`` block (#1742).
+
+    A user running ``wifi.networks`` with custom secret names has no
+    shared ``wifi_ssid`` / ``wifi_password``. Appending the default block
+    would fail import validation; suppress it (pass a non-wifi network so
+    upstream skips it) and land a config the user completes in the editor.
+    """
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config", _import_config_stub(captured)
+    )
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    _write_wifi_secrets(tmp_path, standard=False)
+    ctrl.state.import_result["athom-rgbct-9ade7c"] = AdoptableDevice(
+        name="athom-rgbct-9ade7c",
+        friendly_name="Athom RGBCCT",
+        package_import_url="github://athom-tech/athom-configs/athom-rgbct-light.yaml",
+        project_name="athom.rgbct-light",
+        project_version="1.0.0",
+        network="wifi",
+        ignored=False,
+    )
+
+    result = await ctrl.import_device(
+        name="athom-rgbct-9ade7c",
+        project_name="athom.rgbct-light",
+        package_import_url="github://athom-tech/athom-configs/athom-rgbct-light.yaml",
+    )
+
+    assert result == {"configuration": "athom-rgbct-9ade7c.yaml"}
+    assert captured["args"][5] != "wifi"
+
+
+async def test_import_device_keeps_default_wifi_when_secrets_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """Shared ``wifi_ssid`` / ``wifi_password`` defined → emit the default block."""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "esphome.components.dashboard_import.import_config", _import_config_stub(captured)
+    )
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    _seed_import_state(ctrl)
+    _write_wifi_secrets(tmp_path)
+    ctrl.state.import_result["athom-rgbct-9ade7c"] = AdoptableDevice(
+        name="athom-rgbct-9ade7c",
+        friendly_name="Athom RGBCCT",
+        package_import_url="github://athom-tech/athom-configs/athom-rgbct-light.yaml",
+        project_name="athom.rgbct-light",
+        project_version="1.0.0",
+        network="wifi",
+        ignored=False,
+    )
+
+    await ctrl.import_device(
+        name="athom-rgbct-9ade7c",
+        project_name="athom.rgbct-light",
+        package_import_url="github://athom-tech/athom-configs/athom-rgbct-light.yaml",
     )
 
     assert captured["args"][5] == "wifi"


### PR DESCRIPTION
# What does this implement/fix?

Take Control adoption appended a default `wifi:` block referencing `!secret wifi_ssid` / `wifi_password` whenever the device broadcast `network=wifi`, without checking that those keys exist in `secrets.yaml`. A user running `wifi.networks` with custom secret names (`wifi_0_ssid`, `wifi_0_key`, ...) therefore hit a hard validation failure, "Secret 'wifi_ssid' not defined", before they could open the editor to fix it.

This gates the default block on `wifi_secrets_defined`, the same check the create-device path already uses; when the shared secrets are absent the block is suppressed, so adoption lands a config the user completes in the editor with their own `wifi:`. When the secrets are present, behavior is unchanged.

Suppression rides the existing `network` argument to upstream `import_config` (a non-wifi value already skips the block, same path Ethernet adoption uses); an explicit upstream flag would be a cleaner end state and is noted as a follow-up.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1742

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
