### PR TITLE
Fail the sync loudly when the docs image map loses common components

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1205,6 +1205,7 @@ def build_catalog(
     """Walk every schema file and produce ConfigCatalogEntry-shaped dicts."""
     index = load_index(schema_dir)
     image_map = load_image_map()
+    _require_image_map(image_map)
     out: list[dict] = []
     for path in iter_schema_files(schema_dir):
         try:
@@ -2058,6 +2059,24 @@ def load_image_map() -> dict[str, str]:
             out.setdefault(parts[1], _IMAGE_BASE_URL + image)
     _LOGGER.info("Image map built: %d components", len(out))
     return out
+
+
+# Common components whose docs-index image has shipped for years. Any of
+# them missing from the map means the index fetch failed or its format
+# drifted, not an upstream image removal — emitting anyway strips
+# ``image_url`` catalog-wide (#1911 shipped that way).
+_IMAGE_MAP_SENTINELS = ("wifi", "i2c", "sensor.dht")
+
+
+def _require_image_map(image_map: dict[str, str]) -> None:
+    """Fail the sync loudly when the docs image map lacks a sentinel component."""
+    missing = [cid for cid in _IMAGE_MAP_SENTINELS if cid not in image_map]
+    if missing:
+        raise SystemExit(
+            f"Docs image map is missing {missing} — the components/index.mdx fetch "
+            "failed or its format drifted. Fix the fetch (or update "
+            "_IMAGE_MAP_SENTINELS if the docs page really dropped these) and re-run."
+        )
 
 
 def build_entries_from_file(

--- a/tests/test_sync_components_sub_readings.py
+++ b/tests/test_sync_components_sub_readings.py
@@ -16,6 +16,7 @@ from script.sync_components import (  # type: ignore[import-not-found]
     _mark_platform_domains_multi_conf,
     _multi_instance_targets,
     _require_component_categories,
+    _require_image_map,
     _resolve_auto_load,
     load_index,
 )
@@ -245,6 +246,23 @@ def test_require_component_categories_fails_loud_on_unknown_domain() -> None:
     """A new upstream domain without an enum member kills the sync, naming it."""
     with pytest.raises(SystemExit, match="brand_new_domain"):
         _require_component_categories(frozenset({"sensor", "brand_new_domain"}))
+
+
+def test_require_image_map_passes_with_sentinels_present() -> None:
+    """A map carrying every sentinel component sails through."""
+    _require_image_map({"wifi": "u", "i2c": "u", "sensor.dht": "u", "servo": "u"})
+
+
+def test_require_image_map_fails_loud_on_missing_sentinel() -> None:
+    """A map missing a common component kills the sync, naming it."""
+    with pytest.raises(SystemExit, match=r"sensor\.dht"):
+        _require_image_map({"wifi": "u", "i2c": "u"})
+
+
+def test_require_image_map_fails_loud_on_empty_map() -> None:
+    """A failed docs-index fetch (empty map) refuses to strip images catalog-wide (#1911)."""
+    with pytest.raises(SystemExit, match="wifi"):
+        _require_image_map({})
 
 
 def test_load_index_refuses_bundle_without_platforms(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

The catalog sync treats a failed fetch of esphome.io's `components/index.mdx` as "no images" and emits anyway; that is how #1911 silently stripped `image_url` from all 781 components (the run logged "Could not fetch docs index page" and the PR stats could not show the loss). The sync now checks the built image map for a few common components whose docs image has shipped for years (`wifi`, `i2c`, `sensor.dht`); any of them missing aborts the run with a message naming them, same fail-loud shape as the platform-domain category guard. A real upstream removal of a sentinel image is handled by updating the sentinel list, which the error message points at.

The stripped images come back on the next successful sync run; this guard keeps the failure mode from shipping again.

**Related issue or feature (if applicable):**

- follow-up to #1911

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
