### PR TITLE
Defer offline devices in bulk install instead of queuing a doomed upload

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -159,7 +159,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 | `firmware/clear_queued_update` | `{configuration}` | — | Clears a staged offline update for a device that hasn't woken up yet. |
 | `firmware/reset_build_env` | — | `FirmwareJob` | Queue full reset of `.esphome/` build dirs and PIO cache. **Cancels every in-flight job on both lanes first** (the wipe trashes the whole tree, which a concurrent compile or upload would race). |
 | `firmware/compile_bulk` | `{configurations: string[]}` | `[FirmwareJob]` | Queue multiple compiles |
-| `firmware/install_bulk` | `{configurations: string[], port?: "OTA" \| serial \| ip \| hostname}` | `[FirmwareJob]` | Queue multiple installs. `port` defaults to `"OTA"` and is shared across every queued job — almost always callers want that default rather than a single explicit target across the fleet. Same `port` validation as `firmware/install`. |
+| `firmware/install_bulk` | `{configurations: string[], port?: "OTA" \| serial \| ip \| hostname}` | `[FirmwareJob]` | Queue multiple installs. `port` defaults to `"OTA"` and is shared across every queued job — almost always callers want that default rather than a single explicit target across the fleet. Same `port` validation as `firmware/install`, and the same OFFLINE deferral: an OFFLINE device with an `"OTA"` target queues a single deferred `COMPILE` job that flashes on the device's next wake, instead of a chain whose upload would fail. |
 | `firmware/get_jobs` | `{status?, configuration?}` | `[FirmwareJob]` | List jobs with filters |
 | `firmware/get_job` | `{job_id}` | `FirmwareJob` | Get job with full output |
 | `firmware/follow_job` | `{job_id}` | Streaming | Historical output + live stream for one job |

