### PR TITLE
Normalize deprecated ethernet clk_mode at sync ingest

### DIFF
--- a/esphome_device_builder/controllers/devices/add_component.py
+++ b/esphome_device_builder/controllers/devices/add_component.py
@@ -72,9 +72,8 @@ async def add_component(
     # The required-field gate catches a user-driven form add that omitted a
     # required field. Featured presets come from the board manifest instead
     # (curated, locked, already validated by ``create`` + compile), and the
-    # catalog can't model ESPHome's type-conditional either-or fields — an
-    # ethernet ``LAN8720`` preset legitimately sets ``clk_mode`` where the
-    # schema marks ``clk`` required, so re-gating rejects a valid recommended
+    # catalog can't model ESPHome's type-conditional either-or fields, so
+    # re-gating a variant-scoped requirement rejects a valid recommended
     # add. Trust the manifest; ESPHome validation at compile is the real gate.
     if not is_featured:
         _require_present_fields(component, fields)

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -656,7 +656,7 @@ _FIELD_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
     },
     # ``ethernet.clk`` is ``cv.Optional`` in the schema but a final-validate
     # step requires it for RMII PHYs unless the deprecated ``clk_mode``
-    # migrates into it (removal scheduled 2026.7.0). Mark it required on the
+    # migrates into it (removal scheduled 2026.9.0). Mark it required on the
     # main form; the variant gate already scopes it to the RMII types.
     ("ethernet", "clk"): {
         "required": True,

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1367,20 +1367,17 @@ def _normalized_clk(eth: dict[str, Any]) -> dict[str, Any] | None:
     """Fold deprecated flat ``clk_mode`` into nested ``clk``; ``None`` when unmappable."""
     if "clk_mode" not in eth:
         return eth
+    without = {k: v for k, v in eth.items() if k != "clk_mode"}
+    if "clk" in eth:
+        return without
     clk_mode = eth["clk_mode"]
     # Upstream validates with cv.enum(upper=True, space="_"); mirror it.
     normalized = clk_mode.strip().upper().replace(" ", "_") if isinstance(clk_mode, str) else ""
     match = _CLK_MODE_RE.fullmatch(normalized)
-    out: dict[str, Any] = {}
-    for key, value in eth.items():
-        if key != "clk_mode":
-            out[key] = value
-        elif "clk" not in eth:
-            if match is None:
-                return None
-            mode = "CLK_EXT_IN" if match.group(2) == "IN" else "CLK_OUT"
-            out["clk"] = {"pin": f"GPIO{match.group(1)}", "mode": mode}
-    return out
+    if match is None:
+        return None
+    mode = "CLK_EXT_IN" if match.group(2) == "IN" else "CLK_OUT"
+    return {**without, "clk": {"pin": f"GPIO{match.group(1)}", "mode": mode}}
 
 
 def _extract_ethernet(config: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[int, str]]:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1364,12 +1364,7 @@ def _eth_value_safe(value: Any) -> bool:
 
 
 def _normalized_clk(eth: dict[str, Any]) -> dict[str, Any] | None:
-    """
-    Fold deprecated flat ``clk_mode`` into nested ``clk``.
-
-    ``None`` when ``clk_mode`` is unmappable (upstream would reject the
-    config); an existing nested ``clk`` wins when both are present.
-    """
+    """Fold deprecated flat ``clk_mode`` into nested ``clk``; ``None`` when unmappable."""
     if "clk_mode" not in eth:
         return eth
     clk_mode = eth["clk_mode"]

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -224,9 +224,10 @@ _PLACEHOLDER_PATTERNS: list[re.Pattern[str]] = [
 # unsafe to surface as a preset value or as an ``occupied_by`` label.
 _TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]*\}")
 
-# Legacy flat ``clk_mode: GPIO17_OUT`` encodes the RMII clock pin in the
-# mode string; this pulls the GPIO number out for the occupancy map.
-_CLK_MODE_PIN_RE = re.compile(r"GPIO(\d+)_")
+# Deprecated flat ``clk_mode: GPIO<n>_(IN|OUT)`` encodes the RMII clock
+# pin and direction in the mode string; folded into nested ``clk``
+# ``{mode, pin}`` (upstream removal 2026.9.0).
+_CLK_MODE_RE = re.compile(r"GPIO(\d+)_(IN|OUT)")
 
 # Hardware fields of a top-level ``ethernet:`` block worth locking as a
 # featured-component preset (the PHY/pinout). Network/runtime fields
