### PR TITLE
Hoist the canonical rp2 platform key into shared constants

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/rp2040.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-TARGET_PLATFORM = "rp2040"
+from ....models.boards import RP2_CANONICAL_PLATFORM
+
+TARGET_PLATFORM = RP2_CANONICAL_PLATFORM
 
 BUILD_FILES: tuple[str, ...] = (
     ".pioenvs/{name}/firmware.bin",

--- a/esphome_device_builder/helpers/device_yaml/_generation.py
+++ b/esphome_device_builder/helpers/device_yaml/_generation.py
@@ -8,6 +8,7 @@ import string
 from typing import TYPE_CHECKING, Any
 
 from ...definitions import load_platform_capabilities_index
+from ...models.boards import RP2_CANONICAL_PLATFORM
 from ..yaml import _safe_yaml_scalar, merge_component_yaml
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ _AP_SSID_MAX_LEN = 32
 # allowlist). The fallback is emitted only here; a bare ``ap:`` without
 # a portal can't recover credentials, so other platforms get neither.
 _CAPTIVE_PORTAL_PLATFORMS: frozenset[str] = frozenset(
-    {"esp8266", "esp32", "bk72xx", "ln882x", "rp2040", "rtl87xx"}
+    {"esp8266", "esp32", "bk72xx", "ln882x", RP2_CANONICAL_PLATFORM, "rtl87xx"}
 )
 
 # TODO comment block emitted by ``generate_device_yaml`` for
@@ -136,7 +137,7 @@ def _has_native_wifi(
     """
     if platform == "esp32":
         return not (variant and variant.lower() in _ESP32_NO_WIFI_VARIANTS)
-    if platform == "rp2040":
+    if platform == RP2_CANONICAL_PLATFORM:
         return board is None or board not in _RP2040_NO_WIFI_BOARDS
     return platform in _WIFI_FIRST_PLATFORMS
 

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -35,9 +35,8 @@ class Connectivity(StrEnum):
     LORA = "lora"
 
 
-# Canonical spelling of the RP2 platform key across the catalog and wire,
-# plus the other accepted spelling (esphome#17145 rename). Swap the two
-# values to flip the canonical key once 2026.7 is the runtime floor.
+# Canonical and accepted-alias spellings of the RP2 platform key
+# (esphome#17145 rename); a canonical-key flip starts by swapping these.
 RP2_CANONICAL_PLATFORM = "rp2040"
 RP2_ALIAS_PLATFORM = "rp2"
 
@@ -53,6 +52,14 @@ class Platform(StrEnum):
     LN882X = "ln882x"
     NRF52 = "nrf52"
     HOST = "host"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Platform | None:
+        # Hand-curated manifests and wire payloads may carry either RP2
+        # spelling; fold both onto the canonical member.
+        if isinstance(value, str) and value.lower() in RP2_PLATFORM_ALIASES:
+            return cls.RP2040
+        return None
 
 
 # Inbound platform strings may use either spelling; the catalog stays keyed

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -35,12 +35,19 @@ class Connectivity(StrEnum):
     LORA = "lora"
 
 
+# Canonical spelling of the RP2 platform key across the catalog and wire,
+# plus the other accepted spelling (esphome#17145 rename). Swap the two
+# values to flip the canonical key once 2026.7 is the runtime floor.
+RP2_CANONICAL_PLATFORM = "rp2040"
+RP2_ALIAS_PLATFORM = "rp2"
+
+
 class Platform(StrEnum):
     """ESPHome target platforms."""
 
     ESP32 = "esp32"
     ESP8266 = "esp8266"
-    RP2040 = "rp2040"
+    RP2040 = RP2_CANONICAL_PLATFORM
     BK72XX = "bk72xx"
     RTL87XX = "rtl87xx"
     LN882X = "ln882x"
@@ -48,14 +55,14 @@ class Platform(StrEnum):
     HOST = "host"
 
 
-# Inbound platform strings may use the renamed ``rp2`` key; the catalog stays
-# keyed on ``rp2040``, so both names fold to it at every ingestion boundary.
-RP2_PLATFORM_ALIASES: frozenset[str] = frozenset({"rp2", "rp2040"})
+# Inbound platform strings may use either spelling; the catalog stays keyed
+# on the canonical one, so both fold to it at every ingestion boundary.
+RP2_PLATFORM_ALIASES: frozenset[str] = frozenset({RP2_ALIAS_PLATFORM, RP2_CANONICAL_PLATFORM})
 
 
 def normalize_platform(name: str) -> str:
-    """Fold the renamed ``rp2`` platform key onto the catalog's ``rp2040``."""
-    return "rp2040" if name.lower() == "rp2" else name
+    """Fold the non-canonical RP2 platform spelling onto the canonical one."""
+    return RP2_CANONICAL_PLATFORM if name.lower() == RP2_ALIAS_PLATFORM else name
 
 
 class Esp32Variant(StrEnum):

--- a/esphome_device_builder/models/boards.py
+++ b/esphome_device_builder/models/boards.py
@@ -35,8 +35,8 @@ class Connectivity(StrEnum):
     LORA = "lora"
 
 
-# Canonical and accepted-alias spellings of the RP2 platform key
-# (esphome#17145 rename); a canonical-key flip starts by swapping these.
+# Canonical and accepted-alias spellings of the RP2 platform key;
+# a canonical-key flip starts by swapping these values.
 RP2_CANONICAL_PLATFORM = "rp2040"
 RP2_ALIAS_PLATFORM = "rp2"
 

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -146,9 +146,6 @@ _PLATFORM_DOCS_URL: dict[Platform, str] = {
     Platform.NRF52: "https://esphome.io/components/nrf52.html",
 }
 
-# RP2040/RP2350 also derive pins from ESPHome board data, but as a GPIO matrix:
-# ``BOARDS`` carries ``max_pin`` (full GPIO range), ``RP2040_BOARD_PINS`` only the
-# conventional default-bus pins.
 
 # ESPHome's ``components/esp32/boards.py`` carries ``BOARDS`` (board ->
 # {name, variant}) and ``ESP32_BOARD_PINS`` (board -> {alias: gpio}). The

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -149,7 +149,6 @@ _PLATFORM_DOCS_URL: dict[Platform, str] = {
 # RP2040/RP2350 also derive pins from ESPHome board data, but as a GPIO matrix:
 # ``BOARDS`` carries ``max_pin`` (full GPIO range), ``RP2040_BOARD_PINS`` only the
 # conventional default-bus pins.
-_RP2040_PLATFORM = "rp2040"
 
 # ESPHome's ``components/esp32/boards.py`` carries ``BOARDS`` (board ->
 # {name, variant}) and ``ESP32_BOARD_PINS`` (board -> {alias: gpio}). The

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1288,11 +1288,11 @@ def _mark_platform_domains_multi_conf(entries: list[dict]) -> None:
 
 def _fold_rp2_component_alias(entries: list[dict]) -> None:
     """
-    Collapse esphome 2026.7's renamed ``rp2`` component onto the canonical ``rp2040``.
+    Collapse esphome 2026.7's renamed ``rp2`` component onto the canonical id.
 
-    The richer ``rp2`` schema is re-keyed, the alias shell dropped (its identity
-    fields kept), and ``dependencies`` folded so ``rp2040:`` blocks satisfy them.
-    The catalog stays keyed on ``rp2040`` — see ``normalize_platform``.
+    The richer renamed schema is re-keyed, the alias shell dropped (its
+    identity fields kept), and ``dependencies`` folded so blocks spelled with
+    the canonical key satisfy them — see ``normalize_platform``.
     """
     by_id = {entry["id"]: entry for entry in entries}
     if (rp2 := by_id.get(RP2_ALIAS_PLATFORM)) is not None:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -121,6 +121,8 @@ from esphome_device_builder.controllers.components import (  # noqa: E402
 from esphome_device_builder.controllers.components import variant_to_key  # noqa: E402
 from esphome_device_builder.helpers.automation_keys import is_trigger_key  # noqa: E402
 from esphome_device_builder.models import (  # noqa: E402
+    RP2_ALIAS_PLATFORM,
+    RP2_CANONICAL_PLATFORM,
     AutomationAction,
     AutomationActionIndex,
     AutomationCondition,
@@ -307,10 +309,10 @@ _SKIP_KEYS: frozenset[str] = frozenset({"mqtt_id", "zigbee_id", "then"})
 _DEPRECATED_FIELDS: frozenset[tuple[str, str]] = frozenset(
     {
         ("esp32", "board"),
-        ("rp2040", "board"),
+        (RP2_CANONICAL_PLATFORM, "board"),
         # esphome 2026.7's rename of the rp2040 component; extraction runs
-        # before ``_fold_rp2_component_alias`` re-keys it onto rp2040.
-        ("rp2", "board"),
+        # before ``_fold_rp2_component_alias`` re-keys it onto the canonical id.
+        (RP2_ALIAS_PLATFORM, "board"),
     }
 )
 
@@ -1293,16 +1295,16 @@ def _fold_rp2_component_alias(entries: list[dict]) -> None:
     The catalog stays keyed on ``rp2040`` — see ``normalize_platform``.
     """
     by_id = {entry["id"]: entry for entry in entries}
-    if (rp2 := by_id.get("rp2")) is not None:
-        rp2["id"] = "rp2040"
-        if (shell := by_id.get("rp2040")) is not None:
+    if (rp2 := by_id.get(RP2_ALIAS_PLATFORM)) is not None:
+        rp2["id"] = RP2_CANONICAL_PLATFORM
+        if (shell := by_id.get(RP2_CANONICAL_PLATFORM)) is not None:
             for key in ("name", "image_url", "category"):
                 if shell.get(key):
                     rp2[key] = shell[key]
             entries.remove(shell)
     for entry in entries:
         deps = entry.get("dependencies")
-        if deps and "rp2" in deps:
+        if deps and RP2_ALIAS_PLATFORM in deps:
             entry["dependencies"] = list(dict.fromkeys(normalize_platform(dep) for dep in deps))
 
 
@@ -3235,7 +3237,7 @@ def _emit_platform_capabilities_index() -> None:
     # dependent and stay out of the index — device-builder-helper handles them.
     sentinel = SimpleNamespace(name="{name}")
     download_types: dict[str, list[dict[str, str]]] = {}
-    for component in ("esp32", "esp8266", "rp2040"):
+    for component in ("esp32", "esp8266", RP2_CANONICAL_PLATFORM):
         module = importlib.import_module(f"esphome.components.{component}")
         download_types[component] = [
             {
@@ -4020,10 +4022,10 @@ _CATEGORY_OVERRIDES: dict[str, str] = {
     # them explicitly here makes the override authoritative.
     "esp32": "core",
     "esp8266": "core",
-    "rp2040": "core",
+    RP2_CANONICAL_PLATFORM: "core",
     # esphome 2026.7's rename of rp2040; extraction categorizes before
-    # ``_fold_rp2_component_alias`` re-keys the entry onto rp2040.
-    "rp2": "core",
+    # ``_fold_rp2_component_alias`` re-keys the entry onto the canonical id.
+    RP2_ALIAS_PLATFORM: "core",
     "bk72xx": "core",
     "rtl87xx": "core",
     "ln882x": "core",
@@ -4081,8 +4083,8 @@ _TARGET_PLATFORMS: frozenset[str] = frozenset(
     {
         "esp32",
         "esp8266",
-        "rp2",
-        "rp2040",
+        RP2_ALIAS_PLATFORM,
+        RP2_CANONICAL_PLATFORM,
         "bk72xx",
         "rtl87xx",
         "ln882x",
@@ -5782,7 +5784,7 @@ def _logger_uart_platform_options() -> dict[str, list[dict[str, str]]]:
     for component, values in _logger.UART_SELECTION_LIBRETINY.items():
         add(component, values)
     add("esp8266", _logger.UART_SELECTION_ESP8266)
-    add("rp2040", _logger.UART_SELECTION_RP2040)
+    add(RP2_CANONICAL_PLATFORM, _logger.UART_SELECTION_RP2040)
     add("nrf52", _logger.UART_SELECTION_NRF52)
     return out
 
@@ -5828,7 +5830,7 @@ def _ethernet_type_platform_options() -> dict[str, list[dict[str, str]]]:
     esp32 = set(_ethernet.ETHERNET_TYPES) - (rp2 - set(_ethernet.SPI_ETHERNET_TYPES))
     return {
         "esp32": [{"label": t, "value": t} for t in sorted(esp32)],
-        "rp2040": [{"label": t, "value": t} for t in sorted(rp2)],
+        RP2_CANONICAL_PLATFORM: [{"label": t, "value": t} for t in sorted(rp2)],
     }
 
 

--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -49,7 +49,6 @@ from esphome_device_builder.models.common import FieldPreset, PinFeature
 from script.sync_boards import (
     _LIBRETINY_FAMILIES,
     _NRF52_PLATFORM,
-    _RP2040_PLATFORM,
     _augment_rmii_data_pins,
     _augment_rp2040_onboard_ethernet_pins,
     _backfill_esp32_engineering_sample,
@@ -109,7 +108,7 @@ def test_split_artefacts_match_manifests() -> None:
     _stamp_featured_requires(from_yaml.boards)
     _consolidate_full_setup_bundles(from_yaml.boards)
     from_disk = load_board_catalog()
-    generated = set(_LIBRETINY_FAMILIES) | {_RP2040_PLATFORM, _NRF52_PLATFORM, "esp32", "esp8266"}
+    generated = set(_LIBRETINY_FAMILIES) | {"rp2040", _NRF52_PLATFORM, "esp32", "esp8266"}
     esphome_filled = set(_LIBRETINY_FAMILIES)
     manifest_ids = {b.id for b in from_yaml.boards}
     disk_by_id = {b.id: b for b in from_disk.boards}

--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -32,6 +32,7 @@ from esphome_device_builder.definitions import (
     load_featured_components_index,
 )
 from esphome_device_builder.models.boards import (
+    RP2_CANONICAL_PLATFORM,
     BoardCatalogEntry,
     BoardCatalogIndex,
     BoardEsphomeConfig,
@@ -108,7 +109,12 @@ def test_split_artefacts_match_manifests() -> None:
     _stamp_featured_requires(from_yaml.boards)
     _consolidate_full_setup_bundles(from_yaml.boards)
     from_disk = load_board_catalog()
-    generated = set(_LIBRETINY_FAMILIES) | {"rp2040", _NRF52_PLATFORM, "esp32", "esp8266"}
+    generated = set(_LIBRETINY_FAMILIES) | {
+        RP2_CANONICAL_PLATFORM,
+        _NRF52_PLATFORM,
+        "esp32",
+        "esp8266",
+    }
     esphome_filled = set(_LIBRETINY_FAMILIES)
     manifest_ids = {b.id for b in from_yaml.boards}
     disk_by_id = {b.id: b for b in from_disk.boards}

--- a/tests/test_sync_components_rp2_alias.py
+++ b/tests/test_sync_components_rp2_alias.py
@@ -6,6 +6,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 import esphome_device_builder
 from esphome_device_builder.models.boards import Platform
 
@@ -21,6 +23,11 @@ _DEFINITIONS = Path(esphome_device_builder.__file__).parent / "definitions"
 def test_platform_enum_accepts_both_rp2_spellings() -> None:
     assert Platform("rp2") is Platform.RP2040
     assert Platform("rp2040") is Platform.RP2040
+
+
+def test_platform_enum_still_rejects_unknown_values() -> None:
+    with pytest.raises(ValueError, match="rp3"):
+        Platform("rp3")
 
 
 def _entry(component_id: str, **overrides: object) -> dict:

--- a/tests/test_sync_components_rp2_alias.py
+++ b/tests/test_sync_components_rp2_alias.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import esphome_device_builder
+from esphome_device_builder.models.boards import Platform
 
 _SCRIPT_DIR = Path(__file__).parent.parent / "script"
 if str(_SCRIPT_DIR) not in sys.path:
@@ -15,6 +16,11 @@ if str(_SCRIPT_DIR) not in sys.path:
 import sync_components  # noqa: E402
 
 _DEFINITIONS = Path(esphome_device_builder.__file__).parent / "definitions"
+
+
+def test_platform_enum_accepts_both_rp2_spellings() -> None:
+    assert Platform("rp2") is Platform.RP2040
+    assert Platform("rp2040") is Platform.RP2040
 
 
 def _entry(component_id: str, **overrides: object) -> dict:


### PR DESCRIPTION
# What does this implement/fix?

Hoists the canonical rp2 platform spelling into `RP2_CANONICAL_PLATFORM` / `RP2_ALIAS_PLATFORM` in `models/boards.py` and points every production site that encodes the canonical choice at them; `Platform.RP2040`, `RP2_PLATFORM_ALIASES` and `normalize_platform` derive from the pair, and the sync script's fold pass, `_DEPRECATED_FIELDS`, `_CATEGORY_OVERRIDES`, `_TARGET_PLATFORMS`, the logger and ethernet `platform_options` keys, plus the runtime sites (`artifact_platforms`, wifi and captive portal checks in `device_yaml/_generation.py`) now reference the constants. Flipping the canonical key to rp2 (esphome/backlog#155, once 2026.7 is the runtime floor) becomes swapping the two constant values.

`Platform` gains a `_missing_` hook folding both spellings onto the canonical member, so hand curated board manifests and wire payloads keep deserializing across the flip in either direction. The flip is not purely the value swap; the remaining hand edits (rename the `Platform.RP2040` member and `artifact_platforms/rp2040.py`, bulk edit the board manifests, add the `rp2` translation label key in the frontend, full catalog regen) are greppable via the constants.

Chip and MCU names stay literal on purpose (`mcu: "rp2040"` / `"rp2350"`, devices.esphome.io SoC families, upstream module paths); they name silicon or external taxonomies and do not flip. Tests keep literal `"rp2040"` so the flip breaks them loudly instead of silently following the constant. Also drops the dead `_RP2040_PLATFORM` in `sync_boards.py`. No behavior change; regenerating the catalog produces a byte identical output.

**Related issue or feature (if applicable):**

- groundwork for esphome/backlog#155

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1163 (same const hoist for the frontend's alias sites)

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
