### PR TITLE
Keep intra-word underscores when summarizing component descriptions

### DIFF
--- a/esphome_device_builder/controllers/components/controller.py
+++ b/esphome_device_builder/controllers/components/controller.py
@@ -46,7 +46,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 _MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
-_MD_EMPHASIS_RE = re.compile(r"[*_`]")
+# Intra-word underscores are literal (``zwave_proxy``), not emphasis.
+_MD_EMPHASIS_RE = re.compile(r"[*`]|(?<!\w)_|_(?!\w)")
 _FIRST_SENTENCE_RE = re.compile(r"(.{1,240}?\.)(?:\s|$)")
 
 

--- a/tests/controllers/test_components.py
+++ b/tests/controllers/test_components.py
@@ -213,6 +213,15 @@ def test_summarize_description_truncates_unpunctuated_text() -> None:
     assert comp_controller._summarize_description("word " * 100) == ("word " * 100)[:240]
 
 
+def test_summarize_description_keeps_intra_word_underscores() -> None:
+    """Markdown flattening strips emphasis but not snake_case identifiers."""
+    text = "The `zwave_proxy` component proxies frames via *ESPHome's* _Api_."
+    assert (
+        comp_controller._summarize_description(text)
+        == "The zwave_proxy component proxies frames via ESPHome's Api."
+    )
+
+
 # ── get_component_bodies() unknown-id branch ────────────────────────
 
 


### PR DESCRIPTION
# What does this implement/fix?

The log popover for zwave_proxy showed "The zwaveproxy component allows proxying" because the description summarizer strips every underscore as markdown emphasis, mangling snake_case component names; 245 catalog descriptions carry intra-word underscores and are affected. The emphasis regex now only strips underscores at word edges, so `zwave_proxy` and `i2c_id` survive while `_emphasis_` is still flattened.

**Related issue or feature (if applicable):**

- reported directly from a live dashboard session, no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
