### PR TITLE
Add an O(1) get_by_configuration device lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,7 +524,11 @@ against legacy behaviour before assuming the simpler version suffices.
   `_unindex_name`. Buckets are sorted by `configuration` filename so
   `bucket[0]` consumers and the dedupe path see a deterministic "first
   match". `scanner.get_by_name(name)` returns a fresh list snapshot, so
-  callers iterate without poisoning the index.
+  callers iterate without poisoning the index. A parallel
+  `_devices_by_configuration: dict[str, Device]` (1:1 — a `configuration`
+  filename is unique per path) backs the O(1) `scanner.get_by_configuration`
+  / `DevicesController.get_by_configuration`; prefer it over a linear scan of
+  `get_devices()` when resolving a device by YAML filename.
 - **mDNS-source dedupe must look at every matching device, not just
   `bucket[0]`.** Two YAMLs sharing an `esphome.name` (a config plus a
   `foo (1).yaml` copy, `dashboard_import` siblings) share one mDNS

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -82,15 +82,17 @@ MetadataResolver = Callable[[Path, str], DeviceFileMetadata]
 
 class _DeviceIndex:
     """
-    Path-keyed Device store with lockstep name-keyed and cache-key indexes.
+    Path-keyed Device store with lockstep name / configuration / cache-key shadows.
 
-    The three internal maps (``_devices``, ``_devices_by_name``,
-    ``_cache_keys``) are kept in sync as a structural property of
-    this class — the only mutation entry points (:meth:`set`,
-    :meth:`pop`, :meth:`rebuild_in_path_order`) update all three
-    together. Bypassing requires reaching into the underscore-
-    prefixed attributes, which is exactly what the encapsulation
-    is meant to discourage.
+    The four internal maps (``_devices``, ``_devices_by_name``,
+    ``_devices_by_configuration``, ``_cache_keys``) are kept in sync as a
+    structural property of this class. :meth:`set` / :meth:`pop` are the
+    only entry points that add or remove entries, and they update all four
+    together; :meth:`rebuild_in_path_order` re-keys ``_devices`` /
+    ``_cache_keys`` for iteration order only, leaving the name /
+    configuration shadows' (still-valid) entries in place. Bypassing
+    requires reaching into the underscore-prefixed attributes, which is
+    exactly what the encapsulation is meant to discourage.
 
     The lockstep matters because the scanner's apply / dedupe path
     fans out an mDNS announcement to every Device sharing a
@@ -120,6 +122,12 @@ class _DeviceIndex:
         # ``foo (1).yaml`` copy, ``dashboard_import`` siblings, etc.)
         # and a single broadcast must fan out to all of them.
         self._devices_by_name: dict[str, list[Device]] = {}
+        # Configuration-keyed shadow index; firmware jobs and metadata
+        # mutations resolve a Device by its YAML filename and need an
+        # O(1) lookup instead of a linear scan of every configured YAML.
+        # Unlike the name index this is 1:1 — a ``configuration`` filename
+        # (``path.name``) is unique per tracked path.
+        self._devices_by_configuration: dict[str, Device] = {}
         self._cache_keys: dict[Path, _CacheKey] = {}
 
     @property
@@ -142,6 +150,10 @@ class _DeviceIndex:
         """Return a fresh-list snapshot of every Device whose ``name`` matches."""
         bucket = self._devices_by_name.get(name)
         return list(bucket) if bucket else []
+
+    def get_by_configuration(self, configuration: str) -> Device | None:
+        """Return the Device whose YAML filename equals *configuration*, or ``None``."""
+        return self._devices_by_configuration.get(configuration)
 
     def cache_key(self, path: Path) -> _CacheKey:
         """Return the change-detection cache key for a tracked *path*.
@@ -181,6 +193,8 @@ class _DeviceIndex:
             self._unindex_name(previous)
         self._devices[path] = device
         self._cache_keys[path] = cache_key
+        # 1:1 by filename, so a same-path in-place edit overwrites its own entry.
+        self._devices_by_configuration[device.configuration] = device
         bucket = self._devices_by_name.setdefault(device.name, [])
         insert_at = 0
         while insert_at < len(bucket) and bucket[insert_at].configuration < device.configuration:
@@ -192,6 +206,7 @@ class _DeviceIndex:
         device = self._devices.pop(path, None)
         self._cache_keys.pop(path, None)
         if device is not None:
+            self._devices_by_configuration.pop(device.configuration, None)
             self._unindex_name(device)
         return device
 
@@ -201,9 +216,9 @@ class _DeviceIndex:
         ``devices`` is a user-visible read; without this rebuild
         the post-scan iteration order is set-derived and the
         dashboard sees a different device list every restart.
