### PR TITLE
Share the component-catalog index/body join across the scripts

### DIFF
--- a/script/_component_catalog.py
+++ b/script/_component_catalog.py
@@ -1,0 +1,35 @@
+"""
+Shared component-catalog reader for the definition scripts.
+
+Stdlib ``json`` only (no ``orjson``) so the light ``validate-definitions``
+pre-commit hook env, which runs without the runtime deps, can import it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_component_catalog(index_path: Path, bodies_dir: Path) -> dict[str, dict[str, Any]]:
+    """
+    Join the slim component index with each per-id body, keyed by component id.
+
+    Reads *index_path* (a ``<catalog>.index.json`` carrying a ``components``
+    list) and merges each per-id ``<bodies_dir>/<id>.json`` on top, so every
+    entry carries its full body. Callers own the index-missing policy; this
+    assumes *index_path* exists.
+    """
+    raw = json.loads(index_path.read_text(encoding="utf-8"))
+    by_id: dict[str, dict[str, Any]] = {}
+    for comp in raw.get("components", []):
+        cid = comp.get("id")
+        if not cid:
+            continue
+        body_path = bodies_dir / f"{cid}.json"
+        if body_path.is_file():
+            by_id[cid] = {**comp, **json.loads(body_path.read_text(encoding="utf-8"))}
+        else:
+            by_id[cid] = comp
+    return by_id

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 import logging
 import re
 import shutil
@@ -53,6 +52,7 @@ from esphome_device_builder.constants import (  # noqa: E402
 )
 from esphome_device_builder.helpers.pin_gpio import parse_board_gpio  # noqa: E402
 from esphome_device_builder.models.boards import Esp32Variant  # noqa: E402
+from script._component_catalog import load_component_catalog  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -2248,19 +2248,7 @@ def _load_components_index() -> dict[str, dict[str, Any]]:
         raise SystemExit(
             f"{_COMPONENTS_INDEX_JSON} not found — run script/sync_components.py first."
         )
-    raw = json.loads(_COMPONENTS_INDEX_JSON.read_text(encoding="utf-8"))
-    by_id: dict[str, dict[str, Any]] = {}
-    for comp in raw.get("components", []):
-        cid = comp.get("id")
-        if not cid:
-            continue
-        body_path = _COMPONENTS_BODIES_DIR / f"{cid}.json"
-        if body_path.is_file():
-            body = json.loads(body_path.read_text(encoding="utf-8"))
-            by_id[cid] = {**comp, **body}
-        else:
-            by_id[cid] = comp
-    return by_id
+    return load_component_catalog(_COMPONENTS_INDEX_JSON, _COMPONENTS_BODIES_DIR)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -34,6 +34,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 # Imported from the stdlib-only constants module so this script stays light.
 from esphome_device_builder.constants import BOARD_PIN_KEYS, BUS_CATEGORIES  # noqa: E402
+from script._component_catalog import load_component_catalog  # noqa: E402
 
 DEFINITIONS_DIR = _REPO_ROOT / "esphome_device_builder" / "definitions"
 SCHEMAS_DIR = DEFINITIONS_DIR / "schemas"
@@ -218,19 +219,7 @@ def _build_components_index() -> dict | None:
             file=sys.stderr,
         )
         return None
-    raw = json.loads(COMPONENTS_INDEX_JSON.read_text(encoding="utf-8"))
-    by_id: dict[str, dict] = {}
-    for comp in raw.get("components", []):
-        cid = comp.get("id")
-        if not cid:
-            continue
-        body_path = COMPONENTS_BODIES_DIR / f"{cid}.json"
-        if body_path.is_file():
-            body = json.loads(body_path.read_text(encoding="utf-8"))
-            by_id[cid] = {**comp, **body}
-        else:
-            by_id[cid] = comp
-    return by_id
+    return load_component_catalog(COMPONENTS_INDEX_JSON, COMPONENTS_BODIES_DIR)
 
 
 def _validate_featured(  # noqa: C901

--- a/tests/test_component_catalog.py
+++ b/tests/test_component_catalog.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``load_component_catalog`` in ``script/_component_catalog.py``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from script._component_catalog import load_component_catalog  # type: ignore[import-not-found]
+
+
+def _write(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_merges_body_over_index_entry(tmp_path: Path) -> None:
+    bodies = tmp_path / "components"
+    bodies.mkdir()
+    _write(
+        tmp_path / "index.json",
+        {"components": [{"id": "sensor.dht", "title": "DHT"}]},
+    )
+    _write(bodies / "sensor.dht.json", {"config_entries": [{"key": "pin"}]})
+
+    result = load_component_catalog(tmp_path / "index.json", bodies)
+
+    assert result == {
+        "sensor.dht": {"id": "sensor.dht", "title": "DHT", "config_entries": [{"key": "pin"}]},
+    }
+
+
+def test_keeps_index_entry_without_body(tmp_path: Path) -> None:
+    bodies = tmp_path / "components"
+    bodies.mkdir()
+    _write(tmp_path / "index.json", {"components": [{"id": "sensor.dht", "title": "DHT"}]})
+
+    result = load_component_catalog(tmp_path / "index.json", bodies)
+
+    assert result == {"sensor.dht": {"id": "sensor.dht", "title": "DHT"}}
+
+
+def test_skips_entries_without_id(tmp_path: Path) -> None:
+    bodies = tmp_path / "components"
+    bodies.mkdir()
+    _write(
+        tmp_path / "index.json",
+        {"components": [{"title": "no id"}, {"id": "sensor.dht"}]},
+    )
+
+    result = load_component_catalog(tmp_path / "index.json", bodies)
+
+    assert list(result) == ["sensor.dht"]


### PR DESCRIPTION
# What does this implement/fix?

`validate_definitions._build_components_index` and `sync_esphome_devices._load_components_index` had a byte-identical loop joining `components.index.json` with each per-id body file; `check_device_catalog` imported the sync copy. This moves the join into `load_component_catalog` in a new stdlib-`json`-only `script/_component_catalog.py` (not the `orjson`-based `_catalog_split.py`, which would pull runtime deps into the light `validate-definitions` pre-commit env), so the three consumers share one implementation and each keeps only its own index-missing policy (warn-and-return-None vs raise). Verified both callers still produce an identical 917-entry catalog; adds a unit test.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1853

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

