### PR TITLE
Drain interface monitor via gather so caller cancellation isn't swallowed

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -140,13 +140,13 @@ class MdnsSource:
         # Stop the interface monitor first so it can't reconcile a closing instance.
         if self._interface_monitor_task is not None:
             self._interface_monitor_task.cancel()
-            try:
-                await self._interface_monitor_task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
+            # gather(return_exceptions=True) captures the child's CancelledError —
+            # and any crash — without swallowing a cancellation aimed at *this*
+            # coroutine, mirroring the drain in ``DeviceStateMonitor.stop``.
+            result = await asyncio.gather(self._interface_monitor_task, return_exceptions=True)
+            if isinstance(result[0], Exception):
                 # A crashed monitor task must not abort shutdown before zeroconf closes.
-                _LOGGER.debug("interface monitor task errored during shutdown", exc_info=True)
+                _LOGGER.debug("interface monitor task errored during shutdown", exc_info=result[0])
             self._interface_monitor_task = None
         if self._zeroconf is not None:
             try:


### PR DESCRIPTION
# What does this implement/fix?

Followup to #1770. `MdnsSource.close_zeroconf` cancelled the interface-monitor task and awaited it inside a bare `try: await task; except asyncio.CancelledError: pass`. That swallows a `CancelledError` even when it is aimed at `close_zeroconf` itself, not the child finishing; a cancellation of the shutdown coroutine would be silently eaten, breaking cooperative cancellation.

Switch the drain to `asyncio.gather(task, return_exceptions=True)`, the same idiom `DeviceStateMonitor.stop` already uses. It captures the child's `CancelledError`, and any crash, into the result list without intercepting a cancellation directed at the current coroutine; a returned crash is still debug-logged so a dead monitor does not abort shutdown before zeroconf closes.

No test changes; the existing `test_close_zeroconf_swallows_crashed_interface_monitor` and `test_start_spawns_interface_monitor_and_stop_cancels_it` already exercise the crash and normal-cancel drain paths through the new code.

**Related issue or feature (if applicable):**

- follows up #1770

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
