### PR TITLE
Append the esp32_hosted firmware update entity to generated configs

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -378,14 +378,10 @@ def _append_hosted_firmware_update(
     defaults: list[tuple[ComponentCatalogEntry, dict[str, Any]]] | None,
 ) -> str:
     """
-    Append the co-processor firmware update entity for ``esp32_hosted`` boards.
+    Append the hosted radio's firmware update entity.
 
-    Hosted radios only run the firmware flashed at the factory — often old
-    enough that Bluetooth is broken — and the OTA-updated host firmware never
-    touches it. The ``update.esp32_hosted`` entity is the supported way to
-    bring the radio current; emit it (plus its ``http_request`` dependency)
-    whenever a hosted radio ships in *defaults* and its variant has a
-    published firmware manifest.
+    Emits ``http_request:`` + ``update.esp32_hosted`` when a hosted radio
+    ships in *defaults* and its variant has a published firmware manifest.
     """
     for component, fields in defaults or ():
         if component.id != "esp32_hosted":

--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -264,7 +264,8 @@ def generate_device_yaml(
         # commented-out hint lets the user pick.
         lines.extend(_NO_NETWORK_TODO_LINES)
 
-    return _apply_default_components("\n".join(lines), defaults)
+    yaml_text = _apply_default_components("\n".join(lines), defaults)
+    return _append_hosted_firmware_update(yaml_text, defaults)
 
 
 def _wifi_block_lines(ssid: str, psk: str, ap_name: str, platform: str) -> list[str]:
@@ -362,6 +363,48 @@ def _append_platform_block(
         # esp8266, rp2040, bk72xx, rtl87xx, ln882x, nrf52 — board is required
         lines.append(f"  board: {esphome_cfg.board}")
     lines.append("")
+
+
+# Co-processor variants with a published firmware manifest at
+# https://esphome.github.io/esp-hosted-firmware/manifest/<variant>.json.
+# Others (c2/c3/s3/h2) 404 — no update entity for them until upstream ships one.
+_HOSTED_FIRMWARE_VARIANTS = frozenset({"esp32", "esp32c5", "esp32c6", "esp32c61"})
+
+_HOSTED_FIRMWARE_MANIFEST_URL = "https://esphome.github.io/esp-hosted-firmware/manifest/{}.json"
+
+
+def _append_hosted_firmware_update(
+    yaml_text: str,
+    defaults: list[tuple[ComponentCatalogEntry, dict[str, Any]]] | None,
+) -> str:
+    """
+    Append the co-processor firmware update entity for ``esp32_hosted`` boards.
+
+    Hosted radios only run the firmware flashed at the factory — often old
+    enough that Bluetooth is broken — and the OTA-updated host firmware never
+    touches it. The ``update.esp32_hosted`` entity is the supported way to
+    bring the radio current; emit it (plus its ``http_request`` dependency)
+    whenever a hosted radio ships in *defaults* and its variant has a
+    published firmware manifest.
+    """
+    for component, fields in defaults or ():
+        if component.id != "esp32_hosted":
+            continue
+        variant = str(fields.get("variant", "")).lower()
+        if variant not in _HOSTED_FIRMWARE_VARIANTS:
+            return yaml_text
+        label = variant.removeprefix("esp32").upper() or "ESP32"
+        return (
+            f"{yaml_text}\n"
+            "http_request:\n"
+            "\n"
+            "update:\n"
+            "  - platform: esp32_hosted\n"
+            "    type: http\n"
+            f"    source: {_HOSTED_FIRMWARE_MANIFEST_URL.format(variant)}\n"
+            f"    name: {label} Firmware\n"
+        )
+    return yaml_text
 
 
 def _apply_default_components(

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -2824,6 +2824,48 @@ def test_generate_device_yaml_hosted_radio_enables_wifi_on_p4() -> None:
     assert "no native Wi-Fi" not in out
 
 
+def test_generate_device_yaml_hosted_default_appends_firmware_update() -> None:
+    """An ``esp32_hosted`` default appends its firmware update entity.
+
+    Hosted radios only run factory firmware (often with broken Bluetooth)
+    and host OTA never touches it; ``update.esp32_hosted`` is the fix path.
+    """
+    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    out = generate_device_yaml(
+        "kitchen", "Kitchen", board, ssid="net", psk="pw", defaults=_hosted_defaults()
+    )
+
+    assert "http_request:\n" in out
+    assert (
+        "update:\n"
+        "  - platform: esp32_hosted\n"
+        "    type: http\n"
+        "    source: https://esphome.github.io/esp-hosted-firmware/manifest/esp32c6.json\n"
+        "    name: C6 Firmware\n"
+    ) in out
+    # The update block lands after the hosted component it updates.
+    assert out.index("esp32_hosted:") < out.index("update:")
+
+
+def test_generate_device_yaml_hosted_variant_without_firmware_manifest_skips_update() -> None:
+    """No published firmware manifest for the variant → no update entity, no dead URL."""
+    defaults = [(_make_component("esp32_hosted"), {"variant": "ESP32C3"})]
+    board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
+    out = generate_device_yaml("kitchen", "Kitchen", board, ssid="net", psk="pw", defaults=defaults)
+
+    assert "http_request:" not in out
+    assert "update:" not in out
+
+
+def test_generate_device_yaml_no_hosted_default_appends_no_update() -> None:
+    """Boards without a hosted radio get neither ``http_request:`` nor ``update:``."""
+    board = _make_esp32_board(variant=Esp32Variant.ESP32S3, framework="esp-idf")
+    out = generate_device_yaml("kitchen", "Kitchen", board, ssid="net", psk="pw")
+
+    assert "http_request:" not in out
+    assert "update:" not in out
+
+
 def test_generate_device_yaml_p4_wifi_claim_without_radio_gets_network_todo() -> None:
     """A wifi-claiming P4 with no radio provider in defaults must not emit ``wifi:``.
 

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -2825,11 +2825,7 @@ def test_generate_device_yaml_hosted_radio_enables_wifi_on_p4() -> None:
 
 
 def test_generate_device_yaml_hosted_default_appends_firmware_update() -> None:
-    """An ``esp32_hosted`` default appends its firmware update entity.
-
-    Hosted radios only run factory firmware (often with broken Bluetooth)
-    and host OTA never touches it; ``update.esp32_hosted`` is the fix path.
-    """
+    """An ``esp32_hosted`` default appends ``http_request:`` and its update entity."""
     board = _make_esp32_board(variant=Esp32Variant.ESP32P4, framework="esp-idf")
     out = generate_device_yaml(
         "kitchen", "Kitchen", board, ssid="net", psk="pw", defaults=_hosted_defaults()


### PR DESCRIPTION
# What does this implement/fix?

Boards with an `esp32_hosted` co-processor only run the radio firmware flashed at the factory; host OTA updates never touch it, so some units ship with old enough firmware that Bluetooth is broken and there is no way to fix it from the dashboard. ESPHome's `update.esp32_hosted` entity is the supported fix path, but none of our generated configs included it.

`generate_device_yaml` now appends `http_request:` plus the update entity (`update: - platform: esp32_hosted, type: http, source: https://esphome.github.io/esp-hosted-firmware/manifest/<variant>.json`) whenever a hosted radio ships in the board's default components. The source URL is derived from the co-processor variant and gated on an allowlist of variants that actually have a published manifest (esp32, c5, c6, c61; the others 404), so we never emit a dead URL. Verified end to end: the generated config for the Waveshare P4 boards passes `esphome config` and esphome resolves the entity as a firmware class update.

**Related issue or feature (if applicable):**

- follow-up to #1875 and #1876 from the same ESP32-P4-WIFI6 hardware session

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
