### PR TITLE
Ping cached mDNS `.local` devices instead of latching them ONLINE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,6 +506,15 @@ against legacy behaviour before assuming the simpler version suffices.
     "slow", and "packet loss", and there's no subscription delivering
     TTL-expiry here. Wait for the ICMP sweep in the same loop to decide
     OFFLINE.
+  - **Ping-sweep address-cache path** (`PingSource._select_ping_targets`,
+    for a `.local` host with a zeroconf A/AAAA cache hit). Do **not** claim
+    ONLINE off cache presence — **ping** the cached address (system
+    resolver first, `get_cached_addresses` fallback) and let ICMP decide.
+    A cache hit can be a stale or reflected answer (a router/AP mDNS cache
+    still serving a powered-off device); a `claim=True` `mdns` claim here
+    has no browser `Removed` counterpart, so it locks out `should_ping` and
+    latches the device ONLINE forever (#1776). The `ping`-source result
+    (priority 1) stays sweep-eligible so a dead entry demotes.
 
   Don't add an OFFLINE branch to the active-resolve path without
   re-reading this. The asymmetry is the only way to get aggressive ONLINE

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from ...helpers.hostname import is_local_hostname
 from ...models import Device, DeviceState
 from . import shared
+from .helpers import _pick_ipv4
 
 try:
     from icmplib import async_ping as icmp_ping
@@ -211,7 +212,12 @@ class PingSource:
             if not addresses:
                 monitor.apply(device.name, DeviceState.OFFLINE, "ping")
                 return
-            target = addresses[0]
+            # Ping the IPv4 primary, not ``addresses[0]`` — a resolve/cache
+            # hit can order a scoped IPv6 first even when an IPv4 is present,
+            # and ICMP across subnets is friendlier on V4. ``_pick_ipv4`` is
+            # the same chooser ``apply_ip_addresses`` uses for ``device.ip``,
+            # so the pinged IP and the drawer's primary stay in lockstep.
+            target = _pick_ipv4(addresses)
             # ``apply_ip_addresses`` populates ``device.ip`` (V4 primary)
             # and the full ``device.ip_addresses`` list for ``.local`` hosts
             # that don't broadcast ``_esphomelib._tcp`` (non-API ESPHome

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -212,12 +212,13 @@ class PingSource:
                 monitor.apply(device.name, DeviceState.OFFLINE, "ping")
                 return
             target = addresses[0]
-            # ``apply_ip`` is the only path that populates
-            # ``device.ip`` for ``.local`` hosts that don't broadcast
-            # ``_esphomelib._tcp`` (non-API ESPHome devices); without
-            # it those devices would show an em-dash in the drawer's
-            # IP row even after successful pings.
-            monitor.apply_ip(device.name, target)
+            # ``apply_ip_addresses`` populates ``device.ip`` (V4 primary)
+            # and the full ``device.ip_addresses`` list for ``.local`` hosts
+            # that don't broadcast ``_esphomelib._tcp`` (non-API ESPHome
+            # devices); without it those devices show an em-dash in the
+            # drawer's IP row even after successful pings, and forwarding the
+            # whole set keeps a cached multi-IP device's secondary addresses.
+            monitor.apply_ip_addresses(device.name, addresses)
             await self._ping_device(device, target)
 
     async def _ping_device(self, device: Device, target: str) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -164,14 +164,17 @@ class PingSource:
         for device in monitor._get_devices():
             if not device.address or not shared.should_ping(monitor, device):
                 continue
-            if is_local_hostname(device.address) and (
-                cached := monitor.get_cached_addresses(device.address)
-            ):
-                monitor.apply(device.name, DeviceState.ONLINE, "mdns", claim=True)
-                # Forward every cached IP so the dashboard shows all
-                # of them; ``apply_ip_addresses`` picks the IPv4
-                # primary for ICMP / OTA targeting.
-                monitor.apply_ip_addresses(device.name, cached)
+            if is_local_hostname(device.address) and monitor.get_cached_addresses(device.address):
+                # zeroconf has this ``.local`` host in its mDNS cache. Ping it
+                # (``_resolve_and_ping`` resolves, then falls back to the cached
+                # address) rather than claiming ONLINE off cache presence: a
+                # stale or reflected cache entry for a dead device would
+                # otherwise latch it ONLINE forever, since ``mdns`` priority
+                # locks out the sweep and there is no browser ``Removed`` for a
+                # cache-only claim (#1776). Routed here ahead of the DNS-failure
+                # branch so a cached lookup failure can't strand a device we
+                # still hold an mDNS address for.
+                pingable.append(device)
                 continue
             if monitor.state.dns_cache.has_cached_failure(device.address) and (
                 not device.ip_addresses
@@ -193,6 +196,13 @@ class PingSource:
         monitor = self._monitor
         async with self._concurrency:
             addresses = await monitor.state.dns_cache.async_resolve(device.address)
+            if not addresses and is_local_hostname(device.address):
+                # System resolver couldn't resolve the ``.local`` (no nss-mdns
+                # in most container images). Fall back to zeroconf's own mDNS
+                # cache, kept fresh by the ``AsyncServiceBrowser``, rather than
+                # giving up — but ping still decides liveness, so a stale or
+                # reflected entry demotes instead of latching ONLINE (#1776).
+                addresses = monitor.get_cached_addresses(device.address)
             if not addresses:
                 # mDNS-less devices: the ``.local`` won't resolve but a
                 # prior MQTT/DNS observation left a usable IP. Ping that so

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -30,9 +30,11 @@ from .conftest import (
     record_scheduled_coros,
 )
 
+FakeResolverFactory = Callable[..., Callable[[str], Awaitable[list[str]]]]
+
 
 @pytest.fixture
-def fake_resolver() -> Callable[..., Callable[[str], Awaitable[list[str]]]]:
+def fake_resolver() -> FakeResolverFactory:
     """Build a stub for ``icmplib.async_resolve``.
 
     The factory captures call counts and returns successive results
@@ -297,26 +299,103 @@ async def test_ping_sweep_applies_ip_for_local_hosts(fake_resolver) -> None:
     assert ip_changes == [("kitchen", "192.168.1.50", ["192.168.1.50"])]
 
 
-async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
-    """A ``.local`` device in zeroconf's cache short-circuits before ping.
+async def test_ping_sweep_prefers_system_resolver_over_zeroconf_cache(
+    fake_resolver: FakeResolverFactory,
+) -> None:
+    """A resolvable ``.local`` is pinged at the freshly resolved IP, not the zeroconf cache.
 
-    Catches the case where the ``AsyncServiceBrowser`` ``Added``
-    callback didn't fire for us (multicast packet drop or startup race)
-    but zeroconf's underlying cache has the entry from the periodic
-    PTR queries. Without this rescue the ping sweep falls through to
-    the bare-hostname DNS fallback, which can resolve to an
-    unreachable IP on a different subnet and report a phantom OFFLINE
-    for a device that's actually right there.
+    The zeroconf cache is a fallback; when the system resolver answers,
+    its fresher address wins.
     """
     devices = [_device(address="winefridge.local", name="winefridge")]
-    state_changes: list[tuple[str, object, str]] = []
     ip_changes: list[tuple[str, str, list[str]]] = []
     monitor = DeviceStateMonitor(
         get_devices=lambda: devices,
-        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_state_change=lambda *_: None,
         on_ip_change=lambda n, ip, addrs: ip_changes.append((n, ip, list(addrs))),
     )
 
+    resolver = fake_resolver(["10.0.0.7"])
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = True
+            min_rtt = 1.5
+
+        return _R()
+
+    with (
+        patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(ping_module, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping._ping_sweep()
+
+    assert pinged == ["10.0.0.7"]
+    assert ip_changes[0] == ("winefridge", "10.0.0.7", ["10.0.0.7"])
+
+
+async def test_ping_sweep_falls_back_to_zeroconf_cache_when_resolver_fails(
+    fake_resolver: FakeResolverFactory,
+) -> None:
+    """Unresolvable ``.local`` falls back to the zeroconf-cached IP.
+
+    A live host answers that ping and goes ONLINE via ``ping``.
+    """
+    devices = [_device(address="winefridge.local", name="winefridge")]
+    state_changes: list[tuple[str, object, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_ip_change=lambda *_: None,
+    )
+
+    resolver = fake_resolver(dns_cache_mod.NameLookupError, dns_cache_mod.NameLookupError)
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = True
+            min_rtt = 1.5
+
+        return _R()
+
+    with (
+        patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(ping_module, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping._ping_sweep()
+
+    assert pinged == ["192.168.213.11"]
+    assert state_changes[-1] == ("winefridge", DeviceState.ONLINE, "ping")
+    assert monitor.priority_for("winefridge") == "ping"
+
+
+async def test_ping_sweep_demotes_dead_zeroconf_cached_local(
+    fake_resolver: FakeResolverFactory,
+) -> None:
+    """A dead ``.local`` lingering in zeroconf's cache is demoted, not latched ONLINE (#1776).
+
+    A stale or reflected cached A record (a router mDNS cache still
+    answering for a powered-off device) must not hold it ONLINE: the
+    cached IP is pinged, fails, and the device goes OFFLINE via ``ping``
+    and stays ping-eligible instead of latching ONLINE via ``mdns``.
+    """
+    devices = [_device(address="winefridge.local", name="winefridge")]
+    state_changes: list[tuple[str, object, str]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda n, s, src: state_changes.append((n, s, src)),
+        on_ip_change=lambda *_: None,
+    )
+
+    resolver = fake_resolver(dns_cache_mod.NameLookupError, dns_cache_mod.NameLookupError)
     pinged: list[str] = []
 
     async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
@@ -329,14 +408,14 @@ async def test_ping_sweep_rescues_local_device_from_zeroconf_cache() -> None:
 
     with (
         patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
         await monitor._ping._ping_sweep()
 
-    assert pinged == []
-    assert state_changes == [("winefridge", DeviceState.ONLINE, "mdns")]
-    assert ip_changes == [("winefridge", "192.168.213.11", ["192.168.213.11"])]
-    assert monitor.priority_for("winefridge") == "mdns"
+    assert pinged and set(pinged) == {"192.168.213.11"}
+    assert state_changes[-1] == ("winefridge", DeviceState.OFFLINE, "ping")
+    assert monitor.priority_for("winefridge") == "ping"
 
 
 async def test_ping_sweep_marks_offline_directly_on_dns_failure(fake_resolver) -> None:

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -299,6 +299,44 @@ async def test_ping_sweep_applies_ip_for_local_hosts(fake_resolver) -> None:
     assert ip_changes == [("kitchen", "192.168.1.50", ["192.168.1.50"])]
 
 
+async def test_ping_sweep_targets_ipv4_primary_over_scoped_v6(
+    fake_resolver: FakeResolverFactory,
+) -> None:
+    """A multi-address resolve pings the IPv4 primary, not a scoped V6 ordered first.
+
+    ``device.ip`` and the ping target must be the same IPv4 primary
+    ``_pick_ipv4`` selects; the full set still reaches ``ip_addresses``.
+    """
+    devices = [_device(address="winefridge.local", name="winefridge")]
+    ip_changes: list[tuple[str, str, list[str]]] = []
+    monitor = DeviceStateMonitor(
+        get_devices=lambda: devices,
+        on_state_change=lambda *_: None,
+        on_ip_change=lambda n, ip, addrs: ip_changes.append((n, ip, list(addrs))),
+    )
+
+    resolver = fake_resolver(["fe80::1%en0", "10.0.0.5"])
+    pinged: list[str] = []
+
+    async def fake_ping(target, **_kwargs):  # type: ignore[no-untyped-def]
+        pinged.append(target)
+
+        class _R:
+            is_alive = True
+            min_rtt = 1.5
+
+        return _R()
+
+    with (
+        patch.object(dns_cache_mod, "async_resolve", resolver),
+        patch.object(ping_module, "icmp_ping", fake_ping),
+    ):
+        await monitor._ping._ping_sweep()
+
+    assert pinged == ["10.0.0.5"]
+    assert ip_changes[0] == ("winefridge", "10.0.0.5", ["fe80::1%en0", "10.0.0.5"])
+
+
 async def test_ping_sweep_prefers_system_resolver_over_zeroconf_cache(
     fake_resolver: FakeResolverFactory,
 ) -> None:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1720,18 +1720,19 @@ def test_get_cached_addresses_returns_none_when_addresses_empty(
 async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A ``.local`` device whose mDNS cache only carries V6 still gets an IP.
+    """A ``.local`` device whose mDNS cache only carries V6 is pinged at that V6 address.
 
     Drives the V4-preference helper's fallback branch through the
-    public ping pipeline: the device is ``.local``, the zeroconf
-    cache resolves it but only to a scoped V6 address, and the
-    monitor still claims it ONLINE under the mDNS source and pushes
-    the V6 address into ``Device.ip``. Without the fallback the
+    public ping pipeline: the system resolver can't resolve the
+    ``.local``, so the zeroconf cache supplies a scoped V6 address;
+    the ping targets it and the device goes ONLINE under ``ping``
+    with the V6 address in ``Device.ip``. Without the fallback the
     device would get ``apply_ip("")`` and the dashboard wouldn't
     have an IP to OTA against.
     """
     device = _device(address="kitchen.local", state=DeviceState.UNKNOWN)
     monitor, _callbacks = _make_monitor([device])
+    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=None)
 
     cached_info = MagicMock()
     cached_info.load_from_cache.return_value = True
@@ -1739,9 +1740,10 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
     monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: cached_info)
 
     async def _icmp(*_a: Any, **_kw: Any) -> Any:
-        # Should not be reached — the cached-addresses path
-        # claims ONLINE and skips the icmp probe.
-        raise AssertionError("icmp_ping must not be called for cached-mdns devices")
+        result = MagicMock()
+        result.is_alive = True
+        result.min_rtt = 1.5
+        return result
 
     monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
     _shrink_ping_intervals(monkeypatch)


### PR DESCRIPTION
# What does this implement/fix?

A powered off `.local` device could stay "online" in the dashboard forever. Every ping sweep, if zeroconf still held a cached A record for the hostname (a router or FRITZ!Box answering the hostname query, for example), the sweep marked the device online via `mdns` straight from that cache. That claim took the top priority `mdns` source, so `should_ping` stopped rechecking the device, and there is no browser `Removed` event for a claim that never went through the browser, so nothing ever demoted it; the device latched online with no way back.

Now a cached `.local` address is pinged instead of trusted. The system resolver is tried first and the zeroconf cache is only a fallback, then ICMP decides the state, so a dead device fails the ping and goes offline while a live one stays online. #1750 fixed the same class of bug in the mDNS browser path; this covers the ping sweep path it did not touch.

The ping path now records the full resolved address set via `apply_ip_addresses` and pings the IPv4 primary that `_pick_ipv4` picks, so `device.ip` and the ICMP target stay in lockstep and a scoped IPv6 is never chosen over a v4. This replaces `ip_addresses` with the current resolved set rather than merging, which is intended for a liveness path so stale IPs drop; it can't shrink a live mDNS set, since `should_ping` skips any device a higher priority source owns and the mDNS `Removed` handler clears the list. OTA already read the zeroconf cache directly, so targeting is unchanged. The ping-sweep address-cache invariant is documented in CLAUDE.md alongside the browser and active-resolve paths.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1776

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
