### PR TITLE
Add desktop update commands for the ESPHome Desktop app

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ Base URL: `http://localhost:6052`
 
 ## WebSocket API (`/ws`)
 
-The primary API. A single multiplexed WebSocket handles all 44 commands.
+The primary API. A single multiplexed WebSocket handles all 46 commands.
 
 ### Protocol
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,12 +12,21 @@ The primary API. A single multiplexed WebSocket handles all 44 commands.
 
 On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/models/api.py):
 ```json
-{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false, "desktop_version": ""}
+{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false, "desktop_version": "", "desktop_update_capable": false}
 ```
 
 `ha_ingress` is `true` only when the connection is proxied through the HA Supervisor ingress (the `X-Ingress-Path` header is present); the frontend slims its header in that case so HA's own panel bar isn't doubled up. An add-on reached directly on its exposed port reports `ha_addon: true` but `ha_ingress: false`.
 
 `desktop_version` carries the ESPHome Desktop wrapper version (from the `ESPHOME_DESKTOP_VERSION` env var) when the dashboard runs inside the desktop app, and is `""` otherwise; the value is sanitized server-side (blank, non-printable, or over-length is treated as unset). The frontend renders it as a footer line only when non-empty.
+
+`desktop_update_capable` is `true` only when the dashboard runs inside an ESPHome Desktop app that exposes its update `api` (0.14.0+, which sets `ESPHOME_DESKTOP_BIN`). Older desktop apps set `desktop_version` but not this, so the frontend gates the "Check for updates" menu item on `desktop_update_capable`, not on `desktop_version`.
+
+### Desktop update commands
+
+Available only when `desktop_update_capable` is `true`; both shell out to the desktop app's `esphome-desktop` CLI.
+
+- `desktop/check_update` returns whether an update is available for any component, without installing: `{"any_available": bool, "app": {…}, "esphome": {…}, "device_builder": {…}}`, where each component carries `available`, `installed`, `latest`, and `error`.
+- `desktop/update` triggers the full update (desktop app, ESPHome, device builder) and returns `{"started": true}` immediately. It is fire-and-forget: the desktop app stops and restarts this backend to install, so the WebSocket drops mid-update; re-run `desktop/check_update` after reconnecting to confirm the new versions.
 
 **Send a [`CommandMessage`](../esphome_device_builder/models/api.py):**
 ```json

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -337,6 +337,7 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
         ha_ingress=bool(request.headers.get("X-Ingress-Path")),
         requires_auth=(not pre_authenticated),
         desktop_version=settings.desktop_version,
+        desktop_update_capable=settings.desktop_update_capable,
     )
     await client.send(info.to_dict())
 

--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -273,6 +273,26 @@ class DashboardSettings:
         return raw
 
     @property
+    def desktop_bin(self) -> str:
+        """Path to the ESPHome Desktop ``esphome-desktop`` CLI, from the env.
+
+        Only ESPHome Desktop 0.14.0+ exports ``ESPHOME_DESKTOP_BIN``; older
+        apps set ``ESPHOME_DESKTOP_VERSION`` but not this, so an empty value
+        means "no update `api` available" even when ``desktop_version`` is set.
+        """
+        return os.getenv("ESPHOME_DESKTOP_BIN", "").strip()
+
+    @property
+    def desktop_update_capable(self) -> bool:
+        """Whether the desktop app exposes its update ``api`` (0.14.0+).
+
+        Derived from ``desktop_bin`` presence, not ``desktop_version``, so the
+        "Check for updates" UI stays hidden on older desktop apps that predate
+        the CLI.
+        """
+        return bool(self.desktop_bin)
+
+    @property
     def front_door_open(self) -> bool:
         """Operator disabled external auth (legacy leave_front_door_open env var)."""
         return self.on_ha_addon and get_bool_env("DISABLE_HA_AUTHENTICATION")

--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -34,6 +34,11 @@ _DASHBOARD_SENTINEL_FILE = "___DASHBOARD_SENTINEL___.yaml"
 # is treated as unset rather than rendered in the footer.
 _MAX_DESKTOP_VERSION_LEN = 64
 
+# Upper bound on the ESPHome Desktop CLI path; generous enough for real bundle
+# paths but rejects an absurd env value. A value past this (or non-printable) is
+# treated as unset so `desktop_update_capable` stays false.
+_MAX_DESKTOP_BIN_LEN = 4096
+
 
 @dataclass
 class DashboardSettings:
@@ -279,8 +284,15 @@ class DashboardSettings:
         Only ESPHome Desktop 0.14.0+ exports ``ESPHOME_DESKTOP_BIN``; older
         apps set ``ESPHOME_DESKTOP_VERSION`` but not this, so an empty value
         means "no update `api` available" even when ``desktop_version`` is set.
+
+        Sanitized like ``desktop_version``: a blank, non-printable (control
+        chars / newlines, which would also be a log-injection vector), or
+        absurdly long value is treated as unset.
         """
-        return os.getenv("ESPHOME_DESKTOP_BIN", "").strip()
+        raw = os.getenv("ESPHOME_DESKTOP_BIN", "").strip()
+        if not raw or len(raw) > _MAX_DESKTOP_BIN_LEN or not raw.isprintable():
+            return ""
+        return raw
 
     @property
     def desktop_update_capable(self) -> bool:

--- a/esphome_device_builder/controllers/desktop.py
+++ b/esphome_device_builder/controllers/desktop.py
@@ -1,0 +1,130 @@
+"""ESPHome Desktop update integration.
+
+When the dashboard runs inside the ESPHome Desktop app (0.14.0+), the app
+exports ``ESPHOME_DESKTOP_BIN`` pointing at its ``esphome-desktop`` CLI, which
+speaks a stable, versioned JSON ``api`` over stdout (NDJSON). These commands let
+the frontend check for and trigger a full desktop-app update (the desktop app,
+ESPHome, and the device builder) from the dashboard's kebab menu.
+
+The update is fire-and-forget: ``esphome-desktop api update`` stops and restarts
+this backend to install, so the WS connection drops mid-update; the frontend
+re-checks after it reconnects. The desktop app completes the update regardless
+of this process, so the updater is spawned detached (its own session) and not
+awaited.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ..helpers.api import CommandError, api_command
+from ..helpers.json import loads
+from ..helpers.subprocess import create_subprocess_exec, run_subprocess_capture
+from ..models import ErrorCode
+
+if TYPE_CHECKING:
+    from esphome_device_builder.device_builder import DeviceBuilder
+
+_LOGGER = logging.getLogger(__name__)
+
+# `api check-update` spawns Python for the installed versions and hits GitHub
+# and PyPI; give it headroom over a local command but keep it bounded.
+_CHECK_UPDATE_TIMEOUT = 120.0
+
+
+class DesktopController:
+    """WebSocket endpoints bridging to the ESPHome Desktop CLI (0.14.0+)."""
+
+    def __init__(self, db: DeviceBuilder) -> None:
+        self._db = db
+
+    def _desktop_bin(self) -> str:
+        """Return the CLI path, or raise if the desktop app isn't update-capable.
+
+        The frontend only shows these actions when ``desktop_update_capable``
+        is set, so reaching here without a binary means a stale/forged call;
+        fail loudly rather than shelling out to nothing.
+        """
+        bin_path = self._db.settings.desktop_bin
+        if not bin_path:
+            raise CommandError(
+                ErrorCode.INTERNAL_ERROR,
+                "not running under an update-capable ESPHome Desktop app",
+            )
+        return bin_path
+
+    @api_command("desktop/check_update")
+    async def check_update(self, **kwargs: Any) -> dict[str, Any]:
+        """Report whether any component has an update available (read-only).
+
+        Shells out to ``esphome-desktop api check-update`` and returns its
+        parsed JSON: ``{any_available, app, esphome, device_builder}`` where
+        each component carries ``available``, ``installed``, ``latest``, and
+        ``error``.
+        """
+        bin_path = self._desktop_bin()
+        result = await run_subprocess_capture(
+            bin_path,
+            "api",
+            "check-update",
+            timeout=_CHECK_UPDATE_TIMEOUT,
+            merge_stderr=False,
+        )
+        if result.timed_out:
+            raise CommandError(ErrorCode.INTERNAL_ERROR, "update check timed out")
+        if result.returncode != 0:
+            raise CommandError(
+                ErrorCode.INTERNAL_ERROR,
+                f"update check failed (exit {result.returncode})",
+            )
+        try:
+            # orjson-backed helper; JSONDecodeError (and _last_json_line's
+            # "no output") both subclass ValueError.
+            payload = loads(_last_json_line(result.stdout))
+        except ValueError as err:
+            raise CommandError(
+                ErrorCode.INTERNAL_ERROR, "could not parse update check output"
+            ) from err
+        if not isinstance(payload, dict):
+            raise CommandError(ErrorCode.INTERNAL_ERROR, "unexpected update check output")
+        return payload
+
+    @api_command("desktop/update")
+    async def update(self, **kwargs: Any) -> dict[str, Any]:
+        """Trigger the full desktop update, fire-and-forget.
+
+        Spawns ``esphome-desktop api update`` detached and returns immediately.
+        Stopping this backend for the install won't kill the detached updater,
+        and the desktop app finishes the update even if it did; the frontend
+        polls ``desktop/check_update`` again after the WS reconnects.
+        """
+        bin_path = self._desktop_bin()
+        await create_subprocess_exec(
+            bin_path,
+            "api",
+            "update",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            # Own session so a backend stop/restart during the install does not
+            # signal the updater along with this process group.
+            start_new_session=True,
+        )
+        _LOGGER.info("Triggered ESPHome Desktop update via %s", bin_path)
+        return {"started": True}
+
+
+def _last_json_line(stdout: bytes) -> str:
+    """Last non-empty line of *stdout*, decoded.
+
+    ``api check-update`` emits exactly one JSON line, but taking the last
+    non-empty line is robust to any trailing newline or stray leading output.
+    """
+    text = stdout.decode("utf-8", "replace")
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    raise ValueError("no output")

--- a/esphome_device_builder/controllers/desktop.py
+++ b/esphome_device_builder/controllers/desktop.py
@@ -65,20 +65,34 @@ class DesktopController:
         ``error``.
         """
         bin_path = self._desktop_bin()
-        result = await run_subprocess_capture(
-            bin_path,
-            "api",
-            "check-update",
-            timeout=_CHECK_UPDATE_TIMEOUT,
-            merge_stderr=False,
-        )
+        try:
+            result = await run_subprocess_capture(
+                bin_path,
+                "api",
+                "check-update",
+                timeout=_CHECK_UPDATE_TIMEOUT,
+                merge_stderr=False,
+            )
+        except OSError as err:
+            # Stale/removed ESPHOME_DESKTOP_BIN, permissions, etc. Surface a
+            # clean error instead of an INTERNAL_ERROR traceback.
+            _LOGGER.warning("Could not run ESPHome Desktop CLI %s: %s", bin_path, err)
+            raise CommandError(
+                ErrorCode.INTERNAL_ERROR, "could not run the ESPHome Desktop CLI"
+            ) from err
         if result.timed_out:
+            _LOGGER.warning("ESPHome Desktop update check timed out")
             raise CommandError(ErrorCode.INTERNAL_ERROR, "update check timed out")
         if result.returncode != 0:
-            raise CommandError(
-                ErrorCode.INTERNAL_ERROR,
-                f"update check failed (exit {result.returncode})",
+            # The CLI prints its errors as a JSON `{"type":"err",...}` line on
+            # stdout (kept clean by merge_stderr=False), so surface its message.
+            detail = _error_detail(result.stdout)
+            _LOGGER.warning(
+                "ESPHome Desktop update check failed (exit %s): %s",
+                result.returncode,
+                detail,
             )
+            raise CommandError(ErrorCode.INTERNAL_ERROR, f"update check failed: {detail}")
         try:
             # orjson-backed helper; JSONDecodeError (and _last_json_line's
             # "no output") both subclass ValueError.
@@ -101,19 +115,43 @@ class DesktopController:
         polls ``desktop/check_update`` again after the WS reconnects.
         """
         bin_path = self._desktop_bin()
-        await create_subprocess_exec(
-            bin_path,
-            "api",
-            "update",
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-            # Own session so a backend stop/restart during the install does not
-            # signal the updater along with this process group.
-            start_new_session=True,
-        )
+        try:
+            await create_subprocess_exec(
+                bin_path,
+                "api",
+                "update",
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                # Own session so a backend stop/restart during the install does
+                # not signal the updater along with this process group.
+                start_new_session=True,
+            )
+        except OSError as err:
+            _LOGGER.warning("Could not run ESPHome Desktop CLI %s: %s", bin_path, err)
+            raise CommandError(
+                ErrorCode.INTERNAL_ERROR, "could not run the ESPHome Desktop CLI"
+            ) from err
         _LOGGER.info("Triggered ESPHome Desktop update via %s", bin_path)
         return {"started": True}
+
+
+def _error_detail(stdout: bytes) -> str:
+    """Human-readable failure detail from the CLI's error line, if present.
+
+    On a non-zero exit the `api` prints a JSON `{"type":"err",...,"message":...}`
+    line on stdout; extract that message so operators and the client see the
+    real reason rather than a bare exit code.
+    """
+    try:
+        payload = loads(_last_json_line(stdout))
+    except ValueError:
+        return "no diagnostic output"
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        if isinstance(message, str):
+            return message
+    return "unrecognized error output"
 
 
 def _last_json_line(stdout: bytes) -> str:

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -32,6 +32,7 @@ from .controllers.config import (
     ConfigController,
     DashboardSettings,
 )
+from .controllers.desktop import DesktopController
 from .controllers.devices import DevicesController
 from .controllers.editor import EditorController
 from .controllers.firmware import FirmwareController
@@ -348,6 +349,7 @@ class DeviceBuilder:
         self.components = ComponentCatalog(self)
         self.components.load()
         self.config = ConfigController(self)
+        self.desktop = DesktopController(self)
         self.devices = DevicesController(self)
         self.automations = AutomationsController(self)
         self.firmware = FirmwareController(self)
@@ -431,6 +433,7 @@ class DeviceBuilder:
             self.boards,
             self.components,
             self.config,
+            self.desktop,
             self.devices,
             self.automations,
             self.firmware,

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -114,3 +114,6 @@ class ServerInfoMessage(DashboardModel):
     requires_auth: bool = False
     # ESPHome Desktop wrapper version, from ESPHOME_DESKTOP_VERSION; "" off-desktop.
     desktop_version: str = ""
+    # True when the desktop app (0.14.0+) exposes its update `api` via
+    # ESPHOME_DESKTOP_BIN; gates the frontend's "Check for updates" menu item.
+    desktop_update_capable: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -684,6 +684,7 @@ def make_ws_device_builder(
     on_ha_addon: bool = False,
     trusted_domains: list[str] | None = None,
     desktop_version: str = "",
+    desktop_update_capable: bool = False,
 ) -> MagicMock:
     """MagicMock ``DeviceBuilder`` carrying the settings the /ws handshake reads."""
     settings = MagicMock()
@@ -692,6 +693,7 @@ def make_ws_device_builder(
     settings.on_ha_addon = on_ha_addon
     settings.trusted_domains = [] if trusted_domains is None else trusted_domains
     settings.desktop_version = desktop_version
+    settings.desktop_update_capable = desktop_update_capable
     device_builder = MagicMock()
     device_builder.settings = settings
     return device_builder

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -2082,6 +2082,25 @@ def test_desktop_version_reads_and_sanitizes_env(
     assert settings.desktop_version == ""
 
 
+def test_desktop_bin_and_update_capable_read_env(
+    make_settings: MakeSettingsFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``desktop_bin`` reads the CLI path; ``desktop_update_capable`` tracks it."""
+    settings = make_settings()
+    monkeypatch.delenv("ESPHOME_DESKTOP_BIN", raising=False)
+    assert settings.desktop_bin == ""
+    assert settings.desktop_update_capable is False
+
+    monkeypatch.setenv("ESPHOME_DESKTOP_BIN", "  /Applications/ESPHome.app/bin  ")
+    assert settings.desktop_bin == "/Applications/ESPHome.app/bin"
+    assert settings.desktop_update_capable is True
+
+    # Blank stays not-capable (older desktop app that only sets the version).
+    monkeypatch.setenv("ESPHOME_DESKTOP_BIN", "   ")
+    assert settings.desktop_bin == ""
+    assert settings.desktop_update_capable is False
+
+
 def test_metadata_transaction_persists_without_fcntl(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -2091,14 +2091,26 @@ def test_desktop_bin_and_update_capable_read_env(
     assert settings.desktop_bin == ""
     assert settings.desktop_update_capable is False
 
-    monkeypatch.setenv("ESPHOME_DESKTOP_BIN", "  /Applications/ESPHome.app/bin  ")
-    assert settings.desktop_bin == "/Applications/ESPHome.app/bin"
+    # Real bundle paths (with spaces) are fine.
+    monkeypatch.setenv(
+        "ESPHOME_DESKTOP_BIN",
+        "  /Applications/ESPHome Device Builder.app/Contents/MacOS/esphome-desktop  ",
+    )
+    assert (
+        settings.desktop_bin
+        == "/Applications/ESPHome Device Builder.app/Contents/MacOS/esphome-desktop"
+    )
     assert settings.desktop_update_capable is True
 
-    # Blank stays not-capable (older desktop app that only sets the version).
+    # Blank, control-char (log-injection vector), and absurdly long values all
+    # degrade to "" so desktop_update_capable can't be flipped by junk.
     monkeypatch.setenv("ESPHOME_DESKTOP_BIN", "   ")
     assert settings.desktop_bin == ""
     assert settings.desktop_update_capable is False
+    monkeypatch.setenv("ESPHOME_DESKTOP_BIN", "/bin/esphome\ndesktop")
+    assert settings.desktop_bin == ""
+    monkeypatch.setenv("ESPHOME_DESKTOP_BIN", "/" + "a" * 4096)
+    assert settings.desktop_bin == ""
 
 
 def test_metadata_transaction_persists_without_fcntl(

--- a/tests/test_desktop_controller.py
+++ b/tests/test_desktop_controller.py
@@ -110,6 +110,44 @@ async def test_check_update_unparseable_output_errors(
         await _controller().check_update()
 
 
+async def test_check_update_non_object_payload_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Valid JSON that isn't an object (array/scalar) is rejected.
+    _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(returncode=0, stdout=b"[1, 2, 3]\n", timed_out=False),
+    )
+    with pytest.raises(CommandError):
+        await _controller().check_update()
+
+
+async def test_check_update_nonzero_exit_without_message_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Non-zero exit whose JSON line carries no `message`.
+    _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(returncode=1, stdout=b'{"type":"err"}\n', timed_out=False),
+    )
+    with pytest.raises(CommandError) as exc:
+        await _controller().check_update()
+    assert "unrecognized error output" in exc.value.message
+
+
+async def test_check_update_nonzero_exit_without_output_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Non-zero exit with no output at all.
+    _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(returncode=1, stdout=b"", timed_out=False),
+    )
+    with pytest.raises(CommandError) as exc:
+        await _controller().check_update()
+    assert "no diagnostic output" in exc.value.message
+
+
 async def test_update_spawns_detached(monkeypatch: pytest.MonkeyPatch) -> None:
     exec_mock = AsyncMock(return_value=MagicMock())
     monkeypatch.setattr(

--- a/tests/test_desktop_controller.py
+++ b/tests/test_desktop_controller.py
@@ -58,15 +58,36 @@ async def test_check_update_without_desktop_bin_errors() -> None:
     assert exc.value.code == ErrorCode.INTERNAL_ERROR
 
 
-async def test_check_update_nonzero_exit_errors(
+async def test_check_update_nonzero_exit_surfaces_cli_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # The CLI prints its error as a JSON line on stdout even on a non-zero
+    # exit; the message should reach the CommandError, not just the exit code.
     _patch_capture(
         monkeypatch,
-        CapturedSubprocess(returncode=3, stdout=b'{"type":"err"}\n', timed_out=False),
+        CapturedSubprocess(
+            returncode=3,
+            stdout=b'{"type":"err","code":"not_running","message":"the app is not running"}\n',
+            timed_out=False,
+        ),
     )
-    with pytest.raises(CommandError):
+    with pytest.raises(CommandError) as exc:
         await _controller().check_update()
+    assert "the app is not running" in exc.value.message
+
+
+async def test_check_update_bin_spawn_oserror_is_clean_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A stale/removed ESPHOME_DESKTOP_BIN makes the spawn raise; it must become
+    # a CommandError, not an INTERNAL_ERROR traceback.
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.desktop.run_subprocess_capture",
+        AsyncMock(side_effect=FileNotFoundError("no such file")),
+    )
+    with pytest.raises(CommandError) as exc:
+        await _controller().check_update()
+    assert exc.value.code == ErrorCode.INTERNAL_ERROR
 
 
 async def test_check_update_timeout_errors(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,6 +123,18 @@ async def test_update_spawns_detached(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exec_mock.await_args.args == (_BIN, "api", "update")
     # Own session so a backend restart during install doesn't kill the updater.
     assert exec_mock.await_args.kwargs["start_new_session"] is True
+
+
+async def test_update_bin_spawn_oserror_is_clean_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.desktop.create_subprocess_exec",
+        AsyncMock(side_effect=FileNotFoundError("no such file")),
+    )
+    with pytest.raises(CommandError) as exc:
+        await _controller().update()
+    assert exc.value.code == ErrorCode.INTERNAL_ERROR
 
 
 async def test_update_without_desktop_bin_errors() -> None:

--- a/tests/test_desktop_controller.py
+++ b/tests/test_desktop_controller.py
@@ -1,0 +1,109 @@
+"""Tests for the ESPHome Desktop update-integration controller."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers.desktop import DesktopController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.helpers.subprocess import CapturedSubprocess
+from esphome_device_builder.models import ErrorCode
+
+_BIN = "/Applications/ESPHome Device Builder.app/Contents/MacOS/esphome-desktop"
+
+
+def _controller(desktop_bin: str = _BIN) -> DesktopController:
+    db = MagicMock()
+    db.settings.desktop_bin = desktop_bin
+    return DesktopController(db)
+
+
+def _patch_capture(monkeypatch: pytest.MonkeyPatch, captured: CapturedSubprocess) -> AsyncMock:
+    run = AsyncMock(return_value=captured)
+    monkeypatch.setattr("esphome_device_builder.controllers.desktop.run_subprocess_capture", run)
+    return run
+
+
+async def test_check_update_returns_parsed_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "any_available": True,
+        "app": {"available": True, "installed": "0.14.0", "latest": "0.15.0"},
+        "esphome": {"available": False},
+        "device_builder": {"available": False, "installed": None},
+    }
+    run = _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(
+            returncode=0, stdout=(json.dumps(payload) + "\n").encode(), timed_out=False
+        ),
+    )
+
+    result = await _controller().check_update()
+
+    assert result == payload
+    run.assert_awaited_once()
+    assert run.await_args.args == (_BIN, "api", "check-update")
+    # stderr must be discarded so stdout carries only the JSON line.
+    assert run.await_args.kwargs["merge_stderr"] is False
+
+
+async def test_check_update_without_desktop_bin_errors() -> None:
+    with pytest.raises(CommandError) as exc:
+        await _controller(desktop_bin="").check_update()
+    assert exc.value.code == ErrorCode.INTERNAL_ERROR
+
+
+async def test_check_update_nonzero_exit_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(returncode=3, stdout=b'{"type":"err"}\n', timed_out=False),
+    )
+    with pytest.raises(CommandError):
+        await _controller().check_update()
+
+
+async def test_check_update_timeout_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(returncode=None, stdout=b"", timed_out=True),
+    )
+    with pytest.raises(CommandError):
+        await _controller().check_update()
+
+
+async def test_check_update_unparseable_output_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_capture(
+        monkeypatch,
+        CapturedSubprocess(returncode=0, stdout=b"not json\n", timed_out=False),
+    )
+    with pytest.raises(CommandError):
+        await _controller().check_update()
+
+
+async def test_update_spawns_detached(monkeypatch: pytest.MonkeyPatch) -> None:
+    exec_mock = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.desktop.create_subprocess_exec", exec_mock
+    )
+
+    result = await _controller().update()
+
+    assert result == {"started": True}
+    exec_mock.assert_awaited_once()
+    assert exec_mock.await_args.args == (_BIN, "api", "update")
+    # Own session so a backend restart during install doesn't kill the updater.
+    assert exec_mock.await_args.kwargs["start_new_session"] is True
+
+
+async def test_update_without_desktop_bin_errors() -> None:
+    with pytest.raises(CommandError):
+        await _controller(desktop_bin="").update()

--- a/tests/test_ws_handler_branches.py
+++ b/tests/test_ws_handler_branches.py
@@ -279,3 +279,25 @@ async def test_server_info_carries_desktop_version(
         assert info["desktop_version"] == "1.4.2"
     finally:
         await ws.close()
+
+
+async def test_server_info_carries_desktop_update_capable(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """The handshake frame relays ``settings.desktop_update_capable``."""
+    device_builder = make_ws_device_builder(desktop_update_capable=True)
+    device_builder.command_handlers = {}
+
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True
+    ws_module.init_ws_app(app)
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+
+    ws, info = await _connect_and_drain_server_info(client)
+    try:
+        assert info["desktop_update_capable"] is True
+    finally:
+        await ws.close()


### PR DESCRIPTION
# What does this implement/fix?

Lets the dashboard offer "Check for updates" when it runs inside ESPHome Desktop 0.14.0+; the desktop app exports `ESPHOME_DESKTOP_BIN` pointing at its `esphome-desktop` CLI, and this adds two WebSocket commands that shell out to it. `desktop/check_update` returns per component update availability (desktop app, ESPHome, device builder); `desktop/update` triggers the full update detached and returns immediately, since the desktop app stops and restarts this backend to install. The handshake now carries `desktop_update_capable` so the frontend can gate the menu item; it derives from `ESPHOME_DESKTOP_BIN`, not `desktop_version`, so it stays off on older desktop apps that predate the CLI.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1076

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