--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -130,6 +130,8 @@ async def install_bulk(
 
     ``port`` is shared across every queued job — pass an explicit IP
     only when every device should install against the same target.
+    An OFFLINE device with an OTA target queues a deferred compile-only
+    job (flashed on its next wake) instead of a chain.
     Per-device errors skip that device and keep going; a fleet-wide
     ``NO_COMPATIBLE_PEER`` (``EXACT_REQUIRED`` with no eligible
     peer) re-raises so the operator gets one consolidated error
@@ -144,7 +146,9 @@ async def install_bulk(
             # A chain (COMPILE + dependent UPLOAD) per device, same as single
             # install — so device B's compile pipelines against device A's
             # upload instead of a fused job pinning both to the compile lane.
-            job = await factories.enqueue_install_chain(
+            # An OFFLINE OTA target defers to a compile-only job that flashes
+            # on the device's next wake, instead of a doomed upload (#1928).
+            job = await factories.enqueue_install_or_defer(
                 controller, configuration=config, port=port, build_source=build_source
             )
         except CommandError as exc:

--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -146,8 +146,6 @@ async def install_bulk(
             # A chain (COMPILE + dependent UPLOAD) per device, same as single
             # install — so device B's compile pipelines against device A's
             # upload instead of a fused job pinning both to the compile lane.
-            # An OFFLINE OTA target defers to a compile-only job that flashes
-            # on the device's next wake, instead of a doomed upload (#1928).
             job = await factories.enqueue_install_or_defer(
                 controller, configuration=config, port=port, build_source=build_source
             )

--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -142,12 +142,11 @@ async def install_bulk(
     jobs: list[FirmwareJob] = []
     for config in _configuration_order(controller, configurations):
         try:
-            build_source = controller._resolve_install_source()
             # A chain (COMPILE + dependent UPLOAD) per device, same as single
             # install — so device B's compile pipelines against device A's
             # upload instead of a fused job pinning both to the compile lane.
             job = await factories.enqueue_install_or_defer(
-                controller, configuration=config, port=port, build_source=build_source
+                controller, configuration=config, port=port
             )
         except CommandError as exc:
             if exc.code is ErrorCode.NO_COMPATIBLE_PEER:

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -330,7 +330,6 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         _validate_upload_target(port, bootloader=bootloader)
         await self._validate_configuration_boundary(configuration)
 
-        build_source = self._resolve_install_source(force_local=force_local)
         # Install is a compile + a dependent local upload. The compile (local
         # or dispatched to a receiver) materialises the binary locally; the
         # upload then flashes on the upload lane, freeing the compile lane to
@@ -340,7 +339,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
             self,
             configuration=configuration,
             port=port,
-            build_source=build_source,
+            force_local=force_local,
             flash_bootloader=bootloader,
         )
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -340,21 +340,15 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
                 "Bootloader update requires the device online",
             )
 
-        # Deferral gated ONLY on OFFLINE, avoiding UNKNOWN startup states
-        if port == OTA_PORT and device and device.state == DeviceState.OFFLINE:
-            _LOGGER.info("Device %s is offline. Queuing compile-only job.", configuration)
-            build_source = self._resolve_install_source(force_local=force_local)
-            job = self._create_job(configuration, JobType.COMPILE, build_source=build_source)
-            job.is_deferred_install = True
-            return await self._enqueue(job)
-
         build_source = self._resolve_install_source(force_local=force_local)
         # Install is a compile + a dependent local upload. The compile (local
         # or dispatched to a receiver) materialises the binary locally; the
         # upload then flashes on the upload lane, freeing the compile lane to
         # build the next device — so a slow flash never blocks a compile, and
-        # a remote receiver keeps compiling while we upload locally.
-        return await factories.enqueue_install_chain(
+        # a remote receiver keeps compiling while we upload locally. An
+        # OFFLINE OTA target defers to a compile-only job that flashes on
+        # the device's next wake.
+        return await factories.enqueue_install_or_defer(
             self,
             configuration=configuration,
             port=port,

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -330,24 +330,12 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         _validate_upload_target(port, bootloader=bootloader)
         await self._validate_configuration_boundary(configuration)
 
-        device = self._device_for_configuration(configuration)
-        # No deferral for a bootloader flash — the wake dispatch re-uploads
-        # the app, not the bootloader — and an explicit IP/hostname target
-        # doesn't make a known-OFFLINE device reachable either.
-        if bootloader and device and device.state == DeviceState.OFFLINE:
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                "Bootloader update requires the device online",
-            )
-
         build_source = self._resolve_install_source(force_local=force_local)
         # Install is a compile + a dependent local upload. The compile (local
         # or dispatched to a receiver) materialises the binary locally; the
         # upload then flashes on the upload lane, freeing the compile lane to
         # build the next device — so a slow flash never blocks a compile, and
-        # a remote receiver keeps compiling while we upload locally. An
-        # OFFLINE OTA target defers to a compile-only job that flashes on
-        # the device's next wake.
+        # a remote receiver keeps compiling while we upload locally.
         return await factories.enqueue_install_or_defer(
             self,
             configuration=configuration,

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -161,7 +161,7 @@ async def enqueue_install_or_defer(
     *,
     configuration: str,
     port: str,
-    build_source: JobBuildSource,
+    force_local: bool = False,
     flash_bootloader: bool = False,
 ) -> FirmwareJob:
     """
@@ -170,23 +170,25 @@ async def enqueue_install_or_defer(
     A deferred compile arms ``Device.queued_update`` on completion; the
     wake dispatch flashes an upload-only job when the device comes back.
     A bootloader flash never defers — the wake dispatch re-uploads the
-    app, not the bootloader — so an OFFLINE device raises ``INVALID_ARGS``.
+    app, not the bootloader — so an OFFLINE device raises ``INVALID_ARGS``,
+    ahead of build-source resolution so it wins over ``NO_COMPATIBLE_PEER``.
     """
     device = controller._device_for_configuration(configuration)
     # Deferral gated ONLY on OFFLINE, avoiding UNKNOWN startup states.
-    if device and device.state == DeviceState.OFFLINE:
-        # An explicit IP/hostname target doesn't make a known-OFFLINE
-        # device reachable, so the bootloader refusal skips the port gate.
-        if flash_bootloader:
-            raise CommandError(
-                ErrorCode.INVALID_ARGS,
-                "Bootloader update requires the device online",
-            )
-        if port == OTA_PORT:
-            _LOGGER.info("Device %s is offline. Queuing compile-only job.", configuration)
-            job = create_job(controller, configuration, JobType.COMPILE, build_source=build_source)
-            job.is_deferred_install = True
-            return await controller._enqueue(job)
+    offline = device is not None and device.state == DeviceState.OFFLINE
+    # An explicit IP/hostname target doesn't make a known-OFFLINE
+    # device reachable, so the bootloader refusal skips the port gate.
+    if offline and flash_bootloader:
+        raise CommandError(
+            ErrorCode.INVALID_ARGS,
+            "Bootloader update requires the device online",
+        )
+    build_source = controller._resolve_install_source(force_local=force_local)
+    if offline and port == OTA_PORT:
+        _LOGGER.info("Device %s is offline. Queuing compile-only job.", configuration)
+        job = create_job(controller, configuration, JobType.COMPILE, build_source=build_source)
+        job.is_deferred_install = True
+        return await controller._enqueue(job)
     return await enqueue_install_chain(
         controller,
         configuration=configuration,

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -168,16 +168,24 @@ async def enqueue_install_or_defer(
 
     A deferred compile arms ``Device.queued_update`` on completion; the
     wake dispatch flashes an upload-only job when the device comes back.
+    A bootloader flash never defers — the wake dispatch re-uploads the
+    app, not the bootloader — so an OFFLINE device raises ``INVALID_ARGS``.
     """
     device = controller._device_for_configuration(configuration)
-    # Deferral gated ONLY on OFFLINE (not UNKNOWN startup states), OTA
-    # targets, and app images — the wake dispatch re-uploads the app,
-    # never a bootloader.
-    if port == OTA_PORT and not flash_bootloader and device and device.state == DeviceState.OFFLINE:
-        _LOGGER.info("Device %s is offline. Queuing compile-only job.", configuration)
-        job = create_job(controller, configuration, JobType.COMPILE, build_source=build_source)
-        job.is_deferred_install = True
-        return await controller._enqueue(job)
+    # Deferral gated ONLY on OFFLINE, avoiding UNKNOWN startup states.
+    if device and device.state == DeviceState.OFFLINE:
+        # An explicit IP/hostname target doesn't make a known-OFFLINE
+        # device reachable, so the bootloader refusal skips the port gate.
+        if flash_bootloader:
+            raise CommandError(
+                ErrorCode.INVALID_ARGS,
+                "Bootloader update requires the device online",
+            )
+        if port == OTA_PORT:
+            _LOGGER.info("Device %s is offline. Queuing compile-only job.", configuration)
+            job = create_job(controller, configuration, JobType.COMPILE, build_source=build_source)
+            job.is_deferred_install = True
+            return await controller._enqueue(job)
     return await enqueue_install_chain(
         controller,
         configuration=configuration,

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -10,7 +11,9 @@ from ...helpers.api import CommandError
 from ...helpers.build_scheduler import BuildPath, pick_build_path
 from ...models import (
     LOCAL_JOB_BUILD_SOURCE,
+    OTA_PORT,
     REMOTE_PENDING_JOB_BUILD_SOURCE,
+    DeviceState,
     ErrorCode,
     EventType,
     FirmwareJob,
@@ -22,6 +25,8 @@ from .helpers import _fire_job_lifecycle, _names_touched_by_job
 
 if TYPE_CHECKING:
     from .controller import FirmwareController
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def create_job(
@@ -149,6 +154,37 @@ async def enqueue_install_chain(
     )
     await commit_chain(controller, compile_job, upload_job, supersede_configuration=configuration)
     return compile_job
+
+
+async def enqueue_install_or_defer(
+    controller: FirmwareController,
+    *,
+    configuration: str,
+    port: str,
+    build_source: JobBuildSource,
+    flash_bootloader: bool = False,
+) -> FirmwareJob:
+    """Enqueue an install chain, or a deferred compile-only job when the OTA target is OFFLINE.
+
+    A deferred compile arms ``Device.queued_update`` on completion; the
+    wake dispatch flashes an upload-only job when the device comes back.
+    """
+    device = controller._device_for_configuration(configuration)
+    # Deferral gated ONLY on OFFLINE (not UNKNOWN startup states), OTA
+    # targets, and app images — the wake dispatch re-uploads the app,
+    # never a bootloader.
+    if port == OTA_PORT and not flash_bootloader and device and device.state == DeviceState.OFFLINE:
+        _LOGGER.info("Device %s is offline. Queuing compile-only job.", configuration)
+        job = create_job(controller, configuration, JobType.COMPILE, build_source=build_source)
+        job.is_deferred_install = True
+        return await controller._enqueue(job)
+    return await enqueue_install_chain(
+        controller,
+        configuration=configuration,
+        port=port,
+        build_source=build_source,
+        flash_bootloader=flash_bootloader,
+    )
 
 
 async def commit_chain(

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -164,7 +164,8 @@ async def enqueue_install_or_defer(
     build_source: JobBuildSource,
     flash_bootloader: bool = False,
 ) -> FirmwareJob:
-    """Enqueue an install chain, or a deferred compile-only job when the OTA target is OFFLINE.
+    """
+    Enqueue an install chain, or a deferred compile-only job when the OTA target is OFFLINE.
 
     A deferred compile arms ``Device.queued_update`` on completion; the
     wake dispatch flashes an upload-only job when the device comes back.

--- a/tests/controllers/firmware/test_bulk_order.py
+++ b/tests/controllers/firmware/test_bulk_order.py
@@ -15,6 +15,9 @@ class _DevicesController:
     def get_devices(self) -> list[Device]:
         return self._devices
 
+    def get_by_configuration(self, configuration: str) -> Device | None:
+        return next((d for d in self._devices if d.configuration == configuration), None)
+
 
 def _device(
     configuration: str,

--- a/tests/controllers/firmware/test_offline_queue.py
+++ b/tests/controllers/firmware/test_offline_queue.py
@@ -98,6 +98,79 @@ async def test_install_queues_deferred_compile_for_offline_device(
 
 
 @pytest.mark.asyncio
+async def test_install_bulk_queues_deferred_compile_for_offline_device(
+    firmware_controller: FirmwareController,
+    mock_device: MagicMock,
+) -> None:
+    """Bulk install defers an OFFLINE device to a compile-only job — no UPLOAD queued."""
+    mock_device.state = DeviceState.OFFLINE
+    mock_device.update_available = False
+    mock_device.has_pending_changes = False
+
+    jobs = await firmware_controller.install_bulk(configurations=["test_device.yaml"])
+
+    assert len(jobs) == 1
+    assert jobs[0].job_type == JobType.COMPILE
+    assert jobs[0].is_deferred_install is True
+    job_types = {job.job_type for job in firmware_controller.state.jobs.values()}
+    assert job_types == {JobType.COMPILE}
+
+
+@pytest.mark.asyncio
+async def test_install_bulk_mixed_defers_only_the_offline_device(
+    firmware_controller: FirmwareController,
+    mock_device: MagicMock,
+) -> None:
+    """Mixed bulk queues a full chain for the online device, a deferred compile for the offline."""
+    mock_device.state = DeviceState.OFFLINE
+    mock_device.update_available = False
+    mock_device.has_pending_changes = False
+    online_device = MagicMock()
+    online_device.state = DeviceState.ONLINE
+    online_device.configuration = "online_device.yaml"
+    online_device.update_available = False
+    online_device.has_pending_changes = False
+    devices = {d.configuration: d for d in (mock_device, online_device)}
+    firmware_controller._db.devices.get_devices.return_value = list(devices.values())
+    firmware_controller._db.devices.get_by_configuration.side_effect = devices.get
+
+    jobs = await firmware_controller.install_bulk(
+        configurations=["online_device.yaml", "test_device.yaml"]
+    )
+
+    assert len(jobs) == 2
+    by_config: dict[str, list] = {}
+    for job in firmware_controller.state.jobs.values():
+        by_config.setdefault(job.configuration, []).append(job)
+    online_jobs = by_config["online_device.yaml"]
+    assert {job.job_type for job in online_jobs} == {JobType.COMPILE, JobType.UPLOAD}
+    assert all(job.is_deferred_install is False for job in online_jobs)
+    offline_jobs = by_config["test_device.yaml"]
+    assert [job.job_type for job in offline_jobs] == [JobType.COMPILE]
+    assert offline_jobs[0].is_deferred_install is True
+
+
+@pytest.mark.asyncio
+async def test_install_bulk_explicit_target_does_not_defer(
+    firmware_controller: FirmwareController,
+    mock_device: MagicMock,
+) -> None:
+    """An explicit IP target keeps the full chain even for an OFFLINE device."""
+    mock_device.state = DeviceState.OFFLINE
+    mock_device.update_available = False
+    mock_device.has_pending_changes = False
+
+    jobs = await firmware_controller.install_bulk(
+        configurations=["test_device.yaml"], port="192.168.1.50"
+    )
+
+    assert len(jobs) == 1
+    assert jobs[0].is_deferred_install is False
+    job_types = {job.job_type for job in firmware_controller.state.jobs.values()}
+    assert job_types == {JobType.COMPILE, JobType.UPLOAD}
+
+
+@pytest.mark.asyncio
 async def test_install_bootloader_refuses_offline_device(
     firmware_controller: FirmwareController,
     mock_device: MagicMock,

--- a/tests/controllers/firmware/test_offline_queue.py
+++ b/tests/controllers/firmware/test_offline_queue.py
@@ -18,6 +18,7 @@ from esphome_device_builder.models import (
     JobStatus,
     JobType,
 )
+from tests.conftest import make_device
 
 
 def _job(
@@ -55,6 +56,10 @@ def mock_device() -> MagicMock:
     mock.queued_update = False
     mock.name = "test_device"
     mock.configuration = "test_device.yaml"
+    # Real bools so install_bulk's stale-first sort doesn't touch
+    # MagicMock version attributes.
+    mock.update_available = False
+    mock.has_pending_changes = False
     return mock
 
 
@@ -100,17 +105,11 @@ async def test_install_queues_deferred_compile_for_offline_device(
 @pytest.mark.asyncio
 async def test_install_bulk_queues_deferred_compile_for_offline_device(
     firmware_controller: FirmwareController,
-    mock_device: MagicMock,
 ) -> None:
     """Bulk install defers an OFFLINE device to a compile-only job — no UPLOAD queued."""
-    mock_device.state = DeviceState.OFFLINE
-    mock_device.update_available = False
-    mock_device.has_pending_changes = False
-
     jobs = await firmware_controller.install_bulk(configurations=["test_device.yaml"])
 
     assert len(jobs) == 1
-    assert jobs[0].job_type == JobType.COMPILE
     assert jobs[0].is_deferred_install is True
     job_types = {job.job_type for job in firmware_controller.state.jobs.values()}
     assert job_types == {JobType.COMPILE}
@@ -122,14 +121,7 @@ async def test_install_bulk_mixed_defers_only_the_offline_device(
     mock_device: MagicMock,
 ) -> None:
     """Mixed bulk queues a full chain for the online device, a deferred compile for the offline."""
-    mock_device.state = DeviceState.OFFLINE
-    mock_device.update_available = False
-    mock_device.has_pending_changes = False
-    online_device = MagicMock()
-    online_device.state = DeviceState.ONLINE
-    online_device.configuration = "online_device.yaml"
-    online_device.update_available = False
-    online_device.has_pending_changes = False
+    online_device = make_device("online_device", state=DeviceState.ONLINE)
     devices = {d.configuration: d for d in (mock_device, online_device)}
     firmware_controller._db.devices.get_devices.return_value = list(devices.values())
     firmware_controller._db.devices.get_by_configuration.side_effect = devices.get
@@ -153,13 +145,8 @@ async def test_install_bulk_mixed_defers_only_the_offline_device(
 @pytest.mark.asyncio
 async def test_install_bulk_explicit_target_does_not_defer(
     firmware_controller: FirmwareController,
-    mock_device: MagicMock,
 ) -> None:
     """An explicit IP target keeps the full chain even for an OFFLINE device."""
-    mock_device.state = DeviceState.OFFLINE
-    mock_device.update_available = False
-    mock_device.has_pending_changes = False
-
     jobs = await firmware_controller.install_bulk(
         configurations=["test_device.yaml"], port="192.168.1.50"
     )

--- a/tests/controllers/firmware/test_offline_queue.py
+++ b/tests/controllers/firmware/test_offline_queue.py
@@ -173,6 +173,21 @@ async def test_install_bootloader_refuses_offline_device(
 
 
 @pytest.mark.asyncio
+async def test_bootloader_offline_refusal_wins_over_source_resolution(
+    firmware_controller: FirmwareController,
+) -> None:
+    """The offline refusal fires before build-source resolution can raise NO_COMPATIBLE_PEER."""
+    firmware_controller._resolve_install_source = MagicMock(  # type: ignore[method-assign]
+        side_effect=CommandError(ErrorCode.NO_COMPATIBLE_PEER, "no eligible peer")
+    )
+
+    with pytest.raises(CommandError) as err:
+        await firmware_controller.install(configuration="test_device.yaml", bootloader=True)
+
+    assert err.value.code == ErrorCode.INVALID_ARGS
+
+
+@pytest.mark.asyncio
 async def test_install_bootloader_refuses_offline_device_with_explicit_target(
     firmware_controller: FirmwareController,
     mock_device: MagicMock,


### PR DESCRIPTION
# What does this implement/fix?

Update All queues a compile plus a dependent OTA upload for every device, including devices that are currently offline; the upload is doomed to fail, and retrying it later pays a second full compile. The single device install already handles this case: an offline device with an OTA target gets a compile-only job, the completed compile arms the device's queued update, and the wake dispatch flashes an upload-only job when the device comes back online, with no recompile.

`firmware/install_bulk` never got that branch. This hoists the deferral into a shared `enqueue_install_or_defer` factory used by both the single install and the bulk path, so an offline device in an Update All now compiles once and flashes on its next wake. Online devices, explicit IP targets, and bootloader flashes keep the full chain; the returned job list still carries the chain heads, so there is no wire shape change and no frontend change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1928

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
