### PR TITLE
Wait on the store lock in peer-link identity cancel tests

### DIFF
--- a/tests/test_peer_link_identity.py
+++ b/tests/test_peer_link_identity.py
@@ -225,10 +225,11 @@ async def test_cancelled_first_async_load_still_populates_cache(tmp_path: Path) 
         with pytest.raises(asyncio.CancelledError):
             await first
         load_release.set()
-        for _ in range(50):
-            if landed:
-                break
-            await asyncio.sleep(0.01)
+        # The shielded load holds the store lock until the cache is populated,
+        # so acquiring the lock waits for it deterministically instead of
+        # polling on a fixed budget (which flaked on slow CI runners).
+        async with store._lock:
+            pass
         assert landed, "executor never completed"
         cached_after = await store.async_load()
 
@@ -262,12 +263,12 @@ async def test_cancelled_async_rotate_keeps_cache_consistent_with_disk(tmp_path:
         with pytest.raises(asyncio.CancelledError):
             await rotate_task
         rotate_release.set()
-        # Wait for the shielded background rotation to finish so
-        # the cache update lands before we assert.
-        for _ in range(50):
-            if rotated_identity:
-                break
-            await asyncio.sleep(0.01)
+        # The shielded rotation holds the store lock until it has written the
+        # key and refreshed the cache, so acquiring the lock waits for it to
+        # finish deterministically rather than polling on a fixed budget (which
+        # flaked on slow CI runners).
+        async with store._lock:
+            pass
         assert rotated_identity, "executor never completed"
 
     after = await store.async_load()


### PR DESCRIPTION
# What does this implement/fix?

Two cancel-path tests in `test_peer_link_identity.py` polled for a fixed 0.5 seconds (50 iterations of a 10ms sleep) for the shielded background rotation or load to finish, then asserted it had. On a slow, loaded Windows runner the crypto keygen plus atomic disk write can take longer than that budget, so the assert fires with "executor never completed" and the `windows-latest / Python 3.14` pytest shard goes red intermittently.

The shielded coroutine holds the store's lock until it has written the key and refreshed the cache, so acquiring that lock waits for it to finish deterministically. This replaces the timed poll with an `async with store._lock` in both tests; there is no production code change and no fixed timeout left to tune.

**Related issue or feature (if applicable):**

- surfaced as a flaky `windows-latest / Python 3.14` job on unrelated PRs; no filed issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
