### PR TITLE
Add run_in_executor helper and use it across the codebase

### DIFF
--- a/esphome_device_builder/_remote_build_lifecycle.py
+++ b/esphome_device_builder/_remote_build_lifecycle.py
@@ -16,6 +16,7 @@ from .controllers.config import (
     load_remote_build_settings,
 )
 from .controllers.remote_build.peer_link import PEER_LINK_PATH, make_peer_link_handler
+from .helpers.async_ import run_in_executor
 from .helpers.network_interfaces import (
     bind_available_port,
     ensure_single_host_for_ephemeral_port,
@@ -119,11 +120,10 @@ class RemoteBuildLifecycle:
         """
         if self._db.remote_build_receiver is None or self._db.loop is None:
             return
-        loop = self._db.loop
         settings = self._db.settings
         if settings.on_ha_addon:
-            persisted = await loop.run_in_executor(
-                None, has_remote_build_settings_persisted, settings.config_dir
+            persisted = await run_in_executor(
+                has_remote_build_settings_persisted, settings.config_dir
             )
             if not persisted:
                 _LOGGER.debug(
@@ -133,9 +133,7 @@ class RemoteBuildLifecycle:
                     "default; flip the toggle in Settings to override)"
                 )
                 return
-        rb_settings = await loop.run_in_executor(
-            None, load_remote_build_settings, settings.config_dir
-        )
+        rb_settings = await run_in_executor(load_remote_build_settings, settings.config_dir)
         if not rb_settings.enabled:
             _LOGGER.debug(
                 "Skipping remote-build peer-link site: disabled in settings "
@@ -244,10 +242,9 @@ class RemoteBuildLifecycle:
         """
         if self._db.loop is None:
             return self._runner is not None
-        loop = self._db.loop
         async with self._get_lock():
-            rb_settings = await loop.run_in_executor(
-                None, load_remote_build_settings, self._db.settings.config_dir
+            rb_settings = await run_in_executor(
+                load_remote_build_settings, self._db.settings.config_dir
             )
             if rb_settings.enabled:
                 if self._runner is None:
@@ -389,8 +386,6 @@ class RemoteBuildLifecycle:
         to a specific NIC can override via ``--remote-build-host`` /
         ``$ESPHOME_REMOTE_BUILD_HOST``.
         """
-        loop = self._db.loop
-        assert loop is not None  # caller-checked
         receiver = self._db.remote_build_receiver
         assert receiver is not None  # caller-checked
         settings = self._db.settings
@@ -407,8 +402,7 @@ class RemoteBuildLifecycle:
         # makes the reservation race-free against sibling instances
         # (e.g. the stable/beta/dev add-on flavors) scanning the same
         # range at startup; ``web.SockSite`` below adopts them.
-        bind_port, bound_sockets = await loop.run_in_executor(
-            None,
+        bind_port, bound_sockets = await run_in_executor(
             bind_available_port,
             hosts,
             configured_port,

--- a/esphome_device_builder/api/legacy.py
+++ b/esphome_device_builder/api/legacy.py
@@ -26,7 +26,6 @@ clients keep working.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +33,7 @@ import aiohttp
 from aiohttp import web
 
 from ..helpers.api import CommandError
+from ..helpers.async_ import run_in_executor
 from ..helpers.device_yaml import EsphomeConfigUnavailableError, run_esphome_config
 from ..helpers.event_bus import Event, StreamControls, stream_events
 from ..helpers.json import (
@@ -296,15 +296,14 @@ async def _json_config_response(db: DeviceBuilder, configuration: str) -> web.Re
 
     403 traversal, 404 missing file, 500 no esphome, 503 infra fault, 422 invalid.
     """
-    loop = asyncio.get_running_loop()
     try:
         # ``rel_path`` calls ``Path.resolve``, a blocking syscall — run it in
         # the executor so blockbuster doesn't fault the request on CI.
-        config_path = await loop.run_in_executor(None, db.settings.rel_path, configuration)
+        config_path = await run_in_executor(db.settings.rel_path, configuration)
     except CommandError:
         return json_response({"error": "Forbidden"}, status=403)
 
-    if not await loop.run_in_executor(None, config_path.is_file):
+    if not await run_in_executor(config_path.is_file):
         return json_response({"error": "Not found"}, status=404)
 
     devices = db.devices

--- a/esphome_device_builder/controllers/_build_size_refresher.py
+++ b/esphome_device_builder/controllers/_build_size_refresher.py
@@ -27,11 +27,11 @@ Design constraints driving the class shape:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
+from ..helpers.async_ import run_in_executor
 from ..helpers.build_size import (
     BuildDirSignal,
     BuildSizeRefreshResult,
@@ -95,12 +95,11 @@ class BuildSizeRefresher(WakeWorker[str]):
         CLI-compile drift across the whole catalog without
         saturating disk I/O on the cold path.
         """
-        loop = asyncio.get_running_loop()
         filenames = list(self._get_filenames())
         if not filenames:
             return
         metadata = self._get_metadata_snapshot()
-        stale = await loop.run_in_executor(None, find_stale_build_dirs, filenames, metadata)
+        stale = await run_in_executor(find_stale_build_dirs, filenames, metadata)
         for configuration in stale:
             self.request(configuration)
 
@@ -111,7 +110,6 @@ class BuildSizeRefresher(WakeWorker[str]):
             _LOGGER.exception("Initial build-size fleet sweep failed")
 
     async def _drain(self) -> None:
-        loop = asyncio.get_running_loop()
         # One snapshot per drain cycle, not per item, so the
         # per-device cached-signal lookup is O(1) on a hash
         # rather than O(N) on a fresh fleet-wide copy.
@@ -124,8 +122,7 @@ class BuildSizeRefresher(WakeWorker[str]):
                 info_mtime=coerce_sidecar_int(entry.get("build_size_info_mtime")),
             )
             try:
-                result = await loop.run_in_executor(
-                    None,
+                result = await run_in_executor(
                     refresh_build_size_if_stale,
                     configuration,
                     cached,

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -9,7 +9,6 @@ poll so monitors track YAML edits.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -19,6 +18,7 @@ import yaml
 from esphome.core import EsphomeError
 
 from ..constants import SECRETS_FILENAME
+from ..helpers.async_ import run_in_executor
 from ..helpers.device_yaml import (
     _UNRESOLVED_SUBSTITUTION_RE,
     _extract_resolved_substitutions,
@@ -88,8 +88,7 @@ class DeviceMqttCoordinator:
                 )
             return
 
-        loop = asyncio.get_running_loop()
-        brokers = await loop.run_in_executor(None, self._collect_brokers)
+        brokers = await run_in_executor(self._collect_brokers)
         wanted_keys = {b.key for b in brokers}
         existing_keys = set(self._monitors.keys())
 

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover — paho-mqtt arrives via the [esphome] 
     paho_mqtt = None  # type: ignore[assignment]
 
 
-from ..helpers.async_ import drain_tasks
+from ..helpers.async_ import drain_tasks, run_in_executor
 from ..helpers.json import JSONDecodeError, loads
 from ..models import DeviceState
 
@@ -239,7 +239,7 @@ class DeviceMqttMonitor:
         if self._broker.username:
             client.username_pw_set(self._broker.username, self._broker.password or "")
 
-        await loop.run_in_executor(None, client.connect, self._broker.host, self._broker.port)
+        await run_in_executor(client.connect, self._broker.host, self._broker.port)
         client.loop_start()
         try:
             await asyncio.wait_for(connected.wait(), timeout=_CONNECT_TIMEOUT)

--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -19,6 +19,7 @@ from typing import NamedTuple
 
 from esphome import util
 
+from ..helpers.async_ import run_in_executor
 from ..helpers.device_yaml import load_device_from_storage
 from ..models import Device
 from ._wake_worker import WakeWorker
@@ -345,8 +346,7 @@ class DeviceScanner(WakeWorker[str]):
             # makes a miss here impossible since
             # ``find_path_by_filename`` just located *path*.
             previous_cache_key = self._index.cache_key(path)
-            loop = asyncio.get_running_loop()
-            loaded = await loop.run_in_executor(None, self._load_devices, {path})
+            loaded = await run_in_executor(self._load_devices, {path})
             device = loaded.get(path)
             if device is None:
                 return False
@@ -355,7 +355,7 @@ class DeviceScanner(WakeWorker[str]):
             # snapshotted previous key so the next ``_do_scan``
             # re-evaluates it.
             try:
-                stat = await loop.run_in_executor(None, path.stat)
+                stat = await run_in_executor(path.stat)
                 cache_key: _CacheKey = (
                     stat.st_ino,
                     stat.st_dev,
@@ -392,8 +392,7 @@ class DeviceScanner(WakeWorker[str]):
                 )
 
     async def _do_scan(self) -> None:
-        loop = asyncio.get_running_loop()
-        path_to_cache_key = await loop.run_in_executor(None, self._build_cache_keys)
+        path_to_cache_key = await run_in_executor(self._build_cache_keys)
 
         old_paths = set(self._index.by_path.keys())
         new_paths = set(path_to_cache_key.keys())
@@ -407,7 +406,7 @@ class DeviceScanner(WakeWorker[str]):
 
         paths_to_load = added_paths | updated_paths
         if paths_to_load:
-            loaded = await loop.run_in_executor(None, self._load_devices, paths_to_load)
+            loaded = await run_in_executor(self._load_devices, paths_to_load)
             for path, device in loaded.items():
                 kind = ScanChange.ADDED if path in added_paths else ScanChange.UPDATED
                 self._index.set(path, device, path_to_cache_key[path])

--- a/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/interface_monitor.py
@@ -15,6 +15,8 @@ import logging
 import ifaddr
 from esphome.zeroconf import AsyncEsphomeZeroconf
 
+from ...helpers.async_ import run_in_executor
+
 _LOGGER = logging.getLogger(__name__)
 
 # Interface changes are rare, so a relaxed poll keeps steady-state wakeups low.
@@ -37,11 +39,10 @@ async def monitor_interfaces(
     zeroconf: AsyncEsphomeZeroconf, interval: float = _INTERFACE_POLL_INTERVAL
 ) -> None:
     """Reconcile zeroconf sockets whenever the host's addresses change, until cancelled."""
-    loop = asyncio.get_running_loop()
-    previous = await _safe_snapshot(loop)
+    previous = await _safe_snapshot()
     while True:
         await asyncio.sleep(interval)
-        current = await _safe_snapshot(loop)
+        current = await _safe_snapshot()
         # ``None`` is a failed snapshot, not "no addresses" — skip so a transient
         # ifaddr error can't be read as every interface disappearing.
         if current is None or current == previous:
@@ -71,7 +72,7 @@ def _ip_to_str(ip: str | tuple[str, int, int]) -> str:
     return f"{address}%{scope_id}" if scope_id else address
 
 
-async def _safe_snapshot(loop: asyncio.AbstractEventLoop) -> frozenset[tuple[str, int]] | None:
+async def _safe_snapshot() -> frozenset[tuple[str, int]] | None:
     """Snapshot host addresses off the event loop; ``None`` on failure so the loop retries.
 
     ``ifaddr.get_adapters`` is blocking (reads /proc/net; GetAdaptersAddresses on
@@ -79,7 +80,7 @@ async def _safe_snapshot(loop: asyncio.AbstractEventLoop) -> frozenset[tuple[str
     can't kill the reconciler for the rest of the process's life.
     """
     try:
-        return await loop.run_in_executor(None, address_snapshot)
+        return await run_in_executor(address_snapshot)
     except Exception:
         _LOGGER.exception("host address snapshot failed; will retry")
         return None

--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -9,13 +9,13 @@ config-write debounce on the device editor handles that.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
 from ruamel.yaml import YAMLError
 
 from ...helpers.api import CommandError, api_command
+from ...helpers.async_ import run_in_executor
 from ...models.api import ErrorCode
 from ...models.automations import (
     ApiActionLocation,
@@ -161,8 +161,7 @@ class AutomationsController:
         ``upsert`` / ``delete``).
         """
         text = yaml if yaml is not None else await self._read_config(configuration)
-        loop = asyncio.get_running_loop()
-        scoped = await loop.run_in_executor(None, _scope_from_yaml, text)
+        scoped = await run_in_executor(_scope_from_yaml, text)
         # Scope builders are catalog-free; stamp the catalog title here.
         components = self._db.components
         if components is not None:
@@ -196,8 +195,7 @@ class AutomationsController:
         the form lands empty.
         """
         text = yaml if yaml is not None else await self._read_config(configuration)
-        loop = asyncio.get_running_loop()
-        parsed = await loop.run_in_executor(None, parsing.parse_device_yaml, text)
+        parsed = await run_in_executor(parsing.parse_device_yaml, text)
         return [p.to_dict() for p in parsed]
 
     @api_command("automations/upsert")
@@ -230,9 +228,7 @@ class AutomationsController:
         tree = AutomationTree.from_dict(automation)
         loc = _decode_location(location)
         text = yaml if yaml is not None else await self._read_config(configuration)
-        loop = asyncio.get_running_loop()
-        _new_text, diff = await loop.run_in_executor(
-            None,
+        _new_text, diff = await run_in_executor(
             lambda: writing.render_upsert(text, tree=tree, location=loc),
         )
         return UpsertResponse(yaml_diff=diff).to_dict()
@@ -254,9 +250,7 @@ class AutomationsController:
         """
         loc = _decode_location(location)
         text = yaml if yaml is not None else await self._read_config(configuration)
-        loop = asyncio.get_running_loop()
-        _new_text, diff = await loop.run_in_executor(
-            None,
+        _new_text, diff = await run_in_executor(
             lambda: writing.render_delete(text, location=loc),
         )
         return UpsertResponse(yaml_diff=diff).to_dict()
@@ -268,8 +262,7 @@ class AutomationsController:
     async def _read_config(self, configuration: str) -> str:
         """Read a device's YAML off disk in a worker thread."""
         path = self._db.settings.rel_path(configuration)
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, path.read_text, "utf-8")
+        return await run_in_executor(path.read_text, "utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/config/_preferences_store.py
+++ b/esphome_device_builder/controllers/config/_preferences_store.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.storage import ShutdownRegister, Store
 from ...models import UserPreferences
@@ -67,7 +67,6 @@ class PreferencesStore:
         blob isn't lost), and an undecodable legacy blob is left in place. Both
         fall back to defaults.
         """
-        loop = asyncio.get_running_loop()
         try:
             loaded = await self._store.async_load()
         except _DECODE_ERRORS:
@@ -75,21 +74,21 @@ class PreferencesStore:
                 "preferences store: %s is undecodable; preserving it and using defaults",
                 _STORE_FILENAME,
             )
-            await loop.run_in_executor(None, self._preserve_corrupt_file)
-            await self._migrate_from_sidecar(loop)
+            await run_in_executor(self._preserve_corrupt_file)
+            await self._migrate_from_sidecar()
             return
         if loaded is not None:
             self._state = loaded
             return
-        await self._migrate_from_sidecar(loop)
+        await self._migrate_from_sidecar()
 
-    async def _migrate_from_sidecar(self, loop: asyncio.AbstractEventLoop) -> None:
+    async def _migrate_from_sidecar(self) -> None:
         """Adopt the legacy ``_preferences`` blob, persist it, then strip the key.
 
         The strip is gated on a confirmed write so an unconfirmed flush can't lose
         the prefs on restart (see :meth:`_confirm_and_strip_shared_sync`).
         """
-        migrated = await loop.run_in_executor(None, self._migrate_read_shared_sync)
+        migrated = await run_in_executor(self._migrate_read_shared_sync)
         if migrated is None:
             return
         self._state = migrated
@@ -97,7 +96,7 @@ class PreferencesStore:
             return
         self._store.async_delay_save(self._snapshot, delay=0.0)
         await self._store.async_save_now()
-        stripped = await loop.run_in_executor(None, self._confirm_and_strip_shared_sync)
+        stripped = await run_in_executor(self._confirm_and_strip_shared_sync)
         if not stripped:
             _LOGGER.warning(
                 "preferences store: %s write unconfirmed; keeping %s in %s to retry",

--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
@@ -12,6 +11,7 @@ from esphome.util import get_serial_ports
 
 from ...constants import __version__ as server_version
 from ...helpers.api import CommandError, api_command
+from ...helpers.async_ import run_in_executor
 from ...helpers.secrets_state import (
     SecretsContentError,
     is_valid_secret_key,
@@ -62,8 +62,7 @@ class ConfigController:
     @api_command("config/serial_ports")
     async def get_serial_ports_cmd(self, **kwargs: Any) -> list[dict]:
         """List available serial ports."""
-        loop = asyncio.get_running_loop()
-        ports = await loop.run_in_executor(None, get_serial_ports)
+        ports = await run_in_executor(get_serial_ports)
         return [
             {"port": p.path, "desc": p.description if p.description != "n/a" else p.path}
             for p in ports
@@ -134,9 +133,8 @@ class ConfigController:
     @api_command("config/get_secrets")
     async def get_secrets(self, **kwargs: Any) -> list[str]:
         """Get secret key names from secrets.yaml."""
-        loop = asyncio.get_running_loop()
         config_dir = self._db.settings.config_dir
-        data = await loop.run_in_executor(None, read_secrets_yaml, config_dir)
+        data = await run_in_executor(read_secrets_yaml, config_dir)
         if not data:
             return []
         # ``secrets.yaml`` could legitimately have non-string keys
@@ -204,7 +202,6 @@ class ConfigController:
     @api_command("config/get_info")
     async def get_info(self, *, configuration: str, **kwargs: Any) -> dict | None:
         """Get compiled device metadata (StorageJSON) for a configuration."""
-        loop = asyncio.get_running_loop()
 
         def _load_info() -> dict | None:
             # ``rel_path`` calls ``Path.resolve`` (an ``os.path.abspath``
@@ -231,4 +228,4 @@ class ConfigController:
                 "loaded_integrations": storage.loaded_integrations,
             }
 
-        return await loop.run_in_executor(None, _load_info)
+        return await run_in_executor(_load_info)

--- a/esphome_device_builder/controllers/devices/_metadata_store.py
+++ b/esphome_device_builder/controllers/devices/_metadata_store.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.storage import ShutdownRegister, Store
 from ..config import _load_metadata, metadata_transaction
@@ -80,15 +80,14 @@ class DeviceMetadataStore:
         if loaded is not None:
             self._state = loaded
             return
-        loop = asyncio.get_running_loop()
-        migrated = await loop.run_in_executor(None, self._migrate_read_shared_sync)
+        migrated = await run_in_executor(self._migrate_read_shared_sync)
         self._state = migrated
         if not migrated:
             return
         self._store.async_delay_save(self._snapshot, delay=0.0)
         await self._store.async_save_now()
         keys = list(migrated.keys())
-        await loop.run_in_executor(None, self._migrate_strip_shared_sync, keys)
+        await run_in_executor(self._migrate_strip_shared_sync, keys)
         _LOGGER.info(
             "Migrated %d device metadata entries from %s to %s",
             len(migrated),

--- a/esphome_device_builder/controllers/devices/api_key.py
+++ b/esphome_device_builder/controllers/devices/api_key.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import (
     EsphomeConfigUnavailableError,
     get_api_port,
@@ -28,8 +28,7 @@ async def get_api_key(controller: DevicesController, configuration: str) -> dict
     treats that as the "open the editor and check" signal.
     """
     path = controller._db.settings.rel_path(configuration)
-    loop = asyncio.get_running_loop()
-    config = await loop.run_in_executor(None, load_device_yaml, path)
+    config = await run_in_executor(load_device_yaml, path)
     key = get_resolved_api_encryption_key(config)
     if key:
         return {"key": key}
@@ -50,8 +49,7 @@ async def get_api_connection(controller: DevicesController, configuration: str) 
     plaintext/default-port connection it can't have resolved correctly.
     """
     path = controller._db.settings.rel_path(configuration)
-    loop = asyncio.get_running_loop()
-    config = await loop.run_in_executor(None, load_device_yaml, path)
+    config = await run_in_executor(load_device_yaml, path)
     if config is None:
         raise ValueError(f"could not load YAML for {configuration}")
     return get_resolved_api_encryption_key(config), get_api_port(config)

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import shutil
 from typing import TYPE_CHECKING, Any
@@ -10,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import parse_esphome_meta
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode
@@ -30,7 +30,6 @@ _LOGGER = logging.getLogger(__name__)
 async def archive_single(controller: DevicesController, configuration: str) -> None:
     """Soft-delete: move the YAML into ``<config_dir>/archive/`` and wipe build artifacts."""
     config_path = controller._db.settings.rel_path(configuration)
-    loop = asyncio.get_running_loop()
     config_dir = controller._db.settings.config_dir
 
     def _archive_sync() -> None:
@@ -65,7 +64,7 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
     # archive's removal commit (same serialisation as ``_persist_yaml_mutation``).
     async with controller._yaml_write_lock(configuration):
         try:
-            await loop.run_in_executor(None, _archive_sync)
+            await run_in_executor(_archive_sync)
         except FileExistsError as exc:
             raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
         # Drop volatile fields across both stores: live mDNS state and
@@ -82,7 +81,6 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
 
 async def unarchive_single(controller: DevicesController, configuration: str) -> None:
     """Move an archived YAML back into the active config_dir; refuse on filename clash."""
-    loop = asyncio.get_running_loop()
     config_dir = controller._db.settings.config_dir
     archive_path = config_dir / "archive" / configuration
     target = controller._db.settings.rel_path(configuration)
@@ -100,7 +98,7 @@ async def unarchive_single(controller: DevicesController, configuration: str) ->
         shutil.move(str(archive_path), str(target))
 
     try:
-        await loop.run_in_executor(None, _unarchive_sync)
+        await run_in_executor(_unarchive_sync)
     except FileExistsError as exc:
         raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
 
@@ -142,7 +140,6 @@ def list_archived_sync(controller: DevicesController) -> list[dict[str, Any]]:
 
 async def delete_archived_single(controller: DevicesController, configuration: str) -> None:
     """Permanently remove an archived YAML and its sidecars."""
-    loop = asyncio.get_running_loop()
     config_dir = controller._db.settings.config_dir
     archive_path = config_dir / "archive" / configuration
     active_path = controller._db.settings.rel_path(configuration)
@@ -160,7 +157,7 @@ async def delete_archived_single(controller: DevicesController, configuration: s
         _unlink_compiled_config(configuration)
         return True
 
-    sidecars_purged = await loop.run_in_executor(None, _delete_all)
+    sidecars_purged = await run_in_executor(_delete_all)
     if sidecars_purged:
         # Drop the per-device metadata entry (both the store +
         # shared identity sidecar) on the event loop side and
@@ -172,7 +169,6 @@ async def delete_archived_single(controller: DevicesController, configuration: s
 async def delete_single(controller: DevicesController, configuration: str) -> None:
     """Delete a single device and all associated files."""
     config_path = controller._db.settings.rel_path(configuration)
-    loop = asyncio.get_running_loop()
     config_dir = controller._db.settings.config_dir
 
     def _delete_all() -> None:
@@ -195,7 +191,7 @@ async def delete_single(controller: DevicesController, configuration: str) -> No
     # concurrent editor save's commit on the same config (uniform with
     # ``_persist_yaml_mutation``).
     async with controller._yaml_write_lock(configuration):
-        await loop.run_in_executor(None, _delete_all)
+        await run_in_executor(_delete_all)
         await controller._delete_device_metadata(configuration)
         # Record the removal in git so the YAML stays restorable from
         # history even though its (regenerable) build artifacts are gone.

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -20,6 +20,7 @@ from esphome.zeroconf import AsyncEsphomeZeroconf
 
 from ...constants import is_secrets_file
 from ...helpers.api import CommandError, api_command
+from ...helpers.async_ import run_in_executor
 from ...helpers.build_size import BuildSizeRefreshResult
 from ...helpers.device_yaml import (
     board_requires_wifi,
@@ -250,12 +251,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         """Initialise — load state, scan files, start mDNS + ping + MQTT discovery."""
         self._stopped = False
         self.state.esphome_cmd = _find_esphome_cmd()
-        loop = asyncio.get_running_loop()
         # Seed the store (and migrate on first post-upgrade boot)
         # before the scanner runs — resolver reads off it.
         await self._metadata_store.async_load()
         await self.migrate_board_id_user_set()
-        await loop.run_in_executor(None, self._load_ignored_devices)
+        await run_in_executor(self._load_ignored_devices)
         await self._scanner.scan()
         self._scanner.start()
         _LOGGER.info("Devices controller started — %d devices loaded", len(self._scanner.devices))
@@ -566,10 +566,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             ssid, psk = "", ""  # force the !secret path in the generator
             wifi_requested = True
         else:
-            loop = asyncio.get_running_loop()
-            secrets = await loop.run_in_executor(
-                None, read_secrets_yaml, self._db.settings.config_dir
-            )
+            secrets = await run_in_executor(read_secrets_yaml, self._db.settings.config_dir)
             wifi_secrets_available = wifi_secrets_defined(secrets)
             # A Wi-Fi-only board with no secrets would generate an unflashable
             # no-network stub (its api/ota/web_server defaults need a network).
@@ -668,8 +665,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         actions; full YAML / metadata is left on disk and is fetched
         on demand if the user opens one.
         """
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self._list_archived_sync)
+        return await run_in_executor(self._list_archived_sync)
 
     @api_command("devices/delete_archived")
     async def delete_archived(self, *, configuration: str, **kwargs: Any) -> None:
@@ -968,8 +964,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         ``Path.write_text`` truncates before writing and isn't
         safe for those paths.
         """
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, atomic_write_file, path, content)
+        await run_in_executor(atomic_write_file, path, content)
 
     async def _persist_yaml_mutation(
         self, configuration: str, content: str, *, message: str | None = None
@@ -1060,8 +1055,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
     @staticmethod
     async def _read_yaml_async(path: Path) -> str:
         """Read *path* as UTF-8 text off the executor."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, path.read_text, "utf-8")
+        return await run_in_executor(path.read_text, "utf-8")
 
     def _on_scan_change(self, kind: ScanChange, device: Device) -> None:
         scan_change.on_scan_change(self, kind, device)

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import replace
 from typing import TYPE_CHECKING
@@ -11,6 +10,7 @@ from esphome import const
 from esphome.storage_json import ignored_devices_storage_path
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.lazy_module import async_import_module
 from ...models import (
@@ -58,7 +58,6 @@ async def import_device(
         None,
     )
     network = adoptable.network if adoptable and adoptable.network else const.CONF_WIFI
-    loop = asyncio.get_running_loop()
     # ``esphome.components.dashboard_import`` pulls in ~14 MB of
     # upstream code; load it through ``async_import_module`` so
     # the first adoption pays the cost on the dedicated import
@@ -67,8 +66,7 @@ async def import_device(
     dashboard_import = await async_import_module("esphome.components.dashboard_import")
 
     try:
-        await loop.run_in_executor(
-            None,
+        await run_in_executor(
             dashboard_import.import_config,
             path,
             name,
@@ -93,9 +91,9 @@ async def import_device(
         path.unlink(missing_ok=True)
 
     try:
-        content = await loop.run_in_executor(None, _read)
+        content = await run_in_executor(_read)
     except (OSError, UnicodeDecodeError):
-        await loop.run_in_executor(None, _cleanup)
+        await run_in_executor(_cleanup)
         raise
     await controller._validate_rewritten_yaml_or_raise(
         configuration,
@@ -153,8 +151,7 @@ async def toggle_ignore(controller: DevicesController, *, name: str, ignore: boo
         controller.state.ignored_devices.add(name)
     else:
         controller.state.ignored_devices.discard(name)
-    loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, controller._save_ignored_devices)
+    await run_in_executor(controller._save_ignored_devices)
     # Mirror the new flag onto the cached AdoptableDevice and
     # re-publish ADDED so subscribed frontends update the badge
     # without waiting for a full re-discovery cycle.

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import configuration_stem
 from ...helpers.yaml import (
     ESPHOME_FRIENDLY_NAME_PATH,
@@ -61,7 +61,6 @@ async def clone_device(  # noqa: C901
             "new_name must differ from the source device name",
         )
 
-    loop = asyncio.get_running_loop()
     source_path = controller._db.settings.rel_path(configuration)
     new_path = controller._db.settings.rel_path(new_filename)
     if new_friendly_name is None:
@@ -82,7 +81,7 @@ async def clone_device(  # noqa: C901
         meta = controller._shared_sidecar.get_sync(configuration)
         return content, meta, False
 
-    source_content, source_meta, target_existed = await loop.run_in_executor(None, _gather)
+    source_content, source_meta, target_existed = await run_in_executor(_gather)
     if target_existed:
         msg = f"A device named {new_filename} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
@@ -147,7 +146,7 @@ async def clone_device(  # noqa: C901
             f.write(new_content)
 
     try:
-        await loop.run_in_executor(None, _commit)
+        await run_in_executor(_commit)
     except FileExistsError as exc:
         # Race: another caller created the file between our
         # gather pass and the ``open(... "x")``. Surface as the

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import re
 from typing import TYPE_CHECKING
 
@@ -10,6 +9,7 @@ from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import parse_platform_from_yaml
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, WizardResponse
@@ -98,8 +98,7 @@ async def create_device(  # noqa: C901, PLR0912
     # frontend can offer an overwrite instead of a dead-end error. The
     # write further down is the actual race-safe path; this is a UX
     # optimisation.
-    loop_for_check = asyncio.get_running_loop()
-    file_existed = await loop_for_check.run_in_executor(None, config_path.exists)
+    file_existed = await run_in_executor(config_path.exists)
     if file_existed and not overwrite:
         msg = f"Configuration {filename} already exists"
         raise CommandError(ErrorCode.ALREADY_EXISTS, msg)
@@ -150,8 +149,6 @@ async def create_device(  # noqa: C901, PLR0912
     if not board_id:
         parsed_platform, _pio_board, _variant = parse_platform_from_yaml(yaml_content)
 
-    loop = asyncio.get_running_loop()
-
     def _write_exclusive() -> None:
         # Exclusive-create so a concurrent ``devices/create`` (or
         # any other writer) can't slip between a preflight check
@@ -163,10 +160,10 @@ async def create_device(  # noqa: C901, PLR0912
     if overwriting:
         # Atomic in-place rewrite (stage + move) so a crash can't leave a
         # half-written config; the user explicitly confirmed the overwrite.
-        await loop.run_in_executor(None, atomic_write_file, config_path, yaml_content)
+        await run_in_executor(atomic_write_file, config_path, yaml_content)
     else:
         try:
-            await loop.run_in_executor(None, _write_exclusive)
+            await run_in_executor(_write_exclusive)
         except FileExistsError as exc:
             msg = f"Configuration {filename} already exists"
             raise CommandError(ErrorCode.ALREADY_EXISTS, msg) from exc
@@ -175,7 +172,7 @@ async def create_device(  # noqa: C901, PLR0912
     # and dashboard metadata; only a fresh device gets a new sidecar.
     if not overwriting:
         platform = str(board.esphome.platform) if board else parsed_platform
-        await loop.run_in_executor(None, init_device_storage, filename, name, friendly, platform)
+        await run_in_executor(init_device_storage, filename, name, friendly, platform)
     await controller._register_new_device(
         filename,
         f"{'Overwrite' if overwriting else 'Create'} {filename}",

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import configuration_stem, parse_esphome_meta
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.yaml import (
@@ -201,7 +202,6 @@ async def rename_device(
     config-only since ``esphome rename`` can't keep the same filename.
     """
     new_filename = f"{new_name}.yaml"
-    loop = asyncio.get_running_loop()
     old_path = controller._db.settings.rel_path(configuration)
     new_path = controller._db.settings.rel_path(new_filename)
 
@@ -237,7 +237,7 @@ async def rename_device(
     # Reject up-front if a *different* file already owns the target filename;
     # ``esphome rename`` doesn't check collisions and would silently overwrite
     # an unrelated device's config and OTA-flash firmware to the wrong device.
-    if not in_place and await loop.run_in_executor(None, new_path.exists):
+    if not in_place and await run_in_executor(new_path.exists):
         msg = f"A device named {new_filename} already exists"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
 
@@ -279,7 +279,7 @@ async def _read_device_yaml_or_raise(controller: DevicesController, configuratio
         except FileNotFoundError:
             return None
 
-    content = await asyncio.get_running_loop().run_in_executor(None, _read)
+    content = await run_in_executor(_read)
     if content is None:
         raise CommandError(ErrorCode.INVALID_ARGS, f"Device {configuration} not found")
     return content
@@ -304,7 +304,6 @@ async def _config_only_rename(
     just-written file isn't deleted.
     """
     new_filename = f"{new_name}.yaml"
-    loop = asyncio.get_running_loop()
     old_path = controller._db.settings.rel_path(configuration)
     new_path = controller._db.settings.rel_path(new_filename)
 
@@ -342,10 +341,10 @@ async def _config_only_rename(
 
     await controller._write_yaml_atomic_async(new_path, new_content)
     if not in_place:
-        await loop.run_in_executor(None, lambda: old_path.unlink(missing_ok=True))
+        await run_in_executor(lambda: old_path.unlink(missing_ok=True))
     # The YAML is already renamed; storage migration is best-effort (logs on
     # failure) and the shared metadata-migrate-then-scan always rescans.
-    await loop.run_in_executor(None, _migrate_storage_json, configuration, new_filename, new_name)
+    await run_in_executor(_migrate_storage_json, configuration, new_filename, new_name)
     await migrate_metadata_then_scan(controller, configuration, new_filename)
     return {"configuration": new_filename, "job": None}
 

--- a/esphome_device_builder/controllers/devices/mutations_yaml.py
+++ b/esphome_device_builder/controllers/devices/mutations_yaml.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Literal
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import (
     NETWORK_PROVIDER_COMPONENT_IDS,
     generate_device_yaml,
@@ -183,6 +183,6 @@ async def validate_rewritten_yaml_or_raise(
             # original validation diagnostic the caller is
             # about to see.
             try:
-                await asyncio.get_running_loop().run_in_executor(None, on_error_cleanup)
+                await run_in_executor(on_error_cleanup)
             except Exception:
                 _LOGGER.exception("on_error_cleanup raised; original error preserved")

--- a/esphome_device_builder/controllers/devices/storage_regen.py
+++ b/esphome_device_builder/controllers/devices/storage_regen.py
@@ -8,6 +8,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from ...constants import is_secrets_file
+from ...helpers.async_ import run_in_executor
 from ...helpers.config_hash import read_build_info_hash
 from ...helpers.subprocess import create_subprocess_exec
 
@@ -114,11 +115,10 @@ async def already_failed_recently_async(controller: DevicesController, configura
     (clamped against future-dated stamps so clock skew can't
     lock the regen out indefinitely).
     """
-    loop = asyncio.get_running_loop()
     config_path = controller._db.settings.rel_path(configuration)
 
     try:
-        current_mtime = await loop.run_in_executor(None, lambda: config_path.stat().st_mtime)
+        current_mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
     except OSError:
         return False
     md = controller._metadata_store.get(configuration)
@@ -143,9 +143,8 @@ async def stamp_failure(controller: DevicesController, configuration: str) -> No
     instant the file's mtime was observed.
     """
     config_path = controller._db.settings.rel_path(configuration)
-    loop = asyncio.get_running_loop()
     try:
-        mtime = await loop.run_in_executor(None, lambda: config_path.stat().st_mtime)
+        mtime = await run_in_executor(lambda: config_path.stat().st_mtime)
     except OSError:
         return  # file vanished mid-regen; nothing to stamp.
     controller._metadata_store.update(
@@ -164,8 +163,7 @@ async def finalize_success(controller: DevicesController, configuration: str) ->
     debounced disk write.
     """
     yaml_path = controller._db.settings.rel_path(configuration)
-    loop = asyncio.get_running_loop()
-    new_hash = await loop.run_in_executor(None, read_build_info_hash, yaml_path)
+    new_hash = await run_in_executor(read_build_info_hash, yaml_path)
     fields: dict[str, Any] = {
         "regen_failed_mtime": 0.0,
         "regen_failed_at": 0.0,

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from esphome.core import CORE
 from esphome.storage_json import StorageJSON
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.remote_build_layout import parse_from_configuration as parse_remote_build_path
 from ...helpers.storage_path import resolve_storage_path
 from ...models import FirmwareJob, JobType
@@ -120,9 +121,8 @@ async def verify_chip(controller: FirmwareController, job: FirmwareJob, lane: La
     if not job.port or job.port.upper() == "OTA" or not job.port.startswith("/dev"):
         return  # only check serial ports
 
-    loop = asyncio.get_running_loop()
-    storage = await loop.run_in_executor(
-        None, lambda: StorageJSON.load(resolve_storage_path(job.configuration))
+    storage = await run_in_executor(
+        lambda: StorageJSON.load(resolve_storage_path(job.configuration))
     )
     if storage is None or not storage.target_platform:
         return  # never compiled or no platform recorded — nothing to verify

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -20,7 +20,7 @@ from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError, api_command
-from ...helpers.async_ import create_eager_task, drain_tasks
+from ...helpers.async_ import create_eager_task, drain_tasks, run_in_executor
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
     ErrorCode,
@@ -254,8 +254,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         # and flash the wrong firmware. ``new_filename`` already
         # passed ``rel_path`` so build the path directly.
         new_path = self._db.settings.config_dir / new_filename
-        loop = asyncio.get_running_loop()
-        if await loop.run_in_executor(None, new_path.exists):
+        if await run_in_executor(new_path.exists):
             raise CommandError(
                 ErrorCode.INVALID_ARGS,
                 f"A device named {new_filename} already exists",
@@ -351,10 +350,9 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         # Resolve up front so the caller learns the exact filename the download
         # will save under (so the UI's "saved as …" matches the file), and so a
         # missing artifact fails here rather than on the download navigation.
-        loop = asyncio.get_running_loop()
         try:
-            _, filename = await loop.run_in_executor(
-                None, download_mod._resolve_artifact_path, configuration, file
+            _, filename = await run_in_executor(
+                download_mod._resolve_artifact_path, configuration, file
             )
         except (FileNotFoundError, ValueError) as err:
             raise CommandError(ErrorCode.NOT_FOUND, "Firmware artifact not found") from err
@@ -445,8 +443,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     async def _validate_configuration_boundary(self, configuration: str) -> None:
         """Validate one ``configuration`` inside an executor."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._sync_validate_configuration_boundary, configuration)
+        await run_in_executor(self._sync_validate_configuration_boundary, configuration)
 
     async def _validate_configurations_boundary(self, configurations: list[str]) -> None:
         """
@@ -463,8 +460,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             for config in configurations:
                 self._sync_validate_configuration_boundary(config)
 
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, _validate_all)
+        await run_in_executor(_validate_all)
 
     def _create_job(
         self,

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 import secrets
@@ -22,6 +21,7 @@ from ...definitions import (
     load_platform_capabilities_index,
 )
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.json import JSONDecodeError
 from ...helpers.json import loads as json_loads
 from ...helpers.storage_path import resolve_storage_path
@@ -101,7 +101,6 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
     # attacker-controlled basename inside the storage tree, so the
     # validator below is the gate. Do not reorder.
     await controller._validate_configuration_boundary(configuration)
-    loop = asyncio.get_running_loop()
 
     def _get_types() -> list[dict]:
         storage_path = resolve_storage_path(configuration)
@@ -110,7 +109,7 @@ async def get_binaries(controller: FirmwareController, *, configuration: str) ->
             return []
         return collect_download_entries(storage, storage_path, label=configuration)
 
-    return await loop.run_in_executor(None, _get_types)
+    return await run_in_executor(_get_types)
 
 
 def collect_download_entries(
@@ -311,10 +310,7 @@ async def http_download(request: web.Request) -> web.StreamResponse:
     configuration, file = resolved
     try:
         await db.firmware._validate_configuration_boundary(configuration)
-        loop = asyncio.get_running_loop()
-        path, download_name = await loop.run_in_executor(
-            None, _resolve_artifact_path, configuration, file
-        )
+        path, download_name = await run_in_executor(_resolve_artifact_path, configuration, file)
     except (CommandError, FileNotFoundError, ValueError) as err:
         # Collapse "not built" / "missing" / "traversal" to a bare 404 for the
         # caller, but log so an operator debugging a failed download has a

--- a/esphome_device_builder/controllers/firmware/follow.py
+++ b/esphome_device_builder/controllers/firmware/follow.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import registered_stream
+from ...helpers.async_ import run_in_executor
 from ...helpers.event_bus import StreamControls, stream_events
 from ...models import (
     TERMINAL_JOB_EVENTS,
@@ -225,6 +225,5 @@ async def _initial_snapshot(job: Any, job_id: str) -> list[str]:
     if output:
         return list(output)
     if job.is_terminal:
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, read_job_output, job_id)
+        return await run_in_executor(read_job_output, job_id)
     return []

--- a/esphome_device_builder/controllers/firmware/persistence.py
+++ b/esphome_device_builder/controllers/firmware/persistence.py
@@ -12,7 +12,6 @@ from RAM. ``follow_job`` replays a terminal job's log from disk.
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 import re
@@ -22,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from esphome.core import CORE
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.atomic_io import atomic_write
 from ...models import (
     FirmwareJob,
@@ -169,8 +169,7 @@ async def load_jobs(controller: FirmwareController) -> None:
     first to clear per-run state. A legacy blob that still carries
     inline ``output`` on terminal jobs is migrated to sidecars here.
     """
-    loop = asyncio.get_running_loop()
-    data = await loop.run_in_executor(None, _load_metadata, controller._db.settings.config_dir)
+    data = await run_in_executor(_load_metadata, controller._db.settings.config_dir)
     to_migrate: list[FirmwareJob] = []
     # First pass restores every job into the map and flips active ones to
     # QUEUED; the second pass routes them to a lane, so a dependent's
@@ -198,7 +197,7 @@ async def load_jobs(controller: FirmwareController) -> None:
                         "Failed to migrate job %s output to sidecar", job.job_id, exc_info=True
                     )
 
-        await loop.run_in_executor(None, _migrate)
+        await run_in_executor(_migrate)
 
 
 async def persist_jobs(controller: FirmwareController) -> None:
@@ -214,7 +213,6 @@ async def persist_jobs(controller: FirmwareController) -> None:
 
 
 async def _persist_jobs_locked(controller: FirmwareController) -> None:
-    loop = asyncio.get_running_loop()
     config_dir = controller._db.settings.config_dir
     jobs = list(controller.state.jobs.values())
 
@@ -230,7 +228,7 @@ async def _persist_jobs_locked(controller: FirmwareController) -> None:
         with metadata_transaction(config_dir) as data:
             data[_JOBS_KEY] = [_metadata_dict(job) for job in jobs]
 
-    await loop.run_in_executor(None, _save)
+    await run_in_executor(_save)
 
 
 def job_dict_without_output(job: FirmwareJob) -> dict:

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -33,6 +33,7 @@ import os
 from typing import TYPE_CHECKING, Any, Literal
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
 from ...helpers.remote_artifacts_materialise import (
     MaterialiseError,
@@ -279,10 +280,7 @@ async def _dispatch_and_drive(
 
 async def _build_bundle_or_fail(controller: FirmwareController, job: FirmwareJob) -> bytes | None:
     """Build the YAML bundle; ``None`` + ``_fail_locally`` on failure."""
-    loop = asyncio.get_running_loop()
-    yaml_path = await loop.run_in_executor(
-        None, controller._db.settings.rel_path, job.configuration
-    )
+    yaml_path = await run_in_executor(controller._db.settings.rel_path, job.configuration)
     try:
         return await build_yaml_bundle(yaml_path)
     except FileNotFoundError:
@@ -550,9 +548,7 @@ async def _fetch_and_materialise(
         return False
 
     try:
-        await asyncio.get_running_loop().run_in_executor(
-            None, materialise_remote_artifacts, packed.tarball, job.configuration
-        )
+        await run_in_executor(materialise_remote_artifacts, packed.tarball, job.configuration)
     except MaterialiseError as exc:
         _fail_locally(controller, job, reason=f"materialise failed: {exc}")
         return False
@@ -589,10 +585,7 @@ async def _fetch_and_run_local_upload(
         return
 
     bus = controller.bus
-    loop = asyncio.get_running_loop()
-    yaml_path = await loop.run_in_executor(
-        None, controller._db.settings.rel_path, job.configuration
-    )
+    yaml_path = await run_in_executor(controller._db.settings.rel_path, job.configuration)
 
     # Reset the gauge at the compile → upload seam.
     # :func:`helpers._ingest_output_line` monotonically clamps:

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.subprocess import create_subprocess_exec, iter_lines_with_progress
 from ...models import (
     FirmwareJob,
@@ -105,9 +106,8 @@ async def execute_job(  # noqa: PLR0915, C901
         # end-to-end (matters even for the runner because
         # ``bus.fire`` listeners are interleaved on the loop and
         # blocking here pauses every follower's event delivery).
-        loop = asyncio.get_running_loop()
         config_path = str(
-            await loop.run_in_executor(None, controller._db.settings.rel_path, job.configuration)
+            await run_in_executor(controller._db.settings.rel_path, job.configuration)
         )
         cache_args = controller._build_cache_args(job)
         cmd = controller._build_command(

--- a/esphome_device_builder/controllers/labels.py
+++ b/esphome_device_builder/controllers/labels.py
@@ -9,6 +9,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from ..helpers.api import CommandError, api_command
+from ..helpers.async_ import run_in_executor
 from ..models import ErrorCode, EventType, Label, LabelDeletedData, LabelEventData
 from .config import (
     delete_label_cascade,
@@ -102,8 +103,7 @@ class LabelsController:
     @api_command("labels/list")
     async def list_labels(self, **kwargs: Any) -> list[Label]:
         """Return every label in the global catalog."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, load_labels, self._db.settings.config_dir)
+        return await run_in_executor(load_labels, self._db.settings.config_dir)
 
     @api_command("labels/create")
     async def create_label(

--- a/esphome_device_builder/controllers/onboarding.py
+++ b/esphome_device_builder/controllers/onboarding.py
@@ -17,7 +17,6 @@ who completed an earlier flow.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -25,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from esphome.util import list_yaml_files
 
 from ..helpers.api import api_command
+from ..helpers.async_ import run_in_executor
 from ..models import (
     ExperienceLevel,
     OnboardingState,
@@ -84,10 +84,7 @@ class OnboardingController:
             return
         has_configs = False
         if prefs.onboarding_completed_version == 0:
-            loop = asyncio.get_running_loop()
-            has_configs = await loop.run_in_executor(
-                None, _has_device_configs, self._db.settings.config_dir
-            )
+            has_configs = await run_in_executor(_has_device_configs, self._db.settings.config_dir)
         if _should_migrate_preexisting(prefs, has_device_configs=has_configs):
             self._prefs.mutate(_mark_preexisting)
 

--- a/esphome_device_builder/controllers/remote_build/artifacts_download.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_download.py
@@ -61,11 +61,11 @@ collision is structurally impossible.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.peer_link_bundle import (
     BUNDLE_CHUNK_SIZE_BYTES,
     chunk_bundle,
@@ -238,11 +238,8 @@ class ArtifactsDownloadSender:
 
         self._inflight[session.dashboard_id] = _InflightDownload(job_id=job_id)
         try:
-            loop = asyncio.get_running_loop()
             try:
-                packed = await loop.run_in_executor(
-                    None, pack_build_artifacts, firmware_job.configuration
-                )
+                packed = await run_in_executor(pack_build_artifacts, firmware_job.configuration)
             except FileNotFoundError as exc:
                 # ``FileNotFoundError`` from
                 # :func:`load_build_artifacts` carries the actual

--- a/esphome_device_builder/controllers/remote_build/cleanup_loop.py
+++ b/esphome_device_builder/controllers/remote_build/cleanup_loop.py
@@ -7,6 +7,7 @@ import logging
 from functools import partial
 from typing import TYPE_CHECKING
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.remote_build_cleanup import sweep_remote_builds
 from ...helpers.remote_build_layout import parse_from_configuration
 
@@ -30,7 +31,6 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
     the sleep.
     """
     config_dir = controller._db.settings.config_dir
-    loop = asyncio.get_running_loop()
     while True:
         await asyncio.sleep(_CLEANUP_SWEEP_INTERVAL_SECONDS)
         try:
@@ -45,8 +45,7 @@ async def run_cleanup_loop(controller: ReceiverController) -> None:
                 for job in firmware.active_remote_peer_jobs()
                 if (rbp := parse_from_configuration(job.configuration)) is not None
             )
-            deleted = await loop.run_in_executor(
-                None,
+            deleted = await run_in_executor(
                 partial(
                     sweep_remote_builds,
                     config_dir,

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -18,13 +18,12 @@ reference passed to both at construction.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Any, Literal
 
 from ...helpers.api import api_command
-from ...helpers.async_ import drain_tasks
+from ...helpers.async_ import drain_tasks, run_in_executor
 from ...helpers.event_bus import Event
 from ...helpers.storage import Store
 from ...models import (
@@ -152,10 +151,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         :attr:`ReceiverState.approved_peers` /
         :attr:`ReceiverState.pending_peers`).
         """
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            None, load_remote_build_settings, self._db.settings.config_dir
-        )
+        return await run_in_executor(load_remote_build_settings, self._db.settings.config_dir)
 
     def _on_firmware_queue_transition(self, event: Event[Any]) -> None:
         """Bus listener: broadcast ``queue_status`` to paired offloaders."""

--- a/esphome_device_builder/controllers/remote_build/settings_receiver.py
+++ b/esphome_device_builder/controllers/remote_build/settings_receiver.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...models import (
     MAX_CLEANUP_TTL_SECONDS,
     MIN_CLEANUP_TTL_SECONDS,
@@ -72,8 +72,7 @@ async def modify_settings(
             mutator(settings)
             return settings
 
-    loop = asyncio.get_running_loop()
-    settings = await loop.run_in_executor(None, _txn)
+    settings = await run_in_executor(_txn)
     return to_view(controller, settings)
 
 

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -55,13 +55,13 @@ hit. Phase-6 24h TTL sweeps cold subtrees later.
 
 from __future__ import annotations
 
-import asyncio
 import binascii
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.lazy_module import async_import_module
 from ...helpers.peer_link_bundle import (
     BundleAssembler,
@@ -592,10 +592,8 @@ class SubmitJobReceiver:
         # rely on a preload-ordering invariant in this caller.
         bundle = await async_import_module("esphome.bundle")
         prepare = bundle.prepare_bundle_for_compile
-        loop = asyncio.get_running_loop()
         try:
-            configuration = await loop.run_in_executor(
-                None,
+            configuration = await run_in_executor(
                 _validate_write_extract_bundle,
                 bundle_path,
                 bundle_bytes,

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -15,12 +15,12 @@ dispatch resolve unchanged.
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...models import ErrorCode
 from ._validators import (
     download_artifacts_error_to_command_error,
@@ -52,8 +52,7 @@ async def validate_submit_job_config(
     if not isinstance(configuration, str) or not configuration:
         msg = "configuration must be a non-empty string"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
-    loop = asyncio.get_running_loop()
-    yaml_path = await loop.run_in_executor(None, controller._db.settings.rel_path, configuration)
+    yaml_path = await run_in_executor(controller._db.settings.rel_path, configuration)
     return configuration, yaml_path
 
 
@@ -164,9 +163,7 @@ async def download_artifacts(
     except DownloadArtifactsError as exc:
         raise download_artifacts_error_to_command_error(exc) from exc
     try:
-        return await asyncio.get_running_loop().run_in_executor(
-            None, unpack_artifacts_response, packed, job_id
-        )
+        return await run_in_executor(unpack_artifacts_response, packed, job_id)
     except UnpackArtifactsError as exc:
         raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
 

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...helpers.api import CommandError, api_command
-from ...helpers.async_ import drain_tasks
+from ...helpers.async_ import drain_tasks, run_in_executor
 from ...models import ErrorCode, EventType
 from .git_repo import GIT_COMMIT_ERRORS, GitIndexLockBusyError, GitRepo
 
@@ -108,8 +108,7 @@ class VersionHistoryController:
         assert self._db.config is not None  # type narrowing — loaded before start()
         self._auto_commit_enabled = self._db.config.prefs.snapshot().version_history_enabled
         if not self._auto_commit_enabled:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._repo.discover_existing)
+            await run_in_executor(self._repo.discover_existing)
             if self._repo.enabled:
                 _LOGGER.info(
                     "Version history read-only (auto-commit off; git work tree: %s)",
@@ -128,8 +127,7 @@ class VersionHistoryController:
         discover (from an opted-out start) into a writable adopt; idempotent
         across a re-enable, which finds the repo already set up.
         """
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._repo.discover_or_init)
+        await run_in_executor(self._repo.discover_or_init)
         if not self._repo.enabled:
             return
         _LOGGER.info("Version history active (git work tree: %s)", self._repo.toplevel)
@@ -204,7 +202,7 @@ class VersionHistoryController:
             attempts = 0
             while True:
                 try:
-                    sha = await self._in_executor(self._repo.commit_paths, paths, message)
+                    sha = await run_in_executor(self._repo.commit_paths, paths, message)
                 except GitIndexLockBusyError:
                     attempts += 1
                     if attempts > _LOCK_RETRY_ATTEMPTS:
@@ -263,7 +261,7 @@ class VersionHistoryController:
         if not self._repo.enabled:
             return []
         path = self._db.settings.rel_path(configuration)
-        commits = await self._in_executor(self._repo.log_file, path)
+        commits = await run_in_executor(self._repo.log_file, path)
         return [
             {
                 "sha": c.sha,
@@ -281,7 +279,7 @@ class VersionHistoryController:
         self._require_enabled()
         self._validate_sha(sha)
         path = self._db.settings.rel_path(configuration)
-        content = await self._in_executor(self._repo.file_at, path, sha)
+        content = await run_in_executor(self._repo.file_at, path, sha)
         if content is None:
             raise CommandError(ErrorCode.NOT_FOUND, f"{configuration} not found at {sha}")
         return {"configuration": configuration, "sha": sha, "content": content}
@@ -292,7 +290,7 @@ class VersionHistoryController:
         self._require_enabled()
         self._validate_sha(sha)
         path = self._db.settings.rel_path(configuration)
-        diff = await self._in_executor(self._repo.diff_file, path, sha)
+        diff = await run_in_executor(self._repo.diff_file, path, sha)
         return {"configuration": configuration, "sha": sha, "diff": diff}
 
     @api_command("version_history/list_deleted")
@@ -300,7 +298,7 @@ class VersionHistoryController:
         """Return configs that have history but no working-tree copy (restorable)."""
         if not self._repo.enabled:
             return []
-        deleted = await self._in_executor(self._repo.deleted_files)
+        deleted = await run_in_executor(self._repo.deleted_files)
         return [{"configuration": name} for name in deleted]
 
     @api_command("version_history/restore")
@@ -320,12 +318,12 @@ class VersionHistoryController:
         await self._flush_pending()
         if sha is not None:
             self._validate_sha(sha)
-            content = await self._in_executor(self._repo.file_at, path, sha)
+            content = await run_in_executor(self._repo.file_at, path, sha)
             if content is None:
                 raise CommandError(ErrorCode.NOT_FOUND, f"{configuration} not found at {sha}")
             restored_from = sha
         else:
-            result = await self._in_executor(self._repo.latest_content, path)
+            result = await run_in_executor(self._repo.latest_content, path)
             if result is None:
                 raise CommandError(ErrorCode.NOT_FOUND, f"no history for {configuration}")
             restored_from, content = result
@@ -334,11 +332,6 @@ class VersionHistoryController:
             raise CommandError(ErrorCode.INTERNAL_ERROR, "devices controller unavailable")
         await devices.apply_restored_yaml(configuration, content, restored_from=restored_from[:7])
         return {"configuration": configuration, "restored_from": restored_from, "content": content}
-
-    async def _in_executor[T](self, fn: Callable[..., T], *args: Any) -> T:
-        """Run a synchronous GitRepo call off the event loop."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, fn, *args)
 
     def _require_enabled(self) -> None:
         """Raise if version history isn't available for this config dir."""

--- a/esphome_device_builder/helpers/async_.py
+++ b/esphome_device_builder/helpers/async_.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from asyncio import AbstractEventLoop, Task, gather, get_running_loop
-from collections.abc import Coroutine, Iterable
+from collections.abc import Callable, Coroutine, Iterable
 from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +33,16 @@ async def drain_tasks(tasks: Iterable[Task[Any]], *, log_exceptions: bool = Fals
         # so the expected cancel outcome is skipped here.
         if isinstance(result, Exception):
             _LOGGER.warning("task %r failed during drain", task.get_name(), exc_info=result)
+
+
+async def run_in_executor[T](fn: Callable[..., T], *args: Any) -> T:
+    """Run ``fn(*args)`` in the default executor thread pool.
+
+    Thin wrapper over ``get_running_loop().run_in_executor(None, ...)`` so
+    callers stop re-deriving the loop for the common block-shift-to-a-thread
+    case. Pass a ``functools.partial`` / lambda when *fn* needs keywords.
+    """
+    return await get_running_loop().run_in_executor(None, fn, *args)
 
 
 def create_eager_task[T](

--- a/esphome_device_builder/helpers/config_bundle.py
+++ b/esphome_device_builder/helpers/config_bundle.py
@@ -44,12 +44,12 @@ Errors:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import tempfile
 from pathlib import Path
 
 from ..controllers.firmware.helpers import _find_esphome_cmd
+from .async_ import run_in_executor
 from .subprocess import run_subprocess_capture
 
 _LOGGER = logging.getLogger(__name__)
@@ -104,8 +104,7 @@ async def build_yaml_bundle(yaml_path: Path) -> bytes:
     # stage the post-subprocess read + unlink through their own
     # hops so the dashboard's other tasks keep moving on slow
     # disks.
-    loop = asyncio.get_running_loop()
-    cmd, output_path = await loop.run_in_executor(None, _prepare_build_bundle, yaml_path)
+    cmd, output_path = await run_in_executor(_prepare_build_bundle, yaml_path)
     try:
         result = await run_subprocess_capture(
             *cmd,
@@ -123,9 +122,9 @@ async def build_yaml_bundle(yaml_path: Path) -> bytes:
         if result.returncode != 0:
             output = result.stdout.decode("utf-8", errors="replace").strip()
             raise BundleBuildError(f"esphome bundle exited {result.returncode}", output=output)
-        return await loop.run_in_executor(None, output_path.read_bytes)
+        return await run_in_executor(output_path.read_bytes)
     finally:
-        await loop.run_in_executor(None, _unlink_quietly, output_path)
+        await run_in_executor(_unlink_quietly, output_path)
 
 
 def _prepare_build_bundle(yaml_path: Path) -> tuple[list[str], Path]:

--- a/esphome_device_builder/helpers/config_hash.py
+++ b/esphome_device_builder/helpers/config_hash.py
@@ -31,12 +31,12 @@ mDNS TXT record shape. ``None`` on miss / parse failure;
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 
 from esphome.storage_json import StorageJSON
 
+from .async_ import run_in_executor
 from .json import JSONDecodeError, loads
 from .storage_path import resolve_storage_path
 
@@ -57,8 +57,7 @@ async def compute_yaml_config_hash(yaml_path: Path) -> str | None:
     (typically already in our metadata sidecar) rather than an
     error to propagate.
     """
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, read_build_info_hash, yaml_path)
+    return await run_in_executor(read_build_info_hash, yaml_path)
 
 
 def read_build_info_hash(yaml_path: Path) -> str | None:

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -64,6 +64,8 @@ from typing import TYPE_CHECKING
 import ifaddr
 from zeroconf import ServiceInfo
 
+from .async_ import run_in_executor
+
 if TYPE_CHECKING:
     from esphome.zeroconf import AsyncEsphomeZeroconf
 
@@ -512,8 +514,7 @@ class DashboardAdvertiser:
         if self._info is not None:
             _LOGGER.debug("Dashboard advertise already registered; skipping")
             return
-        loop = asyncio.get_running_loop()
-        addresses = await loop.run_in_executor(None, _local_addresses)
+        addresses = await run_in_executor(_local_addresses)
         info = self.build_service_info(addresses)
         try:
             await zeroconf.async_register_service(info, allow_name_change=True)
@@ -583,8 +584,7 @@ class DashboardAdvertiser:
         zeroconf = self._zeroconf
         if info is None or zeroconf is None:
             return False
-        loop = asyncio.get_running_loop()
-        new_addresses = await loop.run_in_executor(None, _local_addresses)
+        new_addresses = await run_in_executor(_local_addresses)
         new_info = self.build_service_info(new_addresses)
         # Preserve the instance name zeroconf actually registered.
         # ``async_register_service(allow_name_change=True)`` renames the

--- a/esphome_device_builder/helpers/dashboard_identity.py
+++ b/esphome_device_builder/helpers/dashboard_identity.py
@@ -32,7 +32,6 @@ the wire. Rewriting this module to delegate to
 
 from __future__ import annotations
 
-import asyncio
 import re
 import secrets
 from dataclasses import dataclass
@@ -40,6 +39,7 @@ from pathlib import Path
 from typing import Any
 
 from ..controllers.config import metadata_transaction
+from .async_ import run_in_executor
 from .peer_link_identity import PeerLinkIdentity, PeerLinkIdentityStore
 
 _DASHBOARD_ID_BYTES = 24
@@ -93,9 +93,7 @@ async def get_or_create_identities(
 ) -> tuple[PeerLinkIdentity, DashboardIdentity]:
     """Load the peer-link keypair + composed dashboard identity in one shot."""
     peer_link = await identity_store.async_load()
-    dashboard_id = await asyncio.get_running_loop().run_in_executor(
-        None, _get_or_create_dashboard_id, config_dir
-    )
+    dashboard_id = await run_in_executor(_get_or_create_dashboard_id, config_dir)
     return peer_link, DashboardIdentity(
         dashboard_id=dashboard_id,
         pin_sha256=peer_link.pin_sha256,
@@ -122,9 +120,7 @@ async def rotate_identity(
     stays readable across rotations.
     """
     peer_link = await identity_store.async_rotate()
-    dashboard_id = await asyncio.get_running_loop().run_in_executor(
-        None, _get_or_create_dashboard_id, config_dir
-    )
+    dashboard_id = await run_in_executor(_get_or_create_dashboard_id, config_dir)
     return DashboardIdentity(
         dashboard_id=dashboard_id,
         pin_sha256=peer_link.pin_sha256,

--- a/esphome_device_builder/helpers/peer_link_identity.py
+++ b/esphome_device_builder/helpers/peer_link_identity.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
+from .async_ import run_in_executor
 from .atomic_io import atomic_write
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,13 +103,13 @@ class PeerLinkIdentityStore:
         async with self._lock:
             if self._cached is not None:
                 return self._cached
-            identity = await asyncio.get_running_loop().run_in_executor(None, self._load_blocking)
+            identity = await run_in_executor(self._load_blocking)
             self._cached = identity
             return identity
 
     async def _do_rotate_locked(self) -> PeerLinkIdentity:
         async with self._lock:
-            identity = await asyncio.get_running_loop().run_in_executor(None, self._rotate_blocking)
+            identity = await run_in_executor(self._rotate_blocking)
             self._cached = identity
             return identity
 

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -31,6 +31,7 @@ from esphome.helpers import write_file as atomic_write_file
 from ruamel.yaml import YAML
 
 from ..constants import SECRETS_FILENAME
+from .async_ import run_in_executor
 from .yaml import load_yaml_fast_then_esphome
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,9 +43,8 @@ async def write_secrets_locked[T](lock: asyncio.Lock, fn: Callable[..., T], *arg
 
     Pre-bind keyword args with ``functools.partial``.
     """
-    loop = asyncio.get_running_loop()
     async with lock:
-        return await loop.run_in_executor(None, fn, *args)
+        return await run_in_executor(fn, *args)
 
 
 # Bootstrap placeholder strings. Upstream now exports these from

--- a/esphome_device_builder/helpers/storage.py
+++ b/esphome_device_builder/helpers/storage.py
@@ -60,6 +60,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from pathlib import Path
 
+from .async_ import run_in_executor
 from .atomic_io import atomic_write
 
 _LOGGER = logging.getLogger(__name__)
@@ -139,8 +140,7 @@ class Store[T]:
         consumer needs an explicit recovery decision rather
         than silently starting from empty state.
         """
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self._load_sync)
+        return await run_in_executor(self._load_sync)
 
     def _load_sync(self) -> T | None:
         try:
@@ -202,10 +202,9 @@ class Store[T]:
                 # Concurrent ``async_save_now`` already drained
                 # the captured func; nothing to write.
                 return
-            loop = asyncio.get_running_loop()
             try:
                 value = data_func()
-                await loop.run_in_executor(None, self._encode_and_write, value)
+                await run_in_executor(self._encode_and_write, value)
             except Exception:
                 # Background-task write failures shouldn't
                 # propagate — the consumer's mutation is still


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to the `drain_tasks` extraction. Adds a small `run_in_executor(fn, *args)` helper to `helpers/async_.py` and uses it at the ~90 sites across 44 files that hand-roll the default-executor idiom `loop = asyncio.get_running_loop(); await loop.run_in_executor(None, fn, ...)`.

```python
async def run_in_executor[T](fn: Callable[..., T], *args: Any) -> T:
    return await get_running_loop().run_in_executor(None, fn, *args)
```

It mirrors Home Assistant's `async_add_executor_job` shape: callers stop re-deriving the loop for the common block-shift-to-a-thread case, and a `functools.partial` / lambda covers the keyword case. Where a scope only bound `loop` for the executor call, that binding is removed; where `loop` is still used (`call_later`, `create_task`, ...), it stays. `version_history`'s private `_in_executor` proof-of-concept is deleted and its callers point at the shared helper.

No behaviour change: the helper always uses the default executor (every converted site already passed `None`), and only the loop-derivation boilerplate is removed. The one `run_in_executor` that targets a *custom* executor (`helpers/lazy_module.py`'s dedicated import pool) is deliberately left alone. Now-dead `import asyncio` lines and a couple of orphaned `loop` parameters left by the conversion are cleaned up too.

**Related issue or feature (if applicable):**

- follow-up to the `drain_tasks` helper (#1790); no filed issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
