### PR TITLE
Advertise and persist receiver auto-provision capability

### DIFF
--- a/esphome_device_builder/controllers/remote_build/bus_handlers.py
+++ b/esphome_device_builder/controllers/remote_build/bus_handlers.py
@@ -104,13 +104,11 @@ def on_offloader_peer_link_opened(
     controller: OffloaderController, event: Event[OffloaderPeerLinkOpenedData]
 ) -> None:
     """
-    Add ``pin_sha256`` to ``_open_peer_links`` and refresh the receiver version.
+    Add ``pin_sha256`` to ``_open_peer_links``; refresh version + capability.
 
-    Receiver's ``esphome_version`` rides on every
-    ``intent_response`` so a receiver upgrade picks up on
-    next session-open without operator action.
-    ``pick_build_path``'s deferred version-compat gate reads
-    this field.
+    Both ride on every ``intent_response`` so a receiver upgrade
+    picks up on next session-open without operator action.
+    ``pick_build_path``'s deferred version-compat gate reads them.
 
     Empty / oversize versions are dropped silently rather
     than clobbering — empty would lose the captured value
@@ -122,14 +120,20 @@ def on_offloader_peer_link_opened(
     data = event.data
     pin_sha256 = data["pin_sha256"]
     controller.state.open_peer_links.add(pin_sha256)
-    version = data["esphome_version"]
-    if not version or len(version) > PAIRING_VERSION_MAX_LEN:
-        return
     pairing = controller.state.pairings.get(pin_sha256)
-    if pairing is None or pairing.esphome_version == version:
+    if pairing is None:
         return
-    pairing.esphome_version = version
-    controller._schedule_pairings_save()
+    changed = False
+    version = data["esphome_version"]
+    if version and len(version) <= PAIRING_VERSION_MAX_LEN and pairing.esphome_version != version:
+        pairing.esphome_version = version
+        changed = True
+    supported = data["auto_provision_supported"]
+    if pairing.auto_provision_supported != supported:
+        pairing.auto_provision_supported = supported
+        changed = True
+    if changed:
+        controller._schedule_pairings_save()
 
 
 def on_offloader_peer_link_closed(

--- a/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link/wire_io.py
@@ -19,6 +19,7 @@ from esphome.const import __version__ as esphome_version
 from ....helpers import json as _json
 from ....helpers.peer_link_noise import NOISE_ERRORS, PeerLinkNoiseSession
 from ....models import IntentResponse, PeerLinkIntent, RejectReason
+from ..provision import receiver_supports_auto_provision
 
 if TYPE_CHECKING:
     from .handshake import _HandshakeStep
@@ -109,19 +110,20 @@ async def _send_response(
     """Send the post-handshake intent_response as a single ChaCha20-Poly1305 frame.
 
     Payload carries the response discriminator plus the receiver's
