### PR TITLE
Wake the ICMP sweep when a reload changes a device's address

### DIFF
--- a/esphome_device_builder/controllers/_device_scanner.py
+++ b/esphome_device_builder/controllers/_device_scanner.py
@@ -73,9 +73,11 @@ class ScanChange(StrEnum):
 
 
 # Callback invoked for every detected change. Receives the kind of
-# change and the affected ``Device`` model. The owner is responsible
-# for firing whatever events / state updates are appropriate.
-ScanCallback = Callable[[ScanChange, Device], None]
+# change, the affected ``Device`` model, and the previously indexed
+# ``Device`` the change replaced (``None`` for ADDED / REMOVED). The
+# owner is responsible for firing whatever events / state updates are
+# appropriate.
+ScanCallback = Callable[[ScanChange, Device, Device | None], None]
 
 # Callback that resolves the persisted sidecar metadata for a device
 # file. Called once per (added or updated) file during a scan.
@@ -347,6 +349,7 @@ class DeviceScanner(WakeWorker[str]):
             # makes a miss here impossible since
             # ``find_path_by_filename`` just located *path*.
             previous_cache_key = self._index.cache_key(path)
+            previous = self._index.by_path.get(path)
             loaded = await run_in_executor(self._load_devices, {path})
             device = loaded.get(path)
             if device is None:
@@ -366,7 +369,7 @@ class DeviceScanner(WakeWorker[str]):
             except OSError:
                 cache_key = previous_cache_key
             self._index.set(path, device, cache_key)
-            self._on_change(ScanChange.RELOADED, device)
+            self._on_change(ScanChange.RELOADED, device, previous)
             return True
 
     # ------------------------------------------------------------------
@@ -410,13 +413,14 @@ class DeviceScanner(WakeWorker[str]):
             loaded = await run_in_executor(self._load_devices, paths_to_load)
             for path, device in loaded.items():
                 kind = ScanChange.ADDED if path in added_paths else ScanChange.UPDATED
+                previous = self._index.by_path.get(path)
                 self._index.set(path, device, path_to_cache_key[path])
-                self._on_change(kind, device)
+                self._on_change(kind, device, previous)
 
         for path in removed_paths:
             removed_device = self._index.pop(path)
             if removed_device is not None:
