### PR TITLE
Pin CI esphome to the catalog version

### DIFF
--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -80,16 +80,28 @@ jobs:
         # 60 req/hr unauthenticated cap on shared runner IPs.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Read the dispatch input via env, never inline ``${{ inputs.version }}``
+          # into the script: it's attacker-controllable and a textual splice
+          # would run as shell. ``$INPUT_VERSION`` is data, not code.
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "source=manual dispatch" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+            SOURCE="manual dispatch"
           else
             VERSION=$(python -c "import sys; sys.path.insert(0, 'script'); from sync_components import resolve_latest_release; print(resolve_latest_release(include_prereleases=True))")
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "source=latest schema release (incl. prereleases)" >> "$GITHUB_OUTPUT"
+            SOURCE="latest schema release (incl. prereleases)"
           fi
+          # Validate before any downstream step installs / pins / interpolates
+          # it; a value constrained to an esphome version string carries no
+          # shell or sed metacharacters, so the later uses can't be injected.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$'; then
+            echo "::error::Refusing unexpected esphome version '$VERSION'"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "source=$SOURCE" >> "$GITHUB_OUTPUT"
 
       - name: Align esphome to the schema version
         # Install the exact esphome the resolved schema came from so
@@ -109,6 +121,25 @@ jobs:
       - name: Run sync_components
         run: python script/sync_components.py --version "${{ steps.version.outputs.version }}"
 
+      - name: Re-stamp board catalog
+        # boards.index.json carries an ``esphome_version`` stamp from the
+        # installed esphome. The catalog is one logical unit per esphome
+        # version, so re-stamp boards against the same esphome the align step
+        # pinned; otherwise the Test job's ``sync-boards`` pre-commit hook
+        # re-stamps it and the opened PR lands red on every esphome patch.
+        run: python script/sync_boards.py
+
+      - name: Bump esphome pin
+        # CI's lint job installs esphome from esphome-constraints.txt so a new
+        # release doesn't red main on the sync-boards hook. Move the pin in
+        # lockstep with the catalog this run just regenerated, so the opened PR
+        # ships a self-consistent version (pinned esphome == catalog stamp).
+        # ``$VERSION`` comes through env (not inline) and is validated to an
+        # esphome version above, so it carries no sed metacharacters.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: sed -i "s/^esphome==.*/esphome==$VERSION/" esphome-constraints.txt
+
       - name: Smoke-test catalog
         # Catches regressions in popular components (missing fields,
         # type flips, id-vs-reference confusion). Runs BEFORE the
@@ -123,7 +154,11 @@ jobs:
           if git diff --quiet -- \
               esphome_device_builder/definitions/components.index.json \
               esphome_device_builder/definitions/components/ \
