### PR TITLE
Move the automation writer's top-list scan onto the shared YAML scan primitives

### DIFF
--- a/esphome_device_builder/controllers/automations/writing_layout.py
+++ b/esphome_device_builder/controllers/automations/writing_layout.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...helpers.api import CommandError
+from ...helpers.yaml.scan import block_end_index, find_block_header, top_list_item_starts
 from ...models.api import ErrorCode
 from ...models.automations import YamlDiff
 
@@ -17,42 +18,18 @@ def _indent_for_top_list(rendered_item: str) -> str:
     return rendered_item
 
 
-def _locate_top_list_item(  # noqa: C901
+def _locate_top_list_item(
     lines: list[str],
     domain: str,
     index: int,
 ) -> tuple[int, int]:
     """Return the line range of the *index*'th item under ``<domain>:``."""
-    domain_start: int | None = None
-    for idx, line in enumerate(lines):
-        stripped = line.rstrip("\n\r")
-        if stripped == f"{domain}:" or stripped.startswith(f"{domain}:"):
-            domain_start = idx
-            break
+    domain_start = find_block_header(lines, domain)
     if domain_start is None:
         msg = f"Block {domain!r} not present"
         raise CommandError(ErrorCode.NOT_FOUND, msg)
-    domain_end = len(lines)
-    for idx in range(domain_start + 1, len(lines)):
-        stripped = lines[idx].rstrip("\n\r")
-        if stripped and stripped[0].isalpha() and not stripped.startswith(" "):
-            domain_end = idx
-            break
-    # Only column-2 dashes count as top-level list items; deeper
-    # dashes belong to nested action lists inside the item body.
-    item_indent: str | None = None
-    item_starts: list[int] = []
-    for idx in range(domain_start + 1, domain_end):
-        raw = lines[idx].rstrip("\n\r")
-        stripped = raw.lstrip(" ")
-        if not stripped.startswith("- "):
-            continue
-        prefix = raw[: len(raw) - len(stripped)]
-        if item_indent is None:
-            item_indent = prefix
-        if prefix != item_indent:
-            continue
-        item_starts.append(idx)
+    domain_end = block_end_index(lines, domain_start)
+    item_starts = top_list_item_starts(lines, domain_start, domain_end)
     if index < 0 or index >= len(item_starts):
         msg = f"{domain}[{index}] out of range (have {len(item_starts)})"
         raise CommandError(ErrorCode.NOT_FOUND, msg)


### PR DESCRIPTION
# What does this implement/fix?

`_locate_top_list_item` in `controllers/automations/writing_layout.py` carried a verbatim copy of the domain scan from `helpers/yaml/inline.py`, about 25 lines covering the header search, the domain end loop, and the canonical indent dash collector. This rewires it onto the shared primitives from `helpers/yaml/scan.py` (#1895), keeping the `CommandError(NOT_FOUND, ...)` semantics and messages local.

One message only change: the domain header match tightens from `startswith(f"{domain}:")` to the shared header regex, so a `sensor: !include x` line now reports "Block 'sensor' not present" instead of scanning an empty body to the same NOT_FOUND error; both paths already refused the edit.

**Related issue or feature (if applicable):**

- fixes #1893

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
