### PR TITLE
Derive compile progress from ninja build counters

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -53,8 +53,9 @@ _NO_ESPHOME_MODULE_MARKER = "No module named 'esphome'"
 #   * PlatformIO Arduino compile:    ``[ 17%] Compiling foo.cpp.o``
 #     The percentage MUST start the line and live inside square
 #     brackets so PIO's ESP-IDF builds (which don't emit a per-file
-#     percent at all) and the package-extract bar (no ``[NN%]`` shape)
-#     never trip it.
+#     percent at all — their ninja ``[N/M]`` counter is handled
+#     separately by ``_NINJA_PROGRESS_PATTERN``) and the
+#     package-extract bar (no ``[NN%]`` shape) never trip it.
 #   * esptool serial flash (legacy):  ``Writing at 0x10000... (45 %)``
 #     We match a bare parenthesized percentage anywhere in the line:
 #     ``(\s*\d{1,3}\s*%\s*\)``. In practice that is enough for the
@@ -102,6 +103,22 @@ _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\(\s*(\d{1,3})\s*%\s*\)"),
     re.compile(r"Writing at\b.*?(\d{1,3})(?:\.\d+)?\s*%"),
     re.compile(r"^\s*Uploading:.*?\b(\d{1,3})\s*%"),
+)
+
+# ESP-IDF / ninja per-target counter: ``[907/1424] Building C object …``.
+# Kept out of ``_PROGRESS_PATTERNS`` because it carries no percentage —
+# two capture groups plus per-job total tracking derive one (see
+# ``helpers._advance_ninja_progress``). Anchored to the line start and
+# to ninja's literal space after the ``]`` so mid-line ``[N/M]`` text
+# and bare bracketed fragments never trip it; the start anchor tolerates
+# ANSI CSI prefixes (``\x1b[2K`` etc.) — same production concern as the
+# ``Writing at`` pattern above. Counters with totals under
+# ``_NINJA_MIN_TOTAL`` are ignored: ``[1/2] Re-running CMake...``
+# sub-steps and the ~97-step bootloader ExternalProject sub-build would
+# otherwise spike the gauge to ~100 before the app build starts.
+_NINJA_MIN_TOTAL = 100
+_NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
+    r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "
 )
 
 # History retention.

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -107,15 +107,15 @@ _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 # ESP-IDF / ninja per-target counter: ``[907/1424] Building C object …``.
 # Kept out of ``_PROGRESS_PATTERNS`` because it carries no percentage —
-# two capture groups plus per-job total tracking derive one (see
-# ``helpers._advance_ninja_progress``). Anchored to the line start and
-# to ninja's literal space after the ``]`` so mid-line ``[N/M]`` text
-# and bare bracketed fragments never trip it; the start anchor tolerates
-# ANSI CSI prefixes (``\x1b[2K`` etc.) — same production concern as the
-# ``Writing at`` pattern above. Counters with totals under
-# ``_NINJA_MIN_TOTAL`` are ignored: ``[1/2] Re-running CMake...``
-# sub-steps and the ~97-step bootloader ExternalProject sub-build would
-# otherwise spike the gauge to ~100 before the app build starts.
+# ``_parse_progress`` derives one from the two capture groups. Anchored
+# to the line start and to ninja's literal space after the ``]`` so
+# mid-line ``[N/M]`` text and bare bracketed fragments never trip it;
+# the start anchor tolerates ANSI CSI prefixes (``\x1b[2K`` etc.) —
+# same production concern as the ``Writing at`` pattern above. Counters
+# with totals under ``_NINJA_MIN_TOTAL`` are ignored: ``[1/2]
+# Re-running CMake...`` sub-steps and the ~97-step bootloader
+# ExternalProject sub-build would otherwise spike the gauge to ~100
+# before the app build starts.
 _NINJA_MIN_TOTAL = 100
 _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -182,8 +182,9 @@ def _parse_progress(line: str) -> int | None:
     """Extract a 0-100 progress percentage from a build/flash output line.
 
     Returns ``None`` when the line doesn't match one of the known
-    progress shapes (see ``_PROGRESS_PATTERNS``). Stray ``%`` signs
-    elsewhere in the build output (Unpacking bars, memory-usage
+    percent shapes (see ``_PROGRESS_PATTERNS``) or a ninja ``[N/M]``
+    counter with at least ``_NINJA_MIN_TOTAL`` steps. Stray ``%``
+    signs elsewhere in the build output (Unpacking bars, memory-usage
     reports) are intentionally ignored.
     """
     for pattern in _PROGRESS_PATTERNS:
@@ -193,23 +194,11 @@ def _parse_progress(line: str) -> int | None:
         value = int(match.group(1))
         if 0 <= value <= 100:
             return value