-        ``_devices_by_name`` doesn't need a parallel re-sort —
-        its values are name-keyed lists whose iteration order
-        isn't user-visible.
+        ``_devices_by_name`` / ``_devices_by_configuration`` don't
+        need a parallel re-key — their iteration order isn't
+        user-visible and their entries are unchanged here.
 
         ``path_order`` may carry extra paths that were never
         indexed (a YAML that failed to load is in the scanner's
@@ -295,8 +310,7 @@ class DeviceScanner(WakeWorker[str]):
 
     def get_by_configuration(self, configuration: str) -> Device | None:
         """Return the configured device for YAML filename *configuration*, or ``None``."""
-        path = self._index.find_path_by_filename(configuration)
-        return self._index.by_path.get(path) if path is not None else None
+        return self._index.get_by_configuration(configuration)
 
     async def scan(self) -> None:
         """Refresh the device cache from disk, emitting per-file change events."""

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -295,6 +295,10 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         """Snapshot of the currently-loaded devices."""
         return self._scanner.devices
 
+    def get_by_configuration(self, configuration: str) -> Device | None:
+        """Return the configured device for YAML filename *configuration*, or ``None``."""
+        return self._scanner.get_by_configuration(configuration)
+
     async def reload_configuration(self, filename: str) -> bool:
         """
         Force-reload one device's state from disk and the metadata sidecar.

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -54,10 +54,8 @@ async def update_device(
     # unflagged; it re-derives to the same id, so nothing is lost.
     user_set: bool | None = None
     if board_id:
-        displayed = next(
-            (d.board_id for d in controller._scanner.devices if d.configuration == configuration),
-            "",
-        )
+        current = controller.get_by_configuration(configuration)
+        displayed = current.board_id if current is not None else ""
         if board_id != displayed:
             user_set = True
     await controller._persist_device_metadata_async(
@@ -106,10 +104,7 @@ async def set_labels(
     # by the scanner (typo, deleted YAML) would otherwise leave
     # an orphaned ``.device-builder.json`` entry pinning labels
     # to a non-existent device.
-    device = next(
-        (d for d in controller._scanner.devices if d.configuration == configuration),
-        None,
-    )
+    device = controller.get_by_configuration(configuration)
     if device is None:
         raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
 
@@ -132,10 +127,7 @@ async def set_labels(
 
     # Re-fetch from the scanner; reload replaces the Device in
     # the index, so the reference held above is stale.
-    refreshed = next(
-        (d for d in controller._scanner.devices if d.configuration == configuration),
-        None,
-    )
+    refreshed = controller.get_by_configuration(configuration)
     if refreshed is None:
         raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
     return refreshed

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -322,10 +322,8 @@ def _local_device_display_for_job(
     devices_controller = getattr(controller._db, "devices", None)
     if devices_controller is None:
         return "", ""
-    for device in devices_controller.get_devices():
-        if device.configuration == job.configuration:
-            return device.name, device.friendly_name
-    return "", ""
+    device = devices_controller.get_by_configuration(job.configuration)
+    return (device.name, device.friendly_name) if device is not None else ("", "")
 
 
 async def _submit_job_to_receiver(

--- a/tests/controllers/devices/test_listing_api.py
+++ b/tests/controllers/devices/test_listing_api.py
@@ -80,6 +80,18 @@ def test_get_devices_returns_scanner_snapshot(
     assert [d.name for d in snapshot] == ["kitchen", "bedroom"]
 
 
+def test_get_by_configuration_resolves_a_device_by_filename(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """The controller delegates a filename lookup to the scanner, ``None`` if unknown."""
+    controller = make_controller(tmp_path)
+    kitchen = _device("kitchen")
+    controller._scanner.devices = [kitchen, _device("bedroom")]
+
+    assert controller.get_by_configuration("kitchen.yaml") is kitchen
+    assert controller.get_by_configuration("ghost.yaml") is None
+
+
 async def test_get_device_states_returns_configuration_keyed_map(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -448,9 +448,9 @@ async def test_remote_compile_plumbs_device_names_from_local_scanner(
     ``esphome.friendly_name`` from its local scanner at install
     time, so the receiver doesn't have to re-parse the bundled
     YAML just to render the firmware-tasks title. Stub the
-    devices controller's ``get_devices`` to return one Device
-    matching the job's configuration; assert ``submit_job`` is
-    called with both names.
+    devices controller's ``get_by_configuration`` to return one
+    Device matching the job's configuration; assert ``submit_job``
+    is called with both names.
 
     A regression that dropped the lookup (or fell back to
     parsing the YAML on the receiver) would surface here.
@@ -465,7 +465,9 @@ async def test_remote_compile_plumbs_device_names_from_local_scanner(
     fake_device.name = "kitchen"
     fake_device.friendly_name = "AC Float Monitor 32"
     devices_stub = MagicMock()
-    devices_stub.get_devices.return_value = [fake_device]
+    devices_stub.get_by_configuration.side_effect = lambda cfg: (
+        fake_device if cfg == fake_device.configuration else None
+    )
     controller._db.devices = devices_stub
 
     job = _make_remote_job()
@@ -501,7 +503,9 @@ async def test_remote_compile_falls_through_when_no_device_matches(
     unrelated_device.name = "other"
     unrelated_device.friendly_name = "Other"
     devices_stub = MagicMock()
-    devices_stub.get_devices.return_value = [unrelated_device]
+    devices_stub.get_by_configuration.side_effect = lambda cfg: (
+        unrelated_device if cfg == unrelated_device.configuration else None
+    )
     controller._db.devices = devices_stub
 
     job = _make_remote_job()

--- a/tests/test_device_index.py
+++ b/tests/test_device_index.py
@@ -209,6 +209,71 @@ def test_find_path_by_filename_returns_none_when_missing() -> None:
 
 
 # ---------------------------------------------------------------------------
+# get_by_configuration — configuration-keyed lookup (lockstep)
+# ---------------------------------------------------------------------------
+
+
+def test_get_by_configuration_returns_the_device() -> None:
+    """``set`` makes the device resolvable by its ``configuration`` filename."""
+    index = _DeviceIndex()
+    device = _device("kitchen", "kitchen.yaml")
+    index.set(Path("/cfg/kitchen.yaml"), device, (0, 0, 0.0, 0))
+
+    assert index.get_by_configuration("kitchen.yaml") is device
+
+
+def test_get_by_configuration_returns_none_for_unknown() -> None:
+    """An untracked filename yields ``None``."""
+    index = _DeviceIndex()
+    assert index.get_by_configuration("ghost.yaml") is None
+
+
+def test_get_by_configuration_follows_in_place_update() -> None:
+    """Re-``set``-ing the same path returns the fresh Device, not the stale one."""
+    index = _DeviceIndex()
+    path = Path("/cfg/kitchen.yaml")
+    stale = _device("kitchen", "kitchen.yaml", friendly_name="Stale")
+    fresh = _device("kitchen", "kitchen.yaml", friendly_name="Fresh")
+    index.set(path, stale, (0, 0, 0.0, 0))
+    index.set(path, fresh, (1, 2, 3.0, 4))
+
+    assert index.get_by_configuration("kitchen.yaml") is fresh
+
+
+def test_get_by_configuration_survives_name_change() -> None:
+    """A same-file ``esphome.name`` edit keeps the configuration lookup valid."""
+    index = _DeviceIndex()
+    path = Path("/cfg/device.yaml")
+    index.set(path, _device("kitchen", "device.yaml"), (0, 0, 0.0, 0))
+    renamed = _device("lounge", "device.yaml")
+    index.set(path, renamed, (1, 1, 1.0, 1))
+
+    assert index.get_by_configuration("device.yaml") is renamed
+
+
+def test_get_by_configuration_returns_none_after_pop() -> None:
+    """Popping the path drops the configuration entry too."""
+    index = _DeviceIndex()
+    path = Path("/cfg/kitchen.yaml")
+    index.set(path, _device("kitchen", "kitchen.yaml"), (0, 0, 0.0, 0))
+    index.pop(path)
+
+    assert index.get_by_configuration("kitchen.yaml") is None
+
+
+def test_get_by_configuration_distinguishes_name_sharing_siblings() -> None:
+    """Two YAMLs sharing a ``name`` resolve independently by filename."""
+    index = _DeviceIndex()
+    a = _device("kitchen", "a.yaml")
+    b = _device("kitchen", "b.yaml")
+    index.set(Path("/cfg/a.yaml"), a, (0, 0, 0.0, 0))
+    index.set(Path("/cfg/b.yaml"), b, (0, 0, 0.0, 0))
+
+    assert index.get_by_configuration("a.yaml") is a
+    assert index.get_by_configuration("b.yaml") is b
+
+
+# ---------------------------------------------------------------------------
 # rebuild_in_path_order — lexicographic re-key
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# What does this implement/fix?

`DeviceScanner.get_by_configuration` resolved a device by its YAML filename with
a linear path scan (`find_path_by_filename`), and `DevicesController` had no
public equivalent, so callers open-coded `next(d for d in ... if d.configuration
== ...)` scans. This adds a configuration-keyed shadow index to `_DeviceIndex`
(1:1, since a configuration filename is unique per tracked path), maintained in
lockstep in `set` / `pop`, so `get_by_configuration` is an O(1) dict access; it
exposes a public `DevicesController.get_by_configuration` delegating to it, and
converts the in-tree linear scans (`mutations_simple`, `remote_runner`) to the
method. `bulk.py`'s `{configuration: device}` map build stays; it needs every
device. `find_path_by_filename` stays for its other caller. Prep for #1430,
which can drop its `_device_for_configuration` linear scan on rebase
(esphome/device-builder#1430 review r3500409125).

**Related issue or feature (if applicable):**

- refs esphome/device-builder#1430 (review r3500409125)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
