### PR TITLE
Share one per-item core between single and bulk command handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,18 @@ against legacy behaviour before assuming the simpler version suffices.
   `devices/list_archived` (cold archive listing, read-once). `labels/list`
   is the snapshot-fetch-then-events holdover — new code lands through
   `initial_state`, not by copying it.
+- **Single/bulk command pairs share one per-item core function.** Every
+  `X` / `X_bulk` verb keeps its per-item behavior in a single callable
+  both handlers invoke (`factories.enqueue_install_or_defer` /
+  `enqueue_compile` for firmware, `archive.archive_single_checked` /
+  `delete_single` passed to `run_bulk_per_device` for devices). The bulk
+  handler adds only bulk-scoped concerns: batched boundary validation
+  (one executor task via `_validate_configurations_boundary`),
+  ordering (`_configuration_order`), and the per-item error policy
+  (skip-and-collect rows, fleet-wide `NO_COMPATIBLE_PEER` re-raise).
+  Never inline the per-item body in a bulk loop — that's how
+  `install_bulk` missed the offline deferral (#1928). New pairs ship
+  with parity coverage in `tests/test_single_bulk_parity.py`.
 - **Event payloads use TypedDict, not dataclass.** Mirrors HA core's
   `Event[_DataT]` / `EventStateChangedData` pattern. Each event-specific
   shape gets a `TypedDict` next to the controller that fires it (e.g.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,15 +294,16 @@ against legacy behaviour before assuming the simpler version suffices.
 - **Single/bulk command pairs share one per-item core function.** Every
   `X` / `X_bulk` verb keeps its per-item behavior in a single callable
   both handlers invoke (`factories.enqueue_install_or_defer` /
-  `enqueue_compile` for firmware, `archive.archive_single_checked` /
+  `enqueue_compile` for firmware, `archive.archive_single` /
   `delete_single` passed to `run_bulk_per_device` for devices). The bulk
   handler adds only bulk-scoped concerns: batched boundary validation
   (one executor task via `_validate_configurations_boundary`),
-  ordering (`_configuration_order`), and the per-item error policy
-  (skip-and-collect rows, fleet-wide `NO_COMPATIBLE_PEER` re-raise).
-  Never inline the per-item body in a bulk loop — that's how
-  `install_bulk` missed the offline deferral (#1928). New pairs ship
-  with parity coverage in `tests/test_single_bulk_parity.py`.
+  ordering (`_configuration_order`), and the per-item error policy —
+  itself shared, not copy-pasted (`bulk._run_bulk` skips per-item errors
+  and re-raises fleet-wide `NO_COMPATIBLE_PEER`; devices'
+  `run_bulk_per_device` collects `{configuration, success, error}`
+  rows). Never inline the per-item body in a bulk loop — that's how
+  `install_bulk` missed the offline deferral (#1928).
 - **Event payloads use TypedDict, not dataclass.** Mirrors HA core's
   `Event[_DataT]` / `EventStateChangedData` pattern. Each event-specific
   shape gets a `TypedDict` next to the controller that fires it (e.g.

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -29,14 +29,9 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-async def archive_single_checked(controller: DevicesController, configuration: str) -> None:
-    """Boundary-validate the archive filename, then archive; the single/bulk shared core."""
-    _validate_archive_configuration(configuration)
-    await archive_single(controller, configuration)
-
-
 async def archive_single(controller: DevicesController, configuration: str) -> None:
     """Soft-delete: move the YAML into ``<config_dir>/archive/`` and wipe build artifacts."""
+    _validate_archive_configuration(configuration)
     config_path = controller._db.settings.rel_path(configuration)
     config_dir = controller._db.settings.config_dir
 
@@ -87,6 +82,7 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
 
 async def unarchive_single(controller: DevicesController, configuration: str) -> None:
     """Move an archived YAML back into the active config_dir; refuse on filename clash."""
+    _validate_archive_configuration(configuration)
     config_dir = controller._db.settings.config_dir
     archive_path = config_dir / "archive" / configuration
     target = controller._db.settings.rel_path(configuration)
@@ -144,6 +140,7 @@ def list_archived_sync(controller: DevicesController) -> list[dict[str, Any]]:
 
 async def delete_archived_single(controller: DevicesController, configuration: str) -> None:
     """Permanently remove an archived YAML and its sidecars."""
+    _validate_archive_configuration(configuration)
     config_dir = controller._db.settings.config_dir
     archive_path = config_dir / "archive" / configuration
     active_path = controller._db.settings.rel_path(configuration)

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -19,7 +19,7 @@ from ...helpers.build_artifacts import (
 from ...helpers.device_yaml import parse_esphome_meta
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode
-from .helpers import require_file_exists
+from .helpers import _validate_archive_configuration, require_file_exists
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
     from .controller import DevicesController
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def archive_single_checked(controller: DevicesController, configuration: str) -> None:
+    """Boundary-validate the archive filename, then archive; the single/bulk shared core."""
+    _validate_archive_configuration(configuration)
+    await archive_single(controller, configuration)
 
 
 async def archive_single(controller: DevicesController, configuration: str) -> None:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -659,9 +659,8 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         is the catalog → YAML match key. See ``_archive_single``
         for the full keep / clear rationale.
         """
-        _validate_archive_configuration(configuration)
         try:
-            await self._archive_single(configuration)
+            await self._archive_single_checked(configuration)
         except FileNotFoundError as exc:
             raise CommandError(ErrorCode.NOT_FOUND, str(exc)) from exc
         await self._scanner.scan()
@@ -739,12 +738,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         consume a single per-device result list instead of fanning out
         N separate ``devices/archive`` calls.
         """
-
-        async def _archive(configuration: str) -> None:
-            _validate_archive_configuration(configuration)
-            await self._archive_single(configuration)
-
-        return await self._run_bulk_per_device(configurations, _archive)
+        return await self._run_bulk_per_device(configurations, self._archive_single_checked)
 
     async def _run_bulk_per_device(
         self,
@@ -1196,6 +1190,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     async def _archive_single(self, configuration: str) -> None:
         await archive.archive_single(self, configuration)
+
+    async def _archive_single_checked(self, configuration: str) -> None:
+        await archive.archive_single_checked(self, configuration)
 
     async def _unarchive_single(self, configuration: str) -> None:
         await archive.unarchive_single(self, configuration)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -84,7 +84,6 @@ from ._state import DevicesState
 from ._yaml_search_cache import YamlSearchCache
 from .helpers import (
     _build_address_cache_args,
-    _validate_archive_configuration,
     raise_device_not_found,
 )
 from .metadata import DeviceMetadataBase
@@ -660,7 +659,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         for the full keep / clear rationale.
         """
         try:
-            await self._archive_single_checked(configuration)
+            await self._archive_single(configuration)
         except FileNotFoundError as exc:
             raise CommandError(ErrorCode.NOT_FOUND, str(exc)) from exc
         await self._scanner.scan()
@@ -673,7 +672,6 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         ``DEVICE_ADDED`` so the dashboard's active list refreshes
         without a manual reload.
         """
-        _validate_archive_configuration(configuration)
         try:
             await self._unarchive_single(configuration)
         except FileNotFoundError as exc:
@@ -709,7 +707,6 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         when the archive entry is gone — symmetric with
         ``unarchive``.
         """
-        _validate_archive_configuration(configuration)
         try:
             await self._delete_archived_single(configuration)
         except FileNotFoundError as exc:
@@ -738,7 +735,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         consume a single per-device result list instead of fanning out
         N separate ``devices/archive`` calls.
         """
-        return await self._run_bulk_per_device(configurations, self._archive_single_checked)
+        return await self._run_bulk_per_device(configurations, self._archive_single)
 
     async def _run_bulk_per_device(
         self,
@@ -1190,9 +1187,6 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     async def _archive_single(self, configuration: str) -> None:
         await archive.archive_single(self, configuration)
-
-    async def _archive_single_checked(self, configuration: str) -> None:
-        await archive.archive_single_checked(self, configuration)
 
     async def _unarchive_single(self, configuration: str) -> None:
         await archive.unarchive_single(self, configuration)

--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -7,7 +7,7 @@ import re
 from typing import TYPE_CHECKING, NamedTuple
 
 from ...helpers.api import CommandError
-from ...models import OTA_PORT, ErrorCode, FirmwareJob, JobType
+from ...models import OTA_PORT, ErrorCode, FirmwareJob
 from . import factories
 from .helpers import _validate_port
 
@@ -104,13 +104,9 @@ async def compile_bulk(
     jobs: list[FirmwareJob] = []
     for config in _configuration_order(controller, configurations):
         try:
-            build_source = controller._resolve_install_source(force_local=force_local)
-            job = controller._create_job(
-                config,
-                JobType.COMPILE,
-                build_source=build_source,
+            job = await factories.enqueue_compile(
+                controller, configuration=config, force_local=force_local
             )
-            await controller._enqueue(job)
         except CommandError as exc:
             if exc.code is ErrorCode.NO_COMPATIBLE_PEER:
                 # Fleet-wide policy refusal — re-raise so the

--- a/esphome_device_builder/controllers/firmware/bulk.py
+++ b/esphome_device_builder/controllers/firmware/bulk.py
@@ -12,6 +12,8 @@ from . import factories
 from .helpers import _validate_port
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from .controller import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,6 +91,29 @@ def _configuration_order(controller: FirmwareController, configurations: list[st
     return [config for _, config in sorted(enumerate(configurations), key=sort_key)]
 
 
+async def _run_bulk(
+    controller: FirmwareController,
+    configurations: list[str],
+    verb: str,
+    enqueue_one: Callable[[str], Awaitable[FirmwareJob]],
+) -> list[FirmwareJob]:
+    """Enqueue one job per config in stale-first order; the shared bulk error policy."""
+    jobs: list[FirmwareJob] = []
+    for config in _configuration_order(controller, configurations):
+        try:
+            job = await enqueue_one(config)
+        except CommandError as exc:
+            if exc.code is ErrorCode.NO_COMPATIBLE_PEER:
+                # Fleet-wide policy refusal — re-raise so the
+                # operator gets one toast instead of N silent
+                # per-config skips. See issue #985.
+                raise
+            _LOGGER.info("Skipping %s in %s: %s", config, verb, exc.message)
+            continue
+        jobs.append(job)
+    return jobs
+
+
 async def compile_bulk(
     controller: FirmwareController,
     *,
@@ -101,22 +126,13 @@ async def compile_bulk(
     auto-routing may send some REMOTE).
     """
     await controller._validate_configurations_boundary(configurations)
-    jobs: list[FirmwareJob] = []
-    for config in _configuration_order(controller, configurations):
-        try:
-            job = await factories.enqueue_compile(
-                controller, configuration=config, force_local=force_local
-            )
-        except CommandError as exc:
-            if exc.code is ErrorCode.NO_COMPATIBLE_PEER:
-                # Fleet-wide policy refusal — re-raise so the
-                # operator gets one toast instead of N silent
-                # per-config skips. See bulk.py docstring + issue #985.
-                raise
-            _LOGGER.info("Skipping %s in compile_bulk: %s", config, exc.message)
-            continue
-        jobs.append(job)
-    return jobs
+
+    async def _enqueue_one(config: str) -> FirmwareJob:
+        return await factories.enqueue_compile(
+            controller, configuration=config, force_local=force_local
+        )
+
+    return await _run_bulk(controller, configurations, "compile_bulk", _enqueue_one)
 
 
 async def install_bulk(
@@ -135,19 +151,11 @@ async def install_bulk(
     """
     _validate_port(port)
     await controller._validate_configurations_boundary(configurations)
-    jobs: list[FirmwareJob] = []
-    for config in _configuration_order(controller, configurations):
-        try:
-            # A chain (COMPILE + dependent UPLOAD) per device, same as single
-            # install — so device B's compile pipelines against device A's
-            # upload instead of a fused job pinning both to the compile lane.
-            job = await factories.enqueue_install_or_defer(
-                controller, configuration=config, port=port
-            )
-        except CommandError as exc:
-            if exc.code is ErrorCode.NO_COMPATIBLE_PEER:
-                raise
-            _LOGGER.info("Skipping %s in install_bulk: %s", config, exc.message)
-            continue
-        jobs.append(job)
-    return jobs
+
+    async def _enqueue_one(config: str) -> FirmwareJob:
+        # A chain (COMPILE + dependent UPLOAD) per device, same as single
+        # install — so device B's compile pipelines against device A's
+        # upload instead of a fused job pinning both to the compile lane.
+        return await factories.enqueue_install_or_defer(controller, configuration=config, port=port)
+
+    return await _run_bulk(controller, configurations, "install_bulk", _enqueue_one)

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -229,13 +229,9 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         "Download firmware binary" button.
         """
         await self._validate_configuration_boundary(configuration)
-        build_source = self._resolve_install_source(force_local=force_local)
-        job = self._create_job(
-            configuration,
-            JobType.COMPILE,
-            build_source=build_source,
+        return await factories.enqueue_compile(
+            self, configuration=configuration, force_local=force_local
         )
-        return await self._enqueue(job)
 
     @api_command("firmware/upload")
     async def upload(

--- a/esphome_device_builder/controllers/firmware/factories.py
+++ b/esphome_device_builder/controllers/firmware/factories.py
@@ -198,6 +198,18 @@ async def enqueue_install_or_defer(
     )
 
 
+async def enqueue_compile(
+    controller: FirmwareController,
+    *,
+    configuration: str,
+    force_local: bool = False,
+) -> FirmwareJob:
+    """Enqueue one COMPILE job with build-scheduler routing; the single/bulk shared core."""
+    build_source = controller._resolve_install_source(force_local=force_local)
+    job = create_job(controller, configuration, JobType.COMPILE, build_source=build_source)
+    return await controller._enqueue(job)
+
+
 async def commit_chain(
     controller: FirmwareController,
     head: FirmwareJob,


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #1929, which fixed an offline deferral that existed in the single install but not in install_bulk. This makes the underlying convention structural for the two remaining drift prone pairs: every single/bulk command pair now shares exactly one per item core function, so a policy added to one entry point cannot silently miss the other.

`firmware/compile` and `compile_bulk` now both call a new `factories.enqueue_compile` instead of duplicating the resolve, create, enqueue body by hand. `devices/archive` and `archive_bulk` now both call a new `archive.archive_single_checked` (validate plus archive) instead of the bulk closure re declaring the wrapper steps inline. The bulk handlers keep only their bulk scoped concerns: batched boundary validation, stale first ordering, and the per item error policy. CLAUDE.md documents the convention with the canonical examples.

No behavior change; the full test suite passes with no test edits. Follow ups will unify the delete/archive not found error surface (a real drift bug the audit found) and add single/bulk parity guard tests.

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/device-builder/issues/1928

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
