### PR TITLE
Add the image platform-domain category

### DIFF
--- a/esphome_device_builder/models/components.py
+++ b/esphome_device_builder/models/components.py
@@ -65,6 +65,7 @@ class ComponentCategory(StrEnum):
     AUDIO_ADC = "audio_adc"
     AUDIO_DAC = "audio_dac"
     CANBUS = "canbus"
+    IMAGE = "image"
     INFRARED = "infrared"
     MEDIA_SOURCE = "media_source"
     MOTION = "motion"


### PR DESCRIPTION
# What does this implement/fix?

The nightly catalog sync against schema 2026.7.0b1 fails loudly: upstream turned `image` into a platform domain (`image.online_image`, `image.file`, `image.animation`) and the #1907 guard refuses to emit a catalog for a platform domain with no `ComponentCategory` member. This adds the `image` member so the next sync run can materialize the new catalog. Failing run: https://github.com/esphome/device-builder/actions/runs/28995461788/job/86043979944

The frontend needs no rendering change; category chip labels derive from the id (`image` renders as "Image") and the selector's filter list comes off the wire. The companion PR mirrors the enum member in the frontend types.

**Related issue or feature (if applicable):**

- fixes the failing catalog sync linked above

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1154

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
