### PR TITLE
Extract a shared shallow git-clone helper for the sync scripts

### DIFF
--- a/script/_repo_cache.py
+++ b/script/_repo_cache.py
@@ -20,6 +20,7 @@ def ensure_shallow_git_repo(
     clone_timeout: int = 300,
     allow_existing_non_git: bool = False,
     clone_fail_level: int = logging.WARNING,
+    pull_fail_level: int = logging.WARNING,
 ) -> Path | None:
     """
     Clone *url* into *target* (shallow) or refresh it; return the path or None.
@@ -30,9 +31,9 @@ def ensure_shallow_git_repo(
     on-disk snapshot, a failed clone returns None. With *allow_existing_non_git*
     a pre-existing non-git *target* is used as-is rather than cloned into.
 
-    *clone_fail_level* is the log level for a failed clone; pass
-    ``logging.ERROR`` when the repo is a primary data source whose absence
-    yields an empty/partial result the operator must notice.
+    *clone_fail_level* / *pull_fail_level* are the log levels for a failed
+    clone / pull; pass ``logging.ERROR`` when the repo is a primary data source
+    whose absence or stale refresh yields a result the operator must notice.
     """
     if (target / ".git").exists():
         if pull:
@@ -46,10 +47,17 @@ def ensure_shallow_git_repo(
                     timeout=pull_timeout,
                 )
             except (OSError, subprocess.SubprocessError) as exc:
-                _LOGGER.warning("git pull in %s failed: %s; using existing snapshot", target, exc)
+                _LOGGER.log(
+                    pull_fail_level,
+                    "git pull in %s failed: %s; using existing snapshot",
+                    target,
+                    exc,
+                )
             else:
                 if result.returncode != 0:
-                    _LOGGER.warning("git pull failed in %s; using existing snapshot", target)
+                    _LOGGER.log(
+                        pull_fail_level, "git pull failed in %s; using existing snapshot", target
+                    )
         return target
     if allow_existing_non_git and target.exists():
         return target

--- a/script/_repo_cache.py
+++ b/script/_repo_cache.py
@@ -19,6 +19,7 @@ def ensure_shallow_git_repo(
     pull_timeout: int = 120,
     clone_timeout: int = 300,
     allow_existing_non_git: bool = False,
+    clone_fail_level: int = logging.WARNING,
 ) -> Path | None:
     """
     Clone *url* into *target* (shallow) or refresh it; return the path or None.
@@ -28,6 +29,10 @@ def ensure_shallow_git_repo(
     *pull* is False. Every git failure is non-fatal: a failed pull keeps the
     on-disk snapshot, a failed clone returns None. With *allow_existing_non_git*
     a pre-existing non-git *target* is used as-is rather than cloned into.
+
+    *clone_fail_level* is the log level for a failed clone; pass
+    ``logging.ERROR`` when the repo is a primary data source whose absence
+    yields an empty/partial result the operator must notice.
     """
     if (target / ".git").exists():
         if pull:
