### PR TITLE
Reuse the drain_tasks helper for cancel-and-drain teardowns

### DIFF
--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -17,7 +17,7 @@ from esphome.const import __version__ as esphome_version
 from ..constants import __version__
 from ..controllers.auth import AuthError
 from ..helpers.api import CommandError
-from ..helpers.async_ import create_eager_task
+from ..helpers.async_ import create_eager_task, drain_tasks
 from ..helpers.auth import extract_bearer_token
 from ..helpers.event_bus import StreamBackpressureError
 from ..helpers.json import JSONDecodeError, dumps_str, loads
@@ -193,10 +193,7 @@ class WebSocketClient:
 
     async def cleanup(self) -> None:
         """Cancel all pending tasks."""
-        for task in self._tasks:
-            task.cancel()
-        if self._tasks:
-            await asyncio.gather(*self._tasks, return_exceptions=True)
+        await drain_tasks(self._tasks)
 
     async def _handle_command(self, raw: dict[str, Any]) -> None:
         """Parse and dispatch a command."""

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -129,7 +129,7 @@ class DeviceMqttMonitor:
         """Cancel the connect/listen task and forget all observations."""
         if self._task is None:
             return
-        await drain_tasks((self._task,))
+        await drain_tasks((self._task,), log_exceptions=True)
         self._task = None
         self._last_seen.clear()
 

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -25,8 +25,8 @@ try:
 except ImportError:  # pragma: no cover — paho-mqtt arrives via the [esphome] extra
     paho_mqtt = None  # type: ignore[assignment]
 
-import contextlib
 
+from ..helpers.async_ import drain_tasks
 from ..helpers.json import JSONDecodeError, loads
 from ..models import DeviceState
 
@@ -129,9 +129,7 @@ class DeviceMqttMonitor:
         """Cancel the connect/listen task and forget all observations."""
         if self._task is None:
             return
-        self._task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await self._task
+        await drain_tasks((self._task,))
         self._task = None
         self._last_seen.clear()
 

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -8,7 +8,6 @@ schema-driven completion, etc.) will live here too.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import time
 from dataclasses import dataclass, field
@@ -18,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from fnv_hash_fast import fnv1a_32
 
 from ..helpers.api import api_command
+from ..helpers.async_ import drain_tasks
 from ..helpers.json import JSONDecodeError, dumps, loads
 from ..helpers.process import kill_quietly
 from ..helpers.subprocess import create_subprocess_exec
@@ -104,9 +104,7 @@ class EditorController:
     async def stop(self) -> None:
         """Stop the controller."""
         if self._reaper_task is not None:
-            self._reaper_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._reaper_task
+            await drain_tasks((self._reaper_task,))
             self._reaper_task = None
         sessions = list(self._sessions.values())
         self._sessions.clear()

--- a/esphome_device_builder/controllers/editor.py
+++ b/esphome_device_builder/controllers/editor.py
@@ -104,7 +104,7 @@ class EditorController:
     async def stop(self) -> None:
         """Stop the controller."""
         if self._reaper_task is not None:
-            await drain_tasks((self._reaper_task,))
+            await drain_tasks((self._reaper_task,), log_exceptions=True)
             self._reaper_task = None
         sessions = list(self._sessions.values())
         self._sessions.clear()

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -20,7 +20,7 @@ from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError, api_command
-from ...helpers.async_ import create_eager_task
+from ...helpers.async_ import create_eager_task, drain_tasks
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
     ErrorCode,
@@ -381,9 +381,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         try:
             await asyncio.gather(*queue_tasks)
         finally:
-            for task in queue_tasks:
-                task.cancel()
-            await asyncio.gather(*queue_tasks, return_exceptions=True)
+            await drain_tasks(queue_tasks)
 
     async def _execute_job(self, job: FirmwareJob, lane: Lane) -> None:
         await runner.execute_job(self, job, lane)

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -27,6 +27,7 @@ import aiohttp
 from yarl import URL
 
 from ....helpers import json as _json
+from ....helpers.async_ import drain_tasks
 from ....helpers.peer_link_noise import (
     NOISE_ERRORS,
     PeerLinkNoiseSession,
@@ -587,13 +588,7 @@ class PeerLinkClient:
                             f"artifacts_end for job_id={pending_job_id!r}"
                         )
                     )
