### PR TITLE
Consolidate the /ws handshake settings mock into a conftest factory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -674,6 +674,38 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
 
 
 # ---------------------------------------------------------------------------
+# MagicMock ``DeviceBuilder`` for /ws handshake tests
+#
+# The Origin/Host, heartbeat, shutdown, and pre-auth tests each drive
+# ``websocket_handler`` through a stub DeviceBuilder rather than a real
+# one. They only need ``settings`` to answer the fields the opening
+# ``ServerInfoMessage`` reads; hand-rolling that mock per module meant a
+# new handshake field had to be added in five places (and a missing one
+# serialises a ``MagicMock`` into the frame, closing the socket). Building
+# it here keeps that surface in one spot.
+# ---------------------------------------------------------------------------
+
+
+def make_ws_device_builder(
+    *,
+    using_password: bool = False,
+    on_ha_addon: bool = False,
+    trusted_domains: list[str] | None = None,
+    desktop_version: str = "",
+) -> MagicMock:
+    """MagicMock ``DeviceBuilder`` carrying the settings the /ws handshake reads."""
+    settings = MagicMock()
+    settings.using_password = using_password
+    settings.port = 6052
+    settings.on_ha_addon = on_ha_addon
+    settings.trusted_domains = [] if trusted_domains is None else trusted_domains
+    settings.desktop_version = desktop_version
+    device_builder = MagicMock()
+    device_builder.settings = settings
+    return device_builder
+
+
+# ---------------------------------------------------------------------------
 # Hermetic ``DeviceBuilder.start()`` — stubs network / subprocess surfaces
 # so any test that wants a fully-wired DeviceBuilder (lifecycle smoke,
 # mDNS-advertise wiring, command-registry walks) doesn't depend on a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -675,14 +675,6 @@ def make_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> MakeSettin
 
 # ---------------------------------------------------------------------------
 # MagicMock ``DeviceBuilder`` for /ws handshake tests
-#
-# The Origin/Host, heartbeat, shutdown, and pre-auth tests each drive
-# ``websocket_handler`` through a stub DeviceBuilder rather than a real
-# one. They only need ``settings`` to answer the fields the opening
-# ``ServerInfoMessage`` reads; hand-rolling that mock per module meant a
-# new handshake field had to be added in five places (and a missing one
-# serialises a ``MagicMock`` into the frame, closing the socket). Building
-# it here keeps that surface in one spot.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import os
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from aiohttp import web
@@ -42,6 +42,8 @@ from esphome_device_builder.helpers.origin import (
     normalize_host,
     origin_in_allowlist,
 )
+
+from .conftest import make_ws_device_builder
 
 # ---------------------------------------------------------------------------
 # normalize_host
@@ -378,17 +380,9 @@ def test_settings_explicit_empty_cli_overrides_env_var(tmp_path: object) -> None
 
 def _public_site_app(trusted_domains: list[str], *, using_password: bool = True) -> web.Application:
     """Build a minimal aiohttp app wired to ``websocket_handler`` on the public site."""
-    settings = MagicMock()
-    settings.using_password = using_password
-    settings.trusted_domains = trusted_domains
-    settings.port = 6052
-    settings.on_ha_addon = False
-    settings.desktop_version = ""
-
-    device_builder = MagicMock()
-    device_builder.settings = settings
-    device_builder.auth = MagicMock()
-    device_builder.auth.session_store = MagicMock()
+    device_builder = make_ws_device_builder(
+        using_password=using_password, trusted_domains=trusted_domains
+    )
 
     app = web.Application()
     app["device_builder"] = device_builder