@@ -67,6 +72,6 @@ def ensure_shallow_git_repo(
             timeout=clone_timeout,
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        _LOGGER.warning("Could not clone %s: %s", label, exc)
+        _LOGGER.log(clone_fail_level, "Could not clone %s: %s", label, exc)
         return None
     return target

--- a/script/_repo_cache.py
+++ b/script/_repo_cache.py
@@ -31,13 +31,20 @@ def ensure_shallow_git_repo(
     """
     if (target / ".git").exists():
         if pull:
-            result = subprocess.run(
-                ["git", "-C", str(target), "pull", "-q", "--ff-only"],
-                check=False,
-                timeout=pull_timeout,
-            )
-            if result.returncode != 0:
-                _LOGGER.warning("git pull failed in %s; using existing snapshot", target)
+            # Keep the pull non-fatal end to end: a non-zero exit, a timeout, or
+            # git missing all fall back to the on-disk snapshot rather than
+            # aborting the sync.
+            try:
+                result = subprocess.run(
+                    ["git", "-C", str(target), "pull", "-q", "--ff-only"],
+                    check=False,
+                    timeout=pull_timeout,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                _LOGGER.warning("git pull in %s failed: %s; using existing snapshot", target, exc)
+            else:
+                if result.returncode != 0:
+                    _LOGGER.warning("git pull failed in %s; using existing snapshot", target)
         return target
     if allow_existing_non_git and target.exists():
         return target

--- a/script/_repo_cache.py
+++ b/script/_repo_cache.py
@@ -1,0 +1,65 @@
+"""Shared shallow clone/pull cache for the sync scripts' upstream git repos."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def ensure_shallow_git_repo(
+    url: str,
+    target: Path,
+    branch: str,
+    *,
+    label: str,
+    pull: bool = True,
+    pull_timeout: int = 120,
+    clone_timeout: int = 300,
+    allow_existing_non_git: bool = False,
+) -> Path | None:
+    """
+    Clone *url* into *target* (shallow) or refresh it; return the path or None.
+
+    First run does ``git clone --depth=1 --single-branch --branch=<branch>``;
+    a later run with an existing ``.git`` does ``git pull -q --ff-only`` unless
+    *pull* is False. Every git failure is non-fatal: a failed pull keeps the
+    on-disk snapshot, a failed clone returns None. With *allow_existing_non_git*
+    a pre-existing non-git *target* is used as-is rather than cloned into.
+    """
+    if (target / ".git").exists():
+        if pull:
+            result = subprocess.run(
+                ["git", "-C", str(target), "pull", "-q", "--ff-only"],
+                check=False,
+                timeout=pull_timeout,
+            )
+            if result.returncode != 0:
+                _LOGGER.warning("git pull failed in %s; using existing snapshot", target)
+        return target
+    if allow_existing_non_git and target.exists():
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _LOGGER.info("Cloning %s (shallow) to %s", label, target)
+    try:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "-q",
+                "--depth=1",
+                "--single-branch",
+                f"--branch={branch}",
+                url,
+                str(target),
+            ],
+            check=True,
+            timeout=clone_timeout,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        _LOGGER.warning("Could not clone %s: %s", label, exc)
+        return None
+    return target

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -113,6 +113,7 @@ from _catalog_split import (  # noqa: E402
     swap_split_catalog_in,
 )
 from _esphome_version import assert_installed_esphome  # noqa: E402
+from _repo_cache import ensure_shallow_git_repo  # noqa: E402
 
 from esphome_device_builder.controllers.components import (  # noqa: E402
     INTERNAL_COMPONENT_IDS as _INTERNAL_COMPONENT_IDS,
@@ -1881,44 +1882,15 @@ def _extract_mdx_field_descriptions(text: str) -> dict[str, str]:  # noqa: C901
 
 def _ensure_docs_repo() -> Path | None:
     """Clone or update the esphome.io repo (shallow). Returns its path."""
-    import subprocess
-
-    target = _CACHE_ROOT / _DOCS_CLONE_DIR
-    if (target / ".git").exists():
-        # Refresh in-place. ``-q`` and ``--ff-only`` keep it quiet and
-        # safe; failure here just means we keep using the existing
-        # snapshot.
-        subprocess.run(
-            ["git", "-C", str(target), "pull", "-q", "--ff-only"],
-            check=False,
-            timeout=60,
-        )
-        return target
-    if target.exists():
-        # Pre-existing non-git directory — leave alone, use as-is.
-        return target
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    _LOGGER.info("Cloning esphome.io (shallow) to %s", target)
-    try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "-q",
-                "--depth=1",
-                "--single-branch",
-                f"--branch={_DOCS_REPO_BRANCH}",
-                _DOCS_REPO_URL,
-                str(target),
-            ],
-            check=True,
-            timeout=120,
-        )
-    except Exception:
-        _LOGGER.warning("Could not clone esphome.io — descriptions stay empty")
-        return None
-    return target
+    return ensure_shallow_git_repo(
+        _DOCS_REPO_URL,
+        _CACHE_ROOT / _DOCS_CLONE_DIR,
+        _DOCS_REPO_BRANCH,
+        label="esphome.io",
+        pull_timeout=60,
+        clone_timeout=120,
+        allow_existing_non_git=True,
+    )
 
 
 # Frontmatter description matcher — captures the value of the

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -426,6 +426,9 @@ def _ensure_devices_repo(*, pull: bool = True) -> Path | None:
         pull=pull,
         pull_timeout=120,
         clone_timeout=300,
+        # Primary data source: a clone miss yields an empty imported-device
+        # catalog the operator must notice, so keep it loud (was ERROR).
+        clone_fail_level=logging.ERROR,
     )
 
 

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -426,9 +426,11 @@ def _ensure_devices_repo(*, pull: bool = True) -> Path | None:
         pull=pull,
         pull_timeout=120,
         clone_timeout=300,