+    if match := _NINJA_PROGRESS_PATTERN.match(line):
+        done, total = int(match.group(1)), int(match.group(2))
+        if total >= _NINJA_MIN_TOTAL and done <= total:
+            return done * 100 // total
     return None
-
-
-def _parse_ninja_progress(line: str) -> tuple[int, int] | None:
-    """
-    Extract ``(percent, total)`` from a ninja ``[N/M]`` counter line.
-
-    Totals under ``_NINJA_MIN_TOTAL`` (CMake re-run steps, bootloader
-    sub-builds) and malformed ``N > M`` counters return ``None``.
-    """
-    match = _NINJA_PROGRESS_PATTERN.match(line)
-    if match is None:
-        return None
-    done, total = int(match.group(1)), int(match.group(2))
-    if total < _NINJA_MIN_TOTAL or done > total:
-        return None
-    return done * 100 // total, total
 
 
 def _validate_upload_target(port: str, *, bootloader: bool) -> None:
@@ -322,25 +311,6 @@ def _fire_job_lifecycle(job: FirmwareJob, bus: EventBus, event_type: EventType) 
     bus.fire(event_type, payload)
 
 
-def _advance_ninja_progress(job: FirmwareJob, bus: EventBus, line: str) -> None:
-    """
-    Advance ``job.progress`` from a ninja ``[N/M]`` counter line, if any.
-
-    A changed total means a new counter started (sub-build → app build),
-    so the value fires unclamped — mirroring the remote compile → upload
-    seam reset; same-total values keep the monotonic clamp.
-    """
-    parsed = _parse_ninja_progress(line)
-    if parsed is None:
-        return
-    percent, total = parsed
-    if total != job.progress_total:
-        job.progress_total = total
-        _fire_job_progress(job, bus, percent)
-    elif percent > (job.progress or 0):
-        _fire_job_progress(job, bus, percent)
-
-
 def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     r"""
     Append *line* to ``job.output`` and fire local follower events.
@@ -369,10 +339,7 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
        would otherwise look like a regression to the
        progress-bar renderer). Explicit phase transitions
        (compile → upload) call the helper directly to bypass
-       the clamp and reset the gauge. Ninja ``[N/M]`` counters
-       also drive progress (:func:`_advance_ninja_progress`); a
-       total change marks a new sub-build's counter and resets
-       the clamp baseline the same way.
+       the clamp and reset the gauge.
 
     Does **not** handle error-pattern detection — that's a
     local-only concern (the remote path gets a structured
@@ -393,8 +360,6 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
     progress = _parse_progress(line)
-    if progress is not None:
-        if progress > (job.progress or 0):
-            _fire_job_progress(job, bus, progress)
+    if progress is None or progress <= (job.progress or 0):
         return
-    _advance_ninja_progress(job, bus, line)
+    _fire_job_progress(job, bus, progress)

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -34,6 +34,8 @@ from .constants import (
     _INFLIGHT_TRIM_KEEP,
     _MAX_OUTPUT_LINES_INFLIGHT,
     _MAX_OUTPUT_LINES_RETAINED,
+    _NINJA_MIN_TOTAL,
+    _NINJA_PROGRESS_PATTERN,
     _NO_ESPHOME_MODULE_MARKER,
     _OUTPUT_TRIM_NOTICE_PREFIX,
     _PROGRESS_PATTERNS,
@@ -194,6 +196,22 @@ def _parse_progress(line: str) -> int | None:
     return None
 
 
+def _parse_ninja_progress(line: str) -> tuple[int, int] | None:
+    """
+    Extract ``(percent, total)`` from a ninja ``[N/M]`` counter line.
+
+    Totals under ``_NINJA_MIN_TOTAL`` (CMake re-run steps, bootloader
+    sub-builds) and malformed ``N > M`` counters return ``None``.
+    """
+    match = _NINJA_PROGRESS_PATTERN.match(line)
+    if match is None:
+        return None
+    done, total = int(match.group(1)), int(match.group(2))
+    if total < _NINJA_MIN_TOTAL or done > total:
+        return None
+    return done * 100 // total, total
+
+
 def _validate_upload_target(port: str, *, bootloader: bool) -> None:
     """Validate a flash target; ``bootloader=True`` adds the OTA-only gate."""
     _validate_port(port)
@@ -304,6 +322,25 @@ def _fire_job_lifecycle(job: FirmwareJob, bus: EventBus, event_type: EventType) 
     bus.fire(event_type, payload)
 
 
+def _advance_ninja_progress(job: FirmwareJob, bus: EventBus, line: str) -> None:
+    """
+    Advance ``job.progress`` from a ninja ``[N/M]`` counter line, if any.
+
+    A changed total means a new counter started (sub-build → app build),
+    so the value fires unclamped — mirroring the remote compile → upload
+    seam reset; same-total values keep the monotonic clamp.
+    """
+    parsed = _parse_ninja_progress(line)
+    if parsed is None:
+        return
+    percent, total = parsed
+    if total != job.progress_total:
+        job.progress_total = total
+        _fire_job_progress(job, bus, percent)
+    elif percent > (job.progress or 0):
+        _fire_job_progress(job, bus, percent)
+
+
 def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     r"""
     Append *line* to ``job.output`` and fire local follower events.
