### PR TITLE
Unify the remote-build store codecs behind a factory

### DIFF
--- a/esphome_device_builder/controllers/remote_build/_storage_codecs.py
+++ b/esphome_device_builder/controllers/remote_build/_storage_codecs.py
@@ -15,10 +15,11 @@ entirely) is load-bearing enough to live in its own seam.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 from ...helpers.json import dumps as json_dumps
 from ...helpers.json import loads as json_loads
-from ...models import OffloaderRemoteBuildSettings, ReceiverPeers
+from ...models import DashboardModel, OffloaderRemoteBuildSettings, ReceiverPeers
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,44 +32,31 @@ OFFLOADER_PAIRINGS_FILE = ".offloader_pairings.json"
 RECEIVER_PEERS_FILE = ".receiver_peers.json"
 
 
-def encode_pairings(value: OffloaderRemoteBuildSettings) -> bytes:
-    """Serialise the offloader-side pairings shape for the store."""
-    return json_dumps(value.to_dict())
+def _soft_recover_codec[T: DashboardModel](
+    model: type[T], label: str
+) -> tuple[Callable[[T], bytes], Callable[[bytes], T]]:
+    """Build an (encoder, decoder) pair for a model-backed store that soft-recovers.
 
-
-def decode_pairings(raw: bytes) -> OffloaderRemoteBuildSettings:
-    """Decode the offloader-side pairings shape from the store.
-
-    Defaults on a malformed blob rather than crashing dashboard
-    startup. The ``Store`` lets decoder errors propagate so a
-    consumer can pick the recovery posture; here we want
-    "soft-recover to empty" because a corrupt pairings file
-    means every offloader has to re-pair (annoying) but isn't
-    fatal, whereas crashing the dashboard would lock the user
-    out entirely.
+    The decoder defaults to an empty ``model()`` on a malformed blob rather than
+    letting the error propagate: a corrupt *label* file means every paired peer
+    has to re-pair (annoying, not fatal), whereas crashing dashboard startup
+    would lock the user out entirely.
     """
-    try:
-        return OffloaderRemoteBuildSettings.from_dict(json_loads(raw))
-    except Exception:
-        _LOGGER.exception("Corrupt offloader pairings file; resetting to empty")
-        return OffloaderRemoteBuildSettings()
+
+    def encode(value: T) -> bytes:
+        return json_dumps(value.to_dict())
+
+    def decode(raw: bytes) -> T:
+        try:
+            return model.from_dict(json_loads(raw))
+        except Exception:
+            _LOGGER.exception("Corrupt %s file; resetting to empty", label)
+            return model()
+
+    return encode, decode
 
 
-def encode_peers(value: ReceiverPeers) -> bytes:
-    """Serialise the receiver-side peers shape for the store."""
-    return json_dumps(value.to_dict())
-
-
-def decode_peers(raw: bytes) -> ReceiverPeers:
-    """Decode the receiver-side peers shape from the store.
-
-    Soft-recover to empty on malformed blobs, mirror of
-    :func:`decode_pairings`. A corrupt peers file means every
-    paired offloader has to re-pair — annoying, not fatal — so
-    crashing dashboard startup is the wrong recovery posture.
-    """
-    try:
-        return ReceiverPeers.from_dict(json_loads(raw))
-    except Exception:
-        _LOGGER.exception("Corrupt receiver peers file; resetting to empty")
-        return ReceiverPeers()
+encode_pairings, decode_pairings = _soft_recover_codec(
+    OffloaderRemoteBuildSettings, "offloader pairings"
+)
+encode_peers, decode_peers = _soft_recover_codec(ReceiverPeers, "receiver peers")


### PR DESCRIPTION
# What does this implement/fix?

Small follow-up from the duplication sweep. The two remote-build per-file stores each hand-rolled an encode/decode pair that was identical bar the model class and the log label: `encode_pairings`/`decode_pairings` (offloader pairings) and `encode_peers`/`decode_peers` (receiver peers). Both decoders soft-recover to an empty model on a corrupt blob.

This folds them into one local factory `_soft_recover_codec(model, label)` in `_storage_codecs.py`; the four exported names stay importable (they're now the factory's return values), the soft-recover posture and the exact log messages are unchanged. No behaviour change.

Scoped deliberately: the other model-backed stores are left bespoke because they differ in ways a shared factory would only obscure. `PreferencesStore` raises on a corrupt file (the caller preserves it for recovery) and encodes with `dumps_indent`; `DeviceMetadataStore` decodes to a filtered plain dict (not a model) and returns `{}` on corruption. Only the remote-build pair is genuinely the same shape, so the factory stays local to that module rather than becoming a cross-store helper.

**Related issue or feature (if applicable):**

- follow-up to the helper-extraction sweep (`drain_tasks` #1790, `run_in_executor` #1791); no filed issue

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
