### PR TITLE
Declare icmplib as a hard dependency; clarify the disabled-sweep warning

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -7,17 +7,13 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING
 
+from icmplib import async_ping as icmp_ping
+from icmplib.exceptions import ICMPLibError
+
 from ...helpers.hostname import is_local_hostname
 from ...models import Device, DeviceState
 from . import shared
 from .helpers import _pick_ipv4
-
-try:
-    from icmplib import async_ping as icmp_ping
-    from icmplib.exceptions import ICMPLibError
-except ImportError:  # pragma: no cover — icmplib is optional
-    icmp_ping = None  # type: ignore[assignment]
-    ICMPLibError = Exception  # type: ignore[misc,assignment]
 
 if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
@@ -51,8 +47,6 @@ async def _can_use_icmp_lib_with_privilege() -> bool | None:
     not set by default. ``None`` when neither works (sweep
     disabled, state follows mDNS only).
     """
-    if icmp_ping is None:
-        return None
     try:
         await icmp_ping("127.0.0.1", count=0, timeout=0, privileged=True)
     except (ICMPLibError, OSError):
@@ -93,8 +87,10 @@ class PingSource:
         privileged = await _can_use_icmp_lib_with_privilege()
         if privileged is None:
             _LOGGER.warning(
-                "Cannot use icmplib because privileges are insufficient; "
-                "ICMP ping sweep disabled, device state will only update via mDNS"
+                "ICMP ping sweep disabled: opening an ICMP socket was denied in both "
+                "privileged and unprivileged modes (needs CAP_NET_RAW, or "
+                "net.ipv4.ping_group_range covering this process's group); "
+                "device state will only update via mDNS"
             )
             return
         self._privileged = privileged
@@ -124,8 +120,6 @@ class PingSource:
             await asyncio.wait_for(self._wake.wait(), timeout=_PING_INTERVAL)
 
     async def _ping_sweep(self) -> None:
-        if icmp_ping is None:
-            return
         pingable, dns_failed = self._select_ping_targets()
         if not pingable and not dns_failed:
             return

--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -23,11 +23,7 @@ from contextlib import suppress
 from ipaddress import ip_address
 from typing import cast
 
-try:
-    from icmplib import NameLookupError, async_resolve
-except ImportError:  # pragma: no cover — icmplib is optional
-    NameLookupError = Exception  # type: ignore[assignment, misc]
-    async_resolve = None  # type: ignore[assignment]
+from icmplib import NameLookupError, async_resolve
 
 from ..helpers.hostname import normalize_hostname
 

--- a/esphome_device_builder/controllers/_dns_cache.py
+++ b/esphome_device_builder/controllers/_dns_cache.py
@@ -109,9 +109,6 @@ class DNSCache:
         with suppress(ValueError):
             return [str(ip_address(normalized))]
 
-        if async_resolve is None:
-            return None
-
         now = time.monotonic()
         entry = self._cache.get(normalized)
         if entry is not None and entry[0] > now:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
   # validate-result cache (content → cached subprocess result).
   "fnv-hash-fast>=2.0.0",
   "ifaddr>=0.2.0",
-  # Device-status ICMP sweep + DNS resolve. esphome dropped its own
-  # pin with the legacy dashboard (esphome/esphome#17124).
+  # Device-status ICMP sweep + DNS resolve; esphome no longer
+  # ships it transitively since the legacy dashboard was removed.
   "icmplib>=3.0.4",
   "mashumaro>=3.13",
   "orjson>=3.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
   # validate-result cache (content → cached subprocess result).
   "fnv-hash-fast>=2.0.0",
   "ifaddr>=0.2.0",
+  # Device-status ICMP sweep + DNS resolve. esphome dropped its own
+  # pin with the legacy dashboard (esphome/esphome#17124).
+  "icmplib>=3.0.4",
   "mashumaro>=3.13",
   "orjson>=3.9.0",
   "pyyaml>=6.0",

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1428,31 +1428,7 @@ async def test_start_disables_sweep_when_privilege_probe_returns_none(
             await _stop_and_drain(monitor)
 
     monitor.state.dns_cache.async_resolve.assert_not_called()
-    assert any("privileges are insufficient" in rec.message for rec in caplog.records)
-
-
-async def test_start_with_icmplib_unavailable_skips_dns_resolution(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``icmp_ping is None`` (icmplib not installed) → sweep returns immediately.
-
-    Drives via the public ``start``: the bootstrap sleep elapses,
-    the loop reaches ``_ping_sweep``, the sweep sees no icmp
-    primitive, and bails before touching the DNS cache. Pinning
-    the negative — DNS cache untouched — anchors the early-return.
-    """
-    monitor, _callbacks = _make_monitor()
-
-    monkeypatch.setattr(ping_module, "icmp_ping", None)
-    monitor.state.dns_cache.async_resolve = AsyncMock()
-    _shrink_ping_intervals(monkeypatch)
-
-    await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
-    try:
-        await _let_ping_loop_run_briefly(monitor)
-        monitor.state.dns_cache.async_resolve.assert_not_called()
-    finally:
-        await _stop_and_drain(monitor)
+    assert any("ICMP ping sweep disabled" in rec.message for rec in caplog.records)
 
 
 async def test_start_marks_offline_on_icmp_exception(

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -438,15 +438,6 @@ async def test_can_use_icmp_lib_with_privilege_returns_none_when_both_denied() -
     assert fake_ping.await_count == 2
 
 
-async def test_can_use_icmp_lib_with_privilege_returns_none_when_icmplib_missing() -> None:
-    """``icmp_ping`` is ``None`` (icmplib not installed) → probe returns ``None``."""
-    with patch(
-        "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
-        None,
-    ):
-        assert await _can_use_icmp_lib_with_privilege() is None
-
-
 async def test_can_use_icmp_lib_with_privilege_returns_none_on_unexpected_oserror() -> None:
     """Non-permission ``OSError`` also degrades gracefully; the task doesn't die."""
     fake_ping = AsyncMock(side_effect=[OSError("EAFNOSUPPORT"), OSError("EAFNOSUPPORT")])


### PR DESCRIPTION
# What does this implement/fix?

The ICMP ping sweep silently stopped working in the `ghcr.io/esphome/esphome:dev` container: esphome/esphome#17124 removed the legacy web dashboard and with it the `icmplib==3.0.4` pin from esphome's `requirements.txt`. Device-builder was importing icmplib inside `try/except ImportError` guards without declaring it — freeloading on the legacy dashboard's dependency — so on `:dev` the import fails and the probe's `None` return reuses the "Cannot use icmplib because privileges are insufficient" warning. That message sent the reporter chasing `--cap-add` / `--privileged` / `--sysctl ping_group_range` flags that could never help.

- Declare `icmplib>=3.0.4` (the last pin esphome carried) as a hard dependency, so the wheel is self-sufficient and the routine device-builder bump in esphome's Dockerfile restores the sweep on `:dev`.
- Drop the optional-import guards in `ping.py` and `_dns_cache.py`. `_RESOLVE_EXCEPTIONS` now genuinely narrows to icmplib's `NameLookupError` instead of the catch-everything `Exception` fallback the guard substituted.
- Reword the disabled-sweep warning so it only describes what it now exclusively means — both ICMP socket modes denied — and says what to fix (`CAP_NET_RAW`, or `net.ipv4.ping_group_range` covering the process's group).
- Remove the two tests pinning the icmplib-missing branches; update the warning-text assertion.

**Related issue or feature (if applicable):**

- fixes #1863

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
