### PR TITLE
ci: Add release and changelog links to the bump PR body

### DIFF
--- a/.github/workflows/bump-esphome-docker-pin.yml
+++ b/.github/workflows/bump-esphome-docker-pin.yml
@@ -70,13 +70,35 @@ jobs:
             echo "::error::pin 'esphome-device-builder==' not found in $file; update this workflow."
             exit 1
           fi
+          # The version esphome currently ships is the compare base for the
+          # changelog link — grab it before sed overwrites it.
+          previous=$(sed -nE 's/.*esphome-device-builder==([A-Za-z0-9._-]+).*/\1/p' "$file" | head -n1)
           sed -i -E "s/(esphome-device-builder==)[A-Za-z0-9._-]+/\1${VERSION}/" "$file"
           if git diff --quiet -- "$file"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "::notice::esphome already pins esphome-device-builder==${VERSION}; no PR opened."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "previous=${previous}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Build release links
+        id: links
+        if: steps.bump.outputs.changed == 'true'
+        # Release page + a compare link from the version esphome was shipping to
+        # this one. A non-empty diff guarantees previous != VERSION.
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          PREVIOUS: ${{ steps.bump.outputs.previous }}
+        run: |
+          set -euo pipefail
+          {
+            echo "body<<LINKS_EOF"
+            echo "- [Release notes](${RELEASE_URL})"
+            echo "- [Changes](${{ github.server_url }}/${{ github.repository }}/compare/${PREVIOUS}...${VERSION})"
+            echo "LINKS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Open / update pull request
         if: steps.bump.outputs.changed == 'true'
@@ -93,3 +115,5 @@ jobs:
             Bumps the bundled `esphome-device-builder` in the Docker image to `${{ github.event.release.tag_name }}`, released in esphome/device-builder.
 
             Opened automatically by device-builder's release workflow.
+
+            ${{ steps.links.outputs.body }}


### PR DESCRIPTION
# What does this implement/fix?

The auto-generated `esphome-device-builder` bump PR opened on esphome/esphome now includes two links in its body: the GitHub release page for the new version, and a compare view showing the changes from the previously-shipped version to the new one.

The compare base is read from the `esphome-device-builder==` pin in `docker/Dockerfile` *before* `sed` overwrites it, so it reflects exactly the version esphome was actually shipping — correct even if a release was skipped in the bundle. A non-empty diff guarantees the previous version differs from the new one, so the compare link is always valid.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.