-    ``esphome_version`` on every intent. The long-lived
-    ``peer_link`` session captures the version onto
-    :attr:`StoredPairing.esphome_version` so a receiver upgrade
-    surfaces in pick_build_path's version-compat gate on the next
-    session-open without operator action.
+    ``esphome_version`` and ``auto_provision_supported`` capability on
+    every intent. The long-lived ``peer_link`` session captures both
+    onto the :class:`StoredPairing` so a receiver upgrade surfaces in
+    pick_build_path's version-compat gate on the next session-open
+    without operator action.
 
     *reason* rides along on non-OK responses (additive field;
     older offloaders ignore it) so the offloader can tell a
     terminal rejection apart from a transient one.
     """
-    payload: dict[str, str] = {
+    payload: dict[str, str | bool] = {
         "intent_response": response.value,
         "esphome_version": esphome_version,
+        "auto_provision_supported": receiver_supports_auto_provision(),
     }
     if reason is not None:
         payload["reason"] = reason.value

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/__init__.py
@@ -19,6 +19,7 @@ from .client import PeerLinkClient
 from .one_shot import (
     _build_ws_url,
     _drive_initiator_handshake_and_read_response,
+    _extract_auto_provision_supported,
     _extract_receiver_esphome_version,
     await_pair_status,
     drive_initiator_round_trip,
@@ -41,6 +42,7 @@ __all__ = (
     "_SessionLoopState",
     "_build_ws_url",
     "_drive_initiator_handshake_and_read_response",
+    "_extract_auto_provision_supported",
     "_extract_receiver_esphome_version",
     "await_pair_status",
     "drive_initiator_round_trip",

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_dispatch.py
@@ -292,13 +292,16 @@ def dispatch_artifacts_end(client: PeerLinkClient, parsed: dict[str, Any]) -> No
     )
 
 
-def fire_opened(client: PeerLinkClient, *, esphome_version: str = "") -> None:
+def fire_opened(
+    client: PeerLinkClient, *, esphome_version: str = "", auto_provision_supported: bool = False
+) -> None:
     """Fire ``OFFLOADER_PEER_LINK_OPENED`` for a session that reached intent_response=ok."""
     payload: OffloaderPeerLinkOpenedData = {
         "receiver_hostname": client._hostname,
         "receiver_port": client._port,
         "pin_sha256": client._pin_sha256,
         "esphome_version": esphome_version,
+        "auto_provision_supported": auto_provision_supported,
     }
     client._bus.fire(EventType.OFFLOADER_PEER_LINK_OPENED, payload)
 

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -59,6 +59,7 @@ from . import _dispatch, _submit
 from .one_shot import (
     _DEFAULT_TIMEOUT_SECONDS,
     _drive_initiator_handshake_and_read_response,
+    _extract_auto_provision_supported,
     _extract_receiver_esphome_version,
 )
 
@@ -438,12 +439,16 @@ class PeerLinkClient:
                 ):
                     return self._on_handshake_rejected(response)
                 receiver_version = _extract_receiver_esphome_version(response)
+                auto_provision = _extract_auto_provision_supported(response)
                 channel = PeerLinkChannel(
                     noise=session, ws=ws, log_label=f"{self._hostname}:{self._port}"
                 )
                 self._session_was_opened = True
                 self._last_connect_error = ""
-                self._fire_opened(esphome_version=receiver_version)
+                self._fire_opened(
+                    esphome_version=receiver_version,
+                    auto_provision_supported=auto_provision,
+                )
                 try:
                     return await self._run_session_loops(channel)
                 except asyncio.CancelledError:
@@ -635,8 +640,14 @@ class PeerLinkClient:
     def _dispatch_artifacts_end(self, parsed: dict[str, Any]) -> None:
         _dispatch.dispatch_artifacts_end(self, parsed)
 
-    def _fire_opened(self, *, esphome_version: str = "") -> None:
-        _dispatch.fire_opened(self, esphome_version=esphome_version)
+    def _fire_opened(
+        self, *, esphome_version: str = "", auto_provision_supported: bool = False
+    ) -> None:
+        _dispatch.fire_opened(
+            self,
+            esphome_version=esphome_version,
+            auto_provision_supported=auto_provision_supported,
+        )
 
     def _fire_closed(self, reason: str, *, error_detail: str = "") -> None:
         _dispatch.fire_closed(self, reason, error_detail=error_detail)

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/one_shot.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/one_shot.py
@@ -29,6 +29,7 @@ from ....helpers.peer_link_noise import (
     pin_sha256_for_pubkey,
 )
 from ....helpers.peer_link_resolver import make_peer_link_http_session
+from ....helpers.version_compat import is_pep440_version
 from ....models import (
     PAIRING_VERSION_MAX_LEN,
     IntentResponse,
@@ -85,16 +86,29 @@ def _extract_receiver_esphome_version(response: dict[str, Any]) -> str:
     """
     Lift ``esphome_version`` off the post-handshake response.
 
