### PR TITLE
Extract shared rename rewrite and address-resolution helpers

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -11,6 +11,7 @@ from esphome.storage_json import StorageJSON
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import parse_platform_from_yaml
+from ...helpers.hostname import default_mdns_address
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, WizardResponse
 from .helpers import _looks_binary, clean_friendly_name, slugify_hostname
@@ -180,11 +181,6 @@ async def create_device(  # noqa: C901, PLR0912
         clear_metadata=not overwriting,
     )
     return WizardResponse(configuration=filename)
-
-
-def default_mdns_address(name: str) -> str:
-    """Return the mDNS address ESPHome derives from a device *name* by default."""
-    return f"{name}.local"
 
 
 def save_device_storage(filename: str, storage: StorageJSON) -> None:

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -12,21 +12,19 @@ from esphome.storage_json import StorageJSON
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import configuration_stem, parse_esphome_meta
+from ...helpers.hostname import default_mdns_address
 from ...helpers.storage_path import resolve_storage_path
 from ...helpers.yaml import (
-    ESPHOME_NAME_PATH,
     YamlUpsertNotSupportedError,
-    is_retargetable_name,
     parse_substitution_ref,
-    read_yaml_scalar,
-    rewrite_name_or_substitution,
+    rewrite_rename_content,
     upsert_yaml_leaf_under_top_block,
 )
 from ...models import Device, ErrorCode, UpdateDeviceResponse
 from ..config import set_device_labels
 from . import archive
 from .firmware_sync import migrate_metadata_then_scan