@@ -240,7 +241,6 @@ _ETHERNET_HW_FIELDS: frozenset[str] = frozenset(
         "mdc_pin",
         "mdio_pin",
         "clk",
-        "clk_mode",
         "clk_pin",
         "phy_addr",
         "power_pin",
@@ -1363,6 +1363,31 @@ def _eth_value_safe(value: Any) -> bool:
     return True
 
 
+def _normalized_clk(eth: dict[str, Any]) -> dict[str, Any] | None:
+    """
+    Fold deprecated flat ``clk_mode`` into nested ``clk``.
+
+    ``None`` when ``clk_mode`` is unmappable (upstream would reject the
+    config); an existing nested ``clk`` wins when both are present.
+    """
+    if "clk_mode" not in eth:
+        return eth
+    clk_mode = eth["clk_mode"]
+    # Upstream validates with cv.enum(upper=True, space="_"); mirror it.
+    normalized = clk_mode.strip().upper().replace(" ", "_") if isinstance(clk_mode, str) else ""
+    match = _CLK_MODE_RE.fullmatch(normalized)
+    out: dict[str, Any] = {}
+    for key, value in eth.items():
+        if key != "clk_mode":
+            out[key] = value
+        elif "clk" not in eth:
+            if match is None:
+                return None
+            mode = "CLK_EXT_IN" if match.group(2) == "IN" else "CLK_OUT"
+            out["clk"] = {"pin": f"GPIO{match.group(1)}", "mode": mode}
+    return out
+
+
 def _extract_ethernet(config: dict[str, Any]) -> tuple[dict[str, Any] | None, dict[int, str]]:
     """
     Mine a top-level ``ethernet:`` block into a locked featured component.
@@ -1380,6 +1405,9 @@ def _extract_ethernet(config: dict[str, Any]) -> tuple[dict[str, Any] | None, di
     """
     eth = config.get("ethernet")
     if not isinstance(eth, dict) or not isinstance(eth.get("type"), str):
+        return None, {}
+    eth = _normalized_clk(eth)
+    if eth is None:
         return None, {}
     fields: dict[str, Any] = {}
     occupancy: dict[int, str] = {}
@@ -1403,9 +1431,6 @@ def _extract_ethernet(config: dict[str, Any]) -> tuple[dict[str, Any] | None, di
         if gpio is None:
             return None, {}
         occupancy[gpio] = "Ethernet CLK"
-    clk_mode = eth.get("clk_mode")
-    if isinstance(clk_mode, str) and (m := _CLK_MODE_PIN_RE.match(clk_mode)):
-        occupancy[int(m.group(1))] = "Ethernet CLK"
     entry = {
         "id": "onboard_ethernet",
         "component_id": "ethernet",

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1367,6 +1367,10 @@ def _normalized_clk(eth: dict[str, Any]) -> dict[str, Any] | None:
     """Fold deprecated flat ``clk_mode`` into nested ``clk``; ``None`` when unmappable."""
     if "clk_mode" not in eth:
         return eth
+    # clk_mode exists only in upstream's RMII schema (SPI PHYs use clk_pin);
+    # a block carrying it without the RMII-required mdc_pin is invalid upstream.
+    if "mdc_pin" not in eth:
+        return None
     without = {k: v for k, v in eth.items() if k != "clk_mode"}
     if "clk" in eth:
         return without

--- a/tests/test_sync_esphome_devices_ethernet.py
+++ b/tests/test_sync_esphome_devices_ethernet.py
@@ -44,19 +44,27 @@ def test_extracts_rmii_and_marks_pins_occupied() -> None:
 )
 def test_normalizes_each_deprecated_clk_mode(clk_mode: str, pin: str, mode: str) -> None:
     """A GPIO<n>_(IN|OUT) clk_mode folds into nested clk + occupancy (any pin)."""
-    entry, occ = _extract_ethernet({"ethernet": {"type": "LAN8720", "clk_mode": clk_mode}})
+    entry, occ = _extract_ethernet(
+        {"ethernet": {"type": "LAN8720", "mdc_pin": "GPIO23", "clk_mode": clk_mode}}
+    )
     assert entry is not None
     assert entry["fields"]["clk"] == {"value": {"pin": pin, "mode": mode}, "locked": True}
     assert "clk_mode" not in entry["fields"]
-    assert occ == {int(pin.removeprefix("GPIO")): "Ethernet CLK"}
+    assert occ[int(pin.removeprefix("GPIO"))] == "Ethernet CLK"
 
 
 def test_skips_block_on_unknown_clk_mode() -> None:
     """A clk_mode that isn't GPIO<n>_(IN|OUT) would fail upstream validation; skip the block."""
-    assert _extract_ethernet({"ethernet": {"type": "LAN8720", "clk_mode": "EXTERNAL"}}) == (
-        None,
-        {},
-    )
+    assert _extract_ethernet(
+        {"ethernet": {"type": "LAN8720", "mdc_pin": "GPIO23", "clk_mode": "EXTERNAL"}}
+    ) == (None, {})
+
+
+def test_skips_block_when_clk_mode_without_rmii_shape() -> None:
+    """clk_mode is RMII-only; carried on an SPI-shaped block (no mdc_pin) it's invalid."""
+    assert _extract_ethernet(
+        {"ethernet": {"type": "W5500", "cs_pin": 17, "clk_mode": "GPIO17_OUT"}}
+    ) == (None, {})
 
 
 def test_nested_clk_wins_over_clk_mode() -> None:
@@ -65,6 +73,7 @@ def test_nested_clk_wins_over_clk_mode() -> None:
         {
             "ethernet": {
                 "type": "LAN8720",
+                "mdc_pin": "GPIO23",
                 "clk_mode": "GPIO17_OUT",
                 "clk": {"pin": "GPIO0", "mode": "CLK_EXT_IN"},
             }
@@ -76,7 +85,7 @@ def test_nested_clk_wins_over_clk_mode() -> None:
         "locked": True,
     }
     assert "clk_mode" not in entry["fields"]
-    assert occ == {0: "Ethernet CLK"}
+    assert occ[0] == "Ethernet CLK"
 
 
 def test_extracts_spi_pins() -> None:

--- a/tests/test_sync_esphome_devices_ethernet.py
+++ b/tests/test_sync_esphome_devices_ethernet.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from script.sync_esphome_devices import _extract_ethernet  # type: ignore[import-not-found]
 
 
@@ -21,7 +23,60 @@ def test_extracts_rmii_and_marks_pins_occupied() -> None:
     assert entry is not None
     assert entry["component_id"] == "ethernet"
     assert entry["fields"]["type"] == {"value": "LAN8720", "locked": True}
+    assert entry["fields"]["clk"] == {
+        "value": {"pin": "GPIO17", "mode": "CLK_OUT"},
+        "locked": True,
+    }
+    assert "clk_mode" not in entry["fields"]
     assert occ == {23: "Ethernet MDC", 18: "Ethernet MDIO", 17: "Ethernet CLK"}
+
+
+@pytest.mark.parametrize(
+    ("clk_mode", "pin", "mode"),
+    [
+        pytest.param("GPIO0_IN", "GPIO0", "CLK_EXT_IN", id="gpio0_in"),
+        pytest.param("GPIO0_OUT", "GPIO0", "CLK_OUT", id="gpio0_out"),
+        pytest.param("GPIO16_OUT", "GPIO16", "CLK_OUT", id="gpio16_out"),
+        pytest.param("GPIO17_OUT", "GPIO17", "CLK_OUT", id="gpio17_out"),
+        pytest.param("GPIO2_OUT", "GPIO2", "CLK_OUT", id="any_pin_generalizes"),
+        pytest.param("gpio17 out", "GPIO17", "CLK_OUT", id="enum_case_space_tolerant"),
+    ],
+)
+def test_normalizes_each_deprecated_clk_mode(clk_mode: str, pin: str, mode: str) -> None:
+    """A GPIO<n>_(IN|OUT) clk_mode folds into nested clk + occupancy (any pin)."""
+    entry, occ = _extract_ethernet({"ethernet": {"type": "LAN8720", "clk_mode": clk_mode}})
+    assert entry is not None
+    assert entry["fields"]["clk"] == {"value": {"pin": pin, "mode": mode}, "locked": True}
+    assert "clk_mode" not in entry["fields"]
+    assert occ == {int(pin.removeprefix("GPIO")): "Ethernet CLK"}
+
+
+def test_skips_block_on_unknown_clk_mode() -> None:
+    """A clk_mode that isn't GPIO<n>_(IN|OUT) would fail upstream validation; skip the block."""
+    assert _extract_ethernet({"ethernet": {"type": "LAN8720", "clk_mode": "EXTERNAL"}}) == (
+        None,
+        {},
+    )
+
+
+def test_nested_clk_wins_over_clk_mode() -> None:
+    """When both forms are present the nested clk is kept and clk_mode dropped."""
+    entry, occ = _extract_ethernet(
+        {
+            "ethernet": {
+                "type": "LAN8720",
+                "clk_mode": "GPIO17_OUT",
+                "clk": {"pin": "GPIO0", "mode": "CLK_EXT_IN"},
+            }
+        }
+    )
+    assert entry is not None
+    assert entry["fields"]["clk"] == {
+        "value": {"pin": "GPIO0", "mode": "CLK_EXT_IN"},
+        "locked": True,
+    }
+    assert "clk_mode" not in entry["fields"]
+    assert occ == {0: "Ethernet CLK"}
 
 
 def test_extracts_spi_pins() -> None:


### PR DESCRIPTION
# What does this implement/fix?

ESPHome deprecated the flat ethernet `clk_mode` option in favor of nested `clk: {mode, pin}`, with removal punted to 2026.9.0 so device-builder could stop carrying the legacy form (esphome/esphome#17114). This makes the devices sync normalize on ingest: `_extract_ethernet` now folds `clk_mode` into the nested `clk` before the featured preset and pin occupancy are built, so no imported manifest can carry `clk_mode` again. The mapping derives from the `GPIO<n>_(IN|OUT)` naming rule rather than a fixed table, so any pin folds correctly; a `clk_mode` that doesn't match the rule skips the whole block since upstream validation would reject that config, and an existing nested `clk` wins when both are present, matching upstream precedence.

Also rides along: the `sync_components.py` override comment now cites the 2026.9.0 removal target, and the `add_component.py` featured-gate comment drops its stale `clk_mode` example.

Shipped manifests are untouched here; regenerating the 22 imported boards that still carry `clk_mode` follows in a separate PR so each diff stays reviewable.

**Related issue or feature (if applicable):**

- part of esphome/backlog#152

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
