### PR TITLE
Reconcile zeroconf sockets when network interfaces change

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
@@ -17,10 +17,11 @@ from esphome.zeroconf import AsyncEsphomeZeroconf
 
 _LOGGER = logging.getLogger(__name__)
 
-# Interface changes are rare, so a relaxed poll keeps steady-state wakeups low;
-# 2 min still reflects a VPN/Wi-Fi/Docker change well before a user would
-# investigate why a device isn't showing up.
-_INTERFACE_POLL_INTERVAL = 120.0
+# Interface changes are rare, so a relaxed poll keeps steady-state wakeups low.
+# Matches DashboardAdvertiser's _REFRESH_INTERVAL_SECONDS (the existing adapter
+# poll) so the two share one cadence; a change still reconciles well before a
+# user would investigate why a device isn't showing up.
+_INTERFACE_POLL_INTERVAL = 300.0
 
 
 def address_snapshot() -> frozenset[tuple[str, int]]:

--- a/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
@@ -26,7 +26,9 @@ _INTERFACE_POLL_INTERVAL = 120.0
 def address_snapshot() -> frozenset[tuple[str, int]]:
     """Return the host's current (address, prefix) set; a change triggers a reconcile."""
     return frozenset(
-        (str(ip.ip), ip.network_prefix) for adapter in ifaddr.get_adapters() for ip in adapter.ips
+        (_ip_to_str(ip.ip), ip.network_prefix)
+        for adapter in ifaddr.get_adapters()
+        for ip in adapter.ips
     )
 
 
@@ -35,13 +37,13 @@ async def monitor_interfaces(
 ) -> None:
     """Reconcile zeroconf sockets whenever the host's addresses change, until cancelled."""
     loop = asyncio.get_running_loop()
-    # ``ifaddr.get_adapters`` is blocking (reads /proc/net; GetAdaptersAddresses
-    # on Windows) — keep it off the WS event loop, per helpers/network_interfaces.
-    previous = await loop.run_in_executor(None, address_snapshot)
+    previous = await _safe_snapshot(loop)
     while True:
         await asyncio.sleep(interval)
-        current = await loop.run_in_executor(None, address_snapshot)
-        if current == previous:
+        current = await _safe_snapshot(loop)
+        # ``None`` is a failed snapshot, not "no addresses" — skip so a transient
+        # ifaddr error can't be read as every interface disappearing.
+        if current is None or current == previous:
             continue
         try:
             # No-arg reuses the construction-time ``InterfaceChoice.All``, so this
