### PR TITLE
Expose active_source and pending_changes_via_hash on the device snapshot

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -130,6 +130,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 `Device.state`: `DeviceState` — `unknown`, `online`, or `offline` (discovered via mDNS + ping).
 `Device.has_pending_changes`: `true` = config changed since last compile, `false` = up to date, `null` = never compiled.
 `Device.update_available`: `true` = device was compiled with a different ESPHome version than the server.
+`Device.active_source`: `ReachabilitySource` — channel currently driving online state (`mdns` > `mqtt` > `ping`); `unknown` until a source claims it (also the transient default after a restart). The frontend gates the mDNS-sourced out-of-sync / update indicators on `active_source == "mdns"`, since `deployed_version` / `deployed_config_hash` come only from the mDNS broadcast.
 
 ### Firmware
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -129,6 +129,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 
 `Device.state`: `DeviceState` — `unknown`, `online`, or `offline` (discovered via mDNS + ping).
 `Device.has_pending_changes`: `true` = config changed since last compile, `false` = up to date, `null` = never compiled.
+`Device.pending_changes_via_hash`: `true` when `has_pending_changes` came from the mDNS-sourced config-hash compare (vs the local mtime fallback). The frontend gates only this case on a live mDNS, so a local YAML edit still cues "install" when mDNS is dark.
 `Device.update_available`: `true` = device was compiled with a different ESPHome version than the server.
 `Device.active_source`: `ReachabilitySource` — channel currently driving online state (`mdns` > `mqtt` > `ping`); `unknown` until a source claims it (also the transient default after a restart). The frontend gates the mDNS-sourced out-of-sync / update indicators on `active_source == "mdns"`, since `deployed_version` / `deployed_config_hash` come only from the mDNS broadcast.
 

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -56,6 +56,12 @@ _MDNS_REFRESH_PADDING_SECONDS = 1.0
 # back to its owner.
 StateChangeCallback = Callable[[str, DeviceState, str], None]
 
+# Authoritative-source change: fired when the winning ``priority_for``
+# source for a device flips (e.g. mDNS goes dark and ping takes over, or
+# mDNS claims a ping-only device). Lets the owner surface ``active_source``
+# on the device snapshot so the UI can gate mDNS-sourced indicators.
+SourceChangeCallback = Callable[[str, ReachabilitySource], None]
+
 # mDNS IP resolution callback. ``primary`` is the IPv4 we lock onto
 # for ICMP / OTA cache args (or the first scoped IPv6 when no V4 is
 # present); ``addresses`` is the announced set in zeroconf's
@@ -119,6 +125,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         get_devices_by_name: Callable[[str], list[Device]] | None = None,
         presence: SubscriberPresence | None = None,
         resolve_api_connection: ApiConnectionResolver | None = None,
+        on_source_change: SourceChangeCallback | None = None,
     ) -> None:
         super().__init__()
         self._get_devices = get_devices
@@ -133,6 +140,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         )
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
+        self._on_source_change = on_source_change
         self._on_version_change = on_version_change
         self._on_config_hash_change = on_config_hash_change
         self._on_api_encryption_change = on_api_encryption_change
@@ -237,7 +245,14 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
 
     def forget(self, name: str) -> None:
         """Drop the source-precedence ledger entry for *name*."""
