### PR TITLE
Derive platform domains from the schema bundle instead of hand curation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,8 +258,12 @@ select is optional with the right default) come from the live package.
 Platform-domain entries (`sensor.*`, `output.*`, ...) are additionally stamped
 `multi_conf=True` regardless of upstream `MULTI_CONF`, which is absent on
 platform stems; a platform domain is an unbounded YAML list, so every variant is
-repeatable (the `_PLATFORM_DOMAINS` set in `sync_components.py` must match the
-YAML serializer's `_ENTITY_CATEGORIES`, pinned by a test).
+repeatable. The platform-domain set itself is derived, not hand-curated: the
+schema bundle's `core.platforms` (upstream's `IS_PLATFORM_COMPONENT` markers)
+refreshes `_PLATFORM_DOMAINS` at sync time, the shipped catalog's dotted-id
+prefixes seed it at import, and the YAML serializer reads platform-ness off the
+dotted id directly. A new upstream domain missing a `ComponentCategory` member
+fails the sync loudly instead of degrading to MISC.
 Component-level descriptions and titles fall back to the docs MDX
 (`esphome.io` shallow clone) when the schema's index is sparse.
 

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -21,19 +21,16 @@ if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry
 
 
-def _platform_domain(component_id: str) -> str | None:
+def _split_platform_id(component_id: str) -> tuple[str | None, str]:
     """
-    Domain prefix of a qualified ``<domain>.<platform>`` catalog id, else None.
+    Split a catalog id into ``(domain, stem)``; ``(None, id)`` when undotted.
 
-    A dotted id is the catalog's platform marker — those entries render as
-    ``<domain>: [- platform: ...]`` blocks. The id, not ``category``, is
-    the evidence: a domain whose ``ComponentCategory`` member lags upstream
-    loads as MISC, and a bare-id entry with an entity category (the
-    ``ota`` / ``time`` umbrellas) is the legacy bare-mapping form, not a
-    platform.
+    A dotted ``<domain>.<platform>`` id is the catalog's platform marker;
+    a bare-id entry (the ``ota`` / ``time`` umbrellas) is not a platform
+    even when it carries an entity category.
     """