@@ -53,3 +55,30 @@ async def monitor_interfaces(
         else:
             _LOGGER.info("Network interfaces changed; reconciled zeroconf sockets")
             previous = current
+
+
+def _ip_to_str(ip: str | tuple[str, int, int]) -> str:
+    """Normalize an ``ifaddr`` IP (v4 string / v6 ``(addr, flowinfo, scope)`` tuple).
+
+    Mirrors ``helpers.network_interfaces.resolve_bind_host``: keep the ``%scope``
+    on link-local v6, drop flowinfo so a benign flowinfo change isn't read as
+    churn (and so the snapshot is a stable string, not a tuple repr).
+    """
+    if isinstance(ip, str):
+        return ip
+    address, _flowinfo, scope_id = ip
+    return f"{address}%{scope_id}" if scope_id else address
+
+
+async def _safe_snapshot(loop: asyncio.AbstractEventLoop) -> frozenset[tuple[str, int]] | None:
+    """Snapshot host addresses off the event loop; ``None`` on failure so the loop retries.
+
+    ``ifaddr.get_adapters`` is blocking (reads /proc/net; GetAdaptersAddresses on
+    Windows) and can raise on a transient OS hiccup; swallow it so one bad scan
+    can't kill the reconciler for the rest of the process's life.
+    """
+    try:
+        return await loop.run_in_executor(None, address_snapshot)
+    except Exception:
+        _LOGGER.exception("host address snapshot failed; will retry")
+        return None

--- a/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
@@ -1,0 +1,55 @@
+"""Poll for host address changes and reconcile zeroconf's sockets.
+
+zeroconf binds its sockets once at construction and never notices interfaces
+that appear or disappear afterward (a VPN coming up, Wi-Fi reconnecting, a
+Docker network attaching). ``async_update_interfaces`` rescans and reconciles;
+we drive it from a small ``ifaddr`` poll — the portable detection the zeroconf
+docs recommend when no netlink / framework push-signal is wired.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import ifaddr
+from esphome.zeroconf import AsyncEsphomeZeroconf
+
+_LOGGER = logging.getLogger(__name__)
+
+# Interface changes are rare, so a relaxed poll keeps steady-state wakeups low;
+# 2 min still reflects a VPN/Wi-Fi/Docker change well before a user would
+# investigate why a device isn't showing up.
+_INTERFACE_POLL_INTERVAL = 120.0
+
+
+def address_snapshot() -> frozenset[tuple[str, int]]:
+    """Return the host's current (address, prefix) set; a change triggers a reconcile."""
+    return frozenset(
+        (str(ip.ip), ip.network_prefix) for adapter in ifaddr.get_adapters() for ip in adapter.ips
+    )
+
+
+async def monitor_interfaces(
+    zeroconf: AsyncEsphomeZeroconf, interval: float = _INTERFACE_POLL_INTERVAL
+) -> None:
+    """Reconcile zeroconf sockets whenever the host's addresses change, until cancelled."""
+    loop = asyncio.get_running_loop()
+    # ``ifaddr.get_adapters`` is blocking (reads /proc/net; GetAdaptersAddresses
+    # on Windows) — keep it off the WS event loop, per helpers/network_interfaces.
+    previous = await loop.run_in_executor(None, address_snapshot)
+    while True:
+        await asyncio.sleep(interval)
+        current = await loop.run_in_executor(None, address_snapshot)
+        if current == previous:
+            continue
+        try:
+            # No-arg reuses the construction-time ``InterfaceChoice.All``, so this
+            # rescans every interface; a no-op when nothing actually moved.
+            await zeroconf.async_update_interfaces()
+        except Exception:
+            # Log and retry next tick; leave ``previous`` so the change re-attempts.
+            _LOGGER.exception("zeroconf interface reconcile failed; will retry")
+        else:
+            _LOGGER.info("Network interfaces changed; reconciled zeroconf sockets")
+            previous = current

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -110,6 +110,15 @@ class MdnsSource:
         # Docker churn) for the instance's lifetime; cancelled in close_zeroconf.
         if self._zeroconf is not None:
             self._interface_monitor_task = asyncio.create_task(monitor_interfaces(self._zeroconf))
+            self._interface_monitor_task.add_done_callback(self._log_interface_monitor_exit)
+
+    @staticmethod
+    def _log_interface_monitor_exit(task: asyncio.Task[None]) -> None:
+        """Surface an unexpected interface-monitor crash instead of a silent death."""
+        if task.cancelled():
+            return
+        if (exc := task.exception()) is not None:
+            _LOGGER.error("Interface monitor loop crashed: %s", exc, exc_info=exc)
 
     async def cancel_browser(self) -> None:
         """

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -10,7 +10,6 @@ cache-inspection accessors the drawer's reachability snapshot reads.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from collections.abc import Callable
 from operator import attrgetter
@@ -132,8 +131,13 @@ class MdnsSource:
         # Stop the interface monitor first so it can't reconcile a closing instance.
         if self._interface_monitor_task is not None:
             self._interface_monitor_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            try:
                 await self._interface_monitor_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                # A crashed monitor task must not abort shutdown before zeroconf closes.
+                _LOGGER.debug("interface monitor task errored during shutdown", exc_info=True)
             self._interface_monitor_task = None
         if self._zeroconf is not None:
             try:

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -10,6 +10,7 @@ cache-inspection accessors the drawer's reachability snapshot reads.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable
 from operator import attrgetter
@@ -35,6 +36,7 @@ from .helpers import (
     _decode_mdns_txt_records,
     device_name_from_service,
 )
+from .interface_monitor import monitor_interfaces
 from .shared import _MDNS_HOSTNAME_RESOLVE_TIMEOUT, apply_resolved_addresses
 
 if TYPE_CHECKING:
@@ -59,6 +61,7 @@ class MdnsSource:
         # and ``_http._tcp.local.``; halves the zeroconf
         # bookkeeping versus two parallel browsers.
         self._mdns_browser: AsyncServiceBrowser | None = None
+        self._interface_monitor_task: asyncio.Task[None] | None = None
 
     @property
     def zeroconf(self) -> AsyncEsphomeZeroconf | None:
@@ -104,6 +107,11 @@ class MdnsSource:
         except Exception:
             _LOGGER.exception("Could not start mDNS browser — device discovery limited to ping")
 
+        # Keep the responder bound to the live interface set (VPN / Wi-Fi /
+        # Docker churn) for the instance's lifetime; cancelled in close_zeroconf.
+        if self._zeroconf is not None:
+            self._interface_monitor_task = asyncio.create_task(monitor_interfaces(self._zeroconf))
+
     async def cancel_browser(self) -> None:
         """
         Cancel the ``AsyncServiceBrowser``.
@@ -121,6 +129,12 @@ class MdnsSource:
 
     async def close_zeroconf(self) -> None:
         """Close the zeroconf responder, bounded so a wedged socket can't stall shutdown."""
+        # Stop the interface monitor first so it can't reconcile a closing instance.
+        if self._interface_monitor_task is not None:
+            self._interface_monitor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._interface_monitor_task
+            self._interface_monitor_task = None
         if self._zeroconf is not None:
             try:
                 await asyncio.wait_for(self._zeroconf.async_close(), _MDNS_CLOSE_TIMEOUT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dependencies = [
   # lean envs (the sync-boards pre-commit hook, any future
   # esphome-less install path) don't drop it.
   "voluptuous>=0.13.1",
+  # The device-state monitor imports zeroconf directly (browser, responder,
+  # interface reconcile). ``async_update_interfaces`` — used to keep mDNS bound
+  # across interface changes — landed in 0.150.0, so pin that floor rather than
+  # rely on whatever version esphome / aiohttp-asyncmdnsresolver happen to bring.
+  "zeroconf>=0.150.0",
 ]
 description = "ESPHome Device Builder"
 license = "Apache-2.0"

--- a/tests/test_interface_monitor.py
+++ b/tests/test_interface_monitor.py
@@ -1,0 +1,115 @@
+"""Tests for the zeroconf interface-change poller.
+
+``monitor_interfaces`` snapshots the host's addresses on a timer and calls
+``async_update_interfaces`` only when they change; ``MdnsSource`` owns the task
+and tears it down before closing zeroconf.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import esphome_device_builder.controllers._device_state_monitor.interface_monitor as im
+from esphome_device_builder.controllers._device_state_monitor.interface_monitor import (
+    monitor_interfaces,
+)
+
+_A = frozenset({("10.0.0.5", 24)})
+_B = frozenset({("10.0.0.5", 24), ("192.168.1.2", 24)})
+
+
+def _snapshots(monkeypatch: pytest.MonkeyPatch, values: list[frozenset[tuple[str, int]]]) -> None:
+    """Feed ``address_snapshot`` a scripted sequence; the last value repeats."""
+    seq = iter(values)
+    last = values[-1]
+
+    def _next() -> frozenset[tuple[str, int]]:
+        nonlocal last
+        last = next(seq, last)
+        return last
+
+    monkeypatch.setattr(im, "address_snapshot", _next)
+
+
+async def _run_ticks(zeroconf: Any, ticks: int) -> None:
+    """Run ``monitor_interfaces`` for *ticks* sleeps, then cancel cleanly."""
+    seen = 0
+    real_sleep = asyncio.sleep
+
+    async def _counting_sleep(_interval: float) -> None:
+        nonlocal seen
+        seen += 1
+        if seen >= ticks:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(im.asyncio, "sleep", _counting_sleep)
+        with pytest.raises(asyncio.CancelledError):
+            await monitor_interfaces(zeroconf, interval=0)
+
+
+async def test_reconciles_when_addresses_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A change between ticks triggers exactly one ``async_update_interfaces``."""
+    # previous=_A (pre-loop), tick1 sees _A (no-op), tick2 sees _B (reconcile).
+    _snapshots(monkeypatch, [_A, _A, _B])
+    zeroconf = MagicMock()
+    zeroconf.async_update_interfaces = AsyncMock()
+
+    await _run_ticks(zeroconf, ticks=3)
+
+    zeroconf.async_update_interfaces.assert_awaited_once()
+
+
+async def test_no_op_when_addresses_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A constant snapshot never reconciles."""
+    _snapshots(monkeypatch, [_A])
+    zeroconf = MagicMock()
+    zeroconf.async_update_interfaces = AsyncMock()
+
+    await _run_ticks(zeroconf, ticks=3)
+
+    zeroconf.async_update_interfaces.assert_not_awaited()
+
+
+async def test_survives_reconcile_failure_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reconcile raise is swallowed; the change re-attempts on the next tick.
+
+    ``previous`` is left unadvanced after a failure, so the still-different
+    snapshot drives a second ``async_update_interfaces`` rather than the loop
+    dying or the change being lost.
+    """
+    # previous=_A; both ticks see _B → reconcile attempted twice (1st raises).
+    _snapshots(monkeypatch, [_A, _B, _B])
+    zeroconf = MagicMock()
+    zeroconf.async_update_interfaces = AsyncMock(side_effect=[RuntimeError("flap"), None])
+
+    await _run_ticks(zeroconf, ticks=3)
+
+    assert zeroconf.async_update_interfaces.await_count == 2
+
+
+async def test_advances_previous_after_successful_reconcile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once reconciled, the same address set doesn't reconcile again."""
+    # previous=_A; tick1 _B (reconcile), tick2 _B (now equals previous → no-op).
+    _snapshots(monkeypatch, [_A, _B, _B])
+    zeroconf = MagicMock()
+    zeroconf.async_update_interfaces = AsyncMock()
+
+    await _run_ticks(zeroconf, ticks=3)
+
+    zeroconf.async_update_interfaces.assert_awaited_once()
+
+
+async def test_snapshot_is_hashable_and_order_independent() -> None:
+    """``address_snapshot`` returns a frozenset so equality ignores adapter order."""
+    snap = im.address_snapshot()
+    assert isinstance(snap, frozenset)
+    # Reversing the underlying iteration order must not change equality.
+    assert frozenset(reversed(list(snap))) == snap

--- a/tests/test_interface_monitor.py
+++ b/tests/test_interface_monitor.py
@@ -8,6 +8,7 @@ and tears it down before closing zeroconf.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,6 +21,9 @@ from esphome_device_builder.controllers._device_state_monitor.interface_monitor 
 
 _A = frozenset({("10.0.0.5", 24)})
 _B = frozenset({("10.0.0.5", 24), ("192.168.1.2", 24)})
+
+# Sentinel a scripted snapshot yields to make ``address_snapshot`` raise that tick.
+_RAISE = object()
 
 
 def _snapshots(monkeypatch: pytest.MonkeyPatch, values: list[frozenset[tuple[str, int]]]) -> None:
@@ -113,3 +117,45 @@ async def test_snapshot_is_hashable_and_order_independent() -> None:
     assert isinstance(snap, frozenset)
     # Reversing the underlying iteration order must not change equality.
     assert frozenset(reversed(list(snap))) == snap
+
+
+async def test_snapshot_failure_does_not_kill_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A raising ``address_snapshot`` is swallowed; the loop keeps polling and reconciles later.
+
+    A transient ``ifaddr`` error on one tick must not terminate the reconciler
+    for the rest of the process; the next good snapshot still drives a change.
+    """
+    # previous=_A; tick1 snapshot raises (skipped), tick2 sees _B → reconcile.
+    seq = iter([_A, _RAISE, _B, _B])
+
+    def _next() -> frozenset[tuple[str, int]]:
+        value = next(seq, _B)
+        if value is _RAISE:
+            raise OSError("adapters momentarily unavailable")
+        return value  # type: ignore[return-value]
+
+    monkeypatch.setattr(im, "address_snapshot", _next)
+    zeroconf = MagicMock()
+    zeroconf.async_update_interfaces = AsyncMock()
+
+    await _run_ticks(zeroconf, ticks=3)
+
+    zeroconf.async_update_interfaces.assert_awaited_once()
+
+
+def test_address_snapshot_normalizes_ipv4_and_ipv6_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """v4 stays a plain string; link-local v6 keeps ``%scope`` and drops flowinfo; no tuple repr."""
+    v4 = SimpleNamespace(ip="10.0.0.5", network_prefix=24)
+    # ifaddr renders v6 as ``(addr, flowinfo, scope_id)``.
+    v6_link_local = SimpleNamespace(ip=("fe80::1", 0, 7), network_prefix=64)
+    v6_global = SimpleNamespace(ip=("2001:db8::1", 0, 0), network_prefix=64)
+    adapter = SimpleNamespace(ips=[v4, v6_link_local, v6_global])
+    monkeypatch.setattr(im.ifaddr, "get_adapters", lambda: [adapter])
+
+    snap = im.address_snapshot()
+
+    assert ("10.0.0.5", 24) in snap
+    assert ("fe80::1%7", 64) in snap  # scope kept, flowinfo dropped
+    assert ("2001:db8::1", 64) in snap  # scope 0 → no suffix
+    # No raw ``(addr, flowinfo, scope)`` tuple leaked into the snapshot.
+    assert all(isinstance(addr, str) and "(" not in addr for addr, _prefix in snap)

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -20,6 +20,7 @@ manual attribute assignment to avoid spinning up a real
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -241,6 +242,48 @@ async def test_start_spawns_interface_monitor_and_stop_cancels_it(
 
     assert monitor._mdns._interface_monitor_task is None
     assert task.cancelled() or task.done()
+
+
+async def test_interface_monitor_done_callback_logs_unexpected_crash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unexpected monitor exit is surfaced via the done-callback, not lost.
+
+    Mirrors ``_log_api_info_task_exit``: a cancelled task is silent, a crashed
+    one logs at error so a dead reconciler is operator-visible.
+    """
+
+    async def _boom() -> None:
+        raise RuntimeError("monitor crashed")
+
+    task = asyncio.create_task(_boom())
+    with contextlib.suppress(RuntimeError):
+        await task
+
+    with caplog.at_level(logging.ERROR):
+        MdnsSource._log_interface_monitor_exit(task)
+
+    assert "Interface monitor loop crashed" in caplog.text
+
+
+async def test_interface_monitor_done_callback_silent_on_cancel(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cancelled monitor task (normal shutdown) logs nothing."""
+
+    async def _forever() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(_forever())
+    await asyncio.sleep(0)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    with caplog.at_level(logging.ERROR):
+        MdnsSource._log_interface_monitor_exit(task)
+
+    assert caplog.text == ""
 
 
 async def test_close_zeroconf_swallows_crashed_interface_monitor() -> None:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -221,6 +221,28 @@ async def test_stop_cancels_every_async_resource(monkeypatch: pytest.MonkeyPatch
     assert in_flight.cancelled() or in_flight.done()
 
 
+async def test_start_spawns_interface_monitor_and_stop_cancels_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """start() spawns the zeroconf interface monitor; close_zeroconf cancels and clears it.
+
+    Pins the lifecycle the poller depends on: the task comes up with the
+    responder and is torn down before ``async_close`` so it can't reconcile a
+    closing instance or leak past shutdown.
+    """
+    monitor, _callbacks = _make_monitor()
+    await _start_with_captured_dispatch(monitor, monkeypatch)
+    task = monitor._mdns._interface_monitor_task
+    assert task is not None
+    assert not task.done()
+    monitor._mdns._zeroconf.async_close = AsyncMock()
+
+    await _stop_and_drain(monitor)
+
+    assert monitor._mdns._interface_monitor_task is None
+    assert task.cancelled() or task.done()
+
+
 async def test_stop_swallows_browser_cancel_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -243,6 +243,30 @@ async def test_start_spawns_interface_monitor_and_stop_cancels_it(
     assert task.cancelled() or task.done()
 
 
+async def test_close_zeroconf_swallows_crashed_interface_monitor() -> None:
+    """A monitor task that died on a non-cancellation error can't abort shutdown.
+
+    ``close_zeroconf`` awaits the cancelled monitor task; if that task had
+    already crashed, the await re-raises. Shutdown must swallow it and still
+    close zeroconf rather than leaking the error into aiohttp's cleanup.
+    """
+    monitor, _callbacks = _make_monitor()
+
+    async def _boom() -> None:
+        raise RuntimeError("monitor crashed")
+
+    task = asyncio.create_task(_boom())
+    await asyncio.sleep(0)  # let it crash before we hand it to close_zeroconf
+    monitor._mdns._interface_monitor_task = task
+    monitor._mdns._zeroconf = MagicMock()
+    monitor._mdns._zeroconf.async_close = AsyncMock()
+
+    await monitor._mdns.close_zeroconf()  # must not raise
+
+    assert monitor._mdns._interface_monitor_task is None
+    assert monitor._mdns._zeroconf is None
+
+
 async def test_stop_swallows_browser_cancel_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

python-zeroconf binds its sockets once at construction, so it never notices interfaces that come or go afterward (a VPN connecting, Wi-Fi reconnecting, a Docker network attaching); mDNS discovery then silently goes deaf on the changed interface until the process restarts. python-zeroconf 0.150.0 added `async_update_interfaces`, which rescans the host and reconciles the sockets in use (binds responders for interfaces that appeared, tears down ones that went away, re-announces existing registrations).

This wires that in with a small interface monitor that snapshots the host addresses on a relaxed timer and calls `async_update_interfaces` only when the set actually changes; a no-op tick touches nothing. `MdnsSource` owns the task; it comes up with the responder and is cancelled, then awaited, before zeroconf closes so it can never reconcile a closing instance or leak past shutdown. `ifaddr.get_adapters()` is blocking, so every snapshot runs in an executor and the event loop only awaits. Detection is the portable poll the zeroconf docs recommend when no netlink or framework push signal is wired, so it works on the Windows CI matrix too.

**Related issue or feature (if applicable):**

- python-zeroconf 0.150.0 `async_update_interfaces`: https://github.com/python-zeroconf/python-zeroconf/releases/tag/0.150.0

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