@@ -332,7 +369,10 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
        would otherwise look like a regression to the
        progress-bar renderer). Explicit phase transitions
        (compile → upload) call the helper directly to bypass
-       the clamp and reset the gauge.
+       the clamp and reset the gauge. Ninja ``[N/M]`` counters
+       also drive progress (:func:`_advance_ninja_progress`); a
+       total change marks a new sub-build's counter and resets
+       the clamp baseline the same way.
 
     Does **not** handle error-pattern detection — that's a
     local-only concern (the remote path gets a structured
@@ -353,6 +393,8 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
     progress = _parse_progress(line)
-    if progress is None or progress <= (job.progress or 0):
+    if progress is not None:
+        if progress > (job.progress or 0):
+            _fire_job_progress(job, bus, progress)
         return
-    _fire_job_progress(job, bus, progress)
+    _advance_ninja_progress(job, bus, line)

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -196,17 +196,22 @@ class FirmwareJob(DashboardModel):
     # Latched once released onto its lane; a restart then routes it even if
     # the prerequisite was pruned. False without ``depends_on``.
     dependency_released: bool = False
-    # Coarse progress estimate parsed from PlatformIO/esptool output
-    # (0-100). Monotonically non-decreasing *within a phase* — the
-    # streaming ingest only latches a higher parsed percent. At
+    # Coarse progress estimate parsed from PlatformIO/esptool/ninja
+    # output (0-100). Monotonically non-decreasing *within a phase* —
+    # the streaming ingest only latches a higher parsed percent. At
     # known phase seams (REMOTE install's compile → upload boundary
-    # in :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`)
-    # the runner explicitly resets to 0 so subsequent phase percents
-    # aren't silently clamped against the previous phase's peak.
-    # ``None`` when the underlying tooling hasn't emitted a percentage
-    # yet -- most compile output is opaque, but the heavy phases (PIO
-    # build, esptool flash) do emit percentages we can latch onto.
+    # in :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`,
+    # a ninja ``[N/M]`` counter restart detected via ``progress_total``)
+    # the ingest explicitly bypasses the clamp so subsequent phase
+    # percents aren't silently clamped against the previous phase's
+    # peak. ``None`` when the underlying tooling hasn't emitted a
+    # percentage yet -- most compile output is opaque, but the heavy
+    # phases (PIO / ninja build, esptool flash) do emit progress we can
+    # latch onto.
     progress: int | None = None
+    # Last-seen total of a ninja ``[N/M]`` counter; a change marks a new
+    # sub-build's counter and resets the monotonic clamp. Per-run state.
+    progress_total: int | None = None
     # Offloader's ``dashboard_id`` when this job came in via the
     # peer-link ``submit_job`` flow (issue #106). Empty for
     # locally-submitted jobs. Surfaced in the firmware-tasks UI
@@ -395,9 +400,10 @@ class FirmwareJob(DashboardModel):
           another build server uses :meth:`clear_run_state`
           instead, so it doesn't claim a restart that didn't
           happen.)
