### PR TITLE
Relay ESPHOME_DESKTOP_VERSION in the server-info handshake

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -12,10 +12,12 @@ The primary API. A single multiplexed WebSocket handles all 44 commands.
 
 On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/models/api.py):
 ```json
-{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false}
+{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false, "desktop_version": ""}
 ```
 
 `ha_ingress` is `true` only when the connection is proxied through the HA Supervisor ingress (the `X-Ingress-Path` header is present); the frontend slims its header in that case so HA's own panel bar isn't doubled up. An add-on reached directly on its exposed port reports `ha_addon: true` but `ha_ingress: false`.
+
+`desktop_version` carries the ESPHome Desktop wrapper version (from the `ESPHOME_DESKTOP_VERSION` env var) when the dashboard runs inside the desktop app, and is `""` otherwise; the value is sanitized server-side (blank, non-printable, or over-length is treated as unset). The frontend renders it as a footer line only when non-empty.
 
 **Send a [`CommandMessage`](../esphome_device_builder/models/api.py):**
 ```json

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -336,6 +336,7 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
         # (this WS upgrade included).
         ha_ingress=bool(request.headers.get("X-Ingress-Path")),
         requires_auth=(not pre_authenticated),
+        desktop_version=settings.desktop_version,
     )
     await client.send(info.to_dict())
 

--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -30,6 +30,10 @@ _LOGGER = logging.getLogger(__name__)
 
 _DASHBOARD_SENTINEL_FILE = "___DASHBOARD_SENTINEL___.yaml"
 
+# Upper bound on the ESPHome Desktop wrapper version string; a value past this
+# is treated as unset rather than rendered in the footer.
+_MAX_DESKTOP_VERSION_LEN = 64
+
 
 @dataclass
 class DashboardSettings:
@@ -259,6 +263,14 @@ class DashboardSettings:
     @property
     def status_use_mqtt(self) -> bool:
         return bool(get_bool_env("ESPHOME_DASHBOARD_USE_MQTT"))
+
+    @property
+    def desktop_version(self) -> str:
+        """ESPHome Desktop wrapper version from the env; '' when unset or unusable."""
+        raw = os.getenv("ESPHOME_DESKTOP_VERSION", "").strip()
+        if not raw or len(raw) > _MAX_DESKTOP_VERSION_LEN or not raw.isprintable():
+            return ""
+        return raw
 
     @property
     def front_door_open(self) -> bool:

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -112,3 +112,5 @@ class ServerInfoMessage(DashboardModel):
     # add-on reached directly on its exposed port is False, unlike ha_addon.
     ha_ingress: bool = False
     requires_auth: bool = False
+    # ESPHome Desktop wrapper version, from ESPHOME_DESKTOP_VERSION; "" off-desktop.
+    desktop_version: str = ""

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -2062,6 +2062,26 @@ def test_status_use_mqtt_reflects_env(
     assert settings.status_use_mqtt is True
 
 
+def test_desktop_version_reads_and_sanitizes_env(
+    make_settings: MakeSettingsFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``desktop_version`` returns a clean value or '' for unset / unusable input."""
+    settings = make_settings()
+    monkeypatch.delenv("ESPHOME_DESKTOP_VERSION", raising=False)
+    assert settings.desktop_version == ""
+
+    monkeypatch.setenv("ESPHOME_DESKTOP_VERSION", "  1.4.2  ")
+    assert settings.desktop_version == "1.4.2"
+
+    # Blank, control-char, and over-length values all degrade to "".
+    monkeypatch.setenv("ESPHOME_DESKTOP_VERSION", "   ")
+    assert settings.desktop_version == ""
+    monkeypatch.setenv("ESPHOME_DESKTOP_VERSION", "1.4\n2")
+    assert settings.desktop_version == ""
+    monkeypatch.setenv("ESPHOME_DESKTOP_VERSION", "9" * 65)
+    assert settings.desktop_version == ""
+
+
 def test_metadata_transaction_persists_without_fcntl(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -383,6 +383,7 @@ def _public_site_app(trusted_domains: list[str], *, using_password: bool = True)
     settings.trusted_domains = trusted_domains
     settings.port = 6052
     settings.on_ha_addon = False
+    settings.desktop_version = ""
 
     device_builder = MagicMock()
     device_builder.settings = settings
@@ -484,6 +485,7 @@ async def test_handler_skips_gating_on_trusted_site(
     settings.trusted_domains = ["dashboard.example.com"]
     settings.port = 6052
     settings.on_ha_addon = True
+    settings.desktop_version = ""
 
     device_builder = MagicMock()
     device_builder.settings = settings

--- a/tests/test_websocket_heartbeat.py
+++ b/tests/test_websocket_heartbeat.py
@@ -61,6 +61,7 @@ async def test_websocket_response_constructed_with_heartbeat(
     settings.using_password = False
     settings.port = 6052
     settings.on_ha_addon = False
+    settings.desktop_version = ""
 
     auth = MagicMock()
     auth.session_store = MagicMock()

--- a/tests/test_websocket_shutdown.py
+++ b/tests/test_websocket_shutdown.py
@@ -50,6 +50,7 @@ def _bare_app() -> web.Application:
     settings.using_password = False
     settings.port = 6052
     settings.on_ha_addon = False
+    settings.desktop_version = ""
 
     auth = MagicMock()
     auth.session_store = MagicMock()

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -38,6 +38,7 @@ def _make_settings(*, using_password: bool) -> MagicMock:
     settings.port = 6052
     settings.on_ha_addon = False
     settings.trusted_domains = []
+    settings.desktop_version = ""
     return settings
 
 
@@ -268,5 +269,31 @@ async def test_server_info_ha_ingress_reflects_x_ingress_path_header(
     ws, info = await _connect_and_drain_server_info(client)
     try:
         assert info["ha_ingress"] is False
+    finally:
+        await ws.close()
+
+
+async def test_server_info_carries_desktop_version(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """The handshake frame relays ``settings.desktop_version`` (default '')."""
+    device_builder = MagicMock()
+    settings = _make_settings(using_password=False)
+    settings.desktop_version = "1.4.2"
+    device_builder.settings = settings
+    device_builder.auth = MagicMock()
+    device_builder.command_handlers = {}
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True
+    ws_module.init_ws_app(app)
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+
+    ws, info = await _connect_and_drain_server_info(client)
+    try:
+        assert info["desktop_version"] == "1.4.2"
     finally:
         await ws.close()


### PR DESCRIPTION
# What does this implement/fix?

The footer already shows the Device Builder and ESPHome versions; when the dashboard runs inside the ESPHome Desktop app the wrapper sets `ESPHOME_DESKTOP_VERSION`, so this relays it in the `ServerInfoMessage` handshake as a new `desktop_version` field for the frontend to display. The value is read from the env and sanitized in one place (a new `DashboardSettings.desktop_version` property); a blank, control-char, or over-length value is treated as unset, so the frontend renders nothing off-desktop. The field defaults to `""`, so the frame stays compatible with older frontends.

**Related issue or feature (if applicable):**

- N/A; surfaces an env var the desktop wrapper already sets.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1074

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

