### PR TITLE
Lead the All category with board featured recommendations

### DIFF
--- a/esphome_device_builder/controllers/components/controller.py
+++ b/esphome_device_builder/controllers/components/controller.py
@@ -348,11 +348,12 @@ class ComponentCatalog:
         the ADC-family sensors), so the Add-component picker can offer
         valid targets for a cross-domain ``references_component`` field.
 
-        Featured components are surfaced **only** when ``category``
-        explicitly includes ``featured`` and ``board_id`` is set — the
-        regular catalog listing never returns them. Mixed queries
-        (e.g. ``category=["featured", "sensor"]``) return featured
-        entries first followed by the matching regular entries.
+        Featured components lead the results whenever ``board_id`` is
+        set and the filter doesn't scope to a specific non-``featured``
+        category — so the unfiltered "All" listing returns them first,
+        then the regular entries. A specific ``category`` (e.g.
+        ``"sensor"``) drops them unless it names ``featured``; an
+        explicit ``exclude_category=["featured"]`` always wins.
 
         Response entries are the slim :class:`ComponentCatalogIndexEntry`
         shape; the per-field ``config_entries`` tree is fetched on
@@ -363,14 +364,21 @@ class ComponentCatalog:
         include_set = _as_category_set(category) if category else None
         exclude_set = _as_category_set(exclude_category) if exclude_category else None
 
-        include_featured = (
-            include_set is not None
-            and ComponentCategory.FEATURED.value in include_set
-            and board_id is not None
+        # Board id when featured entries apply, else None (one ``is not None``
+        # test, and mypy narrows it for the call below). Featured lead the
+        # results whenever a board is set and the filter isn't scoped to a
+        # specific non-featured category; the "All" listing (no category)
+        # includes them too, and an explicit exclude of ``featured`` always wins.
+        featured_board = (
+            board_id
+            if board_id is not None
+            and (include_set is None or ComponentCategory.FEATURED.value in include_set)
+            and (exclude_set is None or ComponentCategory.FEATURED.value not in exclude_set)
+            else None
         )
         featured_entries = (
-            self._featured_components_for_board(board_id, query)
-            if include_featured and board_id is not None
+            self._featured_components_for_board(featured_board, query)
+            if featured_board is not None
             else []
         )
         # ``provides`` narrows both result sets so a featured-category query
@@ -661,7 +669,12 @@ class ComponentCatalog:
             ):
                 continue
             counts[comp.category] = counts.get(comp.category, 0) + 1
-        if board_id:
+        # Honor an explicit exclude of featured, mirroring the results path, so
+        # the sidebar badge doesn't advertise recommendations the list drops.
+        featured_excluded = (
+            exclude_set is not None and ComponentCategory.FEATURED.value in exclude_set
+        )
+        if board_id and not featured_excluded:
             # Featured rides on the same query so the badge drops to
             # the matches (or vanishes) while the user is searching.
             if query_lower is not None:

--- a/tests/test_featured_components.py
+++ b/tests/test_featured_components.py
@@ -403,11 +403,61 @@ async def test_get_components_featured_only_with_board_id(
     assert all(c.category == ComponentCategory.FEATURED for c in page.components)
 
 
-async def test_get_components_excludes_featured_by_default(
+async def test_get_components_all_leads_with_featured_for_board(
     catalog: ComponentCatalog,
 ) -> None:
-    """A regular catalog query never includes featured entries."""
+    """The unfiltered "All" listing for a board leads with its featured entries."""
     page = await catalog.get_components(board_id="sonoff-basic", limit=2000)
+    ids = {c.id for c in page.components}
+    assert "featured.sonoff-basic.relay" in ids
+    first_non_featured = next(
+        (i for i, c in enumerate(page.components) if c.category != ComponentCategory.FEATURED),
+        len(page.components),
+    )
+    assert first_non_featured > 0
+    assert all(
+        c.category == ComponentCategory.FEATURED for c in page.components[:first_non_featured]
+    )
+
+
+async def test_get_components_no_featured_without_board_id(
+    catalog: ComponentCatalog,
+) -> None:
+    """Without a board there are no recommendations to surface."""
+    page = await catalog.get_components(limit=2000)
+    assert all(not c.id.startswith("featured.") for c in page.components)
+
+
+async def test_get_components_specific_category_excludes_featured(
+    catalog: ComponentCatalog,
+) -> None:
+    """A specific non-``featured`` category stays clean of board recommendations."""
+    page = await catalog.get_components(board_id="sonoff-basic", category="sensor", limit=2000)
+    assert all(not c.id.startswith("featured.") for c in page.components)
+
+
+async def test_get_components_exclude_category_featured_wins(
+    catalog: ComponentCatalog,
+) -> None:
+    """``exclude_category=[featured]`` drops them from All, badge included."""
+    page = await catalog.get_components(
+        board_id="sonoff-basic", exclude_category=["featured"], limit=2000
+    )
+    assert all(not c.id.startswith("featured.") for c in page.components)
+    # The sidebar facet must not advertise what the list dropped.
+    assert all(c["id"] != ComponentCategory.FEATURED.value for c in page.categories)
+
+
+async def test_get_components_all_paginates_across_featured_boundary(
+    catalog: ComponentCatalog,
+) -> None:
+    """Featured lead page 0; a later offset pages into the regular entries."""
+    full = await catalog.get_components(board_id="sonoff-basic", limit=2000)
+    n_featured = sum(1 for c in full.components if c.category == ComponentCategory.FEATURED)
+    assert n_featured > 0
+    # A page starting past every featured entry holds only regular ones.
+    page = await catalog.get_components(board_id="sonoff-basic", offset=n_featured, limit=5)
+    assert page.total == full.total
     assert all(not c.id.startswith("featured.") for c in page.components)
 
 


### PR DESCRIPTION
# What does this implement/fix?

A board's featured cards only appeared under the Recommended category, so the unfiltered All listing, and any search run there, never showed the board's own recommendations. This relaxes the `include_featured` gate so featured entries lead the results whenever a `board_id` is set and the filter is not scoped to a specific non-featured category; a specific category stays clean, and an explicit `exclude_category=["featured"]` still wins. The existing merge and pagination already prepend featured and page across the boundary, so nothing else changed.

**Related issue or feature (if applicable):**

- fixes #1793

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1055

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