-        self.state.state_source.pop(name, None)
+        old = self.state.state_source.pop(name, None)
+        if old is not None:
+            self._emit_source_change(name, old, ReachabilitySource.UNKNOWN)
+
+    def _emit_source_change(self, name: str, old: str, new: str) -> None:
+        """Notify the owner when *name*'s authoritative source actually flips."""
+        if self._on_source_change is not None and old != new:
+            self._on_source_change(name, ReachabilitySource(new))
 
     def apply(self, name: str, state: DeviceState, source: str, *, claim: bool = False) -> bool:
         """
@@ -292,9 +307,11 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         if all_match:
             if claim:
                 self.state.state_source[name] = source
+                self._emit_source_change(name, current_source, source)
             return False
 
         self.state.state_source[name] = source
+        self._emit_source_change(name, current_source, source)
         self._on_state_change(name, state, source)
         return True
 

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -46,6 +46,7 @@ from ...models import (
     EventType,
     ImportBundleResponse,
     JobLifecycleData,
+    ReachabilitySource,
     UpdateDeviceResponse,
     WizardResponse,
 )
@@ -199,6 +200,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             get_devices_by_name=self._scanner.get_by_name,
             on_state_change=self._on_state_change,
             on_ip_change=self._on_ip_change,
+            on_source_change=self._on_source_change,
             on_version_change=self._on_version_change,
             on_config_hash_change=self._on_config_hash_change,
             on_api_encryption_change=self._on_api_encryption_change,
@@ -1099,6 +1101,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     def _on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
         state_callbacks.on_ip_change(self, name, ip, addresses)
+
+    def _on_source_change(self, name: str, source: ReachabilitySource) -> None:
+        state_callbacks.on_source_change(self, name, source)
 
     def _on_version_change(self, name: str, version: str) -> None:
         state_callbacks.on_version_change(self, name, version)

--- a/esphome_device_builder/controllers/devices/state_callbacks.py
+++ b/esphome_device_builder/controllers/devices/state_callbacks.py
@@ -79,13 +79,7 @@ def on_state_change(
 
 
 def on_source_change(controller: DevicesController, name: str, source: ReachabilitySource) -> None:
-    """
-    Track the device's active reachability source on the snapshot.
-
-    The frontend gates the mDNS-sourced out-of-sync / update indicators on
-    ``active_source == mdns``; runtime-only, so it fires ``DEVICE_UPDATED``
-    without persisting.
-    """
+    """Update ``active_source`` and fire DEVICE_UPDATED; runtime-only, not persisted."""
     for device in controller._devices_by_name(name):
         if device.active_source == source:
             continue

--- a/esphome_device_builder/controllers/devices/state_callbacks.py
+++ b/esphome_device_builder/controllers/devices/state_callbacks.py
@@ -7,7 +7,13 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.mac_addresses import derive_interface_macs
-from ...models import Device, DeviceState, DeviceStateChangedData, EventType
+from ...models import (
+    Device,
+    DeviceState,
+    DeviceStateChangedData,
+    EventType,
+    ReachabilitySource,
+)
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -70,6 +76,21 @@ def on_state_change(
                 state=state.value,
             ),
         )
+
+
+def on_source_change(controller: DevicesController, name: str, source: ReachabilitySource) -> None:
+    """
+    Track the device's active reachability source on the snapshot.
+
+    The frontend gates the mDNS-sourced out-of-sync / update indicators on
+    ``active_source == mdns``; runtime-only, so it fires ``DEVICE_UPDATED``
+    without persisting.
+    """
+    for device in controller._devices_by_name(name):
+        if device.active_source == source:
+            continue
+        device.active_source = source
+        controller._fire_device_updated(device)
 
 
 def on_ip_change(controller: DevicesController, name: str, ip: str, addresses: list[str]) -> None:

--- a/esphome_device_builder/controllers/devices/state_callbacks.py
+++ b/esphome_device_builder/controllers/devices/state_callbacks.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from ...helpers.device_yaml import pending_changes_via_hash
 from ...helpers.mac_addresses import derive_interface_macs
 from ...models import (
     Device,
@@ -170,6 +171,9 @@ def on_config_hash_change(controller: DevicesController, name: str, config_hash:
     def _flip_pending(device: Device) -> None:
         if device.expected_config_hash:
             device.has_pending_changes = device.expected_config_hash != config_hash
+            device.pending_changes_via_hash = pending_changes_via_hash(
+                device.expected_config_hash, config_hash
+            )
 
     _apply_logged_observation(
         controller,

--- a/esphome_device_builder/helpers/device_yaml/__init__.py
+++ b/esphome_device_builder/helpers/device_yaml/__init__.py
@@ -29,6 +29,7 @@ from ._loading import (
     compute_has_pending_changes,
     load_device_from_storage,
     load_device_yaml,
+    pending_changes_via_hash,
 )
 from ._parsing import (
     _UNRESOLVED_SUBSTITUTION_RE,
@@ -83,6 +84,7 @@ __all__ = [
     "load_device_yaml",
     "parse_esphome_meta",
     "parse_platform_from_yaml",
+    "pending_changes_via_hash",
     "yaml_has_api_encryption",
     "yaml_has_top_level_block",
 ]

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -407,13 +407,7 @@ def compute_has_pending_changes(
 
 
 def pending_changes_via_hash(expected_config_hash: str, deployed_config_hash: str) -> bool:
-    """
-    Report whether ``has_pending_changes`` came from the config-hash compare.
-
-    Both hashes known and differing means the verdict used the mDNS-sourced
-    deployed hash, not the local mtime fallback; the frontend gates only this
-    (mDNS-dependent) case on a live mDNS, so a local edit still cues "install".
-    """
+    """Report whether the pending verdict is hash-driven: both hashes known and differing."""
     return bool(
         expected_config_hash
         and deployed_config_hash

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -206,6 +206,7 @@ def load_device_from_storage(
         expected_config_hash=expected_config_hash,
         deployed_config_hash=deployed_config_hash,
     )
+    pending_via_hash = pending_changes_via_hash(expected_config_hash, deployed_config_hash)
 
     update_available = bool(deployed_version and deployed_version != const.__version__)
 
@@ -336,6 +337,7 @@ def load_device_from_storage(
         directly_referenced_integrations=directly_referenced_integrations,
         state=state,
         has_pending_changes=has_pending,
+        pending_changes_via_hash=pending_via_hash,
         update_available=update_available,
         # ``uses_mqtt`` keeps its prior shape — the resolved config
         # wins, raw-text fills in mid-edit, and we don't have a
@@ -402,6 +404,21 @@ def compute_has_pending_changes(
     if bin_mtime is None:
         return True
     return yaml_mtime is not None and yaml_mtime > bin_mtime
+
+
+def pending_changes_via_hash(expected_config_hash: str, deployed_config_hash: str) -> bool:
+    """
+    Report whether ``has_pending_changes`` came from the config-hash compare.
+
+    Both hashes known and differing means the verdict used the mDNS-sourced
+    deployed hash, not the local mtime fallback; the frontend gates only this
+    (mDNS-dependent) case on a live mDNS, so a local edit still cues "install".
+    """
+    return bool(
+        expected_config_hash
+        and deployed_config_hash
+        and expected_config_hash != deployed_config_hash
+    )
 
 
 def load_device_yaml(path: Path) -> dict | None:

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -99,6 +99,14 @@ class Device(DashboardModel):
     # whole ``loaded_integrations`` list flat.
     directly_referenced_integrations: list[str] = field(default_factory=list)
     state: DeviceState = DeviceState.UNKNOWN
+    # Reachability channel currently driving the device's online state
+    # (``mdns`` > ``mqtt`` > ``ping``). The deployed version / config-hash
+    # come only from the mDNS broadcast, so the frontend gates the
+    # out-of-sync / update indicators on ``active_source == mdns``: when
+    # mDNS is dark (a ping/MQTT-only "odd setup") those values are stale,
+    # so it hides them rather than showing a false "out of sync". Runtime-
+    # only, not persisted; UNKNOWN until a source claims the device.
+    active_source: ReachabilitySource = ReachabilitySource.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -105,8 +105,7 @@ class Device(DashboardModel):
     active_source: ReachabilitySource = ReachabilitySource.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     # True when ``has_pending_changes`` came from the mDNS-sourced config-hash
-    # compare (vs the local mtime fallback). The frontend gates only this case
-    # on a live mDNS, so a local YAML edit still cues "install" when mDNS is dark.
+    # compare (vs the local mtime fallback).
     pending_changes_via_hash: bool = False
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -104,6 +104,10 @@ class Device(DashboardModel):
     # UNKNOWN until a source claims the device.
     active_source: ReachabilitySource = ReachabilitySource.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed
+    # True when ``has_pending_changes`` came from the mDNS-sourced config-hash
+    # compare (vs the local mtime fallback). The frontend gates only this case
+    # on a live mDNS, so a local YAML edit still cues "install" when mDNS is dark.
+    pending_changes_via_hash: bool = False
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
     # Native API surface flags — drive the lock-icon indicator in

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -99,13 +99,9 @@ class Device(DashboardModel):
     # whole ``loaded_integrations`` list flat.
     directly_referenced_integrations: list[str] = field(default_factory=list)
     state: DeviceState = DeviceState.UNKNOWN
-    # Reachability channel currently driving the device's online state
-    # (``mdns`` > ``mqtt`` > ``ping``). The deployed version / config-hash
-    # come only from the mDNS broadcast, so the frontend gates the
-    # out-of-sync / update indicators on ``active_source == mdns``: when
-    # mDNS is dark (a ping/MQTT-only "odd setup") those values are stale,
-    # so it hides them rather than showing a false "out of sync". Runtime-
-    # only, not persisted; UNKNOWN until a source claims the device.
+    # Reachability channel currently driving online state
+    # (``mdns`` > ``mqtt`` > ``ping``). Runtime-only, not persisted;
+    # UNKNOWN until a source claims the device.
     active_source: ReachabilitySource = ReachabilitySource.UNKNOWN
     has_pending_changes: bool = True  # True until successfully compiled + deployed
     update_available: bool = False  # True if compiled with older ESPHome version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ from esphome_device_builder.models import (
     DeviceState,
     EventType,
     QueueStatus,
+    ReachabilitySource,
 )
 
 if TYPE_CHECKING:
@@ -876,6 +877,10 @@ class RecordingMonitorCallbacks:
         self.calls.append(("on_state_change", name, state, source))
         self._flip(name, "state", state)
 
+    def on_source_change(self, name: str, source: ReachabilitySource) -> None:
+        self.calls.append(("on_source_change", name, source))
+        self._flip(name, "active_source", source)
+
     def on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
         self.calls.append(("on_ip_change", name, ip, list(addresses)))
         self._flip(name, "ip", ip)
@@ -919,6 +924,7 @@ def make_state_monitor_with_callbacks(
         get_devices=lambda: devices,
         on_state_change=callbacks.on_state_change,
         on_ip_change=callbacks.on_ip_change,
+        on_source_change=callbacks.on_source_change,
         on_importable_added=callbacks.on_importable_added,
         on_importable_removed=callbacks.on_importable_removed,
         on_version_change=callbacks.on_version_change,

--- a/tests/test_active_source.py
+++ b/tests/test_active_source.py
@@ -1,9 +1,4 @@
-"""Track ``Device.active_source`` for the UI's out-of-sync gating.
-
-The frontend hides the out-of-sync / update indicators when mDNS is not the
-live source, so a ping/MQTT-only ("mDNS dark") device stops showing a false
-"out of sync" from stale mDNS-sourced deployed version / config hash.
-"""
+"""Tests for ``Device.active_source`` tracking on the device snapshot."""
 
 from __future__ import annotations
 

--- a/tests/test_active_source.py
+++ b/tests/test_active_source.py
@@ -1,0 +1,110 @@
+"""Track ``Device.active_source`` for the UI's out-of-sync gating.
+
+The frontend hides the out-of-sync / update indicators when mDNS is not the
+live source, so a ping/MQTT-only ("mDNS dark") device stops showing a false
+"out of sync" from stale mDNS-sourced deployed version / config hash.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from esphome_device_builder.models import DeviceState, EventType, ReachabilitySource
+
+from .conftest import (
+    close_scheduled_coro,
+    make_device,
+    make_devices_controller_with_bus,
+    make_state_monitor_with_callbacks,
+)
+
+
+def _device(**overrides: Any) -> Any:
+    return make_device(**overrides)
+
+
+# ─── Controller handler ───────────────────────────────────────────
+
+
+async def test_on_source_change_updates_device_fires_event_not_persisted() -> None:
+    """The handler writes ``active_source``, fires DEVICE_UPDATED, and does not persist."""
+    device = _device()
+    controller, captured = make_devices_controller_with_bus(
+        [device], create_background_task=close_scheduled_coro
+    )
+
+    controller._on_source_change("kitchen", ReachabilitySource.MDNS)
+
+    assert device.active_source == ReachabilitySource.MDNS
+    assert any(e.event_type == EventType.DEVICE_UPDATED for e in captured)
+    # Runtime-only: a reachability flip must not write the metadata sidecar.
+    assert "active_source" not in (controller._metadata_store.get(device.configuration) or {})
+
+
+async def test_on_source_change_skips_when_same() -> None:
+    """No-op (no event) when the device already carries the source."""
+    device = _device()
+    device.active_source = ReachabilitySource.MDNS
+    controller, captured = make_devices_controller_with_bus(
+        [device], create_background_task=close_scheduled_coro
+    )
+
+    controller._on_source_change("kitchen", ReachabilitySource.MDNS)
+
+    assert captured == []
+
+
+# ─── Monitor emission ─────────────────────────────────────────────
+
+
+def test_apply_mdns_sets_active_source_then_dedupes() -> None:
+    """An mDNS claim flips the source to mDNS once; a re-announce stays quiet."""
+    device = make_device(state=DeviceState.UNKNOWN)
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+
+    monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True)
+
+    assert device.active_source == ReachabilitySource.MDNS
+    assert callbacks.calls_for("on_source_change") == [
+        ("on_source_change", "kitchen", ReachabilitySource.MDNS)
+    ]
+
+    # Re-announce of the same online+mdns state: the source ledger is unchanged,
+    # so no redundant source-change callback fires.
+    monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True)
+
+    assert len(callbacks.calls_for("on_source_change")) == 1
+
+
+def test_forget_resets_active_source_to_unknown() -> None:
+    """Dropping the ledger entry (mDNS ``Removed``) flips the source to UNKNOWN."""
+    device = make_device(state=DeviceState.UNKNOWN)
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+    monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True)
+
+    monitor.forget("kitchen")
+
+    assert device.active_source == ReachabilitySource.UNKNOWN
+    assert callbacks.calls_for("on_source_change")[-1] == (
+        "on_source_change",
+        "kitchen",
+        ReachabilitySource.UNKNOWN,
+    )
+
+
+def test_ping_takes_over_after_mdns_goes_dark() -> None:
+    """The realistic dark transition: mDNS OFFLINE + forget, then ping revives it."""
+    device = make_device(state=DeviceState.UNKNOWN)
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True)
+
+    # mDNS TTL expiry: the browser marks it OFFLINE via mdns, then forgets it.
+    monitor.apply("kitchen", DeviceState.OFFLINE, "mdns")
+    monitor.forget("kitchen")
+    assert device.active_source == ReachabilitySource.UNKNOWN
+
+    # Ping still reaches it → ping becomes the authoritative source, so the UI
+    # knows the mDNS-sourced deployed_* values are no longer trustworthy.
+    monitor.apply("kitchen", DeviceState.ONLINE, "ping")
+
+    assert device.active_source == ReachabilitySource.PING

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -36,6 +36,7 @@ from esphome_device_builder.helpers.device_yaml import (
     load_device_from_storage,
     parse_esphome_meta,
     parse_platform_from_yaml,
+    pending_changes_via_hash,
 )
 from esphome_device_builder.helpers.device_yaml._parsing import (
     _is_valid_esphome_name,
@@ -496,6 +497,14 @@ def test_in_sync_when_only_one_hash_known() -> None:
         )
         is False
     )