-    Returns ``""`` when missing, non-str, or exceeds
-    :data:`PAIRING_VERSION_MAX_LEN` — the disk-side cap mirrors
-    here so the wire and storage seams can't drift apart.
+    Returns ``""`` when missing, non-str, oversize
+    (:data:`PAIRING_VERSION_MAX_LEN`, the disk-side cap mirrored
+    here so the wire and storage seams can't drift apart), or not a
+    valid PEP 440 version — so a malformed / injected string never
+    reaches storage or a later ``pip install`` argument.
     """
     value = response.get("esphome_version", "")
-    if not isinstance(value, str):
+    if not isinstance(value, str) or len(value) > PAIRING_VERSION_MAX_LEN:
         return ""
-    if len(value) > PAIRING_VERSION_MAX_LEN:
+    if not is_pep440_version(value):
         return ""
     return value
+
+
+def _extract_auto_provision_supported(response: dict[str, Any]) -> bool:
+    """
+    Lift the receiver's ``auto_provision_supported`` flag off the response.
+
+    Missing or non-bool ⇒ ``False`` — an older receiver that never sends
+    the field is treated as unable to provision.
+    """
+    value = response.get("auto_provision_supported", False)
+    return value if isinstance(value, bool) else False
 
 
 def _build_ws_url(hostname: str, port: int) -> URL:

--- a/esphome_device_builder/controllers/remote_build/provision.py
+++ b/esphome_device_builder/controllers/remote_build/provision.py
@@ -1,0 +1,13 @@
+"""Receiver-side auto-provisioning capability seam."""
+
+from __future__ import annotations
+
+
+def receiver_supports_auto_provision() -> bool:
+    """Whether this receiver can build a version-mismatched offloader's esphome.
+
+    Advertised on every peer-link session-open so the offloader only
+    routes a version-mismatched compile here when the receiver can
+    provision the matching esphome. ``False`` until the provisioner lands.
+    """
+    return False

--- a/esphome_device_builder/helpers/version_compat.py
+++ b/esphome_device_builder/helpers/version_compat.py
@@ -8,6 +8,32 @@ from typing import assert_never
 
 _DIGITS_PREFIX_RE = re.compile(r"^(\d+)")
 
+# Pragmatic PEP 440 matcher, not the full grammar: esphome only ever
+# emits release / pre / post / dev / local forms. A regex keeps the
+# cold-import floor clean — ``packaging`` is too heavy to import here.
+_PEP440_RE = re.compile(
+    r"""
+    v?                                                       # optional leading v
+    (?:\d+!)?                                                 # epoch
+    \d+(?:\.\d+)*                                             # release segment
+    (?:[-_.]?(?:a|b|c|rc|alpha|beta|pre|preview)[-_.]?\d*)?   # pre-release
+    (?:(?:[-_.]?post[-_.]?\d*)|-\d+)?                         # post-release
+    (?:[-_.]?dev[-_.]?\d*)?                                   # dev-release
+    (?:\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?                       # local version
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def is_pep440_version(version: str) -> bool:
+    """Return whether *version* is a well-formed PEP 440 version string.
+
+    The single gate for every esphome version string crossing a trust
+    boundary (peer-link advert, provisioning target) so a malformed or
+    injected value never reaches storage or a ``pip install`` argument.
+    """
+    return _PEP440_RE.fullmatch(version) is not None
+
 
 class VersionMatchPolicy(StrEnum):
     """How strictly the offloader filters peers by ESPHome version.

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -71,6 +71,9 @@ _PAIRING_VALIDATOR = vol.Schema(
         # so an ``int``-coerced-to-bool gets rejected (same
         # shape that bit ``cleanup_ttl_seconds``).
         vol.Required("enabled"): bool,
+        # Receiver-advertised capability; older sidecars deserialise
+        # as ``False`` (couldn't provision). Strict ``bool`` as above.
+        vol.Required("auto_provision_supported"): bool,
     }
 )
 
@@ -131,6 +134,11 @@ class StoredPairing(DashboardModel):
     # install to route here. Older sidecars deserialise as
     # ``True`` (the historical implicit behaviour).
     enabled: bool = True
+    # Receiver-advertised: whether it can build a version-mismatched
+    # offloader's esphome by provisioning it. Refreshed on every
+    # peer-link session-open; ``False`` on a fresh row, an older
+    # sidecar, or a receiver without the provisioner.
+    auto_provision_supported: bool = False
 
     def __post_init__(self) -> None:
         """Run :data:`_PAIRING_VALIDATOR`; re-raise as ``ValueError``."""

--- a/esphome_device_builder/models/remote_build/offloader_events.py
+++ b/esphome_device_builder/models/remote_build/offloader_events.py
@@ -222,16 +222,19 @@ class OffloaderPeerLinkOpenedData(TypedDict):
     ``intent_response: ok`` state and the dispatch loop is
     parked. ``esphome_version`` is the receiver's
     :data:`esphome.const.__version__` lifted off the response;
-    empty if the receiver didn't carry the field. The
-    controller subscribes to refresh
-    :attr:`StoredPairing.esphome_version` so pick_build_path's
-    version-compat gate sees fresh values.
+    empty if the receiver didn't carry the field.
+    ``auto_provision_supported`` is the receiver's capability flag
+    (``False`` for an older receiver that never sent it). The
+    controller subscribes to refresh both onto the
+    :class:`StoredPairing` so pick_build_path's version-compat
+    gate sees fresh values.
     """
 
     receiver_hostname: str
     receiver_port: int
     pin_sha256: str
     esphome_version: str
+    auto_provision_supported: bool
 
 
 class OffloaderPeerLinkClosedData(TypedDict):

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -500,6 +500,7 @@ async def test_send_response_advertises_esphome_version() -> None:
     assert parsed == {
         "intent_response": IntentResponse.OK.value,
         "esphome_version": esphome_version,
+        "auto_provision_supported": False,
     }
 
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -62,6 +62,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
     SubmitJobTimeoutError,
     _build_ws_url,
     _DownloadArtifactsState,
+    _extract_auto_provision_supported,
     _extract_receiver_esphome_version,
     drive_initiator_round_trip,
     one_shot,
@@ -1186,6 +1187,7 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
         "receiver_port": 6055,
         "pin_sha256": pin,
         "esphome_version": "",
+        "auto_provision_supported": False,
     }
     offloader._on_offloader_peer_link_opened(MagicMock(data=opened))
     assert pin in offloader.state.open_peer_links
@@ -1211,6 +1213,8 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
     ("response", "expected"),
     [
         ({"esphome_version": "2026.5.0"}, "2026.5.0"),
+        # Dev version is valid PEP 440 (normalises to .dev0); kept as-is.
+        ({"esphome_version": "2026.7.0-dev"}, "2026.7.0-dev"),
         # Older receiver predating the wire change.
         ({}, ""),
         # Malformed: non-string value. Defense-in-depth gate
@@ -1219,31 +1223,50 @@ async def test_offloader_peer_link_event_listeners_update_open_set(
         ({"esphome_version": 12345}, ""),
         ({"esphome_version": None}, ""),
         ({"esphome_version": {"nested": "shape"}}, ""),
-        # At the cap: 64-char version exactly matches the
-        # validator's max; flows through unchanged.
-        ({"esphome_version": "x" * PAIRING_VERSION_MAX_LEN}, "x" * PAIRING_VERSION_MAX_LEN),
-        # One past the cap: a buggy / malicious receiver trying
-        # to poison the sidecar. The wire seam returns empty
-        # rather than firing OPENED with an oversize value that
-        # would survive the in-memory mutation path and then
-        # fail the next StoredPairing.from_dict on a real disk
-        # load.
-        ({"esphome_version": "x" * (PAIRING_VERSION_MAX_LEN + 1)}, ""),
+        # Not a PEP 440 version (garbage / injection): empty so it
+        # can't reach storage or a later pip install argument.
+        ({"esphome_version": "not-a-version"}, ""),
+        ({"esphome_version": "2026.6.4; rm -rf /"}, ""),
+        # Oversize (peer-controlled wire data exceeding the
+        # StoredPairing validator's cap): rejected on length before
+        # the PEP 440 check, so a poison value never survives the
+        # in-memory mutation path into the next disk load.
+        ({"esphome_version": "1.0.0+" + "b" * PAIRING_VERSION_MAX_LEN}, ""),
     ],
 )
 def test_extract_receiver_esphome_version_branches(response: dict[str, Any], expected: str) -> None:
-    """Helper handles missing / non-string / oversize / valid response shapes.
+    """Helper handles missing / non-string / oversize / non-PEP440 / valid shapes.
 
     Pins the post-handshake response → ``StoredPairing.esphome_version``
-    seam: a valid string flows through unchanged; missing field
-    (older receiver), malformed shapes (non-string from a buggy
-    peer), and oversize strings (peer-controlled wire data that
-    exceeds the validator's cap) all fall back to empty so
-    pick_build_path's compat gate sees "unknown" rather than
-    propagating into the next StoredPairing load and poisoning
-    the sidecar.
+    seam: a valid PEP 440 string flows through unchanged; missing field
+    (older receiver), malformed shapes (non-string from a buggy peer),
+    oversize strings (peer-controlled wire data exceeding the cap), and
+    non-PEP440 garbage all fall back to empty so pick_build_path's compat
+    gate sees "unknown" rather than propagating a poison value into the
+    next StoredPairing load or a later pip install.
     """
     assert _extract_receiver_esphome_version(response) == expected
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"auto_provision_supported": True}, True),
+        ({"auto_provision_supported": False}, False),
+        # Older receiver predating the capability field.
+        ({}, False),
+        # Non-bool from a buggy peer falls back to False rather than
+        # a truthy value flipping the capability on.
+        ({"auto_provision_supported": "1"}, False),
+        ({"auto_provision_supported": 1}, False),
+        ({"auto_provision_supported": None}, False),
+    ],
+)
+def test_extract_auto_provision_supported_branches(
+    response: dict[str, Any], expected: bool
+) -> None:
+    """Helper reads the capability flag; missing / non-bool ⇒ ``False``."""
+    assert _extract_auto_provision_supported(response) is expected
 
 
 async def test_peer_link_opened_refreshes_stored_pairing_version(
@@ -1289,6 +1312,7 @@ async def test_peer_link_opened_refreshes_stored_pairing_version(
             "receiver_port": 6055,
             "pin_sha256": pin,
             "esphome_version": version,
+            "auto_provision_supported": False,
         }
         return MagicMock(data=payload)
 
@@ -1327,6 +1351,53 @@ async def test_peer_link_opened_refreshes_stored_pairing_version(
     assert len(save_calls) == 2
 
 
+async def test_peer_link_opened_refreshes_auto_provision_capability(
+    offloader_controller_dir: Path,
+) -> None:
+    """``auto_provision_supported`` lands on the pairing and saves only on change."""
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = MagicMock()
+    pin = "a" * 64
+    pairing = _stub_pairing(
+        receiver_hostname="rcv.local",
+        receiver_port=6055,
+        pin_sha256=pin,
+        status=PeerStatus.APPROVED,
+    )
+    offloader.state.pairings[pin] = pairing
+    save_calls: list[None] = []
+    offloader._schedule_pairings_save = lambda: save_calls.append(None)  # type: ignore[method-assign]
+
+    def _opened(supported: bool) -> Any:
+        payload: OffloaderPeerLinkOpenedData = {
+            "receiver_hostname": "rcv.local",
+            "receiver_port": 6055,
+            "pin_sha256": pin,
+            "esphome_version": "2026.5.0",
+            "auto_provision_supported": supported,
+        }
+        return MagicMock(data=payload)
+
+    assert pairing.auto_provision_supported is False
+
+    # Receiver now advertises the capability: capture + save (the
+    # version also lands on this first OPENED, so at least one save).
+    offloader._on_offloader_peer_link_opened(_opened(True))
+    assert pairing.auto_provision_supported is True
+    saves_after_enable = len(save_calls)
+    assert saves_after_enable >= 1
+
+    # Same capability + same version reconnect: no redundant save.
+    offloader._on_offloader_peer_link_opened(_opened(True))
+    assert len(save_calls) == saves_after_enable
+
+    # Capability flips off (receiver downgraded) even though the
+    # version is unchanged: still persists.
+    offloader._on_offloader_peer_link_opened(_opened(False))
+    assert pairing.auto_provision_supported is False
+    assert len(save_calls) == saves_after_enable + 1
+
+
 async def test_peer_link_opened_for_unknown_pin_is_silent_no_op(
     offloader_controller_dir: Path,
 ) -> None:
@@ -1350,6 +1421,7 @@ async def test_peer_link_opened_for_unknown_pin_is_silent_no_op(
         "receiver_port": 6055,
         "pin_sha256": "a" * 64,
         "esphome_version": "2026.5.0",
+        "auto_provision_supported": False,
     }
     offloader._on_offloader_peer_link_opened(MagicMock(data=payload))
     assert len(save_calls) == 0

--- a/tests/test_version_compat.py
+++ b/tests/test_version_compat.py
@@ -6,10 +6,35 @@ import pytest
 
 from esphome_device_builder.helpers.version_compat import (
     VersionMatchPolicy,
+    is_pep440_version,
     major_versions_match,
     version_satisfies_policy,
     versions_match_exactly,
 )
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        # Real esphome shapes: release, dev, beta, rc, dev-build, epoch/post/local.
+        pytest.param("2026.6.4", True, id="release"),
+        pytest.param("2026.7.0-dev", True, id="dev"),
+        pytest.param("2026.7.0b1", True, id="beta"),
+        pytest.param("2026.7.0.dev20260629", True, id="dev_build"),
+        pytest.param("1.0.0.post1", True, id="post"),
+        pytest.param("1.0.0+local.1", True, id="local"),
+        # Garbage / injection / whitespace: rejected so it can't reach a
+        # pip install argument or the sidecar.
+        pytest.param("", False, id="empty"),
+        pytest.param("not-a-version", False, id="garbage"),
+        pytest.param("2026.6.4; rm -rf /", False, id="shell_injection"),
+        pytest.param("2026.6.4\n", False, id="trailing_newline"),
+        pytest.param("$(whoami)", False, id="command_sub"),
+    ],
+)
+def test_is_pep440_version(version: str, expected: bool) -> None:
+    """Accepts well-formed PEP 440 strings; rejects garbage / injection."""
+    assert is_pep440_version(version) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Groundwork for the same recurring problem as the interpreter seam (#1840); a remote build server on an older esphome silently hands back firmware built with that old version, and the user reinstalls over and over never realizing the receiver is the stale one. The planned fix has the receiver provision a venv with the offloader's esphome version; before the offloader can route a version-mismatched compile to a receiver, it has to know that receiver can actually provision.

This adds that capability negotiation. The receiver advertises an `auto_provision_supported` flag on every peer-link session-open, right alongside the `esphome_version` it already sends; the offloader lifts it off the post-handshake response and persists it on `StoredPairing`, next to the stored version. The flag is sourced from a single seam function that returns `False` today, so nothing advertises the capability yet and no dispatch behaviour changes; the follow up that adds the provisioner flips the seam to the real check and reads the persisted flag when deciding whether to route a mismatched compile. Older receivers that never send the field, and older sidecars without it, read back as `False`, so a mixed version fleet stays safe.

It also validates the receiver's advertised version as a PEP 440 version string at the same wire seam; a malformed or injected value now falls back to unknown rather than reaching storage, and later a pip install argument once the provisioner lands. The check is a small regex so it stays off the cold import path, no `packaging` import.

**Related issue or feature (if applicable):**

- groundwork for remote build version auto provisioning; follows #1840; no issue closed by this PR

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
