### PR TITLE
Resolve /json-config through esphome config

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -475,6 +475,6 @@ For Home Assistant ESPHome integration backward compat only.
 |----------|-------------|
 | `GET /devices` | List devices |
 | `GET /ping` | Online-status map `{<config>.yaml: true\|false\|null}` (third-party widgets, e.g. homepage) |
-| `GET /json-config?configuration=...` | Get parsed YAML as JSON |
+| `GET /json-config?configuration=...` | Fully-resolved config (substitutions/packages/includes/secrets) as JSON, via `esphome config`; 404 missing, 422 invalid, 503 unavailable, 403 traversal |
 | `GET /compile` (WebSocket) | Compile via spawn protocol |
 | `GET /upload` (WebSocket) | Upload via spawn protocol |

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -362,12 +362,12 @@ def create_legacy_routes() -> web.RouteTableDef:
         if not esphome_cmd:
             return json_response({"error": "esphome unavailable"}, status=500)
 
-        # Generic 422 body on failure — ``esphome config`` stderr carries
-        # resolved secrets under ``--show-secrets`` and must not echo back.
-        _rc, config, _stderr = await run_esphome_config(esphome_cmd, config_path)
+        # Generic 422 body — an invalid config's error can carry resolved
+        # secrets (``--show-secrets``), so it never reaches the response.
+        config = await run_esphome_config(esphome_cmd, config_path)
         if config is None:
             return json_response({"error": "Configuration is invalid"}, status=422)
-        return web.json_response(config, dumps=dumps_str)
+        return json_response(config)
 
     @routes.get("/compile")
     async def legacy_compile(request: web.Request) -> web.WebSocketResponse:

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -34,7 +34,7 @@ import aiohttp
 from aiohttp import web
 
 from ..helpers.api import CommandError