+
+
+def test_pending_changes_via_hash_only_when_both_hashes_known_and_differ() -> None:
+    """True only on a hash-driven verdict; mtime-driven / unknown reads False."""
+    assert pending_changes_via_hash("abc", "def") is True
+    assert pending_changes_via_hash("abc", "abc") is False  # in sync
+    assert pending_changes_via_hash("abc", "") is False  # device not broadcasting
+    assert pending_changes_via_hash("", "def") is False  # never compiled
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_mdns_config_hash.py
+++ b/tests/test_mdns_config_hash.py
@@ -175,6 +175,8 @@ async def test_on_config_hash_change_flips_pending_when_hashes_diverge() -> None
 
     assert device.deployed_config_hash == "deadbeef"
     assert device.has_pending_changes is True
+    # The verdict came from the hash compare, so the frontend gates it on mDNS.
+    assert device.pending_changes_via_hash is True
 
 
 async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
@@ -183,6 +185,7 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
         expected_config_hash="abc12345",
         deployed_config_hash="",
         has_pending_changes=True,
+        pending_changes_via_hash=True,
     )
     controller, _captured = make_devices_controller_with_bus([device])
 
@@ -190,6 +193,7 @@ async def test_on_config_hash_change_marks_in_sync_when_hashes_match() -> None:
 
     assert device.deployed_config_hash == "abc12345"
     assert device.has_pending_changes is False
