### PR TITLE
Extract shared device not-found / name-exists error helpers

### DIFF
--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -19,6 +19,7 @@ from ...helpers.build_artifacts import (
 from ...helpers.device_yaml import parse_esphome_meta
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode
+from .helpers import require_file_exists
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -34,9 +35,7 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
     config_dir = controller._db.settings.config_dir
 
     def _archive_sync() -> None:
-        if not config_path.exists():
-            msg = f"File not found: {configuration}"
-            raise FileNotFoundError(msg)
+        require_file_exists(config_path, configuration)
         archive_dir = config_dir / "archive"
         archive_dir.mkdir(parents=True, exist_ok=True)
         target = archive_dir / configuration
@@ -87,9 +86,7 @@ async def unarchive_single(controller: DevicesController, configuration: str) ->
     target = controller._db.settings.rel_path(configuration)
 
     def _unarchive_sync() -> None:
-        if not archive_path.exists():
-            msg = f"Archived file not found: {configuration}"
-            raise FileNotFoundError(msg)
+        require_file_exists(archive_path, configuration, archived=True)
         if target.exists():
             msg = (
                 f"Cannot unarchive {configuration}: an active config "
@@ -146,9 +143,7 @@ async def delete_archived_single(controller: DevicesController, configuration: s
     active_path = controller._db.settings.rel_path(configuration)
 
     def _delete_all() -> bool:
-        if not archive_path.exists():
-            msg = f"Archived file not found: {configuration}"
-            raise FileNotFoundError(msg)
+        require_file_exists(archive_path, configuration, archived=True)
         archive_path.unlink()
         if active_path.exists():
             # An active config with the same filename owns the
@@ -176,9 +171,7 @@ async def delete_single(controller: DevicesController, configuration: str) -> No
         # Existence check stays inside the executor; Path.exists
         # performs a filesystem stat and would block the event
         # loop otherwise.
-        if not config_path.exists():
-            msg = f"File not found: {configuration}"
-            raise FileNotFoundError(msg)
+        require_file_exists(config_path, configuration)
         # Wipe build dir first (inside the helper) so a partial failure
         # later leaves the user able to retry the delete.
         remove_device_files(config_path, configuration)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -85,6 +85,7 @@ from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _build_address_cache_args,
     _validate_archive_configuration,
+    raise_device_not_found,
 )
 from .metadata import DeviceMetadataBase
 
@@ -758,7 +759,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         try:
             return await self._read_yaml_async(self._db.settings.rel_path(configuration))
         except FileNotFoundError as err:
-            raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found") from err
+            raise_device_not_found(configuration, from_exc=err)
 
     @api_command("devices/update_config")
     async def update_config(

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
-from pathlib import PurePosixPath, PureWindowsPath
-from typing import TYPE_CHECKING, Any
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Any, NoReturn
 
 try:
     # ``friendly_name_slugify`` lives in ``esphome.helpers`` from
@@ -52,11 +52,39 @@ __all__ = [
     "_validate_archive_configuration",
     "clean_friendly_name",
     "friendly_name_slugify",
+    "raise_device_name_exists",
+    "raise_device_not_found",
+    "require_file_exists",
     "slugify_hostname",
 ]
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def raise_device_not_found(
+    configuration: str, *, from_exc: BaseException | None = None
+) -> NoReturn:
+    """Raise ``NOT_FOUND`` for a device *configuration* the scanner doesn't track."""
+    err = CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
+    if from_exc is not None:
+        raise err from from_exc
+    raise err
+
+
+def raise_device_name_exists(name: str, *, from_exc: BaseException | None = None) -> NoReturn:
+    """Raise ``INVALID_ARGS`` for a rename/clone target *name* that already exists."""
+    err = CommandError(ErrorCode.INVALID_ARGS, f"A device named {name} already exists")
+    if from_exc is not None:
+        raise err from from_exc
+    raise err
+
+
+def require_file_exists(path: Path, configuration: str, *, archived: bool = False) -> None:
+    """Raise ``FileNotFoundError`` naming *configuration* when *path* is absent."""
+    if not path.exists():
+        prefix = "Archived file" if archived else "File"
+        raise FileNotFoundError(f"{prefix} not found: {configuration}")
 
 
 # C0 controls, DEL, and C1 controls. ESPHome's friendly_name validator

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -65,7 +65,7 @@ _LOGGER = logging.getLogger(__name__)
 def raise_device_not_found(
     configuration: str, *, from_exc: BaseException | None = None
 ) -> NoReturn:
-    """Raise ``NOT_FOUND`` for a device *configuration* the scanner doesn't track."""
+    """Raise ``NOT_FOUND`` for a missing device *configuration*."""
     err = CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
     if from_exc is not None:
         raise err from from_exc

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -19,6 +19,7 @@ from .helpers import (
     _rewrite_required_yaml_leaf,
     clean_friendly_name,
     friendly_name_slugify,
+    raise_device_name_exists,
 )
 
 if TYPE_CHECKING:
@@ -83,8 +84,7 @@ async def clone_device(  # noqa: C901
 
     source_content, source_meta, target_existed = await run_in_executor(_gather)
     if target_existed:
-        msg = f"A device named {new_filename} already exists"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg)
+        raise_device_name_exists(new_filename)
     if source_content is None:
         msg = f"Source device {configuration} not found"
         raise CommandError(ErrorCode.INVALID_ARGS, msg)
@@ -152,8 +152,7 @@ async def clone_device(  # noqa: C901
         # gather pass and the ``open(... "x")``. Surface as the
         # same INVALID_ARGS the preflight produces so the
         # frontend renders a single message.
-        msg = f"A device named {new_filename} already exists"
-        raise CommandError(ErrorCode.INVALID_ARGS, msg) from exc
+        raise_device_name_exists(new_filename, from_exc=exc)
     if carry_board_id and carry_user_set is True:
         await controller._persist_device_metadata_async(
             new_filename, board_id=carry_board_id, board_id_user_set=True

--- a/esphome_device_builder/controllers/devices/mutations_simple.py
+++ b/esphome_device_builder/controllers/devices/mutations_simple.py
@@ -28,6 +28,7 @@ from ..config import set_device_labels
 from ..firmware.rename_flow import RENAME_REMEDY
 from . import archive
 from .firmware_sync import migrate_metadata_then_scan
+from .helpers import raise_device_name_exists, raise_device_not_found
 from .mutations_create import save_device_storage
 
 if TYPE_CHECKING:
@@ -109,7 +110,7 @@ async def set_labels(
     # to a non-existent device.
     device = controller.get_by_configuration(configuration)
     if device is None:
-        raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
+        raise_device_not_found(configuration)
 
     config_dir = controller._db.settings.config_dir
 
@@ -118,7 +119,7 @@ async def set_labels(
             set_device_labels(config_dir, configuration, label_ids)
         except FileNotFoundError as err:
             # YAML vanished mid-write (racing ``devices/delete``) — surface NOT_FOUND.
-            raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found") from err
+            raise_device_not_found(configuration, from_exc=err)
         except (TypeError, ValueError) as err:
             # ``set_device_labels`` raises ``TypeError`` for non-string
             # items and ``ValueError`` for unknown label ids; both
@@ -132,7 +133,7 @@ async def set_labels(
     # the index, so the reference held above is stale.
     refreshed = controller.get_by_configuration(configuration)
     if refreshed is None:
-        raise CommandError(ErrorCode.NOT_FOUND, f"Device {configuration!r} not found")
+        raise_device_not_found(configuration)
     return refreshed
 
 
@@ -247,8 +248,7 @@ async def rename_device(
         # collision check (with its active-retry exemption) lives in
         # ``firmware.rename_chain``.
         if not in_place and await run_in_executor(new_path.exists):
-            msg = f"A device named {new_filename} already exists"
-            raise CommandError(ErrorCode.INVALID_ARGS, msg)
+            raise_device_name_exists(new_filename)
         return await _config_only_rename(
             controller,
             configuration=configuration,

--- a/tests/controllers/devices/test_error_helpers.py
+++ b/tests/controllers/devices/test_error_helpers.py
@@ -1,0 +1,53 @@
+"""Unit tests for the shared device error helpers in ``devices/helpers.py``."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.controllers.devices.helpers import (
+    raise_device_name_exists,
+    raise_device_not_found,
+    require_file_exists,
+)
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+
+def test_raise_device_not_found_code_and_message() -> None:
+    with pytest.raises(CommandError) as exc_info:
+        raise_device_not_found("living.yaml")
+    assert exc_info.value.code is ErrorCode.NOT_FOUND
+    assert exc_info.value.message == "Device 'living.yaml' not found"
+
+
+def test_raise_device_not_found_chains_cause() -> None:
+    cause = FileNotFoundError("gone")
+    with pytest.raises(CommandError) as exc_info:
+        raise_device_not_found("living.yaml", from_exc=cause)
+    assert exc_info.value.__cause__ is cause
+
+
+def test_raise_device_name_exists_code_and_message() -> None:
+    with pytest.raises(CommandError) as exc_info:
+        raise_device_name_exists("living.yaml")
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+    assert exc_info.value.message == "A device named living.yaml already exists"
+
+
+def test_require_file_exists_passes_when_present(tmp_path: Path) -> None:
+    target = tmp_path / "living.yaml"
+    target.write_text("")
+    require_file_exists(target, "living.yaml")
+
+
+def test_require_file_exists_raises_when_absent(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=re.escape("File not found: living.yaml")):
+        require_file_exists(tmp_path / "living.yaml", "living.yaml")
+
+
+def test_require_file_exists_archived_prefix(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=re.escape("Archived file not found: living.yaml")):
+        require_file_exists(tmp_path / "living.yaml", "living.yaml", archived=True)

--- a/tests/controllers/devices/test_error_helpers.py
+++ b/tests/controllers/devices/test_error_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for the shared device error helpers in ``devices/helpers.py``."""
+"""Unit tests for the shared device error helpers in ``controllers/devices/helpers.py``."""
 
 from __future__ import annotations
 

--- a/tests/controllers/devices/test_set_labels.py
+++ b/tests/controllers/devices/test_set_labels.py
@@ -273,6 +273,38 @@ async def test_set_labels_yaml_deleted_mid_write_does_not_orphan(
     assert "labels" not in meta
 
 
+async def test_set_labels_device_gone_after_reload_raises_not_found(
+    tmp_path: Path,
+    make_controller: MakeControllerFactory,
+) -> None:
+    """A device that passes the pre-write check but is gone after ``reload`` raises NOT_FOUND.
+
+    Models a ``devices/delete`` landing between the sidecar write and
+    the post-reload re-fetch; the handler refuses rather than
+    returning a stale reference.
+    """
+    await asyncio.to_thread(save_labels, tmp_path, [Label(id="lbl-a", name="Alpha")])
+
+    controller = make_controller(tmp_path)
+    _attach_reloading_scanner(controller, tmp_path, _make_device())
+
+    real_lookup = controller.get_by_configuration
+    seen = {"n": 0}
+
+    def _lookup(configuration: str) -> Device | None:
+        seen["n"] += 1
+        # First call (pre-write guard) sees the device; the post-reload
+        # re-fetch finds it gone.
+        return None if seen["n"] > 1 else real_lookup(configuration)
+
+    controller.get_by_configuration = _lookup  # type: ignore[method-assign]
+
+    with pytest.raises(CommandError) as exc_info:
+        await controller.set_labels(configuration="kitchen.yaml", label_ids=["lbl-a"])
+
+    assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+
 async def test_set_device_labels_refuses_missing_yaml(tmp_path: Path) -> None:
     """``set_device_labels`` raises ``FileNotFoundError`` and writes nothing when YAML is absent."""
     await asyncio.to_thread(save_labels, tmp_path, [Label(id="lbl-a", name="Alpha")])


### PR DESCRIPTION
# What does this implement/fix?

The devices controllers hand-rolled the same `CommandError` construction in many places. This adds three small helpers to `controllers/devices/helpers.py` and routes the sites whose error code and message already match through them, so it stays a pure refactor with no behaviour change:

- `raise_device_not_found(configuration, *, from_exc=None)` (NOT_FOUND) for `mutations_simple` and `controller.get_config`.
- `raise_device_name_exists(name, *, from_exc=None)` (INVALID_ARGS) for the clone/rename collision checks in `mutations_clone` and `mutations_simple`.
- `require_file_exists(path, configuration, *, archived=False)` for the four archive/unarchive/delete existence checks in `archive.py`.

Deliberately left for a follow-up so this PR changes no error code: the two "device not found" sites that raise `INVALID_ARGS` instead of `NOT_FOUND` (`mutations_simple._read_device_yaml_or_raise`, `firmware/rename_flow`), and the "Configuration ... already exists" group (`mutations_create` raises `ALREADY_EXISTS`, `importable` raises `INVALID_ARGS` for the same message). `firmware/controller.py`'s rename-collision site is left alone too, since importing `devices.helpers` there would introduce a firmware to devices import cycle.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1854

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
