### PR TITLE
Share a YAML manifest loader across the definition scripts

### DIFF
--- a/script/_manifest.py
+++ b/script/_manifest.py
@@ -1,0 +1,29 @@
+"""Shared YAML manifest reader for the definition scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class ManifestError(Exception):
+    """A manifest failed to parse as YAML or wasn't a mapping."""
+
+
+def load_manifest_dict(path: Path) -> dict[str, Any]:
+    """
+    Read and parse *path* as a YAML mapping.
+
+    Raises :class:`ManifestError` (carrying a human reason) on a YAML parse
+    error or a non-mapping document; an ``OSError`` from the read propagates
+    unchanged so callers can tell "can't read" apart from "bad content".
+    """
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"invalid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ManifestError("manifest is not a YAML mapping")
+    return data

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -53,6 +53,7 @@ from esphome_device_builder.constants import (  # noqa: E402
 from esphome_device_builder.helpers.pin_gpio import parse_board_gpio  # noqa: E402
 from esphome_device_builder.models.boards import Esp32Variant  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
+from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 from script._repo_cache import ensure_shallow_git_repo  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -2177,10 +2178,9 @@ def _read_manifest_dict(manifest_path: Path) -> dict[str, Any] | None:
     if not manifest_path.is_file():
         return None
     try:
-        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
+        return load_manifest_dict(manifest_path)
+    except (OSError, ManifestError):
         return None
-    return data if isinstance(data, dict) else None
 
 
 def _imported_remote_id(prior: dict[str, Any] | None) -> tuple[bool, str | None]:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -2179,7 +2179,11 @@ def _read_manifest_dict(manifest_path: Path) -> dict[str, Any] | None:
         return None
     try:
         return load_manifest_dict(manifest_path)
-    except (OSError, ManifestError):
+    except (OSError, ManifestError) as exc:
+        # A present-but-corrupt/unreadable manifest still returns None (the prior
+        # state is unrecoverable either way), but log it so it isn't silently
+        # indistinguishable from a manifest that never existed.
+        _LOGGER.warning("Ignoring unreadable manifest %s: %s", manifest_path, exc)
         return None
 
 

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -19,8 +19,6 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-import yaml
-
 try:
     import jsonschema
 
@@ -35,6 +33,7 @@ if str(_REPO_ROOT) not in sys.path:
 # Imported from the stdlib-only constants module so this script stays light.
 from esphome_device_builder.constants import BOARD_PIN_KEYS, BUS_CATEGORIES  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
+from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 
 DEFINITIONS_DIR = _REPO_ROOT / "esphome_device_builder" / "definitions"
 SCHEMAS_DIR = DEFINITIONS_DIR / "schemas"
@@ -155,12 +154,9 @@ def validate_board(manifest: Path, components_index: dict | None = None) -> list
     board_id = manifest.parent.name
 
     try:
-        data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
-        return [f"{board_id}: invalid YAML: {exc}"]
-
-    if not isinstance(data, dict):
-        return [f"{board_id}: manifest is not a YAML mapping"]
+        data = load_manifest_dict(manifest)
+    except ManifestError as exc:
+        return [f"{board_id}: {exc}"]
 
     # JSON Schema validation
     errors.extend(_validate_against_schema(data, _BOARD_SCHEMA, board_id))
@@ -608,12 +604,9 @@ def validate_component(manifest: Path) -> list[str]:
     comp_id = manifest.parent.name
 
     try:
-        data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
-        return [f"{comp_id}: invalid YAML: {exc}"]
-
-    if not isinstance(data, dict):
-        return [f"{comp_id}: manifest is not a YAML mapping"]
+        data = load_manifest_dict(manifest)
+    except ManifestError as exc:
+        return [f"{comp_id}: {exc}"]
 
     # JSON Schema validation
     errors.extend(_validate_against_schema(data, _COMPONENT_SCHEMA, comp_id))
@@ -664,10 +657,8 @@ def _collect_board_image_urls(boards_dir: Path) -> dict[str, list[str]]:
     urls: dict[str, list[str]] = {}
     for manifest in sorted(boards_dir.glob("*/manifest.yaml")):
         try:
-            data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
-        except yaml.YAMLError:
-            continue
-        if not isinstance(data, dict):
+            data = load_manifest_dict(manifest)
+        except ManifestError:
             continue
         board_id = manifest.parent.name
         for img in data.get("images") or []:

--- a/tests/test_manifest_loader.py
+++ b/tests/test_manifest_loader.py
@@ -11,20 +11,20 @@ from script._manifest import ManifestError, load_manifest_dict  # type: ignore[i
 
 def test_returns_mapping(tmp_path: Path) -> None:
     path = tmp_path / "manifest.yaml"
-    path.write_text("name: dht\npins: []\n")
+    path.write_text("name: dht\npins: []\n", encoding="utf-8")
     assert load_manifest_dict(path) == {"name": "dht", "pins": []}
 
 
 def test_yaml_error_reason(tmp_path: Path) -> None:
     path = tmp_path / "manifest.yaml"
-    path.write_text("key: [unterminated\n")
+    path.write_text("key: [unterminated\n", encoding="utf-8")
     with pytest.raises(ManifestError, match="invalid YAML"):
         load_manifest_dict(path)
 
 
 def test_non_mapping_reason(tmp_path: Path) -> None:
     path = tmp_path / "manifest.yaml"
-    path.write_text("- just\n- a\n- list\n")
+    path.write_text("- just\n- a\n- list\n", encoding="utf-8")
     with pytest.raises(ManifestError, match="not a YAML mapping"):
         load_manifest_dict(path)
 

--- a/tests/test_manifest_loader.py
+++ b/tests/test_manifest_loader.py
@@ -1,0 +1,36 @@
+"""Unit tests for ``load_manifest_dict`` in ``script/_manifest.py``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from script._manifest import ManifestError, load_manifest_dict  # type: ignore[import-not-found]
+
+
+def test_returns_mapping(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text("name: dht\npins: []\n")
+    assert load_manifest_dict(path) == {"name": "dht", "pins": []}
+
+
+def test_yaml_error_reason(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text("key: [unterminated\n")
+    with pytest.raises(ManifestError, match="invalid YAML"):
+        load_manifest_dict(path)
+
+
+def test_non_mapping_reason(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text("- just\n- a\n- list\n")
+    with pytest.raises(ManifestError, match="not a YAML mapping"):
+        load_manifest_dict(path)
+
+
+def test_os_error_propagates(tmp_path: Path) -> None:
+    # A missing file surfaces as OSError (FileNotFoundError), not
+    # ManifestError, so callers can tell "can't read" apart from "bad content".
+    with pytest.raises(FileNotFoundError):
+        load_manifest_dict(tmp_path / "missing.yaml")

--- a/tests/test_sync_esphome_devices_manifest_read.py
+++ b/tests/test_sync_esphome_devices_manifest_read.py
@@ -1,0 +1,34 @@
+"""Coverage for ``_read_manifest_dict``'s missing / corrupt handling."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from script.sync_esphome_devices import _read_manifest_dict  # type: ignore[import-not-found]
+
+
+def test_missing_manifest_returns_none_silently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="sync_esphome_devices"):
+        assert _read_manifest_dict(tmp_path / "manifest.yaml") is None
+    assert caplog.records == []
+
+
+def test_corrupt_manifest_returns_none_and_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text("key: [unterminated\n", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="sync_esphome_devices"):
+        assert _read_manifest_dict(path) is None
+    assert any("Ignoring unreadable manifest" in r.getMessage() for r in caplog.records)
+
+
+def test_valid_manifest_returns_dict(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text("id: foo\n", encoding="utf-8")
+    assert _read_manifest_dict(path) == {"id": "foo"}


### PR DESCRIPTION
# What does this implement/fix?

Four call sites across `validate_definitions.py` and `sync_esphome_devices.py` hand-rolled the same "read a `manifest.yaml`, tolerate a parse error, require a mapping" pattern with subtly different error handling. This adds `load_manifest_dict` (plus a `ManifestError`) in a new `script/_manifest.py`; it reads and parses the file, raises `ManifestError` with a human reason on a YAML error or a non-mapping document, and lets `OSError` propagate so callers can still tell "can't read" apart from "bad content". Each caller keeps its own policy by choosing what to catch, so behaviour is unchanged: the two `validate_*` sites surface the same `invalid YAML: ...` / `manifest is not a YAML mapping` messages, and the two swallow-and-skip sites still skip. Verified the validator still passes over 561 boards; adds a unit test.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1855

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
