### PR TITLE
Make the esphome interpreter selectable per firmware job

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -633,7 +633,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         )
 
     async def _resolve_esphome_cmd(self, job: FirmwareJob) -> list[str]:
-        """Return the esphome CLI invocation to compile *job* with."""
+        """Return the esphome CLI invocation to run *job* with."""
         return self.state.esphome_cmd
 
     def _build_cache_args(self, job: FirmwareJob) -> list[str]:

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -620,9 +620,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         new_name: str = "",
         *,
         flash_bootloader: bool = False,
+        esphome_cmd: list[str] | None = None,
     ) -> list[str]:
         return cli.build_command(
-            self.state.esphome_cmd,
+            esphome_cmd or self.state.esphome_cmd,
             job_type,
             config_path,
             port,
@@ -630,6 +631,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             new_name,
             flash_bootloader=flash_bootloader,
         )
+
+    async def _resolve_esphome_cmd(self, job: FirmwareJob) -> list[str]:
+        """Return the esphome CLI invocation to compile *job* with."""
+        return self.state.esphome_cmd
 
     def _build_cache_args(self, job: FirmwareJob) -> list[str]:
         return cli.build_cache_args(self, job)

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -115,6 +115,7 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
             await run_in_executor(controller._db.settings.rel_path, target_configuration)
         )
         cache_args = controller._build_cache_args(job)
+        esphome_cmd = await controller._resolve_esphome_cmd(job)
         cmd = controller._build_command(
             effective_job_type,
             config_path,
@@ -122,6 +123,7 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
             cache_args,
             job.new_name,
             flash_bootloader=job.flash_bootloader,
+            esphome_cmd=esphome_cmd,
         )
         _LOGGER.debug("Running: %s", " ".join(cmd))
 

--- a/tests/controllers/firmware/test_per_job_esphome_cmd.py
+++ b/tests/controllers/firmware/test_per_job_esphome_cmd.py
@@ -1,0 +1,41 @@
+"""Coverage for the per-job esphome interpreter seam."""
+
+from __future__ import annotations
+
+from esphome_device_builder.models import JobType
+from esphome_device_builder.models.firmware import FirmwareJob
+from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
+
+
+def test_build_command_prefers_the_per_call_esphome_cmd(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    """An explicit ``esphome_cmd`` overrides ``state.esphome_cmd`` in the argv."""
+    controller = bare_firmware_controller_factory(esphome_cmd=["installed", "-m", "esphome"])
+
+    cmd = controller._build_command(
+        JobType.COMPILE, "kitchen.yaml", "", esphome_cmd=["venv/bin/esphome"]
+    )
+
+    assert cmd[:2] == ["venv/bin/esphome", "--dashboard"]
+
+
+def test_build_command_falls_back_to_state_when_unset(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    """``None`` / empty ``esphome_cmd`` keeps the controller-wide invocation."""
+    controller = bare_firmware_controller_factory(esphome_cmd=["installed", "-m", "esphome"])
+
+    for override in (None, []):
+        cmd = controller._build_command(JobType.COMPILE, "kitchen.yaml", "", esphome_cmd=override)
+        assert cmd[:3] == ["installed", "-m", "esphome"]
+
+
+async def test_resolve_esphome_cmd_defaults_to_installed(
+    bare_firmware_controller_factory: BareFirmwareControllerFactory,
+) -> None:
+    """The resolver seam returns the installed invocation for a plain job."""
+    controller = bare_firmware_controller_factory(esphome_cmd=["installed", "-m", "esphome"])
+    job = FirmwareJob(job_id="j1", configuration="kitchen.yaml", job_type=JobType.COMPILE)
+
+    assert await controller._resolve_esphome_cmd(job) == ["installed", "-m", "esphome"]


### PR DESCRIPTION
# What does this implement/fix?

Groundwork for a recurring support problem; an operator's remote build server is running an older esphome than the dashboard, so every remote compile silently produces firmware built with that old version. The user reinstalls again and again, keeps getting the same old version, and files a bug because nothing they do seems to change the result. They never realize the receiver is the one that is out of date. The planned fix has the receiver provision a venv with the dashboard's esphome version and build with that, so a stale receiver stops handing back old firmware.

This PR is only the first step and it is behaviour free on its own. It makes the esphome interpreter selectable per job instead of a single value shared by the whole controller. It adds an overridable `_resolve_esphome_cmd(job)` that returns the installed invocation today, and threads its result into `_build_command` through a new optional `esphome_cmd` argument. With no override the argv is identical to before, so there is no functional change yet; the follow up PRs add the version aware provisioning that hangs off this seam.

**Related issue or feature (if applicable):**

- groundwork for remote build version auto provisioning; no issue closed by this PR

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