+    assert device.pending_changes_via_hash is False
 
 
 async def test_on_config_hash_change_leaves_pending_alone_without_expected_hash() -> None:

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -193,6 +193,7 @@ async def test_apply_service_info_claims_online() -> None:
     callbacks = RecordingMonitorCallbacks([device])
     monitor._on_state_change = callbacks.on_state_change
     monitor._on_ip_change = callbacks.on_ip_change
+    monitor._on_source_change = callbacks.on_source_change
     monitor._on_version_change = callbacks.on_version_change
     monitor._on_config_hash_change = callbacks.on_config_hash_change
     monitor._on_api_encryption_change = callbacks.on_api_encryption_change
@@ -234,6 +235,7 @@ async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
     callbacks = RecordingMonitorCallbacks([device])
     monitor._on_state_change = callbacks.on_state_change
     monitor._on_ip_change = callbacks.on_ip_change
+    monitor._on_source_change = callbacks.on_source_change
     monitor._on_version_change = callbacks.on_version_change
     monitor._on_config_hash_change = callbacks.on_config_hash_change
     monitor._on_api_encryption_change = callbacks.on_api_encryption_change

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from esphome_device_builder.models import Device, DeviceState
+from esphome_device_builder.models import Device, DeviceState, ReachabilitySource
 
 from .conftest import (
     close_scheduled_coro,
@@ -166,4 +166,9 @@ def test_apply_state_repairs_stale_sibling_when_first_match_is_in_sync() -> None
     assert monitor.apply("kitchen", DeviceState.ONLINE, "mdns", claim=True) is True
     assert primary.state == DeviceState.ONLINE
     assert sibling.state == DeviceState.ONLINE
-    assert callbacks.calls == [("on_state_change", "kitchen", DeviceState.ONLINE, "mdns")]
+    # The claim also flips the authoritative source UNKNOWN → mdns, which fires
+    # first; the state fan-out follows.
+    assert callbacks.calls == [
+        ("on_source_change", "kitchen", ReachabilitySource.MDNS),
+        ("on_state_change", "kitchen", DeviceState.ONLINE, "mdns"),
+    ]

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -95,6 +95,7 @@ def _make_monitor(
     callbacks = RecordingMonitorCallbacks(devices)
     monitor._on_state_change = callbacks.on_state_change
     monitor._on_ip_change = callbacks.on_ip_change
+    monitor._on_source_change = callbacks.on_source_change
     monitor._on_version_change = callbacks.on_version_change
     monitor._on_config_hash_change = callbacks.on_config_hash_change
     monitor._on_api_encryption_change = callbacks.on_api_encryption_change

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -107,6 +107,7 @@ def _make_monitor(
     monitor.state.reachability = tracker
     monitor._on_state_change = _flip_state(devices)
     monitor._on_ip_change = lambda _n, _i, _l: None
+    monitor._on_source_change = None
     monitor._on_version_change = None
     monitor._on_config_hash_change = None
     monitor._on_api_encryption_change = None


### PR DESCRIPTION
# What does this implement/fix?

Surfaces two reachability signals on the device snapshot so the frontend can gate the mDNS-sourced out-of-sync / update indicators on a live mDNS. This is the backend half of the #1758 fix; the companion frontend PR consumes them.

The deployed version and config hash come only from a device's mDNS broadcast. In an mDNS-dark setup (a ping or MQTT only "odd setup", e.g. a standalone Docker-bridge dashboard) they go stale, so the dashboard shows a false "Out of sync"; an out-of-band CLI OTA is the reported trigger. Rather than probe live devices to chase the value, we let the UI gracefully degrade and hide the indicators when mDNS is not the live source.

Adds `Device.active_source` (the winning `priority_for` source). It is maintained event-driven from the source ledger we already keep: `apply()` and `forget()` fire a deduped `on_source_change` callback that sets the field and fires `DEVICE_UPDATED` without persisting it (runtime-only, defaults UNKNOWN on load). No new polling, no device connections.

Also adds `Device.pending_changes_via_hash`: true only when `has_pending_changes` came from the mDNS-sourced config-hash compare, not the local mtime fallback. It is a pure function of the two committed hashes, set wherever `has_pending_changes` is. This lets the frontend gate only the mDNS-dependent case, so a local YAML edit still cues install when mDNS is dark (raised by review).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1758 (with the companion frontend PR)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1037 (consumes `active_source`)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
