### PR TITLE
Bucket MQTT monitors per (host, port, username)

### DIFF
--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -96,8 +96,8 @@ class DeviceMqttCoordinator:
         existing_keys = set(self._monitors.keys())
 
         for key in existing_keys - wanted_keys:
-            host, port, _username = key
-            _LOGGER.info("Stopping MQTT monitor for %s:%s", host, port)
+            host, port, username = key
+            _LOGGER.info("Stopping MQTT monitor for %s:%s user %r", host, port, username)
             await self._monitors.pop(key).stop()
 
         for broker in brokers:

--- a/esphome_device_builder/controllers/_device_mqtt_coordinator.py
+++ b/esphome_device_builder/controllers/_device_mqtt_coordinator.py
@@ -2,9 +2,9 @@
 Coordinator for per-broker MQTT discovery monitors.
 
 Reads each MQTT-using device's YAML, resolves ``!secret`` references via
-``secrets.yaml``, groups by broker host/port, and runs one
-:class:`DeviceMqttMonitor` per unique broker. Re-runs lifecycle on each
-poll so monitors track YAML edits.
+``secrets.yaml``, groups by broker host/port/username, and runs one
+:class:`DeviceMqttMonitor` per unique broker login. Re-runs lifecycle on
+each poll so monitors track YAML edits.
 """
 
 from __future__ import annotations
@@ -45,11 +45,11 @@ _BROKER_FIELDS = ("broker", "port", "username", "password")
 
 class DeviceMqttCoordinator:
     """
-    Manage one :class:`DeviceMqttMonitor` per unique broker.
+    Manage one :class:`DeviceMqttMonitor` per unique broker login.
 
     ``reconcile()`` is idempotent — call it after every device scan to
