### PR TITLE
Extract shared YAML line-scan primitives into helpers/yaml/scan

### DIFF
--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -15,6 +15,7 @@ from .scalar import (
     block_body_is_list,
     is_lambda_sentinel,
 )
+from .scan import block_end_index, find_block_header, leading_ws
 
 if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry
@@ -317,29 +318,14 @@ def _find_top_level_block_bounds(file_lines: list[str], key: str) -> tuple[int, 
     trailing blank lines so an inserted item lands directly after the
     last content line. Returns ``None`` when no matching header exists.
     """
-    header_re = re.compile(rf"^{re.escape(key)}:\s*(?:#.*)?$")
-    block_start: int | None = None
-    for idx, line in enumerate(file_lines):
-        if header_re.match(line.rstrip("\n\r")):
-            block_start = idx
-            break
+    block_start = find_block_header(file_lines, key)
     if block_start is None:
         return None
 
-    block_end = len(file_lines)
-    for idx in range(block_start + 1, len(file_lines)):
-        stripped = file_lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            block_end = idx
-            break
+    block_end = block_end_index(file_lines, block_start)
     while block_end > block_start + 1 and not file_lines[block_end - 1].strip():
         block_end -= 1
     return block_start, block_end
-
-
-def _leading_ws(line: str) -> str:
-    """Leading whitespace of *line*."""
-    return line[: len(line) - len(line.lstrip())]
 
 
 def _list_item_indent(file_lines: list[str], header_idx: int, end_idx: int) -> str:
@@ -353,7 +339,7 @@ def _list_item_indent(file_lines: list[str], header_idx: int, end_idx: int) -> s
         if not stripped or stripped.startswith("#"):
             continue
         if stripped.startswith("- ") or stripped == "-":
-            return _leading_ws(file_lines[idx].rstrip("\n\r"))
+            return leading_ws(file_lines[idx].rstrip("\n\r"))
     return ESPHOME_YAML_INDENT
 
 
@@ -376,7 +362,7 @@ def _splice_into_domain_block(existing: str, domain: str, block: str) -> str | N
     block_start, last_content = bounds
 
     dash_indent = _list_item_indent(file_lines, block_start, last_content)
-    src_indent = _leading_ws(block_lines[1])
+    src_indent = leading_ws(block_lines[1])
     items: list[str] = []
     for line in block_lines[1:]:
         if not line.strip():
@@ -443,7 +429,7 @@ def _mapping_body_to_list_item(body_lines: list[str]) -> list[str]:
     body_indent = ""
     for line in body_lines:
         if line.strip() and not line.lstrip().startswith("#"):
-            body_indent = _leading_ws(line)
+            body_indent = leading_ws(line)
             break
     result: list[str] = []
     marked = False

--- a/esphome_device_builder/helpers/yaml/inline.py
+++ b/esphome_device_builder/helpers/yaml/inline.py
@@ -6,6 +6,13 @@ import re
 from dataclasses import dataclass
 
 from .scalar import ESPHOME_YAML_INDENT, block_body_is_list
+from .scan import (
+    block_end_index,
+    find_block_header,
+    key_header_re,
+    leading_ws,
+    top_list_item_starts,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,7 +125,7 @@ def _apply_handler_upsert(
     # Look for an existing ``<handler_key>:`` line under this
     # instance. The key is at exactly ``child_indent`` columns of
     # leading whitespace.
-    handler_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(handler_key)}:\s*(?:#.*)?$")
+    handler_re = key_header_re(handler_key, indent=child_indent)
     handler_start: int | None = None
     handler_end: int | None = None
     for idx in range(instance_start, instance_end):
@@ -189,7 +196,7 @@ def _apply_handler_remove(
 ) -> tuple[str, int, int] | None:
     """Drop ``<handler_key>:`` from the located *span*; the shared remove tail."""
     instance_start, instance_end, child_indent = span
-    handler_re = re.compile(rf"^{re.escape(child_indent)}{re.escape(handler_key)}:\s*(?:#.*)?$")
+    handler_re = key_header_re(handler_key, indent=child_indent)
     for idx in range(instance_start, instance_end):
         if not handler_re.match(lines[idx].rstrip("\n\r")):
             continue
@@ -217,9 +224,7 @@ def _locate_subentity_instance(
     if span is None:
         return None
     instance_start, instance_end, parent_child_indent = span
-    header_re = re.compile(
-        rf"^{re.escape(parent_child_indent)}{re.escape(ref.sub_key)}:\s*(?:#.*)?$"
-    )
+    header_re = key_header_re(ref.sub_key, indent=parent_child_indent)
     sub_start: int | None = None
     for idx in range(instance_start, instance_end):
         if header_re.match(lines[idx].rstrip("\n\r")):
@@ -234,12 +239,12 @@ def _locate_subentity_instance(
     for idx in range(sub_start + 1, sub_end):
         content = lines[idx].rstrip("\n\r")
         if content:
-            sub_child_indent = " " * (len(content) - len(content.lstrip(" ")))
+            sub_child_indent = leading_ws(content)
             break
     return sub_start, sub_end, sub_child_indent
 
 
-def _locate_component_instance(  # noqa: C901
+def _locate_component_instance(
     lines: list[str],
     domain: str,
     component_id: str,
@@ -251,20 +256,10 @@ def _locate_component_instance(  # noqa: C901
     index, one-past-last-line index, and the leading whitespace of
     the instance's child fields.
     """
-    header_re = re.compile(rf"^{re.escape(domain)}:\s*(?:#.*)?$")
-    domain_start: int | None = None
-    for idx, line in enumerate(lines):
-        if header_re.match(line.rstrip("\n\r")):
-            domain_start = idx
-            break
+    domain_start = find_block_header(lines, domain)
     if domain_start is None:
         return None
-    domain_end = len(lines)
-    for idx in range(domain_start + 1, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            domain_end = idx
-            break
+    domain_end = block_end_index(lines, domain_start)
 
     if not block_body_is_list(lines, domain_start, domain_end):
         # Flat singleton mapping (``sun:`` / ``mqtt:``) — its only ``- ``
@@ -272,24 +267,8 @@ def _locate_component_instance(  # noqa: C901
         return _locate_singleton_instance(lines, domain, component_id, domain_start, domain_end)
 
     # Walk the domain body looking for a list item whose first child
-    # line carries ``id: <component_id>``. Only column-2 dashes count
-    # as instance starts — deeper dashes are inner action lists.
-    item_indent: str | None = None
-    item_starts: list[int] = []
-    for idx in range(domain_start + 1, domain_end):
-        raw = lines[idx].rstrip("\n\r")
-        stripped = raw.lstrip(" ")
-        if not stripped.startswith("- "):
-            continue
-        prefix = raw[: len(raw) - len(stripped)]
-        if item_indent is None:
-            item_indent = prefix
-        if prefix != item_indent:
-            # Inner action list — deeper indent than the canonical
-            # list-of-instances. Skip.
-            continue
-        item_starts.append(idx)
-
+    # line carries ``id: <component_id>``.
+    item_starts = top_list_item_starts(lines, domain_start, domain_end)
     bounds = _instance_bounds(lines, item_starts, domain_end)
     for start, end, child_indent in bounds:
         if _instance_declared_id(lines, start, end, child_indent) == component_id:
@@ -311,8 +290,7 @@ def _instance_bounds(
 
 def _child_indent(lines: list[str], start: int) -> str:
     """Leading whitespace of an instance's child fields (its dash indent plus one level)."""
-    dash_indent = lines[start][: len(lines[start]) - len(lines[start].lstrip(" "))]
-    return dash_indent + ESPHOME_YAML_INDENT
+    return leading_ws(lines[start]) + ESPHOME_YAML_INDENT
 
 
 def _locate_idless_instance(

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -52,5 +52,5 @@ def top_list_item_starts(lines: list[str], start: int, end: int) -> list[int]:
 
 
 def leading_ws(line: str) -> str:
-    """Leading whitespace of *line*."""
-    return line[: len(line) - len(line.lstrip())]
+    """Leading spaces of *line* (YAML indentation is spaces-only; a tab counts as content)."""
+    return line[: len(line) - len(line.lstrip(" "))]

--- a/esphome_device_builder/helpers/yaml/scan.py
+++ b/esphome_device_builder/helpers/yaml/scan.py
@@ -1,0 +1,56 @@
+"""Shared line-scan primitives for the YAML text-splice helpers."""
+
+from __future__ import annotations
+
+import re
+
+
+def key_header_re(key: str, *, indent: str = "") -> re.Pattern[str]:
+    """Pattern matching a ``<key>:`` header line at exactly *indent*, bare or with a comment."""
+    return re.compile(rf"^{re.escape(indent)}{re.escape(key)}:\s*(?:#.*)?$")
+
+
+def find_block_header(lines: list[str], key: str) -> int | None:
+    """Index of the column-0 ``<key>:`` header line, or ``None`` when absent."""
+    header_re = key_header_re(key)
+    for idx, line in enumerate(lines):
+        if header_re.match(line.rstrip("\n\r")):
+            return idx
+    return None
+
+
+def block_end_index(lines: list[str], start: int) -> int:
+    """First line after *start* that opens the next top-level block; ``len(lines)`` at EOF."""
+    for idx in range(start + 1, len(lines)):
+        stripped = lines[idx].rstrip("\n\r")
+        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
+            return idx
+    return len(lines)
+
+
+def top_list_item_starts(lines: list[str], start: int, end: int) -> list[int]:
+    """
+    Line indexes of the canonical-indent ``- `` items in a block body.
+
+    The first dash indent seen is canonical; deeper dashes are inner
+    action lists inside an item body and are skipped.
+    """
+    item_indent: str | None = None
+    item_starts: list[int] = []
+    for idx in range(start + 1, end):
+        raw = lines[idx].rstrip("\n\r")
+        stripped = raw.lstrip(" ")
+        if not stripped.startswith("- "):
+            continue
+        prefix = raw[: len(raw) - len(stripped)]
+        if item_indent is None:
+            item_indent = prefix
+        if prefix != item_indent:
+            continue
+        item_starts.append(idx)
+    return item_starts
+
+
+def leading_ws(line: str) -> str:
+    """Leading whitespace of *line*."""
+    return line[: len(line) - len(line.lstrip())]


### PR DESCRIPTION
# What does this implement/fix?

The same low level line scan loops were copy pasted inside `helpers/yaml/`: the domain end scan lived verbatim in both `inline.py` and `component.py`, the `key:` header regex template was compiled in five places, and the leading whitespace arithmetic was inlined at several sites. This moves the verbatim cores into a new `helpers/yaml/scan.py` (`key_header_re`, `find_block_header`, `block_end_index`, `top_list_item_starts`, `leading_ws`) and rewires `inline.py` and `component.py` onto it; each call site keeps its own semantics (return `None` vs raise, trailing blank rewinds, id resolution). No behaviour change.

The automation writer's copy of the same scan in `controllers/automations/writing_layout.py` follows separately (#1893).

**Related issue or feature (if applicable):**

- fixes #1892

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