-                self._on_change(ScanChange.REMOVED, removed_device)
+                self._on_change(ScanChange.REMOVED, removed_device, None)
 
         # Re-key the index in lexicographic-path order so the
         # ``devices`` read returns a stable order across restarts —

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -40,7 +40,7 @@ from .helpers import (
 from .importable import ImportableDiscovery
 from .mdns import MdnsSource
 from .ping import PingSource
-from .shared import _SOURCE_PRIORITY
+from .shared import _SOURCE_PRIORITY, should_ping
 
 _LOGGER = logging.getLogger(__name__)
 # Cap on draining the ping / API-info / resolve tasks at shutdown.
@@ -480,8 +480,17 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._importable.probe_device(device_name, service_name)
 
     def probe_device_ping(self, device_name: str) -> None:
-        """Wake the ICMP sweep loop; a herd of N adds collapses into one early sweep."""
-        self._ping.wake()
+        """
+        Wake the ICMP sweep loop when *device_name* warrants a probe.
+
+        Skipped when :func:`should_ping` says every matching device is
+        already ONLINE under a higher-priority source (the sweep would
+        filter it out anyway); unknown names fail open. A herd of N
+        calls collapses into one early sweep.
+        """
+        devices = self._get_devices_by_name(device_name)
+        if not devices or any(should_ping(self, d) for d in devices):
+            self._ping.wake()
 
     def revisit_importable(self, device_name: str) -> None:
         """Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached."""

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -1084,8 +1084,10 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         """Read *path* as UTF-8 text off the executor."""
         return await run_in_executor(path.read_text, "utf-8")
 
-    def _on_scan_change(self, kind: ScanChange, device: Device) -> None:
-        scan_change.on_scan_change(self, kind, device)
+    def _on_scan_change(
+        self, kind: ScanChange, device: Device, previous: Device | None = None
+    ) -> None:
+        scan_change.on_scan_change(self, kind, device, previous)
 
     def _devices_by_name(self, name: str) -> list[Device]:
         """Every configured device whose ``name`` field matches ``name``.

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ...models import Device, DeviceEventData, EventType, ReachabilitySource
+from ...models import Device, DeviceEventData, EventType
 from .._device_scanner import ScanChange
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ def on_scan_change(
     controller: DevicesController,
     kind: ScanChange,
     device: Device,
-    previous: Device | None = None,
+    previous: Device | None,
 ) -> None:
     """Forward scanner changes onto the event bus and fan out per-kind side effects."""
     # UPDATED and RELOADED both refresh the client row via DEVICE_UPDATED;
@@ -55,14 +55,11 @@ def on_scan_change(
         kind in (ScanChange.UPDATED, ScanChange.RELOADED)
         and previous is not None
         and previous.address != device.address
-        and controller._state_monitor.priority_for(device.name) != ReachabilitySource.MDNS
     ):
-        # The reload swapped in a new address (a ``wifi.use_address``
-        # save, or the post-regen StorageJSON replacing the
+        # The change swapped in a new address (a ``wifi.use_address``
+        # edit, or the post-regen StorageJSON replacing the
         # ``<file>.local`` fallback); without the wake the new address
-        # waits out the remainder of the periodic sweep interval. An
-        # mDNS-claimed device is skipped — its liveness tracking is
-        # name-keyed, so the address change doesn't affect it.
+        # waits out the remainder of the periodic sweep interval.
         controller._state_monitor.probe_device_ping(device.name)
     if kind in (ScanChange.UPDATED, ScanChange.RELOADED, ScanChange.REMOVED):
         # YAML cache key changed (or a reload re-read it); clear any

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ...models import Device, DeviceEventData, EventType
+from ...models import Device, DeviceEventData, EventType, ReachabilitySource
 from .._device_scanner import ScanChange
 
 if TYPE_CHECKING:
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def on_scan_change(controller: DevicesController, kind: ScanChange, device: Device) -> None:
+def on_scan_change(
+    controller: DevicesController,
+    kind: ScanChange,
+    device: Device,
+    previous: Device | None = None,
+) -> None:
     """Forward scanner changes onto the event bus and fan out per-kind side effects."""
     # UPDATED and RELOADED both refresh the client row via DEVICE_UPDATED;
     # only UPDATED (the scanner saw the YAML's mtime/size/inode change) also
@@ -39,13 +44,26 @@ def on_scan_change(controller: DevicesController, kind: ScanChange, device: Devi
         # periodic ping sweep.
         controller._state_monitor.probe_device(device.name)
         # Paired ICMP probe covers ping-only devices that don't
-        # broadcast ``_esphomelib._tcp``; the bootstrap-window
-        # guard inside the monitor wrapper skips it on cold start.
+        # broadcast ``_esphomelib._tcp``; a cold-start herd of wakes
+        # is absorbed into the first post-bootstrap sweep.
         controller._state_monitor.probe_device_ping(device.name)
         # Drop the stale importable row so connected subscribe_events
         # clients stop showing the adopt banner once the device is
         # configured. Idempotent: fires REMOVED only if a row existed.
         controller._on_importable_removed(device.name)
+    if (
+        kind in (ScanChange.UPDATED, ScanChange.RELOADED)
+        and previous is not None
+        and previous.address != device.address
+        and controller._state_monitor.priority_for(device.name) != ReachabilitySource.MDNS
+    ):
+        # The reload swapped in a new address (a ``wifi.use_address``
+        # save, or the post-regen StorageJSON replacing the
+        # ``<file>.local`` fallback); without the wake the new address
+        # waits out the remainder of the periodic sweep interval. An
+        # mDNS-claimed device is skipped — its liveness tracking is
+        # name-keyed, so the address change doesn't affect it.
+        controller._state_monitor.probe_device_ping(device.name)
     if kind in (ScanChange.UPDATED, ScanChange.RELOADED, ScanChange.REMOVED):
         # YAML cache key changed (or a reload re-read it); clear any
         # prior failure marker so the next edit gets a fresh chance at

--- a/tests/benchmarks/test_device_scanner_fleet.py
+++ b/tests/benchmarks/test_device_scanner_fleet.py
@@ -28,7 +28,7 @@ def _make_scanner(config_dir: Path) -> DeviceScanner:
     return DeviceScanner(
         config_dir=config_dir,
         get_metadata=_stub_metadata,
-        on_change=lambda _kind, _device: None,
+        on_change=lambda _kind, _device, _previous: None,
     )
 
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -57,7 +57,6 @@ from tests.conftest import make_device
 from .conftest import (
     CaptureDevicesEventsFactory,
     MakeControllerFactory,
-    RecordingStateMonitor,
     SeedDeviceFactory,
     StubBoardLookups,
 )
@@ -1128,22 +1127,6 @@ def test_on_scan_change_reloaded_without_previous_skips_ping(
     controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
 
     controller._on_scan_change(ScanChange.RELOADED, make_device(name="kitchen", address="x"))
-
-    assert ("probe_device_ping", "kitchen") not in controller._state_monitor.calls
-
-
-def test_on_scan_change_address_change_mdns_claimed_skips_ping(
-    tmp_path: Path, make_controller: MakeControllerFactory
-) -> None:
-    """An address change on an mDNS-claimed device doesn't wake the sweep."""
-    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
-    controller._state_monitor = RecordingStateMonitor(priority_map={"kitchen": "mdns"})
-
-    controller._on_scan_change(
-        ScanChange.RELOADED,
-        make_device(name="kitchen", address="192.168.1.50"),
-        make_device(name="kitchen", address="kitchen.local"),
-    )
 
     assert ("probe_device_ping", "kitchen") not in controller._state_monitor.calls
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -57,6 +57,7 @@ from tests.conftest import make_device
 from .conftest import (
     CaptureDevicesEventsFactory,
     MakeControllerFactory,
+    RecordingStateMonitor,
     SeedDeviceFactory,
     StubBoardLookups,
 )
@@ -1073,6 +1074,78 @@ def test_on_scan_change_reloaded_skips_yaml_updated(
     controller._on_scan_change(ScanChange.RELOADED, device)
 
     assert [e.event_type for e in captured] == [EventType.DEVICE_UPDATED]
+
+
+def test_on_scan_change_reloaded_address_change_wakes_ping(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A reload that swaps in a new address wakes the ICMP sweep."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+
+    controller._on_scan_change(
+        ScanChange.RELOADED,
+        make_device(name="kitchen", address="192.168.1.50"),
+        make_device(name="kitchen", address="kitchen.local"),
+    )
+
+    assert ("probe_device_ping", "kitchen") in controller._state_monitor.calls
+
+
+def test_on_scan_change_updated_address_change_wakes_ping(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A YAML edit that changes the address wakes the ICMP sweep."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+
+    controller._on_scan_change(
+        ScanChange.UPDATED,
+        make_device(name="kitchen", address="192.168.1.50"),
+        make_device(name="kitchen", address="kitchen.local"),
+    )
+
+    assert ("probe_device_ping", "kitchen") in controller._state_monitor.calls
+
+
+def test_on_scan_change_reloaded_same_address_skips_ping(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A reload with an unchanged address doesn't trigger a fleet sweep."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+
+    controller._on_scan_change(
+        ScanChange.RELOADED,
+        make_device(name="kitchen", address="kitchen.local"),
+        make_device(name="kitchen", address="kitchen.local"),
+    )
+
+    assert ("probe_device_ping", "kitchen") not in controller._state_monitor.calls
+
+
+def test_on_scan_change_reloaded_without_previous_skips_ping(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A reload with no previous device stays inert."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+
+    controller._on_scan_change(ScanChange.RELOADED, make_device(name="kitchen", address="x"))
+
+    assert ("probe_device_ping", "kitchen") not in controller._state_monitor.calls
+
+
+def test_on_scan_change_address_change_mdns_claimed_skips_ping(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """An address change on an mDNS-claimed device doesn't wake the sweep."""
+    controller = make_controller(tmp_path, with_state_monitor=True, with_regenerate_state=True)
+    controller._state_monitor = RecordingStateMonitor(priority_map={"kitchen": "mdns"})
+
+    controller._on_scan_change(
+        ScanChange.RELOADED,
+        make_device(name="kitchen", address="192.168.1.50"),
+        make_device(name="kitchen", address="kitchen.local"),
+    )
+
+    assert ("probe_device_ping", "kitchen") not in controller._state_monitor.calls
 
 
 def test_on_scan_change_removed_revisits_importables(

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -823,7 +823,7 @@ async def test_edit_friendly_name_end_to_end_through_real_scanner(
     real_scanner = DeviceScanner(
         tmp_path,
         get_metadata=lambda _cdir, _name: metadata,
-        on_change=lambda _kind, _device: None,
+        on_change=lambda _kind, _device, _previous: None,
     )
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     ctrl._scanner = real_scanner  # swap the recording fake for a real one

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -71,7 +71,7 @@ async def test_reload_rereads_state_and_fires_reloaded(tmp_path: Path) -> None:
     scanner = DeviceScanner(
         config_dir=tmp_path,
         get_metadata=lambda _config_dir, _filename: DeviceFileMetadata(board_id="", ip=""),
-        on_change=lambda kind, device: changes.append((kind, device)),
+        on_change=lambda kind, device, _previous: changes.append((kind, device)),
     )
 
     # Seed the scanner with an initial in-memory snapshot — pre-install
@@ -93,7 +93,7 @@ async def test_reload_unknown_filename_is_noop(tmp_path: Path) -> None:
     scanner = DeviceScanner(
         config_dir=tmp_path,
         get_metadata=lambda _config_dir, _filename: DeviceFileMetadata(board_id="", ip=""),
-        on_change=lambda kind, device: changes.append((kind, device)),
+        on_change=lambda kind, device, _previous: changes.append((kind, device)),
     )
 
     assert await scanner.reload("ghost.yaml") is False
@@ -656,7 +656,7 @@ def test_scanner_get_by_configuration(tmp_path: Path) -> None:
     scanner = DeviceScanner(
         config_dir=tmp_path,
         get_metadata=lambda _config_dir, _filename: DeviceFileMetadata(board_id="", ip=""),
-        on_change=lambda _kind, _device: None,
+        on_change=lambda _kind, _device, _previous: None,
     )
     device = _device()
     scanner._index.set(tmp_path / "kitchen.yaml", device, (0, 0, 0.0, 0))

--- a/tests/test_device_scanner_branches.py
+++ b/tests/test_device_scanner_branches.py
@@ -249,7 +249,9 @@ async def test_scan_updated_passes_previous_device(tmp_path: Path) -> None:
         yaml_path.write_text("esphome:\n  name: kitchen\n# edit\n", encoding="utf-8")
         await scanner.scan()
 
-    assert [(kind, prev) for kind, _dev, prev in events] == [(ScanChange.UPDATED, first_device)]
+    assert [kind for kind, _dev, _prev in events] == [ScanChange.UPDATED]
+    # Identity, not equality — an equal rebuilt Device must not pass.
+    assert events[0][2] is first_device
 
 
 async def test_reload_passes_previous_device(tmp_path: Path) -> None:
@@ -270,7 +272,9 @@ async def test_reload_passes_previous_device(tmp_path: Path) -> None:
         events.clear()
         assert await scanner.reload("kitchen.yaml") is True
 
-    assert [(kind, prev) for kind, _dev, prev in events] == [(ScanChange.RELOADED, first_device)]
+    assert [kind for kind, _dev, _prev in events] == [ScanChange.RELOADED]
+    # Identity, not equality — an equal rebuilt Device must not pass.
+    assert events[0][2] is first_device
 
 
 async def test_scan_removed_passes_none_previous(tmp_path: Path) -> None:

--- a/tests/test_device_scanner_branches.py
+++ b/tests/test_device_scanner_branches.py
@@ -30,13 +30,15 @@ def _stub_metadata(_config_dir: Path, _filename: str) -> DeviceFileMetadata:
     return DeviceFileMetadata(board_id="", ip="", expected_config_hash="")
 
 
-def _make_scanner(config_dir: Path) -> tuple[DeviceScanner, list[tuple[ScanChange, Device]]]:
+def _make_scanner(
+    config_dir: Path,
+) -> tuple[DeviceScanner, list[tuple[ScanChange, Device, Device | None]]]:
     """Build a scanner with a recording on_change callback."""
-    events: list[tuple[ScanChange, Device]] = []
+    events: list[tuple[ScanChange, Device, Device | None]] = []
     scanner = DeviceScanner(
         config_dir=config_dir,
         get_metadata=_stub_metadata,
-        on_change=lambda kind, device: events.append((kind, device)),
+        on_change=lambda kind, device, previous: events.append((kind, device, previous)),
     )
     return scanner, events
 
@@ -169,7 +171,7 @@ async def test_reload_swallows_oserror_on_post_load_stat(tmp_path: Path) -> None
 
     assert ok is True
     # RELOADED still fired with the freshly-loaded Device.
-    assert [(kind, dev.friendly_name) for kind, dev in events] == [
+    assert [(kind, dev.friendly_name) for kind, dev, _prev in events] == [
         (ScanChange.RELOADED, "Kitchen Renamed")
     ]
 
@@ -218,3 +220,77 @@ async def test_scan_skips_yamls_that_fail_to_stat(tmp_path: Path) -> None:
     assert [d.name for d in scanner.devices] == ["good"]
     assert good in scanner.by_path
     assert broken not in scanner.by_path
+
+
+# ---------------------------------------------------------------------------
+# on_change previous-device argument
+# ---------------------------------------------------------------------------
+
+
+async def test_scan_updated_passes_previous_device(tmp_path: Path) -> None:
+    """UPDATED carries the previously indexed Device; ADDED carries None."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    yaml_path = _write_yaml(cfg, "kitchen")
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=lambda path, *_a, **_kw: Device(
+            name=path.stem, friendly_name=path.stem, configuration=path.name
+        ),
+    ):
+        scanner, events = _make_scanner(cfg)
+        await scanner.scan()
+        assert [(kind, prev) for kind, _dev, prev in events] == [(ScanChange.ADDED, None)]
+        first_device = events[0][1]
+        events.clear()
+
+        # Bump the cache key so the next scan classifies UPDATED.
+        yaml_path.write_text("esphome:\n  name: kitchen\n# edit\n", encoding="utf-8")
+        await scanner.scan()
+
+    assert [(kind, prev) for kind, _dev, prev in events] == [(ScanChange.UPDATED, first_device)]
+
+
+async def test_reload_passes_previous_device(tmp_path: Path) -> None:
+    """RELOADED carries the pre-reload Device as previous."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    _write_yaml(cfg, "kitchen")
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=lambda path, *_a, **_kw: Device(
+            name=path.stem, friendly_name=path.stem, configuration=path.name
+        ),
+    ):
+        scanner, events = _make_scanner(cfg)
+        await scanner.scan()
+        first_device = events[0][1]
+        events.clear()
+        assert await scanner.reload("kitchen.yaml") is True
+
+    assert [(kind, prev) for kind, _dev, prev in events] == [(ScanChange.RELOADED, first_device)]
+
+
+async def test_scan_removed_passes_none_previous(tmp_path: Path) -> None:
+    """REMOVED carries None: the fired Device already is the prior indexed one."""
+    cfg = tmp_path / "configs"
+    cfg.mkdir()
+    yaml_path = _write_yaml(cfg, "kitchen")
+
+    with patch(
+        "esphome_device_builder.controllers._device_scanner.load_device_from_storage",
+        side_effect=lambda path, *_a, **_kw: Device(
+            name=path.stem, friendly_name=path.stem, configuration=path.name
+        ),
+    ):
+        scanner, events = _make_scanner(cfg)
+        await scanner.scan()
+        events.clear()
+        yaml_path.unlink()
+        await scanner.scan()
+
+    assert [(kind, dev.name, prev) for kind, dev, prev in events] == [
+        (ScanChange.REMOVED, "kitchen", None)
+    ]

--- a/tests/test_device_scanner_order.py
+++ b/tests/test_device_scanner_order.py
@@ -41,7 +41,7 @@ def _make_scanner(config_dir: Path) -> DeviceScanner:
     return DeviceScanner(
         config_dir=config_dir,
         get_metadata=_stub_metadata,
-        on_change=lambda _kind, _device: None,
+        on_change=lambda _kind, _device, _previous: None,
     )
 
 

--- a/tests/test_device_scanner_request.py
+++ b/tests/test_device_scanner_request.py
@@ -37,7 +37,7 @@ def _make_scanner(config_dir: Path) -> tuple[DeviceScanner, list[tuple[ScanChang
     scanner = DeviceScanner(
         config_dir=config_dir,
         get_metadata=_stub_metadata,
-        on_change=lambda kind, device: events.append((kind, device)),
+        on_change=lambda kind, device, _previous: events.append((kind, device)),
     )
     return scanner, events
 

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -13,19 +13,19 @@ from esphome_device_builder.controllers._device_state_monitor import ping as pin
 from esphome_device_builder.controllers._device_state_monitor.controller import (
     DeviceStateMonitor,
 )
-from esphome_device_builder.models import Device, DeviceState
+from esphome_device_builder.models import Device, DeviceState, ReachabilitySource
 
 from .conftest import make_state_monitor_with_callbacks
 
 
-def _ping_only_device(name: str = "garage") -> Device:
+def _ping_only_device(name: str = "garage", state: DeviceState = DeviceState.UNKNOWN) -> Device:
     """Build a no-API device (ICMP-reachable only) for the test fixtures."""
     return Device(
         name=name,
         friendly_name=name.title(),
         configuration=f"{name}.yaml",
         address=f"{name}.local",
-        state=DeviceState.UNKNOWN,
+        state=state,
         loaded_integrations=["wifi"],
     )
 
@@ -95,6 +95,35 @@ def test_probe_device_ping_sets_wake_event() -> None:
 
     assert monitor._ping._wake.is_set() is True
     assert monitor._tasks == set()
+
+
+def test_probe_device_ping_skips_online_mdns_claimed_device() -> None:
+    """No wake for a device mDNS already tracks ONLINE — the sweep would skip it anyway."""
+    monitor, _ = make_state_monitor_with_callbacks([_ping_only_device(state=DeviceState.ONLINE)])
+    monitor.state.state_source["garage"] = ReachabilitySource.MDNS
+
+    monitor.probe_device_ping("garage")
+
+    assert monitor._ping._wake.is_set() is False
+
+
+def test_probe_device_ping_wakes_offline_mdns_sourced_device() -> None:
+    """A device mDNS declared OFFLINE still wakes the sweep so a new address gets probed."""
+    monitor, _ = make_state_monitor_with_callbacks([_ping_only_device(state=DeviceState.OFFLINE)])
+    monitor.state.state_source["garage"] = ReachabilitySource.MDNS
+
+    monitor.probe_device_ping("garage")
+
+    assert monitor._ping._wake.is_set() is True
+
+
+def test_probe_device_ping_unknown_name_fails_open() -> None:
+    """A name with no matching device still wakes the sweep."""
+    monitor, _ = make_state_monitor_with_callbacks([])
+
+    monitor.probe_device_ping("ghost")
+
+    assert monitor._ping._wake.is_set() is True
 
 
 def test_probe_device_ping_herd_collapses_to_single_set() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Saving a config that adds `wifi.use_address` left the device showing OFFLINE for up to a minute even when the new address was immediately pingable. The save queues a scanner reload plus a background `--only-generate`; when the regen finishes and the reload swaps the StorageJSON-derived address into `Device.address`, nothing wakes the ICMP sweep — `on_scan_change` only calls `probe_device_ping` on `ADDED`, so the new address waits out the remainder of the periodic 60 s `_PING_INTERVAL`.

- Thread the previously indexed `Device` through the scanner's `on_change` callback (`ScanCallback` gains a third `previous` argument; `None` for `ADDED` / `REMOVED`).
- In `on_scan_change`, wake the ICMP sweep when an `UPDATED` / `RELOADED` swapped in a different `address` — a `use_address` save, or the post-regen StorageJSON replacing the `<file>.local` fallback.
- `DeviceStateMonitor.probe_device_ping` (whose `device_name` argument was previously unused) now consults `should_ping` and skips the wake when every matching device is already ONLINE under a higher-priority source — the sweep would filter it out anyway, so waking would just ping the rest of the fleet for nothing. A device mDNS marked OFFLINE still wakes, so a new address gets probed promptly.
- Fix a stale comment on the `ADDED` probe ("bootstrap-window guard inside the monitor wrapper" — no such guard exists; cold-start wakes are absorbed into the first post-bootstrap sweep).

The few-seconds `--only-generate` latency remains (the address is only canonical post-generate); this removes the up-to-60 s sweep idle on top of it.

**Related issue or feature (if applicable):**

- reported directly; no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
