### PR TITLE
Add receiver-side esphome venv provisioner engine

### DIFF
--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -160,8 +160,9 @@ class EnvProvisioner:
         result = await run_subprocess_capture(*args, timeout=timeout)
         if result.timed_out or result.returncode != 0:
             await run_in_executor(_rmtree, venv)
+            status = "timed out" if result.timed_out else f"exit {result.returncode}"
             tail = result.stdout[-_ERROR_TAIL_BYTES:].decode(errors="replace")
-            raise EnvProvisionError(f"failed to {what} for a remote build: {tail}")
+            raise EnvProvisionError(f"failed to {what} for a remote build ({status}): {tail}")
 
 
 def _venv_python(venv: Path) -> Path:
@@ -176,8 +177,15 @@ def _venv_esphome_cmd(venv: Path) -> list[str]:
 
 
 def _release_key(version: str) -> tuple[int, ...]:
-    """Sort key for a plain-release version string (sweep ordering)."""
-    return tuple(int(part) for part in version.split("."))
+    """Sort key for a plain-release version, trailing ``.0`` normalised out.
+
+    So ``2026.6`` and ``2026.6.0`` order equal rather than the shorter one
+    counting as older, which would sweep an effectively-installed venv.
+    """
+    parts = [int(part) for part in version.split(".")]
+    while len(parts) > 1 and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)
 
 
 def _prepare_venv_dir(venv: Path) -> None:

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -1,0 +1,174 @@
+"""Provision + cache one esphome venv per release version (receiver-side).
+
+A receiver whose installed esphome differs from the offloader's builds the
+offloader's version into an isolated venv and compiles from it, instead of
+handing back firmware built with the wrong version. Venvs are cached per
+release under ``<data_dir>/.remote_builds/venvs/esphome-<version>/`` and reused
+across every device/build; a per-version lock serialises concurrent first
+builds of the same version while different versions build concurrently.
+
+RELEASE versions only: a dev / prerelease target can't be pinned to a
+reproducible ``pip install esphome==<version>`` and is refused.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+from esphome.core import CORE
+
+from ...helpers.async_ import run_in_executor
+from ...helpers.remote_build_layout import REMOTE_BUILDS_NAME
+from ...helpers.subprocess import run_subprocess_capture
+from ...helpers.version_compat import is_release_version
+
+_LOGGER = logging.getLogger(__name__)
+
+_VENVS_DIRNAME = "venvs"
+_VENV_PREFIX = "esphome-"
+# Written only after both venv creation and the install succeed, so a venv
+# left half-built by a crash (present dir, no marker) is rebuilt, not reused.
+_READY_MARKER = ".provisioned"
+_VENV_TIMEOUT = 120.0
+# ``pip install esphome`` pulls platformio + a large dep tree; allow generously.
+_PIP_TIMEOUT = 900.0
+# Cap on the subprocess-output tail folded into an error message.
+_ERROR_TAIL_BYTES = 2000
+
+
+class EnvProvisionError(Exception):
+    """A matching esphome venv could not be provisioned."""
+
+
+class EnvProvisioner:
+    """Create + cache one esphome venv per release version, keyed by version."""
+
+    def __init__(self, data_dir: Path | None = None, *, base_python: str | None = None) -> None:
+        # ``data_dir`` / ``base_python`` are injectable for tests; production
+        # reads ``CORE.data_dir`` lazily and builds from ``sys.executable``.
+        self._data_dir = data_dir
+        self._base_python = base_python or sys.executable
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    @property
+    def venvs_dir(self) -> Path:
+        """Base directory holding every per-version venv."""
+        base = self._data_dir if self._data_dir is not None else Path(CORE.data_dir)
+        return base / REMOTE_BUILDS_NAME / _VENVS_DIRNAME
+
+    async def provision(self, version: str) -> list[str]:
+        """Return the esphome command for *version*, building its venv on first use.
+
+        Raises :class:`EnvProvisionError` for a non-release version or a failed
+        venv / pip step; a partial venv is removed so a retry starts clean.
+        """
+        if not is_release_version(version):
+            raise EnvProvisionError(f"cannot provision non-release esphome version {version!r}")
+        venv = self.venvs_dir / f"{_VENV_PREFIX}{version}"
+        async with self._lock_for(version):
+            if not await run_in_executor(_is_ready, venv):
+                await self._build(version, venv)
+        return _venv_esphome_cmd(venv)
+
+    async def sweep_stale(self, installed_version: str) -> None:
+        """Remove cached venvs older than *installed_version* (a startup sweep).
+
+        No-op when *installed_version* isn't a plain release (a dev receiver),
+        since older / newer can't be ordered against it.
+        """
+        if not is_release_version(installed_version):
+            return
+        installed_key = _release_key(installed_version)
+        for venv, version in await run_in_executor(self._list_venvs):
+            if _release_key(version) < installed_key:
+                _LOGGER.info(
+                    "Removing stale esphome venv %s (older than installed %s)",
+                    version,
+                    installed_version,
+                )
+                await run_in_executor(_rmtree, venv)
+
+    async def clean_all(self) -> None:
+        """Remove every cached venv (the receiver's clean-build-env path)."""
+        await run_in_executor(_rmtree, self.venvs_dir)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _lock_for(self, version: str) -> asyncio.Lock:
+        lock = self._locks.get(version)
+        if lock is None:
+            lock = self._locks[version] = asyncio.Lock()
+        return lock
+
+    def _list_venvs(self) -> list[tuple[Path, str]]:
+        """``(dir, version)`` for each ``esphome-<release>`` venv on disk."""
+        venvs_dir = self.venvs_dir
+        if not venvs_dir.is_dir():
+            return []
+        found: list[tuple[Path, str]] = []
+        for child in venvs_dir.iterdir():
+            if not child.is_dir() or not child.name.startswith(_VENV_PREFIX):
+                continue
+            version = child.name[len(_VENV_PREFIX) :]
+            if is_release_version(version):
+                found.append((child, version))
+        return found
+
+    async def _build(self, version: str, venv: Path) -> None:
+        await run_in_executor(_rmtree, venv)  # clear any partial from a prior crash
+        await run_in_executor(_mkdirs, venv.parent)
+        await self._run(
+            "create the venv", venv, _VENV_TIMEOUT, self._base_python, "-m", "venv", str(venv)
+        )
+        await self._run(
+            f"install esphome=={version}",
+            venv,
+            _PIP_TIMEOUT,
+            str(_venv_python(venv)),
+            "-m",
+            "pip",
+            "install",
+            f"esphome=={version}",
+        )
+        await run_in_executor((venv / _READY_MARKER).write_text, version)
+
+    async def _run(self, what: str, venv: Path, timeout: float, *args: str) -> None:
+        result = await run_subprocess_capture(*args, timeout=timeout)
+        if result.timed_out or result.returncode != 0:
+            await run_in_executor(_rmtree, venv)
+            tail = result.stdout[-_ERROR_TAIL_BYTES:].decode(errors="replace")
+            raise EnvProvisionError(f"failed to {what} for a remote build: {tail}")
+
+
+def _venv_python(venv: Path) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / "python.exe"
+    return venv / "bin" / "python"
+
+
+def _venv_esphome_cmd(venv: Path) -> list[str]:
+    """Return the esphome CLI invocation that runs inside *venv*."""
+    return [str(_venv_python(venv)), "-m", "esphome"]
+
+
+def _release_key(version: str) -> tuple[int, ...]:
+    """Sort key for a plain-release version string (sweep ordering)."""
+    return tuple(int(part) for part in version.split("."))
+
+
+def _is_ready(venv: Path) -> bool:
+    return (venv / _READY_MARKER).is_file()
+
+
+def _mkdirs(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _rmtree(path: Path) -> None:
+    shutil.rmtree(path, ignore_errors=True)

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -70,9 +71,9 @@ class EnvProvisioner:
             raise EnvProvisionError(f"cannot provision non-release esphome version {version!r}")
         venv = self.venvs_dir / f"{_VENV_PREFIX}{version}"
         async with self._lock_for(version):
-            if not await self._is_healthy(venv):
+            if not await self._is_healthy(venv, version):
                 await self._build(version, venv)
-                if not await self._is_healthy(venv):
+                if not await self._is_healthy(venv, version):
                     await run_in_executor(_rmtree, venv)
                     raise EnvProvisionError(
                         f"provisioned esphome venv for {version} failed its health check"
@@ -125,12 +126,15 @@ class EnvProvisioner:
                 found.append((child, version))
         return found
 
-    async def _is_healthy(self, venv: Path) -> bool:
-        """Whether *venv*'s esphome actually runs (``python -m esphome version``).
+    async def _is_healthy(self, venv: Path, version: str) -> bool:
+        """Whether *venv* runs the *version* of esphome it's cached for.
 
-        Doubles as the readiness check: a missing venv, a crash-partial (no
-        esphome installed), or a corrupted one all fail here and rebuild, so no
-        separate "finished" marker is needed.
+        Verifies esphome both runs (``python -m esphome version`` exits 0) AND
+        reports the requested version, so a venv whose contents drifted from its
+        directory name (interrupted upgrade, manual pip) is rebuilt rather than
+        trusted on liveness alone — version identity is the whole point of the
+        feature. Also the readiness check: a missing or crash-partial venv fails
+        here, so no separate "finished" marker is needed.
         """
         python = _venv_python(venv)
         if not await run_in_executor(python.is_file):
@@ -138,7 +142,9 @@ class EnvProvisioner:
         result = await run_subprocess_capture(
             str(python), "-m", "esphome", "version", timeout=_HEALTHCHECK_TIMEOUT
         )
-        return not result.timed_out and result.returncode == 0
+        if result.timed_out or result.returncode != 0:
+            return False
+        return _version_in_output(version, result.stdout.decode(errors="replace"))
 
     async def _build(self, version: str, venv: Path) -> None:
         await run_in_executor(_prepare_venv_dir, venv)
@@ -174,6 +180,11 @@ def _venv_python(venv: Path) -> Path:
 def _venv_esphome_cmd(venv: Path) -> list[str]:
     """Return the esphome CLI invocation that runs inside *venv*."""
     return [str(_venv_python(venv)), "-m", "esphome"]
+
+
+def _version_in_output(version: str, output: str) -> bool:
+    """Whether *version* appears in *output* as a whole token, not inside a longer number."""
+    return re.search(rf"(?<![\w.]){re.escape(version)}(?![\w.])", output) is not None
 
 
 def _release_key(version: str) -> tuple[int, ...]:

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -15,27 +15,26 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shutil
 import sys
 from pathlib import Path
 
 from esphome.core import CORE
+from esphome.helpers import rmtree as _esphome_rmtree
 
+from ...helpers import remote_build_layout
 from ...helpers.async_ import run_in_executor
-from ...helpers.remote_build_layout import REMOTE_BUILDS_NAME
 from ...helpers.subprocess import run_subprocess_capture
 from ...helpers.version_compat import is_release_version
 
 _LOGGER = logging.getLogger(__name__)
 
-_VENVS_DIRNAME = "venvs"
 _VENV_PREFIX = "esphome-"
-# Written only after both venv creation and the install succeed, so a venv
-# left half-built by a crash (present dir, no marker) is rebuilt, not reused.
-_READY_MARKER = ".provisioned"
 _VENV_TIMEOUT = 120.0
 # ``pip install esphome`` pulls platformio + a large dep tree; allow generously.
 _PIP_TIMEOUT = 900.0
+# ``esphome version`` just prints a constant, but the interpreter still imports
+# esphome; give the health probe margin on a slow host.
+_HEALTHCHECK_TIMEOUT = 60.0
 # Cap on the subprocess-output tail folded into an error message.
 _ERROR_TAIL_BYTES = 2000
 
@@ -58,20 +57,26 @@ class EnvProvisioner:
     def venvs_dir(self) -> Path:
         """Base directory holding every per-version venv."""
         base = self._data_dir if self._data_dir is not None else Path(CORE.data_dir)
-        return base / REMOTE_BUILDS_NAME / _VENVS_DIRNAME
+        return remote_build_layout.venvs_dir(base)
 
     async def provision(self, version: str) -> list[str]:
         """Return the esphome command for *version*, building its venv on first use.
 
-        Raises :class:`EnvProvisionError` for a non-release version or a failed
-        venv / pip step; a partial venv is removed so a retry starts clean.
+        Raises :class:`EnvProvisionError` for a non-release version, or a venv
+        that won't build or fails its health check; a bad venv is removed so a
+        retry starts clean.
         """
         if not is_release_version(version):
             raise EnvProvisionError(f"cannot provision non-release esphome version {version!r}")
         venv = self.venvs_dir / f"{_VENV_PREFIX}{version}"
         async with self._lock_for(version):
-            if not await run_in_executor(_is_ready, venv):
+            if not await self._is_healthy(venv):
                 await self._build(version, venv)
+                if not await self._is_healthy(venv):
+                    await run_in_executor(_rmtree, venv)
+                    raise EnvProvisionError(
+                        f"provisioned esphome venv for {version} failed its health check"
+                    )
         return _venv_esphome_cmd(venv)
 
     async def sweep_stale(self, installed_version: str) -> None:
@@ -120,9 +125,23 @@ class EnvProvisioner:
                 found.append((child, version))
         return found
 
+    async def _is_healthy(self, venv: Path) -> bool:
+        """Whether *venv*'s esphome actually runs (``python -m esphome version``).
+
+        Doubles as the readiness check: a missing venv, a crash-partial (no
+        esphome installed), or a corrupted one all fail here and rebuild, so no
+        separate "finished" marker is needed.
+        """
+        python = _venv_python(venv)
+        if not await run_in_executor(python.is_file):
+            return False
+        result = await run_subprocess_capture(
+            str(python), "-m", "esphome", "version", timeout=_HEALTHCHECK_TIMEOUT
+        )
+        return not result.timed_out and result.returncode == 0
+
     async def _build(self, version: str, venv: Path) -> None:
-        await run_in_executor(_rmtree, venv)  # clear any partial from a prior crash
-        await run_in_executor(_mkdirs, venv.parent)
+        await run_in_executor(_prepare_venv_dir, venv)
         await self._run(
             "create the venv", venv, _VENV_TIMEOUT, self._base_python, "-m", "venv", str(venv)
         )
@@ -136,7 +155,6 @@ class EnvProvisioner:
             "install",
             f"esphome=={version}",
         )
-        await run_in_executor((venv / _READY_MARKER).write_text, version)
 
     async def _run(self, what: str, venv: Path, timeout: float, *args: str) -> None:
         result = await run_subprocess_capture(*args, timeout=timeout)
@@ -162,13 +180,13 @@ def _release_key(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
 
-def _is_ready(venv: Path) -> bool:
-    return (venv / _READY_MARKER).is_file()
-
-
-def _mkdirs(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
+def _prepare_venv_dir(venv: Path) -> None:
+    """Remove any crash-partial venv and ensure the parent dir exists."""
+    _rmtree(venv)
+    venv.parent.mkdir(parents=True, exist_ok=True)
 
 
 def _rmtree(path: Path) -> None:
-    shutil.rmtree(path, ignore_errors=True)
+    """Remove *path* if present, handling Windows read-only files."""
+    if path.exists():
+        _esphome_rmtree(path)

--- a/esphome_device_builder/helpers/remote_build_layout.py
+++ b/esphome_device_builder/helpers/remote_build_layout.py
@@ -36,6 +36,16 @@ REMOTE_BUILDS_SUBDIR = Path(".esphome") / REMOTE_BUILDS_NAME
 # delete it (PR #552).
 BUNDLE_SUFFIX = ".tar.gz"
 
+# Cached per-version esphome venvs the receiver provisions to build a
+# version-mismatched offloader's firmware; a sibling of the per-dashboard
+# extract dirs, keyed by version rather than dashboard.
+_VENVS_NAME = "venvs"
+
+
+def venvs_dir(data_dir: Path) -> Path:
+    """Return the base dir for the receiver's cached per-version esphome venvs."""
+    return data_dir / REMOTE_BUILDS_NAME / _VENVS_NAME
+
 
 # POSIX-form parts of ``REMOTE_BUILDS_SUBDIR``, pre-split once.
 # :attr:`FirmwareJob.configuration` is forward-slash on every

--- a/esphome_device_builder/helpers/version_compat.py
+++ b/esphome_device_builder/helpers/version_compat.py
@@ -35,6 +35,20 @@ def is_pep440_version(version: str) -> bool:
     return _PEP440_RE.fullmatch(version) is not None
 
 
+# A plain dotted-numeric release (no epoch / pre / post / dev / local segment).
+_RELEASE_RE = re.compile(r"\d+(?:\.\d+)*")
+
+
+def is_release_version(version: str) -> bool:
+    """Return whether *version* is a final release, not a pre / dev / local build.
+
+    Stricter than :func:`is_pep440_version`: only a plain release pins to a
+    reproducible ``pip install esphome==<version>``, so the provisioner
+    refuses anything else (a ``-dev`` build can't be pinned to an exact commit).
+    """
+    return _RELEASE_RE.fullmatch(version) is not None
+
+
 class VersionMatchPolicy(StrEnum):
     """How strictly the offloader filters peers by ESPHome version.
 

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -28,14 +28,23 @@ class _FakeRunner:
 
     On the ``venv`` command it creates the venv's python file, so the health
     probe's ``is_file`` fast-path passes and its ``esphome version`` call runs
-    (mirroring what ``python -m venv`` + install would leave behind). A command
-    whose args contain ``fail_at`` returns a non-zero exit.
+    (mirroring what ``python -m venv`` + install would leave behind). The
+    ``version`` probe reports the version parsed from the venv dir, or
+    ``reports_version`` when set (to simulate a drifted cache). A command whose
+    args contain ``fail_at`` returns a non-zero exit.
     """
 
-    def __init__(self, *, fail_at: str | None = None, block: asyncio.Event | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        fail_at: str | None = None,
+        block: asyncio.Event | None = None,
+        reports_version: str | None = None,
+    ) -> None:
         self.calls: list[tuple[str, ...]] = []
         self._fail_at = fail_at
         self._block = block
+        self._reports_version = reports_version
 
     async def __call__(self, *args: str, timeout: float, **_: object) -> CapturedSubprocess:
         self.calls.append(args)
@@ -43,8 +52,15 @@ class _FakeRunner:
             await self._block.wait()
         if "venv" in args:
             await run_in_executor(_make_venv_python, Path(args[-1]))
-        rc = 1 if self._fail_at is not None and self._fail_at in args else 0
-        return CapturedSubprocess(returncode=rc, stdout=b"pretend output", timed_out=False)
+        if self._fail_at is not None and self._fail_at in args:
+            return CapturedSubprocess(returncode=1, stdout=b"pretend output", timed_out=False)
+        stdout = b"pretend output"
+        if "version" in args:  # health probe: echo the venv's esphome version
+            reported = self._reports_version
+            if reported is None:
+                reported = Path(args[0]).parent.parent.name.removeprefix("esphome-")
+            stdout = f"Version: {reported}\n".encode()
+        return CapturedSubprocess(returncode=0, stdout=stdout, timed_out=False)
 
     def count(self, token: str) -> int:
         return sum(token in call for call in self.calls)
@@ -106,6 +122,20 @@ async def test_provision_rebuilds_unhealthy_existing_venv(
 
     assert "esphome-2026.6.4" in cmd[0]
     assert (runner.count("venv"), runner.count("install")) == (1, 1)  # rebuilt
+
+
+async def test_provision_rejects_venv_reporting_wrong_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A venv that runs but reports a different version fails the health check."""
+    runner = _FakeRunner(reports_version="2025.1.0")  # never the requested version
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    with pytest.raises(EnvProvisionError, match="health check"):
+        await provisioner.provision("2026.6.4")
+
+    assert not _venv_dir(provisioner, "2026.6.4").exists()
 
 
 async def test_provision_refuses_non_release(

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -1,0 +1,159 @@
+"""Coverage for the receiver-side esphome venv provisioner engine."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.remote_build.env_provisioner import (
+    EnvProvisioner,
+    EnvProvisionError,
+)
+from esphome_device_builder.helpers.subprocess import CapturedSubprocess
+
+
+class _FakeRunner:
+    """Stand-in for ``run_subprocess_capture`` that records calls.
+
+    On the ``venv`` command it creates the target dir (so the readiness
+    marker write lands), mirroring what ``python -m venv`` would do. A
+    command whose args contain ``fail_at`` returns a non-zero exit.
+    """
+
+    def __init__(self, *, fail_at: str | None = None, block: asyncio.Event | None = None) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self._fail_at = fail_at
+        self._block = block
+
+    async def __call__(self, *args: str, timeout: float, **_: object) -> CapturedSubprocess:
+        self.calls.append(args)
+        if self._block is not None:
+            await self._block.wait()
+        if "venv" in args:
+            Path(args[-1]).mkdir(parents=True, exist_ok=True)
+        rc = 1 if self._fail_at is not None and self._fail_at in args else 0
+        return CapturedSubprocess(returncode=rc, stdout=b"pretend pip output", timed_out=False)
+
+
+def _patch_runner(monkeypatch: pytest.MonkeyPatch, runner: _FakeRunner) -> None:
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.env_provisioner.run_subprocess_capture",
+        runner,
+    )
+
+
+def _venv_dir(provisioner: EnvProvisioner, version: str) -> Path:
+    return provisioner.venvs_dir / f"esphome-{version}"
+
+
+def _seed_venv(provisioner: EnvProvisioner, version: str) -> Path:
+    """Create a ready-looking cached venv dir on disk."""
+    venv = _venv_dir(provisioner, version)
+    venv.mkdir(parents=True, exist_ok=True)
+    (venv / ".provisioned").write_text(version)
+    return venv
+
+
+async def test_provision_builds_and_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """First provision runs venv + pip and marks ready; a repeat is a cache hit."""
+    runner = _FakeRunner()
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    cmd = await provisioner.provision("2026.6.4")
+
+    assert cmd[-2:] == ["-m", "esphome"]
+    assert "esphome-2026.6.4" in cmd[0]
+    assert (_venv_dir(provisioner, "2026.6.4") / ".provisioned").is_file()
+    assert len(runner.calls) == 2  # one venv, one pip install
+
+    again = await provisioner.provision("2026.6.4")
+    assert again == cmd
+    assert len(runner.calls) == 2  # unchanged: served from cache
+
+
+async def test_provision_refuses_non_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dev / prerelease target is refused before any subprocess runs."""
+    runner = _FakeRunner()
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    with pytest.raises(EnvProvisionError):
+        await provisioner.provision("2026.7.0-dev")
+
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize("fail_at", ["venv", "install"])
+async def test_provision_failure_removes_partial_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fail_at: str
+) -> None:
+    """A failed venv or pip step raises and leaves no half-built (marked) venv."""
+    runner = _FakeRunner(fail_at=fail_at)
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    with pytest.raises(EnvProvisionError):
+        await provisioner.provision("2026.6.4")
+
+    assert not _venv_dir(provisioner, "2026.6.4").exists()
+
+
+async def test_provision_concurrent_same_version_builds_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two concurrent provisions of one version share a single build (per-version lock)."""
+    gate = asyncio.Event()
+    runner = _FakeRunner(block=gate)
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    first = asyncio.ensure_future(provisioner.provision("2026.6.4"))
+    second = asyncio.ensure_future(provisioner.provision("2026.6.4"))
+    await asyncio.sleep(0)  # let both reach the lock
+    gate.set()
+    cmd_a, cmd_b = await asyncio.gather(first, second)
+
+    assert cmd_a == cmd_b
+    assert len(runner.calls) == 2  # only the lock holder built; the other cache-hit
+
+
+async def test_sweep_stale_removes_older_keeps_installed_and_newer(
+    tmp_path: Path,
+) -> None:
+    """Startup sweep drops venvs older than installed; keeps equal / newer."""
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    older = _seed_venv(provisioner, "2026.5.0")
+    same = _seed_venv(provisioner, "2026.6.4")
+    newer = _seed_venv(provisioner, "2026.7.0")
+
+    await provisioner.sweep_stale("2026.6.4")
+
+    assert not older.exists()
+    assert same.exists()
+    assert newer.exists()
+
+
+async def test_sweep_stale_noop_when_installed_is_dev(tmp_path: Path) -> None:
+    """A dev-installed receiver can't order versions, so the sweep does nothing."""
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    kept = _seed_venv(provisioner, "2026.5.0")
+
+    await provisioner.sweep_stale("2026.7.0-dev")
+
+    assert kept.exists()
+
+
+async def test_clean_all_removes_every_venv(tmp_path: Path) -> None:
+    """The clean-build-env path wipes the whole venvs tree."""
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    _seed_venv(provisioner, "2026.5.0")
+    _seed_venv(provisioner, "2026.6.4")
+
+    await provisioner.clean_all()
+
+    assert not provisioner.venvs_dir.exists()

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -137,6 +137,26 @@ async def test_provision_failure_removes_partial_venv(
     assert not _venv_dir(provisioner, "2026.6.4").exists()
 
 
+async def test_provision_timeout_reports_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A step that times out raises with a ``timed out`` status, not empty output."""
+
+    async def _timeout(*_args: str, timeout: float, **_: object) -> CapturedSubprocess:
+        return CapturedSubprocess(returncode=None, stdout=b"", timed_out=True)
+
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.remote_build.env_provisioner.run_subprocess_capture",
+        _timeout,
+    )
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    with pytest.raises(EnvProvisionError, match="timed out"):
+        await provisioner.provision("2026.6.4")
+
+    assert not _venv_dir(provisioner, "2026.6.4").exists()
+
+
 async def test_provision_concurrent_same_version_builds_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -146,8 +166,8 @@ async def test_provision_concurrent_same_version_builds_once(
     _patch_runner(monkeypatch, runner)
     provisioner = EnvProvisioner(data_dir=tmp_path)
 
-    first = asyncio.ensure_future(provisioner.provision("2026.6.4"))
-    second = asyncio.ensure_future(provisioner.provision("2026.6.4"))
+    first = asyncio.create_task(provisioner.provision("2026.6.4"))
+    second = asyncio.create_task(provisioner.provision("2026.6.4"))
     await asyncio.sleep(0)  # let both reach the lock
     gate.set()
     cmd_a, cmd_b = await asyncio.gather(first, second)
@@ -168,6 +188,24 @@ async def test_sweep_stale_removes_older_keeps_installed_and_newer(tmp_path: Pat
     assert not older.exists()
     assert same.exists()
     assert newer.exists()
+
+
+async def test_sweep_stale_tolerates_missing_dir_and_skips_non_venv_entries(
+    tmp_path: Path,
+) -> None:
+    """Sweep is a no-op with no venvs dir and leaves non-``esphome-`` entries alone."""
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    # Nothing provisioned yet: the venvs dir doesn't exist.
+    await provisioner.sweep_stale("2026.6.4")
+
+    older = await _seed_venv(provisioner, "2026.5.0")
+    stray = provisioner.venvs_dir / "not-a-venv"
+    await run_in_executor(_mkdirs, stray)
+
+    await provisioner.sweep_stale("2026.6.4")
+
+    assert not older.exists()  # older release swept
+    assert stray.exists()  # unrelated entry untouched
 
 
 async def test_sweep_stale_noop_when_installed_is_dev(tmp_path: Path) -> None:

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -91,6 +91,23 @@ async def test_provision_builds_and_caches(tmp_path: Path, monkeypatch: pytest.M
     assert runner.count("version") == 2
 
 
+async def test_provision_rebuilds_unhealthy_existing_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A leftover venv dir that fails the health check is rebuilt, not reused."""
+    runner = _FakeRunner()
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    # A crash-interrupted build leaves the dir present but with no runnable
+    # esphome, so the health probe's is_file fast-path fails.
+    await _seed_venv(provisioner, "2026.6.4")
+
+    cmd = await provisioner.provision("2026.6.4")
+
+    assert "esphome-2026.6.4" in cmd[0]
+    assert (runner.count("venv"), runner.count("install")) == (1, 1)  # rebuilt
+
+
 async def test_provision_refuses_non_release(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -10,16 +10,26 @@ import pytest
 from esphome_device_builder.controllers.remote_build.env_provisioner import (
     EnvProvisioner,
     EnvProvisionError,
+    _venv_python,
 )
+from esphome_device_builder.helpers.async_ import run_in_executor
 from esphome_device_builder.helpers.subprocess import CapturedSubprocess
+
+
+def _make_venv_python(venv: Path) -> None:
+    """Create the venv's python file, as ``python -m venv`` would."""
+    python = _venv_python(venv)
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.touch()
 
 
 class _FakeRunner:
     """Stand-in for ``run_subprocess_capture`` that records calls.
 
-    On the ``venv`` command it creates the target dir (so the readiness
-    marker write lands), mirroring what ``python -m venv`` would do. A
-    command whose args contain ``fail_at`` returns a non-zero exit.
+    On the ``venv`` command it creates the venv's python file, so the health
+    probe's ``is_file`` fast-path passes and its ``esphome version`` call runs
+    (mirroring what ``python -m venv`` + install would leave behind). A command
+    whose args contain ``fail_at`` returns a non-zero exit.
     """
 
     def __init__(self, *, fail_at: str | None = None, block: asyncio.Event | None = None) -> None:
@@ -32,9 +42,12 @@ class _FakeRunner:
         if self._block is not None:
             await self._block.wait()
         if "venv" in args:
-            Path(args[-1]).mkdir(parents=True, exist_ok=True)
+            await run_in_executor(_make_venv_python, Path(args[-1]))
         rc = 1 if self._fail_at is not None and self._fail_at in args else 0
-        return CapturedSubprocess(returncode=rc, stdout=b"pretend pip output", timed_out=False)
+        return CapturedSubprocess(returncode=rc, stdout=b"pretend output", timed_out=False)
+
+    def count(self, token: str) -> int:
+        return sum(token in call for call in self.calls)
 
 
 def _patch_runner(monkeypatch: pytest.MonkeyPatch, runner: _FakeRunner) -> None:
@@ -48,16 +61,19 @@ def _venv_dir(provisioner: EnvProvisioner, version: str) -> Path:
     return provisioner.venvs_dir / f"esphome-{version}"
 
 
-def _seed_venv(provisioner: EnvProvisioner, version: str) -> Path:
-    """Create a ready-looking cached venv dir on disk."""
+async def _seed_venv(provisioner: EnvProvisioner, version: str) -> Path:
+    """Create a cached venv dir on disk (recognised by the sweep / clean)."""
     venv = _venv_dir(provisioner, version)
-    venv.mkdir(parents=True, exist_ok=True)
-    (venv / ".provisioned").write_text(version)
+    await run_in_executor(_mkdirs, venv)
     return venv
 
 
+def _mkdirs(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
 async def test_provision_builds_and_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """First provision runs venv + pip and marks ready; a repeat is a cache hit."""
+    """First provision runs venv + pip + health probe; a repeat is a cache hit."""
     runner = _FakeRunner()
     _patch_runner(monkeypatch, runner)
     provisioner = EnvProvisioner(data_dir=tmp_path)
@@ -66,12 +82,13 @@ async def test_provision_builds_and_caches(tmp_path: Path, monkeypatch: pytest.M
 
     assert cmd[-2:] == ["-m", "esphome"]
     assert "esphome-2026.6.4" in cmd[0]
-    assert (_venv_dir(provisioner, "2026.6.4") / ".provisioned").is_file()
-    assert len(runner.calls) == 2  # one venv, one pip install
+    assert (runner.count("venv"), runner.count("install"), runner.count("version")) == (1, 1, 1)
 
     again = await provisioner.provision("2026.6.4")
     assert again == cmd
-    assert len(runner.calls) == 2  # unchanged: served from cache
+    # No rebuild (venv / install unchanged); the health probe runs each time.
+    assert (runner.count("venv"), runner.count("install")) == (1, 1)
+    assert runner.count("version") == 2
 
 
 async def test_provision_refuses_non_release(
@@ -88,11 +105,11 @@ async def test_provision_refuses_non_release(
     assert runner.calls == []
 
 
-@pytest.mark.parametrize("fail_at", ["venv", "install"])
+@pytest.mark.parametrize("fail_at", ["venv", "install", "version"])
 async def test_provision_failure_removes_partial_venv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fail_at: str
 ) -> None:
-    """A failed venv or pip step raises and leaves no half-built (marked) venv."""
+    """A failed venv / pip / health step raises and leaves no usable venv behind."""
     runner = _FakeRunner(fail_at=fail_at)
     _patch_runner(monkeypatch, runner)
     provisioner = EnvProvisioner(data_dir=tmp_path)
@@ -119,17 +136,15 @@ async def test_provision_concurrent_same_version_builds_once(
     cmd_a, cmd_b = await asyncio.gather(first, second)
 
     assert cmd_a == cmd_b
-    assert len(runner.calls) == 2  # only the lock holder built; the other cache-hit
+    assert runner.count("venv") == 1  # only the lock holder built; the other cache-hit
 
 
-async def test_sweep_stale_removes_older_keeps_installed_and_newer(
-    tmp_path: Path,
-) -> None:
+async def test_sweep_stale_removes_older_keeps_installed_and_newer(tmp_path: Path) -> None:
     """Startup sweep drops venvs older than installed; keeps equal / newer."""
     provisioner = EnvProvisioner(data_dir=tmp_path)
-    older = _seed_venv(provisioner, "2026.5.0")
-    same = _seed_venv(provisioner, "2026.6.4")
-    newer = _seed_venv(provisioner, "2026.7.0")
+    older = await _seed_venv(provisioner, "2026.5.0")
+    same = await _seed_venv(provisioner, "2026.6.4")
+    newer = await _seed_venv(provisioner, "2026.7.0")
 
     await provisioner.sweep_stale("2026.6.4")
 
@@ -141,7 +156,7 @@ async def test_sweep_stale_removes_older_keeps_installed_and_newer(
 async def test_sweep_stale_noop_when_installed_is_dev(tmp_path: Path) -> None:
     """A dev-installed receiver can't order versions, so the sweep does nothing."""
     provisioner = EnvProvisioner(data_dir=tmp_path)
-    kept = _seed_venv(provisioner, "2026.5.0")
+    kept = await _seed_venv(provisioner, "2026.5.0")
 
     await provisioner.sweep_stale("2026.7.0-dev")
 
@@ -151,8 +166,8 @@ async def test_sweep_stale_noop_when_installed_is_dev(tmp_path: Path) -> None:
 async def test_clean_all_removes_every_venv(tmp_path: Path) -> None:
     """The clean-build-env path wipes the whole venvs tree."""
     provisioner = EnvProvisioner(data_dir=tmp_path)
-    _seed_venv(provisioner, "2026.5.0")
-    _seed_venv(provisioner, "2026.6.4")
+    await _seed_venv(provisioner, "2026.5.0")
+    await _seed_venv(provisioner, "2026.6.4")
 
     await provisioner.clean_all()
 

--- a/tests/test_version_compat.py
+++ b/tests/test_version_compat.py
@@ -7,10 +7,33 @@ import pytest
 from esphome_device_builder.helpers.version_compat import (
     VersionMatchPolicy,
     is_pep440_version,
+    is_release_version,
     major_versions_match,
     version_satisfies_policy,
     versions_match_exactly,
 )
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        pytest.param("2026.6.4", True, id="release"),
+        pytest.param("2024.12.0", True, id="release_two_digit_month"),
+        # Everything with a pre / dev / post / local / epoch segment is NOT a
+        # plain release, so the provisioner won't pin it.
+        pytest.param("2026.7.0-dev", False, id="dev"),
+        pytest.param("2026.7.0b1", False, id="beta"),
+        pytest.param("2026.7.0rc1", False, id="rc"),
+        pytest.param("1.0.0.post1", False, id="post"),
+        pytest.param("1.0.0+local", False, id="local"),
+        pytest.param("1!2.0.0", False, id="epoch"),
+        pytest.param("", False, id="empty"),
+        pytest.param("not-a-version", False, id="garbage"),
+    ],
+)
+def test_is_release_version(version: str, expected: bool) -> None:
+    """Only plain dotted-numeric releases pass; pre / dev / post / local do not."""
+    assert is_release_version(version) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

The engine for the remote build version fix, the recurring problem where a remote build server on an older esphome silently hands back firmware built with that old version and the user reinstalls over and over never realizing the receiver is stale (follows #1840 and #1844). This adds the receiver-side `EnvProvisioner`; given a target esphome version it builds an isolated venv (`python -m venv` then `pip install esphome==<version>`), caches it per version under `<data_dir>/.remote_builds/venvs/esphome-<version>/`, and returns the esphome command that runs inside it. The venv is reused across every device and build until it goes stale.

Details that matter; a per-version `asyncio.Lock` serialises concurrent first builds of the same version so two jobs don't race on one venv, while different versions build concurrently. A readiness marker is written only after both the venv and the install succeed, so a venv left half built by a crash is rebuilt rather than reused. Only release versions are accepted; a dev or prerelease target can't be pinned to a reproducible install and is refused up front. `sweep_stale()` drops cached venvs older than the receiver's installed esphome (a startup sweep), and `clean_all()` wipes the whole tree for the clean build env path.

This PR is the engine only; nothing calls it yet. The follow up wires it in, flips the capability seam from #1844 to real, consumes it through the per job interpreter seam from #1840, and adds the dispatch change. Tested with a fake installer so no real pip runs in the suite; a later end to end test does a real mismatched version build.

**Related issue or feature (if applicable):**

- groundwork for remote build version auto provisioning; follows #1840 and #1844; no issue closed by this PR

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