-            heartbeat_task.cancel()
-            # ``gather(return_exceptions=True)`` rather than
-            # ``suppress(CancelledError) + await`` — suppressing
-            # CancelledError swallows any outer cancellation that
-            # arrives during the drain (see
-            # ``feedback_no_suppress_cancelled_error``).
-            await asyncio.gather(heartbeat_task, return_exceptions=True)
+            await drain_tasks((heartbeat_task,))
 
     def _build_sync_frame_dispatch(
         self,

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -41,7 +41,7 @@ from .controllers.onboarding import OnboardingController
 from .controllers.remote_build import OffloaderController, ReceiverController
 from .controllers.version_history import VersionHistoryController
 from .helpers.api import CommandHandler, collect_api_commands
-from .helpers.async_ import create_eager_task
+from .helpers.async_ import create_eager_task, drain_tasks
 from .helpers.auth import HASHED_FILENAME_RE, auth_middleware, ingress_peer_guard
 from .helpers.dashboard_advertise import DashboardAdvertiser
 from .helpers.dashboard_identity import get_or_create_identity as get_or_create_dashboard_identity
@@ -485,13 +485,8 @@ class DeviceBuilder:
         if self._network_stopped:
             return
         if self._bg_task:
-            self._bg_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._bg_task
-        for task in self._background_tasks:
-            task.cancel()
-        if self._background_tasks:
-            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+            await drain_tasks((self._bg_task,))
+        await drain_tasks(self._background_tasks)
         # Tear down the remote-build listener (if it was bound)
         # before the controller it depends on. Order matters less
         # here than for zeroconf, but doing it first keeps the

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -485,7 +485,7 @@ class DeviceBuilder:
         if self._network_stopped:
             return
         if self._bg_task:
-            await drain_tasks((self._bg_task,))
+            await drain_tasks((self._bg_task,), log_exceptions=True)
         await drain_tasks(self._background_tasks)
         # Tear down the remote-build listener (if it was bound)
         # before the controller it depends on. Order matters less


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the version-history PR, which moved `drain_tasks` into `helpers/async_.py` as a general cancel-and-drain helper. This reuses it at the hand-rolled sites that do the same thing, so the "cancel then gather, or cancel then suppress and await" idiom lives in one place.

Converted (six sites): teardowns that cancel task(s) then `gather(*tasks, return_exceptions=True)` (`DeviceBuilder.stop_network`'s background set, `WebSocketManager.cleanup`, the firmware queue's finally block, the peer-link client heartbeat), and single-task `stop()` paths that cancel then await under `contextlib.suppress(asyncio.CancelledError)` (`EditorController.stop`, `DeviceMqttMonitor.stop`, plus `DeviceBuilder`'s background probe task). All map onto `drain_tasks`, which snapshots the tasks, cancels them, and gathers with `return_exceptions=True`. The now-unused `contextlib` imports are removed.

The four `gather`-based sites are exact equivalents (default `log_exceptions=False`, same silent-swallow as the bare gather they replace). The three `suppress`-based sites aren't strictly bit-exact: the old `suppress(CancelledError)` only caught cancellation and let a non-cancel teardown exception propagate out of `stop()`, so those three pass `log_exceptions=True` to surface such an exception at WARNING rather than dropping it silently (a normal `CancelledError` is a `BaseException`, so it stays unlogged). These `stop()` paths aren't reached under their own cancellation the way the deliberately-skipped `finally` sites are, so the outer-cancel-propagation difference doesn't arise.

Left alone on purpose: the peer-link session and reachability-stream teardowns keep their `suppress(asyncio.CancelledError)` because it runs in a `finally` reached while the enclosing task is itself being cancelled and deliberately swallows that cancellation so the trailing cleanup (e.g. `unregister_peer_link_session`) still runs; `drain_tasks` gathers, which would propagate the cancel and skip that cleanup. Also skipped: sites that gather bare coroutines rather than cancel tasks (`close_all_websockets`, the ping fan-out), the monitor stop that wraps the gather in `wait_for` for a drain timeout, the mDNS close that inspects the gather result, the wake-worker and dashboard-advertise drains that log at ERROR / DEBUG, the sync-only `cancel()` with no await, and the `TimerHandle` cancels.

**Related issue or feature (if applicable):**

- follow-up to the `drain_tasks` helper added in #1785; no filed issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