@@ -480,17 +474,9 @@ async def test_handler_skips_gating_on_trusted_site(
     enforcing Origin / Host gating there would block legitimate
     supervisor-routed requests with synthesised headers.
     """
-    settings = MagicMock()
-    settings.using_password = True
-    settings.trusted_domains = ["dashboard.example.com"]
-    settings.port = 6052
-    settings.on_ha_addon = True
-    settings.desktop_version = ""
-
-    device_builder = MagicMock()
-    device_builder.settings = settings
-    device_builder.auth = MagicMock()
-    device_builder.auth.session_store = MagicMock()
+    device_builder = make_ws_device_builder(
+        using_password=True, on_ha_addon=True, trusted_domains=["dashboard.example.com"]
+    )
 
     app = web.Application()
     app["device_builder"] = device_builder

--- a/tests/test_websocket_heartbeat.py
+++ b/tests/test_websocket_heartbeat.py
@@ -18,13 +18,15 @@ from __future__ import annotations
 
 import inspect
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
 from esphome_device_builder.api import ws as ws_module
+
+from .conftest import make_ws_device_builder
 
 
 def test_heartbeat_constant_matches_legacy_tornado_interval() -> None:
@@ -57,18 +59,7 @@ async def test_websocket_response_constructed_with_heartbeat(
             captured.update(kwargs)
             super().__init__(*args, **kwargs)
 
-    settings = MagicMock()
-    settings.using_password = False
-    settings.port = 6052
-    settings.on_ha_addon = False
-    settings.desktop_version = ""
-
-    auth = MagicMock()
-    auth.session_store = MagicMock()
-
-    device_builder = MagicMock()
-    device_builder.settings = settings
-    device_builder.auth = auth
+    device_builder = make_ws_device_builder()
 
     app = web.Application()
     app["device_builder"] = device_builder

--- a/tests/test_websocket_shutdown.py
+++ b/tests/test_websocket_shutdown.py
@@ -24,7 +24,6 @@ import gc
 import inspect
 import weakref
 from typing import Any
-from unittest.mock import MagicMock
 
 from aiohttp import WSCloseCode, web
 from pytest_aiohttp.plugin import AiohttpClient
@@ -38,6 +37,8 @@ from esphome_device_builder.api.ws import (
 )
 from esphome_device_builder.device_builder import DeviceBuilder
 
+from .conftest import make_ws_device_builder
+
 
 def _bare_app() -> web.Application:
     """Build a minimal aiohttp app wired with the WS routes + on_shutdown closer.
@@ -46,18 +47,7 @@ def _bare_app() -> web.Application:
     (:meth:`DeviceBuilder.create_app`) so the contract under test
     is what ships, not a hand-built shim that could drift.
     """
-    settings = MagicMock()
-    settings.using_password = False
-    settings.port = 6052
-    settings.on_ha_addon = False
-    settings.desktop_version = ""
-
-    auth = MagicMock()
-    auth.session_store = MagicMock()
-
-    device_builder = MagicMock()
-    device_builder.settings = settings
-    device_builder.auth = auth
+    device_builder = make_ws_device_builder()
 
     app = web.Application()
     app["device_builder"] = device_builder

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -31,15 +31,7 @@ from esphome_device_builder.api import ws as ws_module
 from esphome_device_builder.api.ws import WebSocketClient
 from esphome_device_builder.models import ErrorCode
 
-
-def _make_settings(*, using_password: bool) -> MagicMock:
-    settings = MagicMock()
-    settings.using_password = using_password
-    settings.port = 6052
-    settings.on_ha_addon = False
-    settings.trusted_domains = []
-    settings.desktop_version = ""
-    return settings
+from .conftest import make_ws_device_builder
 
 
 async def _connect_and_drain_server_info(client: Any, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
@@ -76,8 +68,7 @@ async def test_bearer_token_with_valid_session_pre_authenticates(
     auth.session_store = MagicMock()
     auth.session_store.validate = AsyncMock(return_value=session)
 
-    device_builder = MagicMock()
-    device_builder.settings = _make_settings(using_password=True)
+    device_builder = make_ws_device_builder(using_password=True)
     device_builder.auth = auth
     device_builder.command_handlers = {}
 
@@ -137,8 +128,7 @@ async def test_bearer_token_with_invalid_session_falls_back_to_in_band_auth(
     auth.session_store = MagicMock()
     auth.session_store.validate = AsyncMock(return_value=None)
 
-    device_builder = MagicMock()
-    device_builder.settings = _make_settings(using_password=True)
+    device_builder = make_ws_device_builder(using_password=True)
     device_builder.auth = auth
     device_builder.command_handlers = {}
 
@@ -191,9 +181,7 @@ async def test_invalid_json_message_returns_invalid_message_error(
        ``continue``-d instead of breaking out of the message
        loop.
     """
-    device_builder = MagicMock()
-    device_builder.settings = _make_settings(using_password=False)
-    device_builder.auth = MagicMock()
+    device_builder = make_ws_device_builder(using_password=False)
 
     async def _ping_handler(*, client: Any, message_id: str, **_kwargs: Any) -> dict[str, str]:
         return {"pong": "yes"}
@@ -245,9 +233,7 @@ async def test_server_info_ha_ingress_reflects_x_ingress_path_header(
     aiohttp_client: AiohttpClient,
 ) -> None:
     """``ha_ingress`` mirrors whether Supervisor's ``X-Ingress-Path`` header is present."""
-    device_builder = MagicMock()
-    device_builder.settings = _make_settings(using_password=False)
-    device_builder.auth = MagicMock()
+    device_builder = make_ws_device_builder(using_password=False)
     device_builder.command_handlers = {}
 
     app = web.Application()
@@ -277,11 +263,7 @@ async def test_server_info_carries_desktop_version(
     aiohttp_client: AiohttpClient,
 ) -> None:
     """The handshake frame relays ``settings.desktop_version`` (default '')."""
-    device_builder = MagicMock()
-    settings = _make_settings(using_password=False)
-    settings.desktop_version = "1.4.2"
-    device_builder.settings = settings
-    device_builder.auth = MagicMock()
+    device_builder = make_ws_device_builder(desktop_version="1.4.2")
     device_builder.command_handlers = {}
 
     app = web.Application()


### PR DESCRIPTION
# What does this implement/fix?

The `/ws` handshake tests (Origin/Host gating, heartbeat, shutdown, pre-auth) each hand-rolled a MagicMock `settings` with the same fields the opening `ServerInfoMessage` reads. Adding `desktop_version` in #1841 meant editing five files, and a missed site serializes a `MagicMock` into the frame and closes the socket instead of failing loudly; that is a sharp edge worth removing. This hoists the mock into a single `make_ws_device_builder` factory in `tests/conftest.py`, so the next handshake field is a one-line change in one place. No production code and no test behaviour changes; the same seven call sites now build the same mock through the factory.

Stacked on #1841 (its base branch), since that PR is what surfaced the duplication; GitHub retargets this to `main` once #1841 merges.

**Related issue or feature (if applicable):**

- Follow-up to esphome/device-builder#1841

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