-    pick up YAML edits. Adds monitors for new brokers, stops monitors
-    for brokers no longer referenced.
+    pick up YAML edits. Adds monitors for new ``(host, port, username)``
+    logins, stops monitors for logins no longer referenced.
     """
 
     def __init__(
@@ -63,7 +63,7 @@ class DeviceMqttCoordinator:
         self._get_devices = get_devices
         self._on_state_change = on_state_change
         self._on_ip_change = on_ip_change
-        self._monitors: dict[tuple[str, int], DeviceMqttMonitor] = {}
+        self._monitors: dict[tuple[str, int, str | None], DeviceMqttMonitor] = {}
         # Positive-only slow-path cache keyed on ``(yaml_mtime,
         # secrets_mtime)``. Package / ``!include`` edits on a
         # previously-cached device won't invalidate — user needs a
@@ -72,6 +72,9 @@ class DeviceMqttCoordinator:
         # Per-device dedupe for the broker-unresolvable WARNING —
         # WARNING once, DEBUG on repeats.
         self._unresolved_logged: set[str] = set()
+        # Per-login dedupe for the same-username/different-password
+        # WARNING — WARNING once, DEBUG on repeats.
+        self._conflict_logged: set[tuple[str, int, str | None]] = set()
 
     @property
     def active_brokers(self) -> int:
@@ -93,7 +96,7 @@ class DeviceMqttCoordinator:
         existing_keys = set(self._monitors.keys())
 
         for key in existing_keys - wanted_keys:
-            host, port = key
+            host, port, _username = key
             _LOGGER.info("Stopping MQTT monitor for %s:%s", host, port)
             await self._monitors.pop(key).stop()
 
@@ -117,8 +120,9 @@ class DeviceMqttCoordinator:
     def _collect_brokers(self) -> list[MqttBrokerConfig]:
         secrets_map = _load_secrets(self._config_dir)
         secrets_mtime = _safe_mtime(self._config_dir / SECRETS_FILENAME)
-        seen: dict[tuple[str, int], MqttBrokerConfig] = {}
+        seen: dict[tuple[str, int, str | None], MqttBrokerConfig] = {}
         seen_devices: set[str] = set()
+        conflicts: set[tuple[str, int, str | None]] = set()
         for device in self._get_devices():
             if not device.uses_mqtt:
                 continue
@@ -143,15 +147,15 @@ class DeviceMqttCoordinator:
             if existing is None:
                 seen[broker.key] = broker
                 continue
-            if (existing.username, existing.password) != (broker.username, broker.password):
-                _LOGGER.warning(
-                    "Multiple devices reference broker %s:%s with different credentials — "
-                    "using credentials from the first device",
-                    broker.host,
-                    broker.port,
-                )
-        # Drop tracking for devices no longer declaring ``mqtt:``.
+            # Same host/port/username but a different password: the login
+            # is ambiguous, so the first device's password wins.
+            if existing.password != broker.password:
+                conflicts.add(broker.key)
+                self._log_credential_conflict(broker)
+        # Drop tracking for devices no longer declaring ``mqtt:`` and
+        # logins that no longer conflict, so a recurrence re-warns.
         self._unresolved_logged &= seen_devices
+        self._conflict_logged &= conflicts
         self._broker_cache = {k: v for k, v in self._broker_cache.items() if k in seen_devices}
         return list(seen.values())
 
@@ -192,6 +196,24 @@ class DeviceMqttCoordinator:
             configuration,
         )
         self._unresolved_logged.add(configuration)
+
+    def _log_credential_conflict(self, broker: MqttBrokerConfig) -> None:
+        if broker.key in self._conflict_logged:
+            _LOGGER.debug(
+                "Broker %s:%s user %r still referenced with different passwords — using the first",
+                broker.host,
+                broker.port,
+                broker.username,
+            )
+            return
+        _LOGGER.warning(
+            "Multiple devices reference broker %s:%s as user %r with different passwords — "
+            "using the password from the first device",
+            broker.host,
+            broker.port,
+            broker.username,
+        )
+        self._conflict_logged.add(broker.key)
 
 
 # ---------------------------------------------------------------------------

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -57,9 +57,14 @@ class MqttBrokerConfig:
     password: str | None = None
 
     @property
-    def key(self) -> tuple[str, int]:
-        """Identifier for grouping devices to a single broker session."""
-        return (self.host, self.port)
+    def key(self) -> tuple[str, int, str | None]:
+        """Identifier for grouping devices to a single broker session.
+
+        Includes the username so each distinct login gets its own session:
+        a broker with per-user ACLs only lets a login see its own devices'
+        discovery topics, so one session per credential is required.
+        """
+        return (self.host, self.port, self.username)
 
 
 class DeviceMqttMonitor:

--- a/esphome_device_builder/controllers/_device_mqtt_monitor.py
+++ b/esphome_device_builder/controllers/_device_mqtt_monitor.py
@@ -58,12 +58,7 @@ class MqttBrokerConfig:
 
     @property
     def key(self) -> tuple[str, int, str | None]:
-        """Identifier for grouping devices to a single broker session.
-
-        Includes the username so each distinct login gets its own session:
-        a broker with per-user ACLs only lets a login see its own devices'
-        discovery topics, so one session per credential is required.
-        """
+        """Identifier for grouping devices to a single broker session (host, port, username)."""
         return (self.host, self.port, self.username)
 
 

--- a/tests/test_mqtt_monitor.py
+++ b/tests/test_mqtt_monitor.py
@@ -166,12 +166,15 @@ def test_parse_mqtt_block_unresolved_port_substitution_falls_back_to_default() -
     assert config.port == 1883
 
 
-def test_mqtt_broker_config_key_groups_by_host_port() -> None:
+def test_mqtt_broker_config_key_groups_by_host_port_username() -> None:
     a = MqttBrokerConfig(host="broker", port=1883, username="alice")
     b = MqttBrokerConfig(host="broker", port=1883, username="bob")
     c = MqttBrokerConfig(host="broker", port=8883, username="alice")
-    assert a.key == b.key
-    assert a.key != c.key
+    d = MqttBrokerConfig(host="broker", port=1883, username="alice", password="one")
+    e = MqttBrokerConfig(host="broker", port=1883, username="alice", password="two")
+    assert a.key != b.key  # different username → its own session
+    assert a.key != c.key  # different port
+    assert d.key == e.key  # same login, password differs → shared session
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +264,66 @@ async def test_coordinator_groups_devices_with_same_broker(
     assert coord.active_brokers == 1
     assert len(stub_monitor.instances) == 1
     assert stub_monitor.instances[0].broker.host == "192.168.1.10"
+
+
+async def test_coordinator_starts_a_session_per_login_on_one_broker(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Same broker, one MQTT user per device (per-user ACLs): each login
+    # needs its own session, and it isn't a credential conflict.
+    devices = [
+        _write_device(
+            tmp_path, "alpha", "mqtt:\n  broker: 192.168.0.1\n  username: alpha\n  password: a\n"
+        ),
+        _write_device(
+            tmp_path, "beta", "mqtt:\n  broker: 192.168.0.1\n  username: beta\n  password: b\n"
+        ),
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("DEBUG", logger=target):
+        await coord.reconcile()
+    assert coord.active_brokers == 2
+    warnings = [r for r in caplog.records if r.name == target and r.levelname == "WARNING"]
+    assert warnings == []
+
+
+async def test_coordinator_warns_once_on_same_login_different_password(
+    tmp_path: Path,
+    stub_monitor: type[_RecordingMonitor],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Same host/port/username but disagreeing passwords is genuinely
+    # ambiguous; the first password wins and the WARNING is logged once.
+    devices = [
+        _write_device(
+            tmp_path, "alpha", "mqtt:\n  broker: 192.168.0.1\n  username: shared\n  password: a\n"
+        ),
+        _write_device(
+            tmp_path, "beta", "mqtt:\n  broker: 192.168.0.1\n  username: shared\n  password: b\n"
+        ),
+    ]
+    coord = _make_coordinator(tmp_path, devices)
+    target = "esphome_device_builder.controllers._device_mqtt_coordinator"
+    with caplog.at_level("DEBUG", logger=target):
+        await coord.reconcile()
+        await coord.reconcile()
+        await coord.reconcile()
+    assert coord.active_brokers == 1
+    warnings = [
+        r
+        for r in caplog.records
+        if r.name == target and r.levelname == "WARNING" and "different passwords" in r.getMessage()
+    ]
+    debugs = [
+        r
+        for r in caplog.records
+        if r.name == target and r.levelname == "DEBUG" and "different passwords" in r.getMessage()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+    assert len(debugs) >= 2
 
 
 async def test_coordinator_starts_one_monitor_per_unique_broker(


### PR DESCRIPTION
# What does this implement/fix?

When several devices point at the same MQTT broker with different credentials, the coordinator grouped monitors by host and port only, kept the first device's credentials, and logged a "different credentials" WARNING for every other device on every 5s poll; the log filled up. It also meant a broker with per-user ACLs only ever saw the first login's devices, so discovery silently failed for the rest.

This buckets monitors by (host, port, username) instead, so each distinct login gets its own session and can see its own devices; different usernames are no longer a conflict. The only remaining conflict is two devices sharing a username but disagreeing on the password, which now logs once per login and drops to DEBUG on repeats, matching the existing unresolved-broker dedupe.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1794

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