-from .mutations_create import default_mdns_address, save_device_storage
+from .mutations_create import save_device_storage
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -307,34 +305,16 @@ async def _config_only_rename(
     old_path = controller._db.settings.rel_path(configuration)
     new_path = controller._db.settings.rel_path(new_filename)
 
-    # ``esphome.name`` must be retargetable in place: a plain literal (rewrite
-    # the leaf) or a pure ``${var}`` ref whose definition lives in this file's
-    # ``substitutions:`` block (rewrite the def). A missing leaf, a tag, an
-    # embedded substitution (``kitchen_${suffix}``), or a ``${var}`` defined in
-    # a package / !include would flatten the indirection to a literal, so refuse
-    # those and steer to the OTA rename, which resolves them.
-    current = read_yaml_scalar(content, ESPHOME_NAME_PATH)
-    var = parse_substitution_ref(current) if current is not None else None
-    # A pure ``${var}`` ref whose def isn't in this file would be flattened.
-    nonlocal_sub = var is not None and read_yaml_scalar(content, ("substitutions", var)) is None
-    if current is None or not is_retargetable_name(current) or nonlocal_sub:
-        # The OTA rename resolves packages / includes / embedded substitutions,
-        # so steer there for a file-move rename. An in-place rename can't fall
-        # back to it (``esphome rename`` won't keep the same filename), so the
-        # only fix is editing the name to a plain value.
-        remedy = (
-            "Edit esphome.name to a plain value and try again."
-            if in_place
-            else "Bring the device online to rename it."
-        )
-        raise CommandError(
-            ErrorCode.INVALID_ARGS,
-            "Can't rename: esphome.name isn't a plain literal or a local "
-            "${substitution} (it may come from packages, an !include, or an "
-            f"embedded substitution). {remedy}",
-        )
-
-    new_content = rewrite_name_or_substitution(content, ESPHOME_NAME_PATH, new_name)
+    # The OTA rename resolves packages / includes / embedded substitutions,
+    # so steer there for a file-move rename. An in-place rename can't fall
+    # back to it (``esphome rename`` won't keep the same filename), so the
+    # only fix is editing the name to a plain value.
+    remedy = (
+        "Edit esphome.name to a plain value and try again."
+        if in_place
+        else "Bring the device online to rename it."
+    )
+    new_content = rewrite_rename_content(content, new_name, remedy=remedy)
 
     # Validate before any disk change so a bad rewrite never lands on disk.
     await controller._validate_rewritten_yaml_or_raise(new_filename, new_content, action="rename")

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -165,19 +165,28 @@ async def enqueue_install_chain(
     return compile_job
 
 
-def check_rename_lock(controller: FirmwareController, job: FirmwareJob) -> None:
+def check_rename_lock(
+    controller: FirmwareController,
+    job: FirmwareJob,
+    *,
+    exclude_job_ids: frozenset[str] = frozenset(),
+) -> None:
     """Reject *job* if an in-flight rename has either YAML name locked.
 
     A rename touches two filenames (the old it reads from + the
     new it creates on install success); conflicting jobs would
     fight for the same file or land work on a half-flashed device.
     Same-old-config ``RENAME`` retries pass through so supersede
-    can cancel-and-replace.
+    can cancel-and-replace. *exclude_job_ids* skips the named
+    actives so a multi-job chain can be checked without
+    self-rejecting against its own halves.
     """
     new_touches = _names_touched_by_job(job)
     if not new_touches:
         return
     for active in controller.state.active_jobs():
+        if active.job_id in exclude_job_ids:
+            continue
         if active.job_type != JobType.RENAME:
             continue
         # Same-old-config rename retry: let supersede do its thing.

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -177,9 +177,8 @@ def check_rename_lock(
     new it creates on install success); conflicting jobs would
     fight for the same file or land work on a half-flashed device.
     Same-old-config ``RENAME`` retries pass through so supersede
-    can cancel-and-replace. *exclude_job_ids* skips the named
-    actives so a multi-job chain can be checked without
-    self-rejecting against its own halves.
+    can cancel-and-replace. *exclude_job_ids* skips those actives
+    (a chain checking itself).
     """
     new_touches = _names_touched_by_job(job)
     if not new_touches:

--- a/esphome_device_builder/controllers/firmware/rename_flow.py
+++ b/esphome_device_builder/controllers/firmware/rename_flow.py
@@ -1,0 +1,39 @@
+"""Rename-chain helpers: resolve the pre-rename device's OTA address."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from esphome.storage_json import StorageJSON
+
+from ...helpers.async_ import run_in_executor
+from ...helpers.hostname import default_mdns_address
+from ...helpers.storage_path import resolve_storage_path
+
+if TYPE_CHECKING:
+    from .controller import FirmwareController
+
+
+async def resolve_old_device_address(
+    controller: FirmwareController, configuration: str, fallback_name: str
+) -> str:
+    """
+    Return the OTA address a rename flashes — the *pre-rename* device.
+
+    ``StorageJSON.address`` wins (what the fused CLI resolved as
+    ``CORE.address``, honouring ``wifi.use_address`` / ``manual_ip``
+    from the last build); then the scanner's live hostname / IP; then
+    the mDNS default for *fallback_name*.
+    """
+    storage = await run_in_executor(lambda: StorageJSON.load(resolve_storage_path(configuration)))
+    if storage is not None and storage.address:
+        return storage.address
+    devices = controller._db.devices
+    if devices is not None:
+        device = devices.get_by_configuration(configuration)
+        if device is not None:
+            if device.address:
+                return device.address
+            if device.ip:
+                return device.ip
+    return default_mdns_address(fallback_name)

--- a/esphome_device_builder/controllers/firmware/rename_flow.py
+++ b/esphome_device_builder/controllers/firmware/rename_flow.py
@@ -26,8 +26,10 @@ async def resolve_old_device_address(
     the mDNS default for *fallback_name*.
     """
     storage = await run_in_executor(lambda: StorageJSON.load(resolve_storage_path(configuration)))
-    if storage is not None and storage.address:
-        return storage.address
+    # Annotated hop: upstream ``StorageJSON`` is untyped, so ``.address`` is Any.
+    stored_address: str | None = storage.address if storage is not None else None
+    if stored_address:
+        return stored_address
     devices = controller._db.devices
     if devices is not None:
         device = devices.get_by_configuration(configuration)

--- a/esphome_device_builder/controllers/firmware/rename_flow.py
+++ b/esphome_device_builder/controllers/firmware/rename_flow.py
@@ -18,12 +18,11 @@ async def resolve_old_device_address(
     controller: FirmwareController, configuration: str, fallback_name: str
 ) -> str:
     """
-    Return the OTA address a rename flashes — the *pre-rename* device.
+    Return the OTA address a rename flashes (the pre-rename device).
 
-    ``StorageJSON.address`` wins (what the fused CLI resolved as
-    ``CORE.address``, honouring ``wifi.use_address`` / ``manual_ip``
-    from the last build); then the scanner's live hostname / IP; then
-    the mDNS default for *fallback_name*.
+    Priority: ``StorageJSON.address`` (the fused CLI's ``CORE.address``,
+    honours ``wifi.use_address``), then scanner hostname / IP, then the
+    mDNS default for *fallback_name*.
     """
     storage = await run_in_executor(lambda: StorageJSON.load(resolve_storage_path(configuration)))
     # Annotated hop: upstream ``StorageJSON`` is untyped, so ``.address`` is Any.

--- a/esphome_device_builder/helpers/hostname.py
+++ b/esphome_device_builder/helpers/hostname.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 
+def default_mdns_address(name: str) -> str:
+    """Return the mDNS address ESPHome derives from a device *name* by default."""
+    return f"{name}.local"
+
+
 def normalize_hostname(hostname: str) -> str:
     """
     Lower-case *hostname* and strip the trailing FQDN dot.

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -68,6 +68,7 @@ from .scalar import rewrite_yaml_scalar as rewrite_yaml_scalar
 from .substitution import is_retargetable_name as is_retargetable_name
 from .substitution import parse_substitution_ref as parse_substitution_ref
 from .substitution import rewrite_name_or_substitution as rewrite_name_or_substitution
+from .substitution import rewrite_rename_content as rewrite_rename_content
 from .top_block import (
     upsert_yaml_leaf_under_top_block as upsert_yaml_leaf_under_top_block,
 )

--- a/esphome_device_builder/helpers/yaml/substitution.py
+++ b/esphome_device_builder/helpers/yaml/substitution.py
@@ -62,13 +62,10 @@ def rewrite_rename_content(yaml_text: str, new_name: str, *, remedy: str) -> str
     """
     Rewrite ``esphome.name`` (or its local substitution) to *new_name*.
 
-    ``esphome.name`` must be retargetable in place: a plain literal
-    (rewrite the leaf) or a pure ``${var}`` ref whose definition lives in
-    this file's ``substitutions:`` block (rewrite the def). A missing
-    leaf, a tag, an embedded substitution (``kitchen_${suffix}``), or a
-    ``${var}`` defined in a package / !include would flatten the
-    indirection to a literal, so refuse those with
-    ``CommandError(INVALID_ARGS)``, appending *remedy*.
+    Raises ``CommandError(INVALID_ARGS)`` (with *remedy* appended) when the
+    name isn't retargetable in place — missing leaf, tag, embedded
+    substitution, or a ``${var}`` defined outside this file — since
+    rewriting those would flatten the indirection to a literal.
     """
     current = read_yaml_scalar(yaml_text, ESPHOME_NAME_PATH)
     var = parse_substitution_ref(current) if current is not None else None

--- a/esphome_device_builder/helpers/yaml/substitution.py
+++ b/esphome_device_builder/helpers/yaml/substitution.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from ...models import ErrorCode
+from ..api import CommandError
 from .scalar import (
+    ESPHOME_NAME_PATH,
     _safe_yaml_scalar,
     _strip_yaml_quotes,
     is_plain_literal_scalar,
@@ -53,6 +56,32 @@ def is_retargetable_name(value: str) -> bool:
     the tag / indirection.
     """
     return is_plain_literal_scalar(value) or parse_substitution_ref(value) is not None
+
+
+def rewrite_rename_content(yaml_text: str, new_name: str, *, remedy: str) -> str:
+    """
+    Rewrite ``esphome.name`` (or its local substitution) to *new_name*.
+
+    ``esphome.name`` must be retargetable in place: a plain literal
+    (rewrite the leaf) or a pure ``${var}`` ref whose definition lives in
+    this file's ``substitutions:`` block (rewrite the def). A missing
+    leaf, a tag, an embedded substitution (``kitchen_${suffix}``), or a
+    ``${var}`` defined in a package / !include would flatten the
+    indirection to a literal, so refuse those with
+    ``CommandError(INVALID_ARGS)``, appending *remedy*.
+    """
+    current = read_yaml_scalar(yaml_text, ESPHOME_NAME_PATH)
+    var = parse_substitution_ref(current) if current is not None else None
+    # A pure ``${var}`` ref whose def isn't in this file would be flattened.
+    nonlocal_sub = var is not None and read_yaml_scalar(yaml_text, ("substitutions", var)) is None
+    if current is None or not is_retargetable_name(current) or nonlocal_sub:
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            "Can't rename: esphome.name isn't a plain literal or a local "
+            "${substitution} (it may come from packages, an !include, or an "
+            f"embedded substitution). {remedy}",
+        )
+    return rewrite_name_or_substitution(yaml_text, ESPHOME_NAME_PATH, new_name)
 
 
 def rewrite_name_or_substitution(

--- a/tests/controllers/firmware/test_rename_flow.py
+++ b/tests/controllers/firmware/test_rename_flow.py
@@ -1,0 +1,86 @@
+"""Tests for ``rename_flow.resolve_old_device_address``'s fallback order."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.firmware.rename_flow import (
+    resolve_old_device_address,
+)
+from tests._storage_fixtures import write_storage_json
+from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
+
+
+def _wire_devices(controller: MagicMock, *, address: str = "", ip: str = "") -> None:
+    device = MagicMock()
+    device.address = address
+    device.ip = ip
+    devices = MagicMock()
+    devices.get_by_configuration.return_value = device
+    controller._db.devices = devices
+
+
+@pytest.mark.asyncio
+async def test_storage_address_wins(
+    tmp_path: Path,
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    controller = bare_firmware_controller_factory(with_mock_db=True)
+    _wire_devices(controller, address="scanner.local", ip="10.0.0.9")
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"address": "use-addr.example"})
+
+    assert await resolve_old_device_address(controller, "kitchen.yaml", "kitchen") == (
+        "use-addr.example"
+    )
+
+
+@pytest.mark.asyncio
+async def test_scanner_address_when_storage_missing(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    controller = bare_firmware_controller_factory(with_mock_db=True)
+    _wire_devices(controller, address="scanner.local", ip="10.0.0.9")
+
+    assert await resolve_old_device_address(controller, "kitchen.yaml", "kitchen") == (
+        "scanner.local"
+    )
+
+
+@pytest.mark.asyncio
+async def test_scanner_ip_when_storage_address_empty(
+    tmp_path: Path,
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    controller = bare_firmware_controller_factory(with_mock_db=True)
+    _wire_devices(controller, ip="10.0.0.9")
+    write_storage_json(tmp_path, "kitchen.yaml", overrides={"address": ""})
+
+    assert await resolve_old_device_address(controller, "kitchen.yaml", "kitchen") == "10.0.0.9"
+
+
+@pytest.mark.asyncio
+async def test_mdns_default_when_nothing_known(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    controller = bare_firmware_controller_factory(with_mock_db=True)
+
+    assert await resolve_old_device_address(controller, "kitchen.yaml", "kitchen_1") == (
+        "kitchen_1.local"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mdns_default_when_device_unknown_to_scanner(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    controller = bare_firmware_controller_factory(with_mock_db=True)
+    devices = MagicMock()
+    devices.get_by_configuration.return_value = None
+    controller._db.devices = devices
+
+    assert await resolve_old_device_address(controller, "kitchen.yaml", "kitchen") == (
+        "kitchen.local"
+    )

--- a/tests/controllers/firmware/test_rename_lock.py
+++ b/tests/controllers/firmware/test_rename_lock.py
@@ -110,6 +110,28 @@ def test_rename_retry_on_same_old_config_is_allowed(
     controller._check_rename_lock(retry)
 
 
+def test_exclude_job_ids_skips_named_actives(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A chain checks its own tail without self-rejecting; other actives still lock."""
+    rename = _job("rn1", "kitchen.yaml", JobType.RENAME, new_name="livingroom")
+    other = _job("rn2", "garage.yaml", JobType.RENAME, new_name="shed")
+    controller = firmware_controller_factory(rename, with_settings=False)
+    controller.state.jobs[other.job_id] = other
+    new = _job("inst1", "livingroom.yaml", JobType.INSTALL)
+
+    with pytest.raises(CommandError):
+        factories.check_rename_lock(controller, new, exclude_job_ids=frozenset({"rn2"}))
+
+    factories.check_rename_lock(controller, new, exclude_job_ids=frozenset({"rn1"}))
+
+    clash_with_other = _job("inst2", "shed.yaml", JobType.INSTALL)
+    with pytest.raises(CommandError):
+        factories.check_rename_lock(
+            controller, clash_with_other, exclude_job_ids=frozenset({"rn1"})
+        )
+
+
 def test_lock_lifts_when_rename_terminates(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -34,6 +34,7 @@ import pytest
 import yaml
 from esphome.core import EsphomeError
 
+from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.yaml import (
     YamlUpsertNotSupportedError,
     _mapping_body_to_list_item,
@@ -51,6 +52,7 @@ from esphome_device_builder.helpers.yaml import (
     read_yaml_scalar,
     rewrite_api_encryption_key,
     rewrite_name_or_substitution,
+    rewrite_rename_content,
     rewrite_yaml_scalar,
     upsert_yaml_leaf_under_top_block,
 )
@@ -60,6 +62,7 @@ from esphome_device_builder.helpers.yaml.scalar import (
     _plain_is_fast_safe,
     _plain_is_safe,
 )
+from esphome_device_builder.models import ErrorCode
 from esphome_device_builder.models.common import ConfigEntry, ConfigEntryType
 from esphome_device_builder.models.components import (
     ComponentCatalogEntry,
@@ -226,6 +229,41 @@ def test_rewrite_name_or_substitution_handles_mixed_value_via_leaf() -> None:
     out = rewrite_name_or_substitution(yaml, ("esphome", "name"), "bedroom-bulb")
     assert "  prefix: my\n" in out  # untouched
     assert "  name: bedroom-bulb\n" in out  # leaf flipped to literal
+
+
+# ---------------------------------------------------------------------------
+# rewrite_rename_content
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_rename_content_rewrites_literal() -> None:
+    yaml = "esphome:\n  name: kitchen\n"
+    out = rewrite_rename_content(yaml, "bedroom-bulb", remedy="Fix it.")
+    assert out == "esphome:\n  name: bedroom-bulb\n"
+
+
+def test_rewrite_rename_content_redirects_through_local_substitution() -> None:
+    yaml = "substitutions:\n  devicename: kitchen\nesphome:\n  name: ${devicename}\n"
+    out = rewrite_rename_content(yaml, "bedroom-bulb", remedy="Fix it.")
+    assert "  devicename: bedroom-bulb\n" in out
+    assert "  name: ${devicename}\n" in out
+
+
+@pytest.mark.parametrize(
+    "yaml",
+    [
+        pytest.param("wifi:\n  ssid: x\n", id="missing_name"),
+        pytest.param("esphome:\n  name: kitchen_${suffix}\n", id="embedded_substitution"),
+        pytest.param("esphome:\n  name: ${devicename}\n", id="nonlocal_substitution"),
+        pytest.param("esphome:\n  name: !include name.yaml\n", id="tagged_value"),
+    ],
+)
+def test_rewrite_rename_content_refuses_non_retargetable(yaml: str) -> None:
+    """Shapes that would flatten indirection (or have no name) refuse with the remedy."""
+    with pytest.raises(CommandError) as excinfo:
+        rewrite_rename_content(yaml, "bedroom-bulb", remedy="Do the thing.")
+    assert excinfo.value.code == ErrorCode.INVALID_ARGS
+    assert excinfo.value.message.endswith("Do the thing.")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Behavior free prep for decomposing the rename flow so it can use a remote build server (#1812). The rename job today is a single fused esphome rename subprocess, which is why it always compiles locally; splitting it into a compile plus a dependent flash needs a few helpers to live where both the devices and firmware controllers can reach them. This extracts the esphome.name retargetability check and rewrite from _config_only_rename into helpers.yaml.rewrite_rename_content, moves default_mdns_address to helpers.hostname so the firmware package can use it without importing the devices package, adds an exclude_job_ids parameter to check_rename_lock so a future two job chain can be checked without self rejecting, and adds controllers/firmware/rename_flow.py with the old device OTA address resolution (StorageJSON address first, then the scanner's hostname or IP, then the mDNS default). No behavior changes; the config only rename path produces the same output and errors as before.

**Related issue or feature (if applicable):**

- prep for https://github.com/esphome/device-builder/issues/1812

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