-        - **Clears per-run state** — ``progress`` / ``error`` /
-          ``started_at`` / ``completed_at`` / ``exit_code``
-          back to their defaults.
+        - **Clears per-run state** — ``progress`` /
+          ``progress_total`` / ``error`` / ``started_at`` /
+          ``completed_at`` / ``exit_code`` back to their
+          defaults.
         - **Doesn't change ``status``** — the caller decides
           the transition (load path flips ``RUNNING`` →
           ``QUEUED``; future callers might want a different
@@ -466,6 +472,7 @@ class FirmwareJob(DashboardModel):
         restart notice that never happened.
         """
         self.progress = None
+        self.progress_total = None
         self.error = None
         self.failure_reason = JobFailureReason.NONE
         self.started_at = None
@@ -536,16 +543,16 @@ class JobProgressData(TypedDict):
     Payload for ``EventType.JOB_PROGRESS``.
 
     Coarse 0-100 progress estimate parsed from PlatformIO /
-    esptool output. The streaming ingest only fires this event
-    when the parsed percent advances, so the gauge climbs
+    esptool / ninja output. The streaming ingest only fires this
+    event when the parsed percent advances, so the gauge climbs
     monotonically *within a phase*. At known phase seams
     (REMOTE install's compile → upload boundary —
-    :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`)
-    the runner explicitly fires a ``progress=0`` reset so the
-    next phase's percents don't get clamped against the
-    previous phase's peak. Subscribers should render the bar
-    from the latest event rather than asserting non-decreasing
-    progress.
+    :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`
+    — and a ninja ``[N/M]`` counter restarting with a new total)
+    the ingest explicitly bypasses the clamp so the next phase's
+    percents don't get clamped against the previous phase's
+    peak. Subscribers should render the bar from the latest
+    event rather than asserting non-decreasing progress.
     """
 
     job_id: str

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -196,22 +196,17 @@ class FirmwareJob(DashboardModel):
     # Latched once released onto its lane; a restart then routes it even if
     # the prerequisite was pruned. False without ``depends_on``.
     dependency_released: bool = False
-    # Coarse progress estimate parsed from PlatformIO/esptool/ninja
-    # output (0-100). Monotonically non-decreasing *within a phase* —
-    # the streaming ingest only latches a higher parsed percent. At
+    # Coarse progress estimate parsed from PlatformIO/ninja/esptool
+    # output (0-100). Monotonically non-decreasing *within a phase* — the
+    # streaming ingest only latches a higher parsed percent. At
     # known phase seams (REMOTE install's compile → upload boundary
-    # in :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`,
-    # a ninja ``[N/M]`` counter restart detected via ``progress_total``)
-    # the ingest explicitly bypasses the clamp so subsequent phase
-    # percents aren't silently clamped against the previous phase's
-    # peak. ``None`` when the underlying tooling hasn't emitted a
-    # percentage yet -- most compile output is opaque, but the heavy
-    # phases (PIO / ninja build, esptool flash) do emit progress we can
-    # latch onto.
+    # in :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`)
+    # the runner explicitly resets to 0 so subsequent phase percents
+    # aren't silently clamped against the previous phase's peak.
+    # ``None`` when the underlying tooling hasn't emitted a percentage
+    # yet -- most compile output is opaque, but the heavy phases (PIO
+    # build, esptool flash) do emit percentages we can latch onto.
     progress: int | None = None
-    # Last-seen total of a ninja ``[N/M]`` counter; a change marks a new
-    # sub-build's counter and resets the monotonic clamp. Per-run state.
-    progress_total: int | None = None
     # Offloader's ``dashboard_id`` when this job came in via the
     # peer-link ``submit_job`` flow (issue #106). Empty for
     # locally-submitted jobs. Surfaced in the firmware-tasks UI
@@ -400,10 +395,9 @@ class FirmwareJob(DashboardModel):
           another build server uses :meth:`clear_run_state`
           instead, so it doesn't claim a restart that didn't
           happen.)