-from ..helpers.device_yaml import run_esphome_config
+from ..helpers.device_yaml import EsphomeConfigUnavailableError, run_esphome_config
 from ..helpers.event_bus import Event, StreamControls, stream_events
 from ..helpers.json import (
     JSONDecodeError,
@@ -291,6 +291,39 @@ async def _handle_spawn(
     await _stream_job_to_legacy_ws(ws, bus, job)
 
 
+async def _json_config_response(db: DeviceBuilder, configuration: str) -> web.Response:
+    """Resolve *configuration* via ``esphome config`` and return it as JSON.
+
+    403 traversal, 404 missing file, 500 no esphome, 503 infra fault, 422 invalid.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        # ``rel_path`` calls ``Path.resolve``, a blocking syscall — run it in
+        # the executor so blockbuster doesn't fault the request on CI.
+        config_path = await loop.run_in_executor(None, db.settings.rel_path, configuration)
+    except CommandError:
+        return json_response({"error": "Forbidden"}, status=403)
+
+    if not await loop.run_in_executor(None, config_path.is_file):
+        return json_response({"error": "Not found"}, status=404)
+
+    devices = db.devices
+    esphome_cmd = devices.state.esphome_cmd if devices is not None else []
+    if not esphome_cmd:
+        return json_response({"error": "esphome unavailable"}, status=500)
+
+    # 503 (retryable) for an infra fault vs 422 for a config that ran and failed;
+    # the body stays generic either way — an invalid config's error can carry
+    # resolved secrets (``--show-secrets``).
+    try:
+        config = await run_esphome_config(esphome_cmd, config_path)
+    except EsphomeConfigUnavailableError:
+        return json_response({"error": "esphome config unavailable"}, status=503)
+    if config is None:
+        return json_response({"error": "Configuration is invalid"}, status=422)
+    return json_response(config)
+
+
 def create_legacy_routes() -> web.RouteTableDef:
     """Create backward-compatible REST + WS routes for HA."""
     routes = web.RouteTableDef()
@@ -344,30 +377,8 @@ def create_legacy_routes() -> web.RouteTableDef:
         detection needs), so a raw ``load_yaml`` can't leak unresolved
         ``${vars}`` / unmerged packages or 500 on ``EFloat`` / ``!lambda``.
         """
-        configuration = request.query.get("configuration", "")
         db = request.app["device_builder"]
-        loop = asyncio.get_running_loop()
-        try:
-            # ``rel_path`` calls ``Path.resolve``, a blocking syscall —
-            # run it in the executor so blockbuster doesn't fault the
-            # request on CI.
-            config_path = await loop.run_in_executor(None, db.settings.rel_path, configuration)
-        except CommandError:
-            return json_response({"error": "Forbidden"}, status=403)
-
-        if not await loop.run_in_executor(None, config_path.is_file):
-            return json_response({"error": "Not found"}, status=404)
-
-        esphome_cmd = db.devices.state.esphome_cmd
-        if not esphome_cmd:
-            return json_response({"error": "esphome unavailable"}, status=500)
-
-        # Generic 422 body — an invalid config's error can carry resolved
-        # secrets (``--show-secrets``), so it never reaches the response.
-        config = await run_esphome_config(esphome_cmd, config_path)
-        if config is None:
-            return json_response({"error": "Configuration is invalid"}, status=422)
-        return json_response(config)
+        return await _json_config_response(db, request.query.get("configuration", ""))
 
     @routes.get("/compile")
     async def legacy_compile(request: web.Request) -> web.WebSocketResponse:

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -32,15 +32,13 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from aiohttp import web
-from esphome import yaml_util
-from esphome.core import EsphomeError
 
 from ..helpers.api import CommandError
+from ..helpers.device_yaml import run_esphome_config
 from ..helpers.event_bus import Event, StreamControls, stream_events
 from ..helpers.json import (
     JSONDecodeError,
     dumps_str,
-    dumps_str_non_str_keys,
     json_response,
     loads,
 )
@@ -339,7 +337,13 @@ def create_legacy_routes() -> web.RouteTableDef:
 
     @routes.get("/json-config")
     async def legacy_json_config(request: web.Request) -> web.Response:
-        """Legacy GET /json-config — parsed YAML config as JSON."""
+        """Legacy GET /json-config — fully-resolved config as JSON.
+
+        Resolves substitutions / packages / includes / secrets via
+        ``esphome config --show-secrets`` (same path HA's encryption-key
+        detection needs), so a raw ``load_yaml`` can't leak unresolved
+        ``${vars}`` / unmerged packages or 500 on ``EFloat`` / ``!lambda``.
+        """
         configuration = request.query.get("configuration", "")
         db = request.app["device_builder"]
         loop = asyncio.get_running_loop()
@@ -351,23 +355,19 @@ def create_legacy_routes() -> web.RouteTableDef:
         except CommandError:
             return json_response({"error": "Forbidden"}, status=403)
 
-        try:
-            # ``yaml_util.load_yaml`` expects a ``Path`` (it calls
-            # ``fname.open(...)``); a string would raise
-            # ``AttributeError`` deep in the loader, which falls
-            # past the ``EsphomeError`` catch below and surfaces as
-            # the default aiohttp 500 instead of our diagnostic
-            # ``{"error": ...}`` body. Keep the real ``Path`` here.
-            config = await loop.run_in_executor(None, yaml_util.load_yaml, config_path)
-        except EsphomeError as exc:
-            return json_response({"error": str(exc)}, status=500)
+        if not await loop.run_in_executor(None, config_path.is_file):
+            return json_response({"error": "Not found"}, status=404)
 
-        # ESPHome's ``yaml_util.load_yaml`` returns an ``OrderedDict``
-        # whose keys are ``EStr`` (a ``str`` subclass that carries
-        # source-position info). orjson's strict default rejects
-        # non-exact-``str`` keys; ``dumps_str_non_str_keys`` flips
-        # the ``OPT_NON_STR_KEYS`` option just for this endpoint.
-        return web.json_response(config, dumps=dumps_str_non_str_keys)
+        esphome_cmd = db.devices.state.esphome_cmd
+        if not esphome_cmd:
+            return json_response({"error": "esphome unavailable"}, status=500)
+
+        # Generic 422 body on failure — ``esphome config`` stderr carries
+        # resolved secrets under ``--show-secrets`` and must not echo back.
+        _rc, config, _stderr = await run_esphome_config(esphome_cmd, config_path)
+        if config is None:
+            return json_response({"error": "Configuration is invalid"}, status=422)
+        return web.json_response(config, dumps=dumps_str)
 
     @routes.get("/compile")
     async def legacy_compile(request: web.Request) -> web.WebSocketResponse:

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING
 
 from ...helpers.device_yaml import (
@@ -15,8 +14,6 @@ from ...helpers.device_yaml import (
 
 if TYPE_CHECKING:
     from .controller import DevicesController
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def get_api_key(controller: DevicesController, configuration: str) -> dict[str, str]:
@@ -71,7 +68,7 @@ async def resolve_via_esphome_config(controller: DevicesController, configuratio
     if not esphome_cmd:
         return ""
     config_path = controller._db.settings.rel_path(configuration)
-    _rc, config, _stderr = await run_esphome_config(esphome_cmd, config_path)
+    config = await run_esphome_config(esphome_cmd, config_path)
     if config is None:
         return ""
     return get_resolved_api_encryption_key(config)

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -6,14 +6,12 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
-import yaml
-
 from ...helpers.device_yaml import (
     get_api_port,
     get_resolved_api_encryption_key,
     load_device_yaml,
+    run_esphome_config,
 )
-from ...helpers.subprocess import create_subprocess_exec
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -62,47 +60,18 @@ async def get_api_connection(controller: DevicesController, configuration: str) 
 
 
 async def resolve_via_esphome_config(controller: DevicesController, configuration: str) -> str:
-    r"""
+    """
     Subprocess fallback for :func:`get_api_key`.
 
-    ``--show-secrets`` is required: without it ESPHome wraps each
-    secret value in the ANSI conceal SGR (``\x1b[8m...\x1b[28m``)
-    and ``yaml.safe_load`` would treat the wrapped string as the
-    key. Returns ``""`` on every failure path.
+    Delegates to :func:`helpers.device_yaml.run_esphome_config`, which fully
+    resolves substitutions / packages / secrets. Returns ``""`` on every
+    failure path.
     """
     esphome_cmd = controller.state.esphome_cmd
     if not esphome_cmd:
         return ""
-    config_path = str(controller._db.settings.rel_path(configuration))
-    cmd = [*esphome_cmd, "--dashboard", "config", config_path, "--show-secrets"]
-    try:
-        proc = await create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout_bytes, _ = await proc.communicate()
-    except OSError as exc:
-        _LOGGER.debug("esphome config subprocess failed for %s: %s", configuration, exc)
+    config_path = controller._db.settings.rel_path(configuration)
+    _rc, config, _stderr = await run_esphome_config(esphome_cmd, config_path)
+    if config is None:
         return ""
-    if proc.returncode != 0:
-        _LOGGER.debug(
-            "esphome config returned %s for %s; key extraction skipped",
-            proc.returncode,
-            configuration,
-        )
-        return ""
-    try:
-        resolved = yaml.safe_load(stdout_bytes.decode("utf-8", errors="replace"))
-    except yaml.YAMLError as exc:
-        # Log the exception class only; ``str(yaml.YAMLError)``
-        # includes context lines from the ``--show-secrets``
-        # output, which carry resolved Wi-Fi passwords / API
-        # keys verbatim and would leak into log scrapes.
-        _LOGGER.debug(
-            "esphome config output for %s did not parse as YAML (%s)",
-            configuration,
-            type(exc).__name__,
-        )
-        return ""
-    return get_resolved_api_encryption_key(resolved)
+    return get_resolved_api_encryption_key(config)

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from ...helpers.device_yaml import (
+    EsphomeConfigUnavailableError,
     get_api_port,
     get_resolved_api_encryption_key,
     load_device_yaml,
@@ -62,13 +63,17 @@ async def resolve_via_esphome_config(controller: DevicesController, configuratio
 
     Delegates to :func:`helpers.device_yaml.run_esphome_config`, which fully
     resolves substitutions / packages / secrets. Returns ``""`` on every
-    failure path.
+    failure path — an infra fault and a keyless config both collapse to the
+    "open the editor and check" sentinel the UI already handles.
     """
     esphome_cmd = controller.state.esphome_cmd
     if not esphome_cmd:
         return ""
     config_path = controller._db.settings.rel_path(configuration)
-    config = await run_esphome_config(esphome_cmd, config_path)
+    try:
+        config = await run_esphome_config(esphome_cmd, config_path)
+    except EsphomeConfigUnavailableError:
+        return ""
     if config is None:
         return ""
     return get_resolved_api_encryption_key(config)

--- a/esphome_device_builder/helpers/device_yaml/__init__.py
+++ b/esphome_device_builder/helpers/device_yaml/__init__.py
@@ -53,6 +53,7 @@ from ._parsing import (
     yaml_has_api_encryption,
     yaml_has_top_level_block,
 )
+from ._resolve import run_esphome_config
 
 __all__ = [
     "DEFAULT_API_PORT",
@@ -85,6 +86,7 @@ __all__ = [
     "parse_esphome_meta",
     "parse_platform_from_yaml",
     "pending_changes_via_hash",
+    "run_esphome_config",
     "yaml_has_api_encryption",
     "yaml_has_top_level_block",
 ]

--- a/esphome_device_builder/helpers/device_yaml/__init__.py
+++ b/esphome_device_builder/helpers/device_yaml/__init__.py
@@ -53,12 +53,13 @@ from ._parsing import (
     yaml_has_api_encryption,
     yaml_has_top_level_block,
 )
-from ._resolve import run_esphome_config
+from ._resolve import EsphomeConfigUnavailableError, run_esphome_config
 
 __all__ = [
     "DEFAULT_API_PORT",
     "NETWORK_PROVIDER_COMPONENT_IDS",
     "_UNRESOLVED_SUBSTITUTION_RE",
+    "EsphomeConfigUnavailableError",
     "EsphomeMeta",
     "StorageJSON",
     "_extract_resolved_substitutions",

--- a/esphome_device_builder/helpers/device_yaml/_resolve.py
+++ b/esphome_device_builder/helpers/device_yaml/_resolve.py
@@ -26,7 +26,12 @@ class _SafeLoaderIgnoreUnknown(FastestSafeLoader):
 
 
 def _ignore_unknown(loader: yaml.Loader, node: yaml.Node) -> str:
-    return f"{node.tag} {node.value}"
+    # esphome config output emits only scalar custom tags (``!lambda``);
+    # a non-scalar node's ``value`` is a node-pair list, so fall back to
+    # the bare tag rather than stringifying that into the result.
+    if isinstance(node, yaml.ScalarNode):
+        return f"{node.tag} {node.value}"
+    return node.tag
 
 
 # ``esphome config`` output still carries ``!lambda`` (and any future
@@ -56,19 +61,25 @@ async def run_esphome_config(esphome_cmd: list[str], config_path: Path) -> dict[
             stderr=asyncio.subprocess.DEVNULL,
         )
     except OSError as exc:
-        _LOGGER.debug("esphome config spawn failed for %s: %s", config_path, exc)
+        # Infrastructure failure (missing binary, FD exhaustion), not a user
+        # config error — warn so it's visible at the default log level.
+        _LOGGER.warning("esphome config spawn failed for %s: %s", config_path, exc)
         return None
     try:
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
     except TimeoutError:
         kill_quietly(proc)
         await proc.wait()
-        _LOGGER.debug("esphome config timed out for %s", config_path)
+        _LOGGER.warning(
+            "esphome config timed out after %ss for %s", _ESPHOME_CONFIG_TIMEOUT, config_path
+        )
         return None
     except asyncio.CancelledError:
         kill_quietly(proc)
         raise
     if proc.returncode != 0:
+        # Usually a genuinely invalid config the caller surfaces as 422 / empty
+        # key — debug, so a user mid-edit doesn't spam the operator's log.
         _LOGGER.debug("esphome config returned %s for %s", proc.returncode, config_path)
         return None
     return _parse_resolved_config(stdout)
@@ -83,4 +94,7 @@ def _parse_resolved_config(stdout: bytes) -> dict[str, Any] | None:
         # lines from ``--show-secrets`` output, which carry resolved secrets.
         _LOGGER.debug("esphome config output did not parse as YAML (%s)", type(exc).__name__)
         return None
-    return data if isinstance(data, dict) else None
+    if not isinstance(data, dict):
+        _LOGGER.debug("esphome config output parsed to %s, not a mapping", type(data).__name__)
+        return None
+    return data

--- a/esphome_device_builder/helpers/device_yaml/_resolve.py
+++ b/esphome_device_builder/helpers/device_yaml/_resolve.py
@@ -29,6 +29,14 @@ _MAX_CONCURRENT_CONFIG = 3
 _config_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_CONFIG)
 
 
+class EsphomeConfigUnavailableError(Exception):
+    """``esphome config`` could not run to completion.
+
+    A retryable infrastructure fault (spawn failure, timeout, signal kill),
+    distinct from a config that ran and failed validation (returns ``None``).
+    """
+
+
 class _SafeLoaderIgnoreUnknown(FastestSafeLoader):
     """SafeLoader that renders unknown ESPHome tags (``!lambda``) as strings."""
 
@@ -54,13 +62,16 @@ async def run_esphome_config(esphome_cmd: list[str], config_path: Path) -> dict[
 
     Fully resolves substitutions, packages, includes, and secrets — the
     output is plain YAML (no ESPHome ``EFloat`` / ``Lambda`` / ``IncludeFile``
-    wrappers). Returns ``None`` when the spawn failed, the command exited
-    non-zero, or the output didn't parse to a mapping. ``--show-secrets`` is
-    required: without it ESPHome conceal-wraps secret values in an ANSI SGR.
+    wrappers). ``--show-secrets`` is required: without it ESPHome conceal-wraps
+    secret values in an ANSI SGR.
 
-    Failure detail is logged here (never the resolved-secret-bearing stderr)
-    rather than returned, so callers only branch on ``None``. Concurrent runs
-    are capped (:data:`_MAX_CONCURRENT_CONFIG`); excess callers queue.
+    Returns the resolved dict on success, ``None`` when the config ran but was
+    invalid (non-zero exit) or its output wasn't a mapping, and raises
+    :class:`EsphomeConfigUnavailableError` on an infrastructure fault (spawn failure,
+    timeout, signal kill) so a caller can answer "retry later" rather than
+    "your config is wrong". Failure detail is logged here (never the
+    resolved-secret-bearing stderr). Concurrent runs are capped
+    (:data:`_MAX_CONCURRENT_CONFIG`); excess callers queue.
     """
     cmd = [*esphome_cmd, "--dashboard", "config", str(config_path), "--show-secrets"]
     # Hold the gate only across the subprocess (where the RAM lives); the
@@ -73,26 +84,33 @@ async def run_esphome_config(esphome_cmd: list[str], config_path: Path) -> dict[
                 stderr=asyncio.subprocess.DEVNULL,
             )
         except OSError as exc:
-            # Infrastructure failure (missing binary, FD exhaustion), not a user
-            # config error — warn so it's visible at the default log level.
             _LOGGER.warning("esphome config spawn failed for %s: %s", config_path, exc)
-            return None
+            raise EsphomeConfigUnavailableError(f"spawn failed: {exc}") from exc
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
-        except TimeoutError:
+        except TimeoutError as exc:
             kill_quietly(proc)
             await proc.wait()
             _LOGGER.warning(
                 "esphome config timed out after %ss for %s", _ESPHOME_CONFIG_TIMEOUT, config_path
             )
-            return None
+            raise EsphomeConfigUnavailableError("timed out") from exc
         except asyncio.CancelledError:
+            # Don't await proc.wait() here: it would suppress / delay the
+            # cancellation propagation. The SIGKILL'd child is reaped by
+            # asyncio's watcher (matches helpers.subprocess.run_subprocess_capture).
             kill_quietly(proc)
             raise
-        if proc.returncode != 0:
-            # Usually a genuinely invalid config the caller surfaces as 422 /
-            # empty key — debug, so a user mid-edit doesn't spam the log.
-            _LOGGER.debug("esphome config returned %s for %s", proc.returncode, config_path)
+        returncode = proc.returncode
+        if returncode and returncode < 0:
+            # Negative == terminated by a signal (crash / OOM kill), not a
+            # validation failure — an infrastructure fault, surface it.
+            _LOGGER.warning("esphome config killed by signal %s for %s", -returncode, config_path)
+            raise EsphomeConfigUnavailableError(f"killed by signal {-returncode}")
+        if returncode != 0:
+            # A genuinely invalid config the caller surfaces as 422 / empty key —
+            # debug, so a user mid-edit doesn't spam the operator's log.
+            _LOGGER.debug("esphome config returned %s for %s", returncode, config_path)
             return None
     return _parse_resolved_config(stdout)
 

--- a/esphome_device_builder/helpers/device_yaml/_resolve.py
+++ b/esphome_device_builder/helpers/device_yaml/_resolve.py
@@ -20,6 +20,14 @@ _LOGGER = logging.getLogger(__name__)
 # forever on a wedged subprocess.
 _ESPHOME_CONFIG_TIMEOUT = 60.0
 
+# Each spawn imports ``esphome.components`` (~70 MiB RSS). Cap concurrent
+# subprocesses so a burst — HA adding several devices, a fleet key-resolve —
+# can't stack N×70 MiB on a low-RAM host (HA Green). Callers queue past the cap.
+# The process runs a single event loop for its lifetime, so one module-level
+# semaphore gates every call site.
+_MAX_CONCURRENT_CONFIG = 3
+_config_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_CONFIG)
+
 
 class _SafeLoaderIgnoreUnknown(FastestSafeLoader):
     """SafeLoader that renders unknown ESPHome tags (``!lambda``) as strings."""
@@ -51,37 +59,41 @@ async def run_esphome_config(esphome_cmd: list[str], config_path: Path) -> dict[
     required: without it ESPHome conceal-wraps secret values in an ANSI SGR.
 
     Failure detail is logged here (never the resolved-secret-bearing stderr)
-    rather than returned, so callers only branch on ``None``.
+    rather than returned, so callers only branch on ``None``. Concurrent runs
+    are capped (:data:`_MAX_CONCURRENT_CONFIG`); excess callers queue.
     """
     cmd = [*esphome_cmd, "--dashboard", "config", str(config_path), "--show-secrets"]
-    try:
-        proc = await create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-    except OSError as exc:
-        # Infrastructure failure (missing binary, FD exhaustion), not a user
-        # config error — warn so it's visible at the default log level.
-        _LOGGER.warning("esphome config spawn failed for %s: %s", config_path, exc)
-        return None
-    try:
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
-    except TimeoutError:
-        kill_quietly(proc)
-        await proc.wait()
-        _LOGGER.warning(
-            "esphome config timed out after %ss for %s", _ESPHOME_CONFIG_TIMEOUT, config_path
-        )
-        return None
-    except asyncio.CancelledError:
-        kill_quietly(proc)
-        raise
-    if proc.returncode != 0:
-        # Usually a genuinely invalid config the caller surfaces as 422 / empty
-        # key — debug, so a user mid-edit doesn't spam the operator's log.
-        _LOGGER.debug("esphome config returned %s for %s", proc.returncode, config_path)
-        return None
+    # Hold the gate only across the subprocess (where the RAM lives); the
+    # parse below runs once it's released.
+    async with _config_semaphore:
+        try:
+            proc = await create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            # Infrastructure failure (missing binary, FD exhaustion), not a user
+            # config error — warn so it's visible at the default log level.
+            _LOGGER.warning("esphome config spawn failed for %s: %s", config_path, exc)
+            return None
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
+        except TimeoutError:
+            kill_quietly(proc)
+            await proc.wait()
+            _LOGGER.warning(
+                "esphome config timed out after %ss for %s", _ESPHOME_CONFIG_TIMEOUT, config_path
+            )
+            return None
+        except asyncio.CancelledError:
+            kill_quietly(proc)
+            raise
+        if proc.returncode != 0:
+            # Usually a genuinely invalid config the caller surfaces as 422 /
+            # empty key — debug, so a user mid-edit doesn't spam the log.
+            _LOGGER.debug("esphome config returned %s for %s", proc.returncode, config_path)
+            return None
     return _parse_resolved_config(stdout)
 
 

--- a/esphome_device_builder/helpers/device_yaml/_resolve.py
+++ b/esphome_device_builder/helpers/device_yaml/_resolve.py
@@ -35,41 +35,43 @@ def _ignore_unknown(loader: yaml.Loader, node: yaml.Node) -> str:
 _SafeLoaderIgnoreUnknown.add_constructor(None, _ignore_unknown)
 
 
-async def run_esphome_config(
-    esphome_cmd: list[str], config_path: Path
-) -> tuple[int | None, dict[str, Any] | None, str]:
+async def run_esphome_config(esphome_cmd: list[str], config_path: Path) -> dict[str, Any] | None:
     """
-    Run ``esphome config <path> --show-secrets``; return ``(rc, parsed, stderr)``.
+    Run ``esphome config <path> --show-secrets``; return the resolved config.
 
     Fully resolves substitutions, packages, includes, and secrets — the
     output is plain YAML (no ESPHome ``EFloat`` / ``Lambda`` / ``IncludeFile``
-    wrappers). ``parsed`` is ``None`` when the spawn failed, the command
-    exited non-zero, or the output didn't parse to a mapping. ``--show-secrets``
-    is required: without it ESPHome conceal-wraps secret values in an ANSI SGR.
+    wrappers). Returns ``None`` when the spawn failed, the command exited
+    non-zero, or the output didn't parse to a mapping. ``--show-secrets`` is
+    required: without it ESPHome conceal-wraps secret values in an ANSI SGR.
+
+    Failure detail is logged here (never the resolved-secret-bearing stderr)
+    rather than returned, so callers only branch on ``None``.
     """
     cmd = [*esphome_cmd, "--dashboard", "config", str(config_path), "--show-secrets"]
     try:
         proc = await create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
         )
     except OSError as exc:
         _LOGGER.debug("esphome config spawn failed for %s: %s", config_path, exc)
-        return None, None, str(exc)
+        return None
     try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
     except TimeoutError:
         kill_quietly(proc)
         await proc.wait()
-        return None, None, "esphome config timed out"
+        _LOGGER.debug("esphome config timed out for %s", config_path)
+        return None
     except asyncio.CancelledError:
         kill_quietly(proc)
         raise
-    stderr_text = stderr.decode("utf-8", errors="replace")
     if proc.returncode != 0:
-        return proc.returncode, None, stderr_text
-    return proc.returncode, _parse_resolved_config(stdout), stderr_text
+        _LOGGER.debug("esphome config returned %s for %s", proc.returncode, config_path)
+        return None
+    return _parse_resolved_config(stdout)
 
 
 def _parse_resolved_config(stdout: bytes) -> dict[str, Any] | None:

--- a/esphome_device_builder/helpers/device_yaml/_resolve.py
+++ b/esphome_device_builder/helpers/device_yaml/_resolve.py
@@ -1,0 +1,84 @@
+"""Resolve a device config through the ``esphome config`` subprocess."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..subprocess import create_subprocess_exec, kill_quietly
+from ..yaml import FastestSafeLoader
+
+_LOGGER = logging.getLogger(__name__)
+
+# ``esphome config`` validates the full config (imports components,
+# resolves packages); the first run on a cold process can take a few
+# seconds. 60s is generous headroom over that without hanging a request
+# forever on a wedged subprocess.
+_ESPHOME_CONFIG_TIMEOUT = 60.0
+
+
+class _SafeLoaderIgnoreUnknown(FastestSafeLoader):
+    """SafeLoader that renders unknown ESPHome tags (``!lambda``) as strings."""
+
+
+def _ignore_unknown(loader: yaml.Loader, node: yaml.Node) -> str:
+    return f"{node.tag} {node.value}"
+
+
+# ``esphome config`` output still carries ``!lambda`` (and any future
+# custom tag) the dumper emits; the catch-all None constructor stringifies
+# them so a plain SafeLoader doesn't raise and the result is JSON-native.
+_SafeLoaderIgnoreUnknown.add_constructor(None, _ignore_unknown)
+
+
+async def run_esphome_config(
+    esphome_cmd: list[str], config_path: Path
+) -> tuple[int | None, dict[str, Any] | None, str]:
+    """
+    Run ``esphome config <path> --show-secrets``; return ``(rc, parsed, stderr)``.
+
+    Fully resolves substitutions, packages, includes, and secrets — the
+    output is plain YAML (no ESPHome ``EFloat`` / ``Lambda`` / ``IncludeFile``
+    wrappers). ``parsed`` is ``None`` when the spawn failed, the command
+    exited non-zero, or the output didn't parse to a mapping. ``--show-secrets``
+    is required: without it ESPHome conceal-wraps secret values in an ANSI SGR.
+    """
+    cmd = [*esphome_cmd, "--dashboard", "config", str(config_path), "--show-secrets"]
+    try:
+        proc = await create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError as exc:
+        _LOGGER.debug("esphome config spawn failed for %s: %s", config_path, exc)
+        return None, None, str(exc)
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_ESPHOME_CONFIG_TIMEOUT)
+    except TimeoutError:
+        kill_quietly(proc)
+        await proc.wait()
+        return None, None, "esphome config timed out"
+    except asyncio.CancelledError:
+        kill_quietly(proc)
+        raise
+    stderr_text = stderr.decode("utf-8", errors="replace")
+    if proc.returncode != 0:
+        return proc.returncode, None, stderr_text
+    return proc.returncode, _parse_resolved_config(stdout), stderr_text
+
+
+def _parse_resolved_config(stdout: bytes) -> dict[str, Any] | None:
+    """Parse ``esphome config`` output; ``None`` on YAML error or non-mapping."""
+    try:
+        data = yaml.load(stdout, Loader=_SafeLoaderIgnoreUnknown)  # noqa: S506
+    except yaml.YAMLError as exc:
+        # Log the exception class only; ``str(yaml.YAMLError)`` echoes context
+        # lines from ``--show-secrets`` output, which carry resolved secrets.
+        _LOGGER.debug("esphome config output did not parse as YAML (%s)", type(exc).__name__)
+        return None
+    return data if isinstance(data, dict) else None

--- a/esphome_device_builder/helpers/json.py
+++ b/esphome_device_builder/helpers/json.py
@@ -38,30 +38,6 @@ def dumps(obj: Any) -> bytes:
     return orjson.dumps(obj)
 
 
-def dumps_str_non_str_keys(obj: Any) -> str:
-    """
-    Serialise *obj* allowing dict keys whose type isn't *exactly* ``str``.
-
-    Wraps orjson's ``OPT_NON_STR_KEYS`` — keys that are ``str``
-    subclasses, ``int``, ``float``, ``bool``, ``datetime``,
-    ``UUID``, etc. all serialise instead of raising ``TypeError:
-    Dict key must be str``. ESPHome's ``yaml_util`` returns dicts
-    whose keys are ``EStr`` (a ``str`` subclass that carries
-    source-position info), which is what the legacy
-    ``/json-config`` endpoint feeds in.
-
-    Use this helper for that endpoint (and only there); the strict
-    default of ``dumps`` still catches the more common bug shape —
-    a dict with non-string keys leaking into a response — for
-    every other call site.
-
-    Returns ``str`` so it can be passed straight to aiohttp's
-    ``web.json_response(dumps=...)`` (which expects a ``str``-
-    returning callable, like ``dumps_str``).
-    """
-    return orjson.dumps(obj, option=orjson.OPT_NON_STR_KEYS).decode()
-
-
 def dumps_str(obj: Any) -> str:
     """Serialise *obj* to a compact JSON ``str``.
 

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -452,7 +452,9 @@ async def test_json_config_returns_422_on_invalid_config(
 
     assert resp.status == 422
     body = await resp.json()
-    assert "error" in body
+    # Pin the generic body: a future refactor that echoes esphome's stderr
+    # (which carries resolved secrets under --show-secrets) must fail here.
+    assert body == {"error": "Configuration is invalid"}
 
 
 async def test_json_config_returns_404_on_missing_file(

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -402,7 +402,7 @@ async def test_json_config_returns_resolved_config(
     """
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
     resolved = {"esphome": {"name": "kitchen", "platform": "ESP32"}, "sensor": [{"delta": 0.1}]}
-    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=(0, resolved, "")))
+    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=resolved))
     client = await aiohttp_client(_make_json_config_app(tmp_path))
 
     resp = await client.get("/json-config", params={"configuration": "kitchen.yaml"})
@@ -439,13 +439,13 @@ async def test_json_config_rejects_traversal(
 async def test_json_config_returns_422_on_invalid_config(
     tmp_path: Path, aiohttp_client: AiohttpClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``esphome config`` failure (rc!=0 → ``config=None``) surfaces as 422.
+    """``esphome config`` failure (``None``) surfaces as a generic 422.
 
-    The body is generic — ``--show-secrets`` stderr carries resolved
-    secrets and must not echo back.
+    The body is generic; an invalid config's error can carry resolved
+    secrets, so the helper's detail never reaches the response.
     """
     (tmp_path / "broken.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=(2, None, "boom")))
+    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=None))
     client = await aiohttp_client(_make_json_config_app(tmp_path))
 
     resp = await client.get("/json-config", params={"configuration": "broken.yaml"})
@@ -453,7 +453,6 @@ async def test_json_config_returns_422_on_invalid_config(
     assert resp.status == 422
     body = await resp.json()
     assert "error" in body
-    assert "boom" not in body["error"]
 
 
 async def test_json_config_returns_404_on_missing_file(

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -13,14 +13,13 @@ Routes covered:
   ``ignored_devices``. Upstream:
   ``ListDevicesHandler`` /
   ``build_device_list_response``.
-- ``GET /json-config`` — parsed YAML config as JSON. Upstream:
-  ``JsonConfigRequestHandler``. **Note**: upstream spawns
-  ``esphome config`` for substitution / package resolution
-  and returns 422 with stderr on parse failure / 404 on
-  missing file. Our impl loads raw YAML directly and surfaces
-  parse errors as 500. The deviation is documented in the
-  tests below — pin our actual contract so a future refactor
-  to match upstream surfaces.
+- ``GET /json-config`` — fully-resolved config as JSON. Like
+  upstream's ``JsonConfigRequestHandler``, it spawns ``esphome
+  config --show-secrets`` (via ``run_esphome_config``) so
+  substitutions / packages / includes / secrets all resolve —
+  the data HA's encryption-key detection needs. Returns 404 on
+  a missing file, 422 on an invalid config, 403 on a traversal
+  (our hardening over upstream's 404).
 - ``GET /compile`` and ``GET /upload`` — WebSocket spawn
   protocol. Frame shapes match upstream verbatim:
   ``{event: "line", data: <text>}`` per output chunk,
@@ -378,19 +377,33 @@ async def test_ping_triggers_poll(tmp_path: Path, aiohttp_client: AiohttpClient)
 # ---------------------------------------------------------------------------
 
 
-async def test_json_config_returns_parsed_yaml(
-    tmp_path: Path, aiohttp_client: AiohttpClient
-) -> None:
-    """Happy path: valid YAML → JSON-serialised dict response.
+def _make_json_config_app(
+    tmp_path: Path, *, esphome_cmd: list[str] | None = None
+) -> web.Application:
+    """``_make_app`` plus a devices stub carrying ``state.esphome_cmd``.
 
-    HA reads device metadata (esphome.name, esphome.platform,
-    etc.) off this endpoint to populate the integration UI.
+    ``legacy_json_config`` reads ``db.devices.state.esphome_cmd`` to spawn
+    ``esphome config``; the resolution itself is patched per-test via
+    ``legacy.run_esphome_config``.
     """
-    (tmp_path / "kitchen.yaml").write_text(
-        "esphome:\n  name: kitchen\n  platform: ESP32\n",
-        encoding="utf-8",
-    )
-    client = await aiohttp_client(_make_app(tmp_path))
+    devices = MagicMock()
+    devices.state.esphome_cmd = ["esphome"] if esphome_cmd is None else esphome_cmd
+    return _make_app(tmp_path, devices=devices)
+
+
+async def test_json_config_returns_resolved_config(
+    tmp_path: Path, aiohttp_client: AiohttpClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: ``esphome config`` output → JSON-serialised dict response.
+
+    HA reads device metadata + the resolved ``api.encryption.key`` off this
+    endpoint; the resolved config is what carries it (substitutions expanded,
+    packages merged).
+    """
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    resolved = {"esphome": {"name": "kitchen", "platform": "ESP32"}, "sensor": [{"delta": 0.1}]}
+    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=(0, resolved, "")))
+    client = await aiohttp_client(_make_json_config_app(tmp_path))
 
     resp = await client.get("/json-config", params={"configuration": "kitchen.yaml"})
 
@@ -398,6 +411,7 @@ async def test_json_config_returns_parsed_yaml(
     body = await resp.json()
     assert body["esphome"]["name"] == "kitchen"
     assert body["esphome"]["platform"] == "ESP32"
+    assert body["sensor"][0]["delta"] == 0.1
 
 
 @pytest.mark.parametrize(
@@ -422,46 +436,45 @@ async def test_json_config_rejects_traversal(
     assert body == {"error": "Forbidden"}
 
 
-async def test_json_config_returns_500_on_yaml_parse_failure(
-    tmp_path: Path, aiohttp_client: AiohttpClient
+async def test_json_config_returns_422_on_invalid_config(
+    tmp_path: Path, aiohttp_client: AiohttpClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Malformed YAML → 500 with the parser's error message in the body.
+    """``esphome config`` failure (rc!=0 → ``config=None``) surfaces as 422.
 
-    Note: upstream returns 422 with the ``esphome config``
-    subprocess's stderr (which carries a richer error message
-    because it's run through the substitution / package
-    resolver). Our impl loads raw YAML directly and surfaces
-    the parser exception verbatim — pin the 500 contract so a
-    refactor toward the upstream "422 + spawn" shape surfaces
-    here.
+    The body is generic — ``--show-secrets`` stderr carries resolved
+    secrets and must not echo back.
     """
-    (tmp_path / "broken.yaml").write_text(
-        "esphome:\n  name: kitchen\n  invalid: [unclosed list\n",
-        encoding="utf-8",
-    )
-    client = await aiohttp_client(_make_app(tmp_path))
+    (tmp_path / "broken.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    monkeypatch.setattr(legacy, "run_esphome_config", AsyncMock(return_value=(2, None, "boom")))
+    client = await aiohttp_client(_make_json_config_app(tmp_path))
 
     resp = await client.get("/json-config", params={"configuration": "broken.yaml"})
 
-    assert resp.status == 500
+    assert resp.status == 422
     body = await resp.json()
     assert "error" in body
+    assert "boom" not in body["error"]
 
 
-async def test_json_config_returns_500_on_missing_file(
+async def test_json_config_returns_404_on_missing_file(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:
-    """A missing YAML file surfaces as 500 (not 404).
-
-    Upstream returns 404 in this case; our impl lets the YAML
-    loader's ``FileNotFoundError`` bubble through the
-    ``except Exception`` and lands as 500. Documented as a
-    deviation — HA's library treats both as "request failed,
-    retry".
-    """
-    client = await aiohttp_client(_make_app(tmp_path))
+    """A missing YAML file surfaces as 404 before any subprocess spawn."""
+    client = await aiohttp_client(_make_json_config_app(tmp_path))
 
     resp = await client.get("/json-config", params={"configuration": "ghost.yaml"})
+
+    assert resp.status == 404
+
+
+async def test_json_config_returns_500_when_esphome_unavailable(
+    tmp_path: Path, aiohttp_client: AiohttpClient
+) -> None:
+    """No resolved ``esphome`` binary (empty ``esphome_cmd``) → 500."""
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    client = await aiohttp_client(_make_json_config_app(tmp_path, esphome_cmd=[]))
+
+    resp = await client.get("/json-config", params={"configuration": "kitchen.yaml"})
 
     assert resp.status == 500
 

--- a/tests/api/test_legacy.py
+++ b/tests/api/test_legacy.py
@@ -457,6 +457,27 @@ async def test_json_config_returns_422_on_invalid_config(
     assert body == {"error": "Configuration is invalid"}
 
 
+async def test_json_config_returns_503_on_infra_fault(
+    tmp_path: Path, aiohttp_client: AiohttpClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An infra fault (spawn fail / timeout) is a retryable 503, not a 422.
+
+    HA must keep retrying a config that would resolve once esphome is reachable,
+    rather than treating a transient backend fault as a permanent config error.
+    """
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    monkeypatch.setattr(
+        legacy,
+        "run_esphome_config",
+        AsyncMock(side_effect=legacy.EsphomeConfigUnavailableError("timed out")),
+    )
+    client = await aiohttp_client(_make_json_config_app(tmp_path))
+
+    resp = await client.get("/json-config", params={"configuration": "kitchen.yaml"})
+
+    assert resp.status == 503
+
+
 async def test_json_config_returns_404_on_missing_file(
     tmp_path: Path, aiohttp_client: AiohttpClient
 ) -> None:

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -33,7 +33,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 import pytest
 
 import esphome_device_builder.controllers.devices.add_component as add_component_mod
-import esphome_device_builder.controllers.devices.api_key as api_key_mod
+import esphome_device_builder.helpers.device_yaml._resolve as resolve_mod
 from esphome_device_builder.controllers._device_scanner import ScanChange
 from esphome_device_builder.controllers.devices.add_component import _entry_gate_active
 from esphome_device_builder.helpers.api import CommandError
@@ -366,7 +366,7 @@ async def test_get_api_key_falls_back_to_esphome_config_subprocess(
         return fake_proc
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(api_key_mod, "create_subprocess_exec", _fake_create_subprocess)
+        mp.setattr(resolve_mod, "create_subprocess_exec", _fake_create_subprocess)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": "ZGFzaGJvYXJkLWtleS1mcm9tLWVzcGhvbWUtY29uZmln"}
@@ -399,7 +399,7 @@ async def test_get_api_key_subprocess_returns_empty_on_nonzero_exit(
         return fake_proc
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(api_key_mod, "create_subprocess_exec", _fake_create_subprocess)
+        mp.setattr(resolve_mod, "create_subprocess_exec", _fake_create_subprocess)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
@@ -430,7 +430,7 @@ async def test_get_api_key_subprocess_returns_empty_on_unparsable_yaml(
         return fake_proc
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(api_key_mod, "create_subprocess_exec", _fake_create_subprocess)
+        mp.setattr(resolve_mod, "create_subprocess_exec", _fake_create_subprocess)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
@@ -457,7 +457,7 @@ async def test_get_api_key_subprocess_returns_empty_on_oserror(
         raise OSError("simulated subprocess startup failure")
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(api_key_mod, "create_subprocess_exec", _boom)
+        mp.setattr(resolve_mod, "create_subprocess_exec", _boom)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}
@@ -482,7 +482,7 @@ async def test_get_api_key_skips_subprocess_when_fast_path_finds_key(
     spawn_spy = AsyncMock()
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(api_key_mod, "create_subprocess_exec", spawn_spy)
+        mp.setattr(resolve_mod, "create_subprocess_exec", spawn_spy)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": "a/c+inline-key=="}
@@ -513,7 +513,7 @@ async def test_get_api_key_fallback_skipped_when_esphome_cmd_unset(
     spawn_spy = AsyncMock()
 
     with pytest.MonkeyPatch.context() as mp:
-        mp.setattr(api_key_mod, "create_subprocess_exec", spawn_spy)
+        mp.setattr(resolve_mod, "create_subprocess_exec", spawn_spy)
         result = await controller.get_api_key(configuration="kitchen.yaml")
 
     assert result == {"key": ""}

--- a/tests/real_compile/test_json_config_resolution.py
+++ b/tests/real_compile/test_json_config_resolution.py
@@ -39,12 +39,9 @@ async def test_run_esphome_config_resolves_substitutions_packages_and_secrets(
         encoding="utf-8",
     )
 
-    rc, config, _stderr = await run_esphome_config(
-        [sys.executable, "-m", "esphome"], tmp_path / "test.yaml"
-    )
+    config = await run_esphome_config([sys.executable, "-m", "esphome"], tmp_path / "test.yaml")
 
-    assert rc == 0, "esphome config should validate the repro"
-    assert config is not None
+    assert config is not None, "esphome config should validate and resolve the repro"
     assert config["esphome"]["name"] == "livingroom"  # substitution expanded
     assert config["api"]["encryption"]["key"] == key  # package merged + secret resolved
     assert config["sensor"][0]["filters"][0]["delta"] == 0.1  # float, not a 500

--- a/tests/real_compile/test_json_config_resolution.py
+++ b/tests/real_compile/test_json_config_resolution.py
@@ -1,0 +1,51 @@
+"""Real-``esphome config`` pin for ``/json-config`` resolution (#1765).
+
+Spawns a real ``esphome config --show-secrets`` to prove the end-to-end
+contract HA depends on: substitutions expanded, packages merged, secrets
+resolved, floats/lambdas serialisable — none of which a raw ``load_yaml``
+produces.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import sys
+from pathlib import Path
+
+from esphome_device_builder.helpers.device_yaml import run_esphome_config
+from esphome_device_builder.helpers.json import dumps_str
+
+
+async def test_run_esphome_config_resolves_substitutions_packages_and_secrets(
+    tmp_path: Path,
+) -> None:
+    """Resolved JSON carries the real key (package + secret), expanded name, float."""
+    key = base64.b64encode(os.urandom(32)).decode()
+    (tmp_path / "secrets.yaml").write_text(
+        f'api_key: "{key}"\nwifi_pw: "wifipass8"\n', encoding="utf-8"
+    )
+    (tmp_path / "base_pkg.yaml").write_text(
+        "api:\n  encryption:\n    key: !secret api_key\n", encoding="utf-8"
+    )
+    (tmp_path / "test.yaml").write_text(
+        "substitutions:\n  devname: livingroom\n"
+        "packages:\n  base: !include base_pkg.yaml\n"
+        "esphome:\n  name: ${devname}\n"
+        "esp32:\n  variant: esp32c3\n  framework:\n    type: esp-idf\n"
+        "wifi:\n  ssid: myssid\n  password: !secret wifi_pw\n"
+        "sensor:\n  - platform: adc\n    pin: GPIO01\n    id: test_adc\n"
+        "    filters:\n      - delta: 0.1\n",
+        encoding="utf-8",
+    )
+
+    rc, config, _stderr = await run_esphome_config(
+        [sys.executable, "-m", "esphome"], tmp_path / "test.yaml"
+    )
+
+    assert rc == 0, "esphome config should validate the repro"
+    assert config is not None
+    assert config["esphome"]["name"] == "livingroom"  # substitution expanded
+    assert config["api"]["encryption"]["key"] == key  # package merged + secret resolved
+    assert config["sensor"][0]["filters"][0]["delta"] == 0.1  # float, not a 500
+    assert dumps_str(config)  # serialises with plain orjson

--- a/tests/test_helpers_json.py
+++ b/tests/test_helpers_json.py
@@ -1,11 +1,4 @@
-"""Tests for ``helpers/json.py`` orjson wrappers.
-
-Most of the helpers are thin enough that their behavior is
-self-evident from a glance, but ``dumps_str_non_str_keys`` flips
-an orjson option and only one endpoint depends on the result —
-worth a dedicated test so a future "let's drop the unused option"
-cleanup doesn't silently regress legacy ``/json-config``.
-"""
+"""Tests for ``helpers/json.py`` orjson wrappers + ``cors_middleware``."""
 
 from __future__ import annotations
 
@@ -15,12 +8,7 @@ import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
-from esphome_device_builder.helpers.json import (
-    cors_middleware,
-    dumps,
-    dumps_str_non_str_keys,
-    loads,
-)
+from esphome_device_builder.helpers.json import cors_middleware, dumps
 
 
 class _StrSubclass(str):
@@ -30,44 +18,12 @@ class _StrSubclass(str):
 
 
 def test_dumps_rejects_str_subclass_keys() -> None:
-    """Plain ``dumps`` keeps orjson's strict default.
+    """Plain ``dumps`` keeps orjson's strict default: non-exact-``str`` keys raise.
 
-    Non-exact-``str`` keys raise ``TypeError``. The strict default
-    catches the common bug of leaking a non-string key into a JSON
-    response, so this test pins it — the legacy ``/json-config``
-    endpoint reaches for ``dumps_str_non_str_keys`` precisely
-    because plain ``dumps`` would refuse its EStr-keyed input.
+    Catches the common bug of leaking a non-string key into a JSON response.
     """
     with pytest.raises(TypeError, match="Dict key must be str"):
         dumps({_StrSubclass("hello"): "world"})
-
-
-def test_dumps_str_non_str_keys_serialises_str_subclass_keys() -> None:
-    """``dumps_str_non_str_keys`` permits ``str``-subclass keys.
-
-    ESPHome's ``yaml_util.load_yaml`` returns dicts whose keys are
-    ``EStr`` (a ``str`` subclass carrying source-position info), and
-    legacy ``/json-config`` ships those dicts straight to HA. The
-    helper has to round-trip them as plain JSON strings.
-    """
-    payload = {_StrSubclass("esphome"): {_StrSubclass("name"): "kitchen"}}
-    out = dumps_str_non_str_keys(payload)
-    assert isinstance(out, str)
-    assert loads(out) == {"esphome": {"name": "kitchen"}}
-
-
-def test_dumps_str_non_str_keys_serialises_plain_str_keys() -> None:
-    """Plain ``str`` keys round-trip through the permissive helper.
-
-    The option name is ``OPT_NON_STR_KEYS``, and the spelling makes
-    it sound like it *replaces* string-key handling — it doesn't, it
-    adds non-``str`` keys to what's already accepted. Pin that so a
-    future reader doesn't reach for a separate helper for the
-    common case.
-    """
-    out = dumps_str_non_str_keys({"plain": 1, "nested": {"x": 2}})
-    assert isinstance(out, str)
-    assert loads(out) == {"plain": 1, "nested": {"x": 2}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_esphome_config.py
+++ b/tests/test_run_esphome_config.py
@@ -1,0 +1,116 @@
+"""Tests for ``helpers.device_yaml.run_esphome_config``.
+
+The subprocess primitive behind ``/json-config`` and the
+``devices/get_api_key`` package fallback — it runs ``esphome config
+--show-secrets`` and parses the fully-resolved output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import esphome_device_builder.helpers.device_yaml._resolve as resolve_mod
+from esphome_device_builder.helpers.device_yaml import run_esphome_config
+from esphome_device_builder.helpers.json import dumps_str
+
+
+def _fake_proc(stdout: bytes, stderr: bytes, returncode: int) -> MagicMock:
+    proc = MagicMock()
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    proc.returncode = returncode
+    return proc
+
+
+def _patch_spawn(mp: pytest.MonkeyPatch, proc: MagicMock) -> None:
+    async def _spawn(*_args: Any, **_kwargs: Any) -> Any:
+        return proc
+
+    mp.setattr(resolve_mod, "create_subprocess_exec", _spawn)
+
+
+async def test_parses_resolved_output_and_stringifies_unknown_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rc 0 → parsed dict; ``!lambda`` survives as a plain string, not a raise."""
+    stdout = b"esphome:\n  name: kitchen\nlambda_value: !lambda 'return 1;'\n"
+    _patch_spawn(monkeypatch, _fake_proc(stdout, b"", 0))
+
+    rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert rc == 0
+    assert config is not None
+    assert config["esphome"]["name"] == "kitchen"
+    # Unknown tag rendered as a string → JSON-native, serialises cleanly.
+    assert isinstance(config["lambda_value"], str)
+    assert dumps_str(config)
+
+
+async def test_nonzero_exit_returns_none_config_with_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A validation failure (rc!=0) yields ``(rc, None, stderr)``."""
+    _patch_spawn(monkeypatch, _fake_proc(b"Failed config\n", b"boom", 2))
+
+    rc, config, stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert rc == 2
+    assert config is None
+    assert stderr == "boom"
+
+
+async def test_unparsable_output_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rc 0 but malformed stdout degrades to ``None`` rather than raising."""
+    _patch_spawn(monkeypatch, _fake_proc(b"not yaml: [unterminated", b"", 0))
+
+    _rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert config is None
+
+
+async def test_non_mapping_output_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Output that parses to a list/scalar (not a mapping) returns ``None``."""
+    _patch_spawn(monkeypatch, _fake_proc(b"- one\n- two\n", b"", 0))
+
+    _rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert config is None
+
+
+async def test_spawn_oserror_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A spawn failure (binary missing / FD exhaustion) degrades to ``None``."""
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("simulated spawn failure")
+
+    monkeypatch.setattr(resolve_mod, "create_subprocess_exec", _boom)
+
+    rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert rc is None
+    assert config is None
+
+
+async def test_timeout_kills_and_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wedged subprocess past the timeout is killed and returns ``None``."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.wait = AsyncMock()
+    proc.returncode = None
+    killed: list[bool] = []
+    _patch_spawn(monkeypatch, proc)
+    monkeypatch.setattr(resolve_mod, "kill_quietly", lambda _p: killed.append(True))
+
+    async def _instant_timeout(coro: Any, timeout: float) -> Any:
+        coro.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(resolve_mod.asyncio, "wait_for", _instant_timeout)
+
+    _rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert config is None
+    assert killed == [True]

--- a/tests/test_run_esphome_config.py
+++ b/tests/test_run_esphome_config.py
@@ -81,19 +81,28 @@ async def test_non_mapping_output_returns_none(monkeypatch: pytest.MonkeyPatch) 
     assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
 
 
-async def test_spawn_oserror_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A spawn failure (binary missing / FD exhaustion) degrades to ``None``."""
+async def test_spawn_oserror_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A spawn failure (binary missing / FD exhaustion) is a retryable infra fault."""
 
     async def _boom(*_args: Any, **_kwargs: Any) -> Any:
         raise OSError("simulated spawn failure")
 
     monkeypatch.setattr(resolve_mod, "create_subprocess_exec", _boom)
 
-    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
+    with pytest.raises(resolve_mod.EsphomeConfigUnavailableError):
+        await run_esphome_config(["esphome"], Path("kitchen.yaml"))
 
 
-async def test_timeout_kills_and_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A wedged subprocess past the timeout is killed and returns ``None``."""
+async def test_signal_kill_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A negative return code (killed by a signal) is infra, not invalid config."""
+    _patch_spawn(monkeypatch, _fake_proc(b"", b"", -9))
+
+    with pytest.raises(resolve_mod.EsphomeConfigUnavailableError):
+        await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+
+async def test_timeout_kills_and_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wedged subprocess past the timeout is killed and surfaces as infra fault."""
     proc = MagicMock()
     proc.communicate = AsyncMock(side_effect=TimeoutError)
     proc.wait = AsyncMock()
@@ -108,7 +117,8 @@ async def test_timeout_kills_and_returns_none(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(resolve_mod.asyncio, "wait_for", _instant_timeout)
 
-    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
+    with pytest.raises(resolve_mod.EsphomeConfigUnavailableError):
+        await run_esphome_config(["esphome"], Path("kitchen.yaml"))
     assert killed == [True]
 
 

--- a/tests/test_run_esphome_config.py
+++ b/tests/test_run_esphome_config.py
@@ -35,13 +35,12 @@ def _patch_spawn(mp: pytest.MonkeyPatch, proc: MagicMock) -> None:
 async def test_parses_resolved_output_and_stringifies_unknown_tags(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rc 0 → parsed dict; ``!lambda`` survives as a plain string, not a raise."""
+    """Exit 0 returns a parsed dict; ``!lambda`` survives as a string, not a raise."""
     stdout = b"esphome:\n  name: kitchen\nlambda_value: !lambda 'return 1;'\n"
     _patch_spawn(monkeypatch, _fake_proc(stdout, b"", 0))
 
-    rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+    config = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
 
-    assert rc == 0
     assert config is not None
     assert config["esphome"]["name"] == "kitchen"
     # Unknown tag rendered as a string → JSON-native, serialises cleanly.
@@ -49,35 +48,25 @@ async def test_parses_resolved_output_and_stringifies_unknown_tags(
     assert dumps_str(config)
 
 
-async def test_nonzero_exit_returns_none_config_with_stderr(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A validation failure (rc!=0) yields ``(rc, None, stderr)``."""
+async def test_nonzero_exit_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A validation failure (rc!=0) yields ``None``."""
     _patch_spawn(monkeypatch, _fake_proc(b"Failed config\n", b"boom", 2))
 
-    rc, config, stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
-
-    assert rc == 2
-    assert config is None
-    assert stderr == "boom"
+    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
 
 
 async def test_unparsable_output_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Rc 0 but malformed stdout degrades to ``None`` rather than raising."""
+    """Exit 0 but malformed stdout degrades to ``None`` rather than raising."""
     _patch_spawn(monkeypatch, _fake_proc(b"not yaml: [unterminated", b"", 0))
 
-    _rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
-
-    assert config is None
+    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
 
 
 async def test_non_mapping_output_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """Output that parses to a list/scalar (not a mapping) returns ``None``."""
     _patch_spawn(monkeypatch, _fake_proc(b"- one\n- two\n", b"", 0))
 
-    _rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
-
-    assert config is None
+    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
 
 
 async def test_spawn_oserror_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -88,10 +77,7 @@ async def test_spawn_oserror_returns_none(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(resolve_mod, "create_subprocess_exec", _boom)
 
-    rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
-
-    assert rc is None
-    assert config is None
+    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
 
 
 async def test_timeout_kills_and_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -110,7 +96,5 @@ async def test_timeout_kills_and_returns_none(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(resolve_mod.asyncio, "wait_for", _instant_timeout)
 
-    _rc, config, _stderr = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
-
-    assert config is None
+    assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
     assert killed == [True]

--- a/tests/test_run_esphome_config.py
+++ b/tests/test_run_esphome_config.py
@@ -123,3 +123,47 @@ async def test_cancellation_kills_proc_and_reraises(monkeypatch: pytest.MonkeyPa
     with pytest.raises(asyncio.CancelledError):
         await run_esphome_config(["esphome"], Path("kitchen.yaml"))
     assert killed == [True]
+
+
+async def test_caps_concurrent_subprocesses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No more than ``_MAX_CONCURRENT_CONFIG`` subprocesses run at once."""
+    # A contended ``asyncio.Semaphore`` binds to its loop; give this test its
+    # own gate so it doesn't bind the shared module-level one to a test loop.
+    monkeypatch.setattr(
+        resolve_mod, "_config_semaphore", asyncio.Semaphore(resolve_mod._MAX_CONCURRENT_CONFIG)
+    )
+    gate = asyncio.Event()
+    active = 0
+    peak = 0
+
+    async def _communicate() -> tuple[bytes, bytes]:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await gate.wait()
+        active -= 1
+        return b"esphome:\n  name: x\n", b""
+
+    async def _spawn(*_args: Any, **_kwargs: Any) -> Any:
+        proc = MagicMock()
+        proc.communicate = _communicate
+        proc.returncode = 0
+        return proc
+
+    monkeypatch.setattr(resolve_mod, "create_subprocess_exec", _spawn)
+    cap = resolve_mod._MAX_CONCURRENT_CONFIG
+    tasks = [
+        asyncio.create_task(run_esphome_config(["esphome"], Path("x.yaml"))) for _ in range(cap + 3)
+    ]
+    # Let the first batch acquire the gate and pile up against the cap.
+    for _ in range(100):
+        if peak >= cap:
+            break
+        await asyncio.sleep(0)
+
+    assert peak == cap  # the cap was reached...
+    gate.set()
+    results = await asyncio.gather(*tasks)
+
+    assert peak == cap  # ...and never exceeded, even as the rest drained
+    assert all(r == {"esphome": {"name": "x"}} for r in results)

--- a/tests/test_run_esphome_config.py
+++ b/tests/test_run_esphome_config.py
@@ -7,6 +7,7 @@ The subprocess primitive behind ``/json-config`` and the
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -45,6 +46,17 @@ async def test_parses_resolved_output_and_stringifies_unknown_tags(
     assert config["esphome"]["name"] == "kitchen"
     # Unknown tag rendered as a string → JSON-native, serialises cleanly.
     assert isinstance(config["lambda_value"], str)
+    assert dumps_str(config)
+
+
+async def test_non_scalar_unknown_tag_falls_back_to_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-scalar unknown tag yields the bare tag, not a node-pair-list repr."""
+    stdout = b"top: !weird\n  a: 1\n  b: 2\n"
+    _patch_spawn(monkeypatch, _fake_proc(stdout, b"", 0))
+
+    config = await run_esphome_config(["esphome"], Path("kitchen.yaml"))
+
+    assert config == {"top": "!weird"}
     assert dumps_str(config)
 
 
@@ -97,4 +109,17 @@ async def test_timeout_kills_and_returns_none(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(resolve_mod.asyncio, "wait_for", _instant_timeout)
 
     assert await run_esphome_config(["esphome"], Path("kitchen.yaml")) is None
+    assert killed == [True]
+
+
+async def test_cancellation_kills_proc_and_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """External cancellation during the wait kills the proc and propagates."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(side_effect=asyncio.CancelledError)
+    killed: list[bool] = []
+    _patch_spawn(monkeypatch, proc)
+    monkeypatch.setattr(resolve_mod, "kill_quietly", lambda _p: killed.append(True))
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_esphome_config(["esphome"], Path("kitchen.yaml"))
     assert killed == [True]


### PR DESCRIPTION
# What does this implement/fix?

The `/json-config` endpoint did a raw `yaml_util.load_yaml`. That left `${substitutions}` unexpanded, never merged `packages:`, and handed orjson ESPHome wrapper types it cannot serialize (EFloat, Lambda, IncludeFile), so a config containing a float returned a 500. Home Assistant reads this endpoint to detect the API encryption key, so the failure dropped HA back to prompting for the key (#1765).

It now resolves the config the same way the legacy dashboard and `devices/get_api_key` already do; it runs `esphome config --show-secrets` and serializes the plain validated output. Substitutions, packages, includes and secrets all resolve, and the three wrapper types are gone because the validated output carries none of them. The subprocess and parse are factored into a shared `run_esphome_config` helper, so the key fallback reuses the same code path. Status codes now match upstream; 404 for a missing file, 422 for an invalid config, 403 for a traversal.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1765

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