-        # Primary data source: a clone miss yields an empty imported-device
-        # catalog the operator must notice, so keep it loud (was ERROR).
+        # Primary data source: a clone miss (empty catalog) or a stale-pull
+        # (regenerating from outdated upstream) both need operator attention,
+        # so keep both loud (clone was ERROR; pull elevated to match).
         clone_fail_level=logging.ERROR,
+        pull_fail_level=logging.ERROR,
     )
 
 

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -44,6 +44,9 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _repo_cache import ensure_shallow_git_repo  # noqa: E402
 
 from esphome_device_builder.constants import (  # noqa: E402
     BOARD_PIN_KEYS,
@@ -417,40 +420,15 @@ def _ensure_devices_repo(*, pull: bool = True) -> Path | None:
     which is what the smoke test does so it inspects the same revision
     the sync just produced.
     """
-    target = _DEVICES_CLONE_DIR
-    if (target / ".git").exists():
-        if not pull:
-            return target
-        result = subprocess.run(
-            ["git", "-C", str(target), "pull", "-q", "--ff-only"],
-            check=False,
-            timeout=120,
-        )
-        if result.returncode != 0:
-            _LOGGER.warning("git pull failed in %s — using existing snapshot", target)
-        return target
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    _LOGGER.info("Cloning devices.esphome.io (shallow) to %s", target)
-    try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "-q",
-                "--depth=1",
-                "--single-branch",
-                f"--branch={_DEVICES_REPO_BRANCH}",
-                _DEVICES_REPO_URL,
-                str(target),
-            ],
-            check=True,
-            timeout=300,
-        )
-    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        _LOGGER.error("Could not clone devices.esphome.io: %s", exc)
-        return None
-    return target
+    return ensure_shallow_git_repo(
+        _DEVICES_REPO_URL,
+        _DEVICES_CLONE_DIR,
+        _DEVICES_REPO_BRANCH,
+        label="devices.esphome.io",
+        pull=pull,
+        pull_timeout=120,
+        clone_timeout=300,
+    )
 
 
 def _get_repo_revision(repo: Path) -> str:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -44,9 +44,6 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-
-from _repo_cache import ensure_shallow_git_repo  # noqa: E402
 
 from esphome_device_builder.constants import (  # noqa: E402
     BOARD_PIN_KEYS,
@@ -56,6 +53,7 @@ from esphome_device_builder.constants import (  # noqa: E402
 from esphome_device_builder.helpers.pin_gpio import parse_board_gpio  # noqa: E402
 from esphome_device_builder.models.boards import Esp32Variant  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
+from script._repo_cache import ensure_shallow_git_repo  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/tests/test_repo_cache.py
+++ b/tests/test_repo_cache.py
@@ -42,6 +42,20 @@ def test_pulls_existing_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert "pull" in fake.calls[0]
 
 
+def test_pull_nonzero_exit_keeps_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _make_git_repo(tmp_path)
+    fake = _FakeRun(returncode=1)
+    monkeypatch.setattr(subprocess, "run", fake)
+    assert ensure_shallow_git_repo("url", target, "main", label="x") == target
+
+
+def test_pull_timeout_is_non_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _make_git_repo(tmp_path)
+    fake = _FakeRun(raises=subprocess.TimeoutExpired("git", 1))
+    monkeypatch.setattr(subprocess, "run", fake)
+    assert ensure_shallow_git_repo("url", target, "main", label="x") == target
+
+
 def test_skips_pull_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     target = _make_git_repo(tmp_path)
     fake = _FakeRun()

--- a/tests/test_repo_cache.py
+++ b/tests/test_repo_cache.py
@@ -1,0 +1,79 @@
+"""Unit tests for ``ensure_shallow_git_repo`` in ``script/_repo_cache.py``."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from script._repo_cache import ensure_shallow_git_repo  # type: ignore[import-not-found]
+
+
+class _FakeRun:
+    """Record ``subprocess.run`` calls and return a canned result."""
+
+    def __init__(self, returncode: int = 0, raises: Exception | None = None) -> None:
+        self.returncode = returncode
+        self.raises = raises
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        self.calls.append(cmd)
+        if self.raises is not None:
+            raise self.raises
+        return subprocess.CompletedProcess(cmd, self.returncode)
+
+
+def _make_git_repo(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    (target / ".git").mkdir(parents=True)
+    return target
+
+
+def test_pulls_existing_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _make_git_repo(tmp_path)
+    fake = _FakeRun()
+    monkeypatch.setattr(subprocess, "run", fake)
+    result = ensure_shallow_git_repo("url", target, "main", label="x")
+    assert result == target
+    assert fake.calls[0][:3] == ["git", "-C", str(target)]
+    assert "pull" in fake.calls[0]
+
+
+def test_skips_pull_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _make_git_repo(tmp_path)
+    fake = _FakeRun()
+    monkeypatch.setattr(subprocess, "run", fake)
+    result = ensure_shallow_git_repo("url", target, "main", label="x", pull=False)
+    assert result == target
+    assert fake.calls == []
+
+
+def test_clones_when_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "repo"
+    fake = _FakeRun()
+    monkeypatch.setattr(subprocess, "run", fake)
+    result = ensure_shallow_git_repo("url", target, "current", label="x")
+    assert result == target
+    assert fake.calls[0][:2] == ["git", "clone"]
+    assert "--branch=current" in fake.calls[0]
+    assert fake.calls[0][-2:] == ["url", str(target)]
+
+
+def test_clone_failure_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "repo"
+    fake = _FakeRun(raises=subprocess.CalledProcessError(1, "git"))
+    monkeypatch.setattr(subprocess, "run", fake)
+    assert ensure_shallow_git_repo("url", target, "main", label="x") is None
+
+
+def test_existing_non_git_used_as_is(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+    fake = _FakeRun()
+    monkeypatch.setattr(subprocess, "run", fake)
+    result = ensure_shallow_git_repo("url", target, "main", label="x", allow_existing_non_git=True)
+    assert result == target
+    assert fake.calls == []

--- a/tests/test_repo_cache.py
+++ b/tests/test_repo_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -81,6 +82,18 @@ def test_clone_failure_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     fake = _FakeRun(raises=subprocess.CalledProcessError(1, "git"))
     monkeypatch.setattr(subprocess, "run", fake)
     assert ensure_shallow_git_repo("url", target, "main", label="x") is None
+
+
+def test_clone_failure_honours_log_level(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "repo"
+    fake = _FakeRun(raises=subprocess.CalledProcessError(1, "git"))
+    monkeypatch.setattr(subprocess, "run", fake)
+    with caplog.at_level(logging.DEBUG, logger="script._repo_cache"):
+        ensure_shallow_git_repo("url", target, "main", label="x", clone_fail_level=logging.ERROR)
+    clone_records = [r for r in caplog.records if "Could not clone" in r.getMessage()]
+    assert [r.levelno for r in clone_records] == [logging.ERROR]
 
 
 def test_existing_non_git_used_as_is(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_repo_cache.py
+++ b/tests/test_repo_cache.py
@@ -57,6 +57,18 @@ def test_pull_timeout_is_non_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert ensure_shallow_git_repo("url", target, "main", label="x") == target
 
 
+def test_pull_failure_honours_log_level(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = _make_git_repo(tmp_path)
+    fake = _FakeRun(returncode=1)
+    monkeypatch.setattr(subprocess, "run", fake)
+    with caplog.at_level(logging.DEBUG, logger="script._repo_cache"):
+        ensure_shallow_git_repo("url", target, "main", label="x", pull_fail_level=logging.ERROR)
+    pull_records = [r for r in caplog.records if "git pull" in r.getMessage()]
+    assert [r.levelno for r in pull_records] == [logging.ERROR]
+
+
 def test_skips_pull_when_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     target = _make_git_repo(tmp_path)
     fake = _FakeRun()


### PR DESCRIPTION
# What does this implement/fix?

`sync_components._ensure_docs_repo` and `sync_esphome_devices._ensure_devices_repo` were near-identical; both clone an upstream repo shallow on first run, `git pull --ff-only` after, and treat any git failure as non-fatal. This extracts that into `ensure_shallow_git_repo` in a new `script/_repo_cache.py`, with the timeouts, the `pull=False` skip, and the pre-existing-non-git escape hatch as keyword arguments. Both scripts now call the helper and keep their own URL/branch/dir constants; adds a unit test for the branch behavior.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1852

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