-        - **Clears per-run state** — ``progress`` /
-          ``progress_total`` / ``error`` / ``started_at`` /
-          ``completed_at`` / ``exit_code`` back to their
-          defaults.
+        - **Clears per-run state** — ``progress`` / ``error`` /
+          ``started_at`` / ``completed_at`` / ``exit_code``
+          back to their defaults.
         - **Doesn't change ``status``** — the caller decides
           the transition (load path flips ``RUNNING`` →
           ``QUEUED``; future callers might want a different
@@ -472,7 +466,6 @@ class FirmwareJob(DashboardModel):
         restart notice that never happened.
         """
         self.progress = None
-        self.progress_total = None
         self.error = None
         self.failure_reason = JobFailureReason.NONE
         self.started_at = None
@@ -543,16 +536,16 @@ class JobProgressData(TypedDict):
     Payload for ``EventType.JOB_PROGRESS``.
 
     Coarse 0-100 progress estimate parsed from PlatformIO /
-    esptool / ninja output. The streaming ingest only fires this
-    event when the parsed percent advances, so the gauge climbs
+    esptool output. The streaming ingest only fires this event
+    when the parsed percent advances, so the gauge climbs
     monotonically *within a phase*. At known phase seams
     (REMOTE install's compile → upload boundary —
-    :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`
-    — and a ninja ``[N/M]`` counter restarting with a new total)
-    the ingest explicitly bypasses the clamp so the next phase's
-    percents don't get clamped against the previous phase's
-    peak. Subscribers should render the bar from the latest
-    event rather than asserting non-decreasing progress.
+    :func:`controllers.firmware.remote_runner._fetch_and_run_local_upload`)
+    the runner explicitly fires a ``progress=0`` reset so the
+    next phase's percents don't get clamped against the
+    previous phase's peak. Subscribers should render the bar
+    from the latest event rather than asserting non-decreasing
+    progress.
     """
 
     job_id: str

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -634,39 +634,6 @@ async def test_ninja_compile_progress_lines_fire_job_progress(
     assert job.status == JobStatus.COMPLETED
 
 
-async def test_ninja_sub_build_counter_restart_unpins_progress(
-    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
-) -> None:
-    """A counter restarting with a new total resets the monotonic clamp.
-
-    A ≥100-step sub-build can run its counter to 100% before the
-    app build starts; without the total-change reset the gauge
-    would freeze at the sub-build's peak.
-    """
-    controller = firmware_controller_factory(with_queue=True)
-    _wire_real_queue(controller)
-    _fake_esphome(
-        controller,
-        "import sys\n"
-        "print('[120/240] Building sub-build a.c.obj')\n"
-        "print('[240/240] Linking sub-build.elf')\n"
-        "print('[1/1424] Building C object esp-idf/a.c.obj')\n"
-        "print('[907/1424] Building C object esp-idf/b.c.obj')\n"
-        "print('[1424/1424] Linking firmware.elf')\n"
-        "sys.exit(0)\n",
-    )
-    _seed_yaml(tmp_path)
-
-    job = await controller.compile(configuration="kitchen.yaml")
-    captured = await _run_until_terminal(controller)
-
-    progress_values = [d["progress"] for d in captured["job_progress"]]
-    # The 0 is the total-change reset firing past the clamp.
-    assert progress_values == [50, 100, 0, 63, 100]
-    assert job.progress == 100
-    assert job.status == JobStatus.COMPLETED
-
-
 # ---------------------------------------------------------------------------
 # RESET_BUILD_ENV — routes through the same subprocess pipeline
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -602,6 +602,71 @@ async def test_compile_progress_lines_fire_job_progress(
     assert job.status == JobStatus.COMPLETED
 
 
+async def test_ninja_compile_progress_lines_fire_job_progress(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """Ninja ``[N/M]`` counters drive ``JOB_PROGRESS`` for ESP-IDF builds.
+
+    ESP-IDF builds emit no percentage at all; the per-target
+    counter is the only progress signal, and sub-100 totals
+    (CMake re-runs) must not move the gauge.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        "import sys\n"
+        "print('[1/2] Re-running CMake...')\n"
+        "print('[100/1424] Building C object esp-idf/a.c.obj')\n"
+        "print('[907/1424] Building C object esp-idf/b.c.obj')\n"
+        "print('[1424/1424] Linking firmware.elf')\n"
+        "sys.exit(0)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+    captured = await _run_until_terminal(controller)
+
+    progress_values = [d["progress"] for d in captured["job_progress"]]
+    # The [1/2] CMake sub-step is below the total floor and fires nothing.
+    assert progress_values == [7, 63, 100]
+    assert job.progress == 100
+    assert job.status == JobStatus.COMPLETED
+
+
+async def test_ninja_sub_build_counter_restart_unpins_progress(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Path
+) -> None:
+    """A counter restarting with a new total resets the monotonic clamp.
+
+    A ≥100-step sub-build can run its counter to 100% before the
+    app build starts; without the total-change reset the gauge
+    would freeze at the sub-build's peak.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _fake_esphome(
+        controller,
+        "import sys\n"
+        "print('[120/240] Building sub-build a.c.obj')\n"
+        "print('[240/240] Linking sub-build.elf')\n"
+        "print('[1/1424] Building C object esp-idf/a.c.obj')\n"
+        "print('[907/1424] Building C object esp-idf/b.c.obj')\n"
+        "print('[1424/1424] Linking firmware.elf')\n"
+        "sys.exit(0)\n",
+    )
+    _seed_yaml(tmp_path)
+
+    job = await controller.compile(configuration="kitchen.yaml")
+    captured = await _run_until_terminal(controller)
+
+    progress_values = [d["progress"] for d in captured["job_progress"]]
+    # The 0 is the total-change reset firing past the clamp.
+    assert progress_values == [50, 100, 0, 63, 100]
+    assert job.progress == 100
+    assert job.status == JobStatus.COMPLETED
+
+
 # ---------------------------------------------------------------------------
 # RESET_BUILD_ENV — routes through the same subprocess pipeline
 # ---------------------------------------------------------------------------
@@ -825,3 +890,7 @@ async def test_compile_cr_progress_lines_collapsed_in_storage(
     assert "[2/3] Compiling b.o\r" not in job.output
     assert "[3/3] Compiling c.o\r" not in job.output
     assert job.output[-1] == "INFO Compile finished.\n"
+
+    # Totals under the ninja floor never move the gauge.
+    assert captured["job_progress"] == []
+    assert job.progress is None

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -7,10 +7,9 @@ real ones (PlatformIO ``[ NN%]`` per-file markers, esptool
 ``(NN %)``, ESPHome OTA ``Uploading: 100%``) and skip everything
 else (PIO platform-extract bars, memory-usage reports, stray
 percentages in narrative log text). ESP-IDF builds emit no percent
-at all — their ninja ``[N/M]`` counter goes through
-``_parse_ninja_progress`` / ``_advance_ninja_progress`` instead,
-with a total floor so ``[1/2] Re-running CMake...`` sub-steps and
-the bootloader sub-build never drive the gauge.
+at all — their ninja ``[N/M]`` counter derives one, with a total
+floor so ``[1/2] Re-running CMake...`` sub-steps and the bootloader
+sub-build never drive the gauge.
 
 The regression these tests guard against: a wide-open
 ``\d{1,3}%`` regex pinned ``job.progress`` to 100 the moment
@@ -21,17 +20,9 @@ real work.
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
-from esphome_device_builder.controllers.firmware.helpers import (
-    _advance_ninja_progress,
-    _parse_ninja_progress,
-    _parse_progress,
-)
-from esphome_device_builder.helpers.event_bus import EventBus
-from esphome_device_builder.models import EventType, FirmwareJob, JobType
+from esphome_device_builder.controllers.firmware.helpers import _parse_progress
 
 
 class TestRealProgressLines:
@@ -194,7 +185,7 @@ class TestOutOfRange:
 
 
 class TestNinjaCounterLines:
-    """Ninja ``[N/M]`` counters resolve to ``(percent, total)`` above the total floor."""
+    """Ninja ``[N/M]`` counters resolve to a percentage above the total floor."""
 
     @pytest.mark.parametrize(
         ("line", "expected"),
@@ -202,28 +193,28 @@ class TestNinjaCounterLines:
             (
                 "[907/1424] Building C object esp-idf/bt/CMakeFiles/__idf_bt.dir/"
                 "host/bluedroid/bta/av/bta_av_cfg.c.obj",
-                (63, 1424),
+                63,
             ),
             (
                 "[707/1473] Building C object esp-idf/mbedtls/mbedtls/library/"
                 "CMakeFiles/mbedtls.dir/mbedtls_debug.c.obj",
-                (47, 1473),
+                47,
             ),
-            ("[1424/1424] Linking .pioenvs/firmware.elf", (100, 1424)),
-            ("[1/1424] Generating memory view", (0, 1424)),
+            ("[1424/1424] Linking .pioenvs/firmware.elf", 100),
+            ("[1/1424] Generating memory view", 0),
             # Total exactly at the floor still counts.
-            ("[50/100] Building C object foo.c.obj", (50, 100)),
-            ("    [907/1424] Building C object foo.c.obj", (63, 1424)),
+            ("[50/100] Building C object foo.c.obj", 50),
+            ("    [907/1424] Building C object foo.c.obj", 63),
             # CR-terminated in-place refresh chunk.
-            ("[907/1424] Building C object foo.c.obj\r", (63, 1424)),
+            ("[907/1424] Building C object foo.c.obj\r", 63),
             # ANSI clear-line prefix — a bare ``^\s*`` anchor would
             # silently fail in production while passing plain-text tests
             # (same trap as the esptool ``Writing at`` pattern).
-            ("\x1b[2K[907/1424] Building C object foo.c.obj", (63, 1424)),
+            ("\x1b[2K[907/1424] Building C object foo.c.obj", 63),
         ],
     )
-    def test_counter_lines_parse(self, line: str, expected: tuple[int, int]) -> None:
-        assert _parse_ninja_progress(line) == expected
+    def test_counter_lines_parse(self, line: str, expected: int) -> None:
+        assert _parse_progress(line) == expected
 
     @pytest.mark.parametrize(
         "line",
@@ -242,75 +233,10 @@ class TestNinjaCounterLines:
             # glued counter isn't its output shape.
             "[907/1424]",
             "[907/1424]Building C object foo.c.obj",
-            # Percent shapes belong to ``_parse_progress``.
-            "[ 17%] Compiling .pio/foo.cpp.o",
-            "[100%] Linking firmware.elf",
-            # Other build noise.
-            "Unpacking [####################################] 100%",
-            "RAM:   [==        ]  19.3% (used 63276 bytes from 327680 bytes)",
+            # Build noise that brackets digits without being a counter.
             "otadata,data,ota,0x9000,8K,",
             "*" * 79,
-            "",
         ],
     )
     def test_non_counter_lines_ignored(self, line: str) -> None:
-        assert _parse_ninja_progress(line) is None
-
-    def test_counter_lines_never_match_percent_whitelist(self) -> None:
-        assert _parse_progress("[907/1424] Building C object foo.c.obj") is None
-
-
-class TestAdvanceNinjaProgress:
-    """Counter-driven gauge: monotonic within a total, unclamped on a total change."""
-
-    def _advance(self, job: FirmwareJob, lines: list[str]) -> list[int]:
-        bus = EventBus()
-        fired: list[int] = []
-        bus.add_listener(EventType.JOB_PROGRESS, lambda event: fired.append(event.data["progress"]))
-        for line in lines:
-            _advance_ninja_progress(job, bus, line)
-        return fired
-
-    def _make_job(self, **overrides: Any) -> FirmwareJob:
-        defaults: dict[str, Any] = {
-            "job_id": "j-1",
-            "configuration": "kitchen.yaml",
-            "job_type": JobType.COMPILE,
-        }
-        defaults.update(overrides)
-        return FirmwareJob(**defaults)
-
-    def test_same_total_climbs_monotonically(self) -> None:
-        job = self._make_job()
-        fired = self._advance(
-            job,
-            [
-                "[100/1424] Building a.c.obj",
-                "[907/1424] Building b.c.obj",
-                "[900/1424] Building repeat.c.obj",
-                "[1424/1424] Linking firmware.elf",
-            ],
-        )
-        assert fired == [7, 63, 100]
-        assert job.progress == 100
-        assert job.progress_total == 1424
-
-    def test_total_change_bypasses_clamp(self) -> None:
-        job = self._make_job()
-        fired = self._advance(
-            job,
-            [
-                "[240/240] Linking sub-build.elf",
-                "[1/1424] Building a.c.obj",
-                "[907/1424] Building b.c.obj",
-            ],
-        )
-        assert fired == [100, 0, 63]
-        assert job.progress == 63
-
-    def test_sub_floor_totals_leave_job_untouched(self) -> None:
-        job = self._make_job()
-        fired = self._advance(job, ["[1/2] Re-running CMake...", "[97/97] Linking bootloader"])
-        assert fired == []
-        assert job.progress is None
-        assert job.progress_total is None
+        assert _parse_progress(line) is None

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -6,7 +6,11 @@ progress. The ``_parse_progress`` whitelist has to pick out the
 real ones (PlatformIO ``[ NN%]`` per-file markers, esptool
 ``(NN %)``, ESPHome OTA ``Uploading: 100%``) and skip everything
 else (PIO platform-extract bars, memory-usage reports, stray
-percentages in narrative log text).
+percentages in narrative log text). ESP-IDF builds emit no percent
+at all — their ninja ``[N/M]`` counter goes through
+``_parse_ninja_progress`` / ``_advance_ninja_progress`` instead,
+with a total floor so ``[1/2] Re-running CMake...`` sub-steps and
+the bootloader sub-build never drive the gauge.
 
 The regression these tests guard against: a wide-open
 ``\d{1,3}%`` regex pinned ``job.progress`` to 100 the moment
@@ -17,9 +21,17 @@ real work.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
-from esphome_device_builder.controllers.firmware.helpers import _parse_progress
+from esphome_device_builder.controllers.firmware.helpers import (
+    _advance_ninja_progress,
+    _parse_ninja_progress,
+    _parse_progress,
+)
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models import EventType, FirmwareJob, JobType
 
 
 class TestRealProgressLines:
@@ -179,3 +191,126 @@ class TestOutOfRange:
         # 100 is allowed; the regex accepts up to three digits to
         # cover this exact value.
         assert _parse_progress("[100%] Linking firmware.elf") == 100
+
+
+class TestNinjaCounterLines:
+    """Ninja ``[N/M]`` counters resolve to ``(percent, total)`` above the total floor."""
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            (
+                "[907/1424] Building C object esp-idf/bt/CMakeFiles/__idf_bt.dir/"
+                "host/bluedroid/bta/av/bta_av_cfg.c.obj",
+                (63, 1424),
+            ),
+            (
+                "[707/1473] Building C object esp-idf/mbedtls/mbedtls/library/"
+                "CMakeFiles/mbedtls.dir/mbedtls_debug.c.obj",
+                (47, 1473),
+            ),
+            ("[1424/1424] Linking .pioenvs/firmware.elf", (100, 1424)),
+            ("[1/1424] Generating memory view", (0, 1424)),
+            # Total exactly at the floor still counts.
+            ("[50/100] Building C object foo.c.obj", (50, 100)),
+            ("    [907/1424] Building C object foo.c.obj", (63, 1424)),
+            # CR-terminated in-place refresh chunk.
+            ("[907/1424] Building C object foo.c.obj\r", (63, 1424)),
+            # ANSI clear-line prefix — a bare ``^\s*`` anchor would
+            # silently fail in production while passing plain-text tests
+            # (same trap as the esptool ``Writing at`` pattern).
+            ("\x1b[2K[907/1424] Building C object foo.c.obj", (63, 1424)),
+        ],
+    )
+    def test_counter_lines_parse(self, line: str, expected: tuple[int, int]) -> None:
+        assert _parse_ninja_progress(line) == expected
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Totals under the floor: CMake sub-steps, bootloader
+            # sub-build, tiny incremental rebuilds.
+            "[1/2] Re-running CMake...",
+            "[97/97] Linking bootloader.elf",
+            "[3/7] Building C object foo.c.obj",
+            "[0/0] nothing",
+            # Malformed: done past total.
+            "[150/100] Building C object foo.c.obj",
+            # Mid-line counters are narrative text, not progress.
+            "note: see [110/200] above",
+            # Ninja always puts a space after the ``]`` — a bare or
+            # glued counter isn't its output shape.
+            "[907/1424]",
+            "[907/1424]Building C object foo.c.obj",
+            # Percent shapes belong to ``_parse_progress``.
+            "[ 17%] Compiling .pio/foo.cpp.o",
+            "[100%] Linking firmware.elf",
+            # Other build noise.
+            "Unpacking [####################################] 100%",
+            "RAM:   [==        ]  19.3% (used 63276 bytes from 327680 bytes)",
+            "otadata,data,ota,0x9000,8K,",
+            "*" * 79,
+            "",
+        ],
+    )
+    def test_non_counter_lines_ignored(self, line: str) -> None:
+        assert _parse_ninja_progress(line) is None
+
+    def test_counter_lines_never_match_percent_whitelist(self) -> None:
+        assert _parse_progress("[907/1424] Building C object foo.c.obj") is None
+
+
+class TestAdvanceNinjaProgress:
+    """Counter-driven gauge: monotonic within a total, unclamped on a total change."""
+
+    def _advance(self, job: FirmwareJob, lines: list[str]) -> list[int]:
+        bus = EventBus()
+        fired: list[int] = []
+        bus.add_listener(EventType.JOB_PROGRESS, lambda event: fired.append(event.data["progress"]))
+        for line in lines:
+            _advance_ninja_progress(job, bus, line)
+        return fired
+
+    def _make_job(self, **overrides: Any) -> FirmwareJob:
+        defaults: dict[str, Any] = {
+            "job_id": "j-1",
+            "configuration": "kitchen.yaml",
+            "job_type": JobType.COMPILE,
+        }
+        defaults.update(overrides)
+        return FirmwareJob(**defaults)
+
+    def test_same_total_climbs_monotonically(self) -> None:
+        job = self._make_job()
+        fired = self._advance(
+            job,
+            [
+                "[100/1424] Building a.c.obj",
+                "[907/1424] Building b.c.obj",
+                "[900/1424] Building repeat.c.obj",
+                "[1424/1424] Linking firmware.elf",
+            ],
+        )
+        assert fired == [7, 63, 100]
+        assert job.progress == 100
+        assert job.progress_total == 1424
+
+    def test_total_change_bypasses_clamp(self) -> None:
+        job = self._make_job()
+        fired = self._advance(
+            job,
+            [
+                "[240/240] Linking sub-build.elf",
+                "[1/1424] Building a.c.obj",
+                "[907/1424] Building b.c.obj",
+            ],
+        )
+        assert fired == [100, 0, 63]
+        assert job.progress == 63
+
+    def test_sub_floor_totals_leave_job_untouched(self) -> None:
+        job = self._make_job()
+        fired = self._advance(job, ["[1/2] Re-running CMake...", "[97/97] Linking bootloader"])
+        assert fired == []
+        assert job.progress is None
+        assert job.progress_total is None


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF builds emit ninja `[907/1424]` counters instead of the PlatformIO `[ 17%]` per file percent, and every pattern in the progress whitelist requires a literal `%`, so these builds showed no compile progress at all. `_parse_progress` now derives the percentage from the counter as `N*100/M` and the existing monotonic clamp applies unchanged. Totals under 100 are ignored so `[1/2] Re-running CMake...` sub steps and the bootloader sub build never move the bar, and the counter must sit at the line start (ANSI tolerant) with ninja's literal space after the `]`.

**Related issue or feature (if applicable):**

- reported directly from a live dashboard session, no issue filed

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
