### PR TITLE
Enrich config/serial_ports with USB ids and an ESP hint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -303,7 +303,7 @@ Parsing and writing live on the backend: the frontend exchanges structured `Auto
 | Command | Args | Response | Description |
 |---------|------|----------|-------------|
 | `config/version` | — | `{server_version, esphome_version}` | Get versions |
-| `config/serial_ports` | — | `[{port, desc}]` | List serial ports |
+| `config/serial_ports` | — | `[{port, desc, vid, pid, hint}]` | List serial ports. `vid`/`pid` are the USB ids (`null` when unknown); `hint` is `esp` (Espressif native USB), `bridge` (common USB-UART bridge chip), or `null` |
 | `config/get_preferences` | — | `UserPreferences` | Get user preferences |
 | `config/set_preferences` | `{theme?, dashboard_view?, experience_level?, remote_compute_only?, version_history_enabled?, device_editor_layout?, secrets_editor_layout?, ...}` | `UserPreferences` | Update preferences (partial). `experience_level` is `beginner` / `expert` (or `null` until chosen); `remote_compute_only` marks an install as a remote build node. `version_history_enabled` (default `true`) gates the git auto-commit of config edits; setting it `false` stops new commits and skips repo creation, leaving any existing repo intact. `device_editor_layout` is `visual` / `yaml` / `both` and `secrets_editor_layout` is `visual` / `yaml` (the secrets editor has no split view); they persist which editor panes the user keeps open. |
 | `config/get_secrets` | — | `[string]` | List secret key names |

--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from esphome.const import __version__ as esphome_version
 from esphome.storage_json import StorageJSON
-from esphome.util import get_serial_ports
 
 from ...constants import __version__ as server_version
 from ...helpers.api import CommandError, api_command
@@ -30,6 +29,7 @@ from .chip_detect import (
     _is_valid_port_name,
     _read_app_descriptor_board_id,
 )
+from .serial_ports import SerialPortInfo, list_serial_ports
 
 if TYPE_CHECKING:
     from ...device_builder import DeviceBuilder
@@ -60,13 +60,9 @@ class ConfigController:
         return {"server_version": server_version, "esphome_version": esphome_version}
 
     @api_command("config/serial_ports")
-    async def get_serial_ports_cmd(self, **kwargs: Any) -> list[dict]:
+    async def get_serial_ports_cmd(self, **kwargs: Any) -> list[SerialPortInfo]:
         """List available serial ports."""
-        ports = await run_in_executor(get_serial_ports)
-        return [
-            {"port": p.path, "desc": p.description if p.description != "n/a" else p.path}
-            for p in ports
-        ]
+        return await run_in_executor(list_serial_ports)
 
     @api_command("config/detect_chip")
     async def detect_chip_cmd(self, **kwargs: Any) -> dict:

--- a/esphome_device_builder/controllers/config/serial_ports.py
+++ b/esphome_device_builder/controllers/config/serial_ports.py
@@ -1,0 +1,60 @@
+"""Serial-port enumeration enriched with USB metadata for the port pickers."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from esphome.util import get_serial_ports
+from serial.tools.list_ports import comports
+
+# Espressif's USB VID — the built-in USB-Serial-JTAG / USB-OTG peripheral
+# on C3/C6/S2/S3/P4 chips, so a port with this VID *is* an ESP device.
+ESPRESSIF_VID = 0x303A
+# USB-UART bridge chips commonly wired to an ESP on dev boards: FTDI,
+# Prolific, Silicon Labs CP210x, QinHeng CH340/CH9102.
+_BRIDGE_VIDS = frozenset({0x0403, 0x067B, 0x10C4, 0x1A86})
+
+SerialPortHint = Literal["esp", "bridge"]
+
+
+class SerialPortInfo(TypedDict):
+    """One ``config/serial_ports`` entry."""
+
+    port: str
+    desc: str
+    vid: int | None
+    pid: int | None
+    hint: SerialPortHint | None
+
+
+def list_serial_ports() -> list[SerialPortInfo]:
+    """
+    Enumerate serial ports with USB ids and a picker hint (blocking).
+
+    ``hint`` is ``esp`` for Espressif native-USB devices, ``bridge`` for
+    common USB-UART bridge chips, ``None`` when the VID is unknown.
+    """
+    usb_info = {p.device: p for p in comports(include_links=True) if p.device}
+    result: list[SerialPortInfo] = []
+    for port in get_serial_ports():
+        info = usb_info.get(port.path)
+        vid: int | None = info.vid if info is not None else None
+        pid: int | None = info.pid if info is not None else None
+        result.append(
+            SerialPortInfo(
+                port=port.path,
+                desc=port.description if port.description != "n/a" else port.path,
+                vid=vid,
+                pid=pid,
+                hint=_hint_for_vid(vid),
+            )
+        )
+    return result
+
+
+def _hint_for_vid(vid: int | None) -> SerialPortHint | None:
+    if vid == ESPRESSIF_VID:
+        return "esp"
+    if vid in _BRIDGE_VIDS:
+        return "bridge"
+    return None

--- a/tests/test_config_controller.py
+++ b/tests/test_config_controller.py
@@ -33,6 +33,7 @@ import sys
 import threading
 from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1176,34 +1177,101 @@ def test_rel_path_bounds_control_byte_payload(make_settings: MakeSettingsFactory
 # ---------------------------------------------------------------------------
 
 
+def _patch_port_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    ports: list[SerialPort],
+    usb: list[SimpleNamespace] | None = None,
+) -> None:
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.config.serial_ports.get_serial_ports",
+        lambda: ports,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.config.serial_ports.comports",
+        lambda include_links: usb or [],
+    )
+
+
 async def test_get_serial_ports_returns_path_and_desc(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Each upstream ``SerialPort`` round-trips as ``{port, desc}``.
+    """Each upstream ``SerialPort`` round-trips as ``{port, desc, vid, pid, hint}``.
 
     Pin the field renaming (``path`` → ``port``,
     ``description`` → ``desc``). The executor-route is asserted
     separately in ``test_get_serial_ports_runs_in_executor`` —
-    monkeypatching ``get_serial_ports`` to a sync lambda here
-    means a regression that dropped ``run_in_executor`` would
-    still pass this test, so the contract gets its own dedicated
-    pin.
+    monkeypatching the port scan to sync lambdas here means a
+    regression that dropped ``run_in_executor`` would still pass
+    this test, so the contract gets its own dedicated pin.
     """
-    fake_ports = [
-        SerialPort(path="/dev/ttyUSB0", description="USB Serial"),
-        SerialPort(path="/dev/ttyACM0", description="Arduino Uno"),
-    ]
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.config.controller.get_serial_ports",
-        lambda: fake_ports,
+    _patch_port_scan(
+        monkeypatch,
+        [
+            SerialPort(path="/dev/ttyUSB0", description="USB Serial"),
+            SerialPort(path="/dev/ttyACM0", description="Arduino Uno"),
+        ],
     )
     controller = _make_controller(tmp_path)
 
     result = await controller.get_serial_ports_cmd()
 
     assert result == [
-        {"port": "/dev/ttyUSB0", "desc": "USB Serial"},
-        {"port": "/dev/ttyACM0", "desc": "Arduino Uno"},
+        {"port": "/dev/ttyUSB0", "desc": "USB Serial", "vid": None, "pid": None, "hint": None},
+        {"port": "/dev/ttyACM0", "desc": "Arduino Uno", "vid": None, "pid": None, "hint": None},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("vid", "hint"),
+    [
+        pytest.param(0x303A, "esp", id="espressif"),
+        pytest.param(0x10C4, "bridge", id="cp210x"),
+        pytest.param(0x1A86, "bridge", id="ch340"),
+        pytest.param(0x0403, "bridge", id="ftdi"),
+        pytest.param(0x067B, "bridge", id="prolific"),
+        pytest.param(0x2341, None, id="unknown-vid"),
+        pytest.param(None, None, id="no-vid"),
+    ],
+)
+async def test_get_serial_ports_usb_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, vid: int | None, hint: str | None
+) -> None:
+    """USB VID classifies the port: Espressif → ``esp``, UART bridges → ``bridge``."""
+    _patch_port_scan(
+        monkeypatch,
+        [SerialPort(path="/dev/ttyUSB0", description="USB Serial")],
+        [SimpleNamespace(device="/dev/ttyUSB0", vid=vid, pid=0x1001)],
+    )
+    controller = _make_controller(tmp_path)
+
+    result = await controller.get_serial_ports_cmd()
+
+    assert result == [
+        {"port": "/dev/ttyUSB0", "desc": "USB Serial", "vid": vid, "pid": 0x1001, "hint": hint}
+    ]
+
+
+async def test_get_serial_ports_without_usb_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A port absent from the ``comports`` scan (by-id symlink) gets null USB fields."""
+    _patch_port_scan(
+        monkeypatch,
+        [SerialPort(path="/dev/serial/by-id/usb-foo", description="USB Serial Port")],
+        [SimpleNamespace(device="/dev/ttyUSB0", vid=0x303A, pid=0x1001)],
+    )
+    controller = _make_controller(tmp_path)
+
+    result = await controller.get_serial_ports_cmd()
+
+    assert result == [
+        {
+            "port": "/dev/serial/by-id/usb-foo",
+            "desc": "USB Serial Port",
+            "vid": None,
+            "pid": None,
+            "hint": None,
+        }
     ]
 
 
@@ -1230,8 +1298,11 @@ async def test_get_serial_ports_runs_in_executor(
         return [SerialPort(path="/dev/ttyUSB0", description="USB Serial")]
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.config.controller.get_serial_ports",
+        "esphome_device_builder.controllers.config.serial_ports.get_serial_ports",
         _record_thread,
+    )
+    monkeypatch.setattr(
+        "esphome_device_builder.controllers.config.serial_ports.comports", lambda include_links: []
     )
     controller = _make_controller(tmp_path)
 
@@ -1257,15 +1328,14 @@ async def test_get_serial_ports_substitutes_path_for_na_description(
     the fallback would make the chooser look broken without
     actually being broken.
     """
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.config.controller.get_serial_ports",
-        lambda: [SerialPort(path="/dev/ttyUSB0", description="n/a")],
-    )
+    _patch_port_scan(monkeypatch, [SerialPort(path="/dev/ttyUSB0", description="n/a")])
     controller = _make_controller(tmp_path)
 
     result = await controller.get_serial_ports_cmd()
 
-    assert result == [{"port": "/dev/ttyUSB0", "desc": "/dev/ttyUSB0"}]
+    assert result == [
+        {"port": "/dev/ttyUSB0", "desc": "/dev/ttyUSB0", "vid": None, "pid": None, "hint": None}
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1758,10 +1828,7 @@ async def test_get_serial_ports_returns_empty_when_no_ports(
     ports available" off an empty list; a regression that
     returned ``None`` would break iteration in the frontend.
     """
-    monkeypatch.setattr(
-        "esphome_device_builder.controllers.config.controller.get_serial_ports",
-        list,
-    )
+    _patch_port_scan(monkeypatch, [])
     controller = _make_controller(tmp_path)
 
     result = await controller.get_serial_ports_cmd()


### PR DESCRIPTION
# What does this implement/fix?

Beginners picking a server serial port can't tell which entry is their board; the list only shows a device path and a pyserial description, and on a machine with a webcam or other USB serial devices the right one is a guess. `config/serial_ports` entries now also carry the USB `vid`/`pid` and a `hint` field, `esp` for Espressif native USB (VID 0x303A, the built-in USB-Serial-JTAG on C3/C6/S2/S3/P4) and `bridge` for the common USB-UART bridge chips (CP210x, CH340, FTDI, Prolific), so the frontend can badge and sort likely candidates first.

**Related issue or feature (if applicable):**

- feedback from an Apollo Automation Starter Kit beginner test, "a beginner might need help figuring out which COM port to select"

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1137

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