-    domain, sep, _stem = component_id.partition(".")
-    return domain if sep else None
+    domain, sep, stem = component_id.partition(".")
+    return (domain, stem) if sep else (None, component_id)
 
 
 def merge_component_yaml(
@@ -62,7 +59,7 @@ def merge_component_yaml(
     block = generate_component_yaml(component, fields)
     if _redefines_existing_id(existing, block, fields.get("id")):
         return existing
-    domain = _platform_domain(component.id)
+    domain, _ = _split_platform_id(component.id)
     if domain is not None:
         spliced = _splice_into_domain_block(existing, domain, block)
         if spliced is not None:
@@ -107,13 +104,11 @@ def generate_component_yaml(  # noqa: C901
     _coerce_string_map_values(component, fields)
     comp_id = component.id
 
-    domain = _platform_domain(comp_id)
-
     # Catalog ids are qualified as ``<domain>.<platform>`` (e.g.
     # ``output.gpio``, ``light.binary``) so distinct platforms can
     # share a stem across categories. ESPHome YAML expects the bare
-    # platform stem under ``platform:``, so strip the qualifier.
-    unqualified = comp_id.split(".", 1)[1] if domain is not None else comp_id
+    # platform stem under ``platform:``.
+    domain, unqualified = _split_platform_id(comp_id)
 
     # Resolve the top-level id once. We only emit it when the caller
     # explicitly opted in by including ``id`` in fields; when they

--- a/esphome_device_builder/helpers/yaml/component.py
+++ b/esphome_device_builder/helpers/yaml/component.py
@@ -21,58 +21,19 @@ if TYPE_CHECKING:
     from ...models import ComponentCatalogEntry
 
 
-# Platform categories that use the list-under-platform YAML pattern
-# (`sensor: [- platform: ...]`) rather than a single top-level key.
-# Must include every ComponentCategory value whose components carry
-# `<domain>.<platform>` ids in the catalog — otherwise add_component
-# falls through to writing the qualified id literally as a top-level
-# YAML key (`time.homeassistant:`), which ESPHome rejects and our own
-# YAML parser can't handle either (the regex only accepts
-# `[a-zA-Z_][a-zA-Z0-9_]*:`, no dots).
-_ENTITY_CATEGORIES = {
-    # Home Assistant entity domains
-    "sensor",
-    "binary_sensor",
-    "switch",
-    "light",
-    "fan",
-    "cover",
-    "climate",
-    "button",
-    "number",
-    "select",
-    "text",
-    "text_sensor",
-    "lock",
-    "valve",
-    "media_player",
-    "speaker",
-    "microphone",
-    "camera",
-    "display",
-    "touchscreen",
-    "output",
-    "datetime",
-    "event",
-    "update",
-    "alarm_control_panel",
-    # Other platform-pattern domains the sync script tags as their
-    # own categories. Each one shows up in YAML as `<domain>: [-
-    # platform: ...]` blocks.
-    "ota",
-    "time",
-    "audio_adc",
-    "audio_dac",
-    "canbus",
-    "infrared",
-    "media_source",
-    "motion",
-    "one_wire",
-    "packet_transport",
-    "radio_frequency",
-    "stepper",
-    "water_heater",
-}
+def _platform_domain(component_id: str) -> str | None:
+    """
+    Domain prefix of a qualified ``<domain>.<platform>`` catalog id, else None.
+
+    A dotted id is the catalog's platform marker — those entries render as
+    ``<domain>: [- platform: ...]`` blocks. The id, not ``category``, is
+    the evidence: a domain whose ``ComponentCategory`` member lags upstream
+    loads as MISC, and a bare-id entry with an entity category (the
+    ``ota`` / ``time`` umbrellas) is the legacy bare-mapping form, not a
+    platform.
+    """
+    domain, sep, _stem = component_id.partition(".")
+    return domain if sep else None
 
 
 def merge_component_yaml(
@@ -101,9 +62,9 @@ def merge_component_yaml(
     block = generate_component_yaml(component, fields)
     if _redefines_existing_id(existing, block, fields.get("id")):
         return existing
-    is_platform = component.category in _ENTITY_CATEGORIES
-    if is_platform:
-        spliced = _splice_into_domain_block(existing, str(component.category), block)
+    domain = _platform_domain(component.id)
+    if domain is not None:
+        spliced = _splice_into_domain_block(existing, domain, block)
         if spliced is not None:
             return spliced
     elif component.multi_conf:
@@ -115,7 +76,7 @@ def merge_component_yaml(
     return _append_block(existing, block)
 
 
-def generate_component_yaml(  # noqa: C901, PLR0912
+def generate_component_yaml(  # noqa: C901
     component: ComponentCatalogEntry,
     fields: dict[str, Any],
 ) -> str:
@@ -123,7 +84,7 @@ def generate_component_yaml(  # noqa: C901, PLR0912
     Generate a YAML block for adding a component to a device config.
 
     Platform-style components (``sensor``, ``switch``, ...) are emitted
-    as a list under their category with a ``- platform: <id>`` entry;
+    as a list under their domain with a ``- platform: <id>`` entry;
     everything else is emitted as a top-level mapping keyed by the
     component id.
 
@@ -144,19 +105,15 @@ def generate_component_yaml(  # noqa: C901, PLR0912
     """
     fields = dict(fields)
     _coerce_string_map_values(component, fields)
-    category = component.category
     comp_id = component.id
 
-    is_platform = category in _ENTITY_CATEGORIES
+    domain = _platform_domain(comp_id)
 
-    if is_platform:
-        # Catalog ids are qualified as ``<domain>.<platform>`` (e.g.
-        # ``output.gpio``, ``light.binary``) so distinct platforms can
-        # share a stem across categories. ESPHome YAML expects the bare
-        # platform stem under ``platform:``, so strip the qualifier.
-        unqualified = comp_id.split(".", 1)[1] if "." in comp_id else comp_id
-    else:
-        unqualified = comp_id
+    # Catalog ids are qualified as ``<domain>.<platform>`` (e.g.
+    # ``output.gpio``, ``light.binary``) so distinct platforms can
+    # share a stem across categories. ESPHome YAML expects the bare
+    # platform stem under ``platform:``, so strip the qualifier.
+    unqualified = comp_id.split(".", 1)[1] if domain is not None else comp_id
 
     # Resolve the top-level id once. We only emit it when the caller
     # explicitly opted in by including ``id`` in fields; when they
@@ -193,8 +150,8 @@ def generate_component_yaml(  # noqa: C901, PLR0912
         autofill.update(sub)
         fields[entry.key] = autofill
 
-    if is_platform:
-        lines = [f"{category}:", f"{ESPHOME_YAML_INDENT}- platform: {unqualified}"]
+    if domain is not None:
+        lines = [f"{domain}:", f"{ESPHOME_YAML_INDENT}- platform: {unqualified}"]
         indent = ESPHOME_YAML_INDENT * 2
         for key, value in fields.items():
             lines.extend(_emit_field(key, value, indent))

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -128,6 +128,7 @@ from esphome_device_builder.models import (  # noqa: E402
     AutomationTrigger,
     AutomationTriggerIndex,
     ComponentCatalogEntry,
+    ComponentCategory,
     Filter,
     FilterIndex,
     LightEffect,
@@ -139,51 +140,43 @@ from script._light_schemas import (  # noqa: E402
     resolve_light_effects_applies_to,
 )
 
-# Top-level platform domains in the schema (also keys in our category enum).
-# Components keyed as ``<id>.<domain>`` in the schema files — e.g.
-# ``dht.sensor`` lives in dht.json under the key ``dht.sensor``.
-_PLATFORM_DOMAINS: frozenset[str] = frozenset(
-    {
-        "sensor",
-        "binary_sensor",
-        "switch",
-        "light",
-        "fan",
-        "cover",
-        "climate",
-        "button",
-        "number",
-        "select",
-        "text",
-        "text_sensor",
-        "lock",
-        "valve",
-        "media_player",
-        "speaker",
-        "microphone",
-        "camera",
-        "display",
-        "touchscreen",
-        "output",
-        "datetime",
-        "event",
-        "update",
-        "alarm_control_panel",
-        "stepper",
-        "audio_adc",
-        "audio_dac",
-        "media_source",
-        "one_wire",
-        "canbus",
-        "infrared",
-        "time",
-        "water_heater",
-        "ota",
-        "packet_transport",
-        "motion",
-        "radio_frequency",
-    }
-)
+
+def _platform_domains_from_shipped_index() -> frozenset[str]:
+    """Platform domains present in the checked-in catalog (dotted-id prefixes)."""
+    payload = orjson.loads(_OUTPUT_INDEX_FILE.read_bytes())
+    return frozenset(c["id"].split(".", 1)[0] for c in payload["components"] if "." in c["id"])
+
+
+def _derive_platform_domains(core: dict) -> frozenset[str]:
+    """
+    Authoritative platform domains: the schema bundle's ``core.platforms`` keys.
+
+    Upstream's schema generator fills ``core.platforms`` from exactly the
+    components marked ``IS_PLATFORM_COMPONENT = True``, so a new entity
+    domain lands here without any hand-maintained list.
+    """
+    return frozenset(core.get("platforms") or {})
+
+
+def _require_component_categories(domains: frozenset[str]) -> None:
+    """Fail the sync loudly when a platform domain has no ``ComponentCategory`` member."""
+    missing = sorted(domains - {c.value for c in ComponentCategory})
+    if missing:
+        raise SystemExit(
+            f"New upstream platform domain(s) without a ComponentCategory member: {missing}. "
+            "Add the enum member(s) in esphome_device_builder/models/components.py and "
+            "coordinate the frontend category UI, then re-run."
+        )
+
+
+# Top-level platform domains in the schema. Components are keyed as
+# ``<id>.<domain>`` in the schema files — e.g. ``dht.sensor`` lives in
+# dht.json under the key ``dht.sensor``. Seeded from the shipped catalog
+# so importers (tests, sibling scripts) see the set without a schema
+# bundle; ``load_index`` refreshes it from the fresh bundle's
+# ``core.platforms`` so a new upstream domain joins the walk the same
+# sync it appears.
+_PLATFORM_DOMAINS: frozenset[str] = _platform_domains_from_shipped_index()
 
 # Top-level components whose ``CONFIG_SCHEMA`` is a ``cv.ensure_list`` (a list of
 # instances) but which don't set the component-registry ``MULTI_CONF`` flag, so
@@ -1088,7 +1081,15 @@ class SchemaIndex:
 
 
 def load_index(schema_dir: Path) -> SchemaIndex:
-    """Read every index in the bundle into one merged SchemaIndex."""
+    """
+    Read every index in the bundle into one merged SchemaIndex.
+
+    Also refreshes ``_PLATFORM_DOMAINS`` from the fresh bundle's
+    ``core.platforms`` — without this a new upstream domain's
+    ``<domain>.json`` is never opened, and the gap self-perpetuates
+    into the next shipped index.
+    """
+    global _PLATFORM_DOMAINS  # noqa: PLW0603 — sync-wide refresh; every consumer runs after load_index
     metadata: dict[str, dict[str, Any]] = {}
 
     # 1. esphome.json — core.components and core.platforms.
@@ -1100,6 +1101,10 @@ def load_index(schema_dir: Path) -> SchemaIndex:
         metadata[cid] = meta or {}
     for pid, meta in (core.get("platforms") or {}).items():
         metadata[pid] = meta or {}
+
+    if fresh_domains := _derive_platform_domains(core):
+        _require_component_categories(fresh_domains)
+        _PLATFORM_DOMAINS = fresh_domains
 
     # 2. Each <domain>.json — domain.components map. Key under both the
     # bare stem and the qualified ``<domain>.<stem>`` form so lookups
@@ -4284,9 +4289,9 @@ def _enumerate_platform_manifests(loader: Any, stem: str) -> list[Any]:
     platform manifest can't tank the whole sync.
 
     Iterates ``_PLATFORM_DOMAINS`` (the same set the catalog walk
-    already uses for schema-keyed platform entries) so adding a
-    domain in one place automatically covers the introspection
-    walk too — no parallel list to keep in sync. Sorted so the
+    already uses for schema-keyed platform entries) so a domain
+    derived from the schema bundle automatically covers the
+    introspection walk too — no parallel list. Sorted so the
     catalog output is deterministic across runs — frozenset
     iteration is hash-randomised per process and would otherwise
     flip refinement results between syncs when two platform

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -141,21 +141,15 @@ from script._light_schemas import (  # noqa: E402
 )
 
 
+def _domains_from_ids(component_ids: Iterable[str]) -> frozenset[str]:
+    """Platform domains among *component_ids* — the ``<domain>.<stem>`` dotted-id prefixes."""
+    return frozenset(cid.split(".", 1)[0] for cid in component_ids if "." in cid)
+
+
 def _platform_domains_from_shipped_index() -> frozenset[str]:
-    """Platform domains present in the checked-in catalog (dotted-id prefixes)."""
+    """Platform domains present in the checked-in catalog."""
     payload = orjson.loads(_OUTPUT_INDEX_FILE.read_bytes())
-    return frozenset(c["id"].split(".", 1)[0] for c in payload["components"] if "." in c["id"])
-
-
-def _derive_platform_domains(core: dict) -> frozenset[str]:
-    """
-    Authoritative platform domains: the schema bundle's ``core.platforms`` keys.
-
-    Upstream's schema generator fills ``core.platforms`` from exactly the
-    components marked ``IS_PLATFORM_COMPONENT = True``, so a new entity
-    domain lands here without any hand-maintained list.
-    """
-    return frozenset(core.get("platforms") or {})
+    return _domains_from_ids(c["id"] for c in payload["components"])
 
 
 def _require_component_categories(domains: frozenset[str]) -> None:
@@ -172,10 +166,8 @@ def _require_component_categories(domains: frozenset[str]) -> None:
 # Top-level platform domains in the schema. Components are keyed as
 # ``<id>.<domain>`` in the schema files — e.g. ``dht.sensor`` lives in
 # dht.json under the key ``dht.sensor``. Seeded from the shipped catalog
-# so importers (tests, sibling scripts) see the set without a schema
-# bundle; ``load_index`` refreshes it from the fresh bundle's
-# ``core.platforms`` so a new upstream domain joins the walk the same
-# sync it appears.
+# so importing the module needs no schema bundle; ``load_index``
+# refreshes it from the fresh bundle.
 _PLATFORM_DOMAINS: frozenset[str] = _platform_domains_from_shipped_index()
 
 # Top-level components whose ``CONFIG_SCHEMA`` is a ``cv.ensure_list`` (a list of
@@ -1085,9 +1077,11 @@ def load_index(schema_dir: Path) -> SchemaIndex:
     Read every index in the bundle into one merged SchemaIndex.
 
     Also refreshes ``_PLATFORM_DOMAINS`` from the fresh bundle's
-    ``core.platforms`` — without this a new upstream domain's
-    ``<domain>.json`` is never opened, and the gap self-perpetuates
-    into the next shipped index.
+    ``core.platforms`` (upstream's ``IS_PLATFORM_COMPONENT`` set) —
+    without this a new upstream domain's ``<domain>.json`` is never
+    opened, and the gap self-perpetuates into the next shipped index.
+    A bundle with no ``core.platforms`` fails loud rather than silently
+    syncing against the stale shipped set.
     """
     global _PLATFORM_DOMAINS  # noqa: PLW0603 — sync-wide refresh; every consumer runs after load_index
     metadata: dict[str, dict[str, Any]] = {}
@@ -1099,12 +1093,18 @@ def load_index(schema_dir: Path) -> SchemaIndex:
         core = {}
     for cid, meta in (core.get("components") or {}).items():
         metadata[cid] = meta or {}
-    for pid, meta in (core.get("platforms") or {}).items():
+    platforms = core.get("platforms") or {}
+    for pid, meta in platforms.items():
         metadata[pid] = meta or {}
 
-    if fresh_domains := _derive_platform_domains(core):
-        _require_component_categories(fresh_domains)
-        _PLATFORM_DOMAINS = fresh_domains
+    if not platforms:
+        raise SystemExit(
+            f"Schema bundle at {schema_dir} has no core.platforms (esphome.json missing or "
+            "empty); refusing to sync against the stale shipped domain set."
+        )
+    fresh_domains = frozenset(platforms)
+    _require_component_categories(fresh_domains)
+    _PLATFORM_DOMAINS = fresh_domains
 
     # 2. Each <domain>.json — domain.components map. Key under both the
     # bare stem and the qualified ``<domain>.<stem>`` form so lookups
@@ -6974,7 +6974,7 @@ def build_automations(  # noqa: C901
     # gates the action/condition id flip in :func:`_automation_id_prefix`.
     # Derived from the just-built component set, not ``_PLATFORM_DOMAINS``,
     # so the flip decision rests on the same evidence as ``_automation_domain``.
-    platform_domains = {cid.split(".", 1)[0] for cid in component_ids if "." in cid}
+    platform_domains = _domains_from_ids(component_ids)
 
     for path in iter_schema_files(schema_dir):
         try:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1104,6 +1104,13 @@ def load_index(schema_dir: Path) -> SchemaIndex:
         )
     fresh_domains = frozenset(platforms)
     _require_component_categories(fresh_domains)
+    if dropped := sorted(_PLATFORM_DOMAINS - fresh_domains):
+        _LOGGER.warning(
+            "Platform domain(s) in the shipped catalog but absent from the fresh "
+            "schema bundle: %s. Expected for a genuine upstream removal; check the "
+            "catalog diff if not.",
+            dropped,
+        )
     _PLATFORM_DOMAINS = fresh_domains
 
     # 2. Each <domain>.json — domain.components map. Key under both the

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1077,11 +1077,9 @@ def load_index(schema_dir: Path) -> SchemaIndex:
     Read every index in the bundle into one merged SchemaIndex.
 
     Also refreshes ``_PLATFORM_DOMAINS`` from the fresh bundle's
-    ``core.platforms`` (upstream's ``IS_PLATFORM_COMPONENT`` set) —
-    without this a new upstream domain's ``<domain>.json`` is never
-    opened, and the gap self-perpetuates into the next shipped index.
-    A bundle with no ``core.platforms`` fails loud rather than silently
-    syncing against the stale shipped set.
+    ``core.platforms`` (upstream's ``IS_PLATFORM_COMPONENT`` set):
+    a bundle with no ``core.platforms`` fails loud, and a shipped
+    domain missing from the fresh bundle logs a warning.
     """
     global _PLATFORM_DOMAINS  # noqa: PLW0603 — sync-wide refresh; every consumer runs after load_index
     metadata: dict[str, dict[str, Any]] = {}

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from script.sync_components import (  # type: ignore[import-not-found]
     _PLATFORM_DOMAINS,
     _apply_auto_loaded_reference_advanced,
     _convert_field,
+    _derive_platform_domains,
     _is_own_id_field,
     _mark_platform_domains_multi_conf,
     _multi_instance_targets,
+    _require_component_categories,
     _resolve_auto_load,
 )
 
@@ -221,26 +225,37 @@ def test_shipped_platform_entries_are_multi_conf() -> None:
     assert _load_body("sensor.dht")["multi_conf"] is True
 
 
-def test_platform_domains_match_yaml_entity_categories() -> None:
-    """``_PLATFORM_DOMAINS`` must equal the YAML serializer's ``_ENTITY_CATEGORIES``."""
-    # If they drift, a platform domain stamped multi_conf=True here would fall into
-    # the serializer's multi_conf branch and render invalid list-form ``<id>:`` YAML.
-    from esphome_device_builder.helpers.yaml.component import (  # noqa: PLC0415
-        _ENTITY_CATEGORIES,
-    )
-
-    assert set(_PLATFORM_DOMAINS) == set(_ENTITY_CATEGORIES)
-
-
 def test_platform_domains_have_component_categories() -> None:
     """Every platform domain needs a ``ComponentCategory`` member, else it loads as MISC."""
-    # A domain in the sets but missing from the enum is silently coerced to MISC at
+    # A domain in the set but missing from the enum is silently coerced to MISC at
     # load time, breaking the category filter — the exact bug #1832 fixed.
     from esphome_device_builder.models.components import (  # noqa: PLC0415
         ComponentCategory,
     )
 
+    assert _PLATFORM_DOMAINS
     assert set(_PLATFORM_DOMAINS) <= {c.value for c in ComponentCategory}
+
+
+def test_platform_domains_exclude_camera() -> None:
+    """``camera`` is not a platform domain upstream; the old hand list carried it."""
+    # No IS_PLATFORM_COMPONENT marker, no camera.json in the schema bundle, no
+    # ``camera.*`` catalog entry — the derived set dropping it is intentional.
+    assert "camera" not in _PLATFORM_DOMAINS
+
+
+def test_derive_platform_domains_reads_core_platforms() -> None:
+    """The derived set is exactly ``core.platforms``' keys."""
+    core = {"platforms": {"sensor": {}, "valve": {"docs": None}}, "components": {"wifi": {}}}
+    assert _derive_platform_domains(core) == frozenset({"sensor", "valve"})
+    assert _derive_platform_domains({}) == frozenset()
+
+
+def test_require_component_categories_fails_loud_on_unknown_domain() -> None:
+    """A new upstream domain without an enum member kills the sync, naming it."""
+    _require_component_categories(_PLATFORM_DOMAINS)
+    with pytest.raises(SystemExit, match="brand_new_domain"):
+        _require_component_categories(frozenset({"sensor", "brand_new_domain"}))
 
 
 def test_resolve_auto_load_handles_callable() -> None:

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -11,12 +11,12 @@ from script.sync_components import (  # type: ignore[import-not-found]
     _PLATFORM_DOMAINS,
     _apply_auto_loaded_reference_advanced,
     _convert_field,
-    _derive_platform_domains,
     _is_own_id_field,
     _mark_platform_domains_multi_conf,
     _multi_instance_targets,
     _require_component_categories,
     _resolve_auto_load,
+    load_index,
 )
 
 _UNUSED_SCHEMA_DIR = Path("/unused")
@@ -229,12 +229,8 @@ def test_platform_domains_have_component_categories() -> None:
     """Every platform domain needs a ``ComponentCategory`` member, else it loads as MISC."""
     # A domain in the set but missing from the enum is silently coerced to MISC at
     # load time, breaking the category filter — the exact bug #1832 fixed.
-    from esphome_device_builder.models.components import (  # noqa: PLC0415
-        ComponentCategory,
-    )
-
     assert _PLATFORM_DOMAINS
-    assert set(_PLATFORM_DOMAINS) <= {c.value for c in ComponentCategory}
+    _require_component_categories(_PLATFORM_DOMAINS)
 
 
 def test_platform_domains_exclude_camera() -> None:
@@ -244,18 +240,16 @@ def test_platform_domains_exclude_camera() -> None:
     assert "camera" not in _PLATFORM_DOMAINS
 
 
-def test_derive_platform_domains_reads_core_platforms() -> None:
-    """The derived set is exactly ``core.platforms``' keys."""
-    core = {"platforms": {"sensor": {}, "valve": {"docs": None}}, "components": {"wifi": {}}}
-    assert _derive_platform_domains(core) == frozenset({"sensor", "valve"})
-    assert _derive_platform_domains({}) == frozenset()
-
-
 def test_require_component_categories_fails_loud_on_unknown_domain() -> None:
     """A new upstream domain without an enum member kills the sync, naming it."""
-    _require_component_categories(_PLATFORM_DOMAINS)
     with pytest.raises(SystemExit, match="brand_new_domain"):
         _require_component_categories(frozenset({"sensor", "brand_new_domain"}))
+
+
+def test_load_index_refuses_bundle_without_platforms(tmp_path: Path) -> None:
+    """A bundle with no ``core.platforms`` fails loud instead of syncing the stale set."""
+    with pytest.raises(SystemExit, match=r"core\.platforms"):
+        load_index(tmp_path)
 
 
 def test_resolve_auto_load_handles_callable() -> None:

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -250,6 +251,20 @@ def test_load_index_refuses_bundle_without_platforms(tmp_path: Path) -> None:
     """A bundle with no ``core.platforms`` fails loud instead of syncing the stale set."""
     with pytest.raises(SystemExit, match=r"core\.platforms"):
         load_index(tmp_path)
+
+
+def test_load_index_warns_on_dropped_domain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A domain in the shipped set but gone from the fresh bundle logs a warning."""
+    from script import sync_components  # noqa: PLC0415
+
+    monkeypatch.setattr(sync_components, "_PLATFORM_DOMAINS", frozenset({"sensor", "switch"}))
+    (tmp_path / "esphome.json").write_text(json.dumps({"core": {"platforms": {"sensor": {}}}}))
+    with caplog.at_level(logging.WARNING, logger="sync_components"):
+        sync_components.load_index(tmp_path)
+    assert "switch" in caplog.text
+    assert frozenset({"sensor"}) == sync_components._PLATFORM_DOMAINS
 
 
 def test_resolve_auto_load_handles_callable() -> None:

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1091,9 +1091,8 @@ def test_merge_component_yaml_preserves_following_blocks_after_splice() -> None:
 def test_merge_component_yaml_appends_non_platform_component() -> None:
     """A non-platform component (e.g. ``i2c``) emits as a top-level mapping.
 
-    These don't carry a ``platform`` key and aren't in
-    ``_ENTITY_CATEGORIES``, so they always fall through to the
-    plain-append path.
+    These carry a bare (undotted) id and no ``platform`` key, so they
+    always fall through to the plain-append path.
     """
     component = _component(component_id="i2c", category=ComponentCategory.BUS)
     fields: dict[str, Any] = {"sda": "GPIO21", "scl": "GPIO22"}
@@ -1353,12 +1352,11 @@ def test_merge_component_yaml_accepts_incomplete_draft() -> None:
 def test_merge_component_yaml_splices_other_platform_categories(
     category: ComponentCategory,
 ) -> None:
-    """Splice works for every category in ``_ENTITY_CATEGORIES``.
+    """Splice works across platform domains, not just ``sensor``.
 
-    Pin a couple of representative platform domains beyond
-    ``sensor`` so a regression that hardcodes the splice to one
-    domain shows up in CI. Add new ones if a future bug points at
-    a specific category.
+    Pin a couple of representative domains so a regression that
+    hardcodes the splice to one domain shows up in CI. Add new ones
+    if a future bug points at a specific domain.
     """
     component_id = f"{category.value}.gpio"
     component = _component(component_id=component_id, category=category)
@@ -1371,6 +1369,23 @@ def test_merge_component_yaml_splices_other_platform_categories(
     assert result.count(f"{category.value}:\n") == 1
     assert "- platform: ledc" in result
     assert "- platform: gpio" in result
+
+
+def test_merge_component_yaml_umbrella_entry_emits_legacy_bare_mapping() -> None:
+    """A bare-id entry with an entity category (the ``ota`` umbrella) is not a platform.
+
+    The legacy bare-mapping form is what the umbrella documents;
+    ``- platform: ota`` names a platform that doesn't exist.
+    """
+    component = _component(component_id="ota", category=ComponentCategory.OTA)
+
+    result = merge_component_yaml("esphome:\n  name: kitchen\n", component, {})
+    assert "ota:" in result
+    assert "- platform: ota" not in result
+
+    # Re-adding over an existing ota block is a no-op, not a duplicate key.
+    existing = "esphome:\n  name: kitchen\n\nota:\n  - platform: esphome\n"
+    assert merge_component_yaml(existing, component, {}) == existing
 
 
 _RTTTL_MAPPING = "rtttl:\n  id: rtttl_1\n  output: buzz\n"


### PR DESCRIPTION
# What does this implement/fix?

The sync script's `_PLATFORM_DOMAINS` was a hand maintained 38 entry frozenset; when ESPHome adds a new entity domain and nobody updates it, that domain's platforms silently drop out of the catalog walk, the exact failure #1902 hit. The set is now derived: `load_index` reads it fresh from the schema bundle's `core.platforms`, which upstream's schema generator fills from exactly the components marked `IS_PLATFORM_COMPONENT = True`, and the module level default seeds from the checked in catalog's dotted id prefixes so tests and sibling scripts work without a bundle. A fresh domain that has no `ComponentCategory` member fails the sync loudly with instructions instead of degrading to MISC; the enum stays the one deliberate surface since a new domain needs frontend category UI coordination anyway.

The runtime twin `_ENTITY_CATEGORIES` in the YAML serializer is gone too; platform-ness now reads off the dotted id directly, and the splice target comes from the id prefix rather than the category. That keeps emission correct even while an enum member lags, and it fixes a latent umbrella bug: adding the bare `ota` or `time` catalog entry used to emit an invalid `- platform: ota` list item, now it appends the legacy bare mapping the umbrella's own description documents.

`camera` drops out of the derived set. It was vestigial in all the hand lists: no `IS_PLATFORM_COMPONENT` marker upstream, no `camera.json` in the schema bundle, no `camera.*` entry or `camera` category anywhere in the shipped catalog, so the generated output is unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1904

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