-            && [ -z "$(git ls-files --others --exclude-standard esphome_device_builder/definitions/components/)" ]; then
+              esphome_device_builder/definitions/boards.index.json \
+              esphome_device_builder/definitions/board_bodies/ \
+              esphome_device_builder/definitions/featured_components.index.json \
+              esphome-constraints.txt \
+            && [ -z "$(git ls-files --others --exclude-standard esphome_device_builder/definitions/components/ esphome_device_builder/definitions/board_bodies/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -129,6 +129,13 @@ jobs:
         # re-stamps it and the opened PR lands red on every esphome patch.
         run: python script/sync_boards.py
 
+      - name: Validate definitions
+        # Re-validate every board (curated + imported) against the JSON Schema
+        # and the component catalog cross-references before the PR opens, so a
+        # re-stamp that regenerated an invalid board catalog never gets proposed
+        # for merge. Mirrors the device-catalog sync.
+        run: python script/validate_definitions.py
+
       - name: Bump esphome pin
         # CI's lint job installs esphome from esphome-constraints.txt so a new
         # release doesn't red main on the sync-boards hook. Move the pin in

--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -3,7 +3,12 @@ name: Sync device catalog
 # Re-runs ``script/sync_esphome_devices.py`` against the
 # devices.esphome.io upstream and opens a pull request when imported
 # manifests under ``definitions/boards/`` change. Introspects against
-# the latest prerelease esphome so new chip variants surface early.
+# the pinned esphome (``esphome-constraints.txt``), the same version CI
+# and the committed catalog use: ``sync_boards.py`` re-stamps
+# boards.index.json from the installed esphome, so a newer prerelease
+# here would commit a stamp the pinned Test job can't match. The catalog
+# advances to a new esphome as one unit when the component sync bumps the
+# pin on release, so new chip variants surface then rather than mid-beta.
 #
 # Triggers
 # --------
@@ -55,12 +60,13 @@ jobs:
         # ``sync_boards.py`` introspects ESPHome's per-platform board
         # modules to regenerate board pins, so the esphome extra is
         # required; ``test`` carries jsonschema for validate_definitions.
-        # The second install tracks the latest prerelease esphome so
-        # board-pin introspection picks up new chip variants as soon as
-        # a beta ships.
-        run: |
-          uv pip install --system -e '.[esphome,test]'
-          uv pip install --system --upgrade --prerelease=allow esphome
+        # ``-c esphome-constraints.txt`` pins esphome to the same version
+        # the committed catalog (and CI) use: ``sync_boards.py`` re-stamps
+        # boards.index.json from the installed esphome, so introspecting a
+        # newer prerelease here would commit a stamp the Test job's pinned
+        # lint can't match. The catalog advances to a new esphome as one
+        # unit when the component sync bumps the pin on release.
+        run: uv pip install --system -c esphome-constraints.txt -e '.[esphome,test]'
 
       - name: Run sync_esphome_devices
         run: python script/sync_esphome_devices.py
@@ -77,7 +83,7 @@ jobs:
         # JSON Schema and the component catalog cross-references.
         run: python script/validate_definitions.py
 
-      - name: Regenerate boards.json
+      - name: Regenerate board catalog
         # The opened PR needs to ship the regenerated catalog
         # alongside the imported manifests — without this, a merge
         # would land new YAMLs the dashboard never sees.
@@ -92,7 +98,7 @@ jobs:
           # script writes untracked manifests that diff would silently miss,
           # so we'd never open a PR. ``git status --porcelain`` covers
           # added / modified / deleted in one go.
-          if [ -z "$(git status --porcelain -- esphome_device_builder/definitions/boards/ esphome_device_builder/definitions/boards.json)" ]; then
+          if [ -z "$(git status --porcelain -- esphome_device_builder/definitions/boards/ esphome_device_builder/definitions/boards.index.json esphome_device_builder/definitions/board_bodies/ esphome_device_builder/definitions/featured_components.index.json)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,13 @@ jobs:
         # installs into the runner's Python instead of a venv —
         # matches the existing pip-based CI shape so subsequent
         # ``pre-commit`` / ``python script/...`` steps keep working
-        # without a ``uv run`` prefix.
-        run: uv pip install --system -e '.[esphome,test]'
+        # without a ``uv run`` prefix. ``-c esphome-constraints.txt``
+        # pins esphome to the version the committed catalog was generated
+        # against; the ``sync-boards`` pre-commit hook below re-stamps
+        # boards.index.json from the installed esphome, so an unpinned
+        # "latest" would red this job on every esphome release until the
+        # catalog is re-synced. The sync workflows bump that pin.
+        run: uv pip install --system -c esphome-constraints.txt -e '.[esphome,test]'
 
       - name: Cache pre-commit hook envs
         # Keyed on the python version + ``.pre-commit-config.yaml``
@@ -84,13 +89,18 @@ jobs:
       - name: Validate board / component manifests
         run: python script/validate_definitions.py
 
-      - name: Verify boards.json is in sync with manifests
+      - name: Verify board catalog is in sync with manifests
         # Catches PRs that bypass the pre-commit hook — the diff
         # fails the build if the committed JSON doesn't match what
-        # the script regenerates from the YAMLs.
+        # the script regenerates from the YAMLs. esphome is pinned
+        # (esphome-constraints.txt), so the regenerated esphome_version
+        # stamp matches the committed catalog rather than drifting.
         run: |
           python script/sync_boards.py
-          git diff --exit-code -- esphome_device_builder/definitions/boards.json
+          git diff --exit-code -- \
+            esphome_device_builder/definitions/boards.index.json \
+            esphome_device_builder/definitions/board_bodies/ \
+            esphome_device_builder/definitions/featured_components.index.json
 
       - name: Smoke-test component catalog
         run: python script/check_catalog.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,10 +97,19 @@ jobs:
         # stamp matches the committed catalog rather than drifting.
         run: |
           python script/sync_boards.py
-          git diff --exit-code -- \
-            esphome_device_builder/definitions/boards.index.json \
+          # ``git diff --exit-code`` only sees tracked modifications and would
+          # miss a newly generated *untracked* body file (a manifest added
+          # without regenerating), so gate on porcelain status (tracked +
+          # untracked) and surface the drift for debugging.
+          paths="esphome_device_builder/definitions/boards.index.json \
             esphome_device_builder/definitions/board_bodies/ \
-            esphome_device_builder/definitions/featured_components.index.json
+            esphome_device_builder/definitions/featured_components.index.json"
+          if [ -n "$(git status --porcelain -- $paths)" ]; then
+            git status --porcelain -- $paths
+            git diff -- $paths
+            echo "::error::Board catalog is out of sync with manifests; run script/sync_boards.py and commit."
+            exit 1
+          fi
 
       - name: Smoke-test component catalog
         run: python script/check_catalog.py

--- a/esphome-constraints.txt
+++ b/esphome-constraints.txt
@@ -1,0 +1,7 @@
+# Pinned esphome for CI's catalog-enforcement (the lint job's sync-boards hook
+# re-stamps boards.index.json from the installed esphome). Kept here so a new
+# esphome release does not spontaneously red main and every PR; the catalog
+# sync workflows bump this line when they regenerate the catalog against a new
+# esphome. Not the package's runtime dependency (that stays esphome>=… in
+# pyproject); this only constrains CI installs via uv pip install -c.
+esphome==2026.6.3


### PR DESCRIPTION
# What does this implement/fix?

CI installs esphome unpinned, so when a new esphome ships the lint job's `sync-boards` pre-commit hook re-stamps `boards.index.json` from the newer esphome and reds `main` plus every open PR until the catalog is re-synced by hand; this is what broke the 2026.6.3 catalog PR and would recur on every release.

Pin esphome for CI in `esphome-constraints.txt` and install the lint job with `-c`, so a release no longer reds CI; the catalog advances only when a sync deliberately bumps the pin. The component sync writes the pin in lockstep with the catalog it regenerates, and the device sync now follows the pin instead of tracking the latest prerelease, so both sync PRs stay self-consistent (pinned esphome equals the committed board stamp). While here, the lint backstop and the device-sync change gate are fixed to check `boards.index.json` instead of a `boards.json` that does not exist, and the component-sync version resolution is hardened against shell injection; the dispatch input is read via env and the resolved version is validated before any step installs, pins, or interpolates it.

Runtime test jobs (pytest, e2e) stay on the latest esphome on purpose, alongside the beta and dev channel jobs, so forward-compat breakage still surfaces; only the catalog-enforcing lint job is pinned.

**Related issue or feature (if applicable):**

- Surfaced by the 2026.6.3 catalog sync (PR #1740); no separate tracking issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
