### PR TITLE
Add single/bulk parity guards for every command pair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,10 @@ against legacy behaviour before assuming the simpler version suffices.
   and re-raises fleet-wide `NO_COMPATIBLE_PEER`; devices'
   `run_bulk_per_device` collects `{configuration, success, error}`
   rows). Never inline the per-item body in a bulk loop — that's how
-  `install_bulk` missed the offline deferral (#1928).
+  `install_bulk` missed the offline deferral (#1928). New pairs ship
+  with parity coverage: `tests/test_single_bulk_parity.py` (every
+  `*_bulk` command has a single twin) plus per-verb scenarios in
+  `tests/controllers/{firmware,devices}/test_single_bulk_parity.py`.
 - **Event payloads use TypedDict, not dataclass.** Mirrors HA core's
   `Event[_DataT]` / `EventStateChangedData` pattern. Each event-specific
   shape gets a `TypedDict` next to the controller that fires it (e.g.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,9 +304,9 @@ against legacy behaviour before assuming the simpler version suffices.
   `run_bulk_per_device` collects `{configuration, success, error}`
   rows). Never inline the per-item body in a bulk loop — that's how
   `install_bulk` missed the offline deferral (#1928). New pairs ship
-  with parity coverage: `tests/test_single_bulk_parity.py` (every
-  `*_bulk` command has a single twin) plus per-verb scenarios in
-  `tests/controllers/{firmware,devices}/test_single_bulk_parity.py`.
+  with parity coverage: the inventory guards in
+  `tests/test_single_bulk_parity.py` plus per-verb scenarios beside
+  each controller suite.
 - **Event payloads use TypedDict, not dataclass.** Mirrors HA core's
   `Event[_DataT]` / `EventStateChangedData` pattern. Each event-specific
   shape gets a `TypedDict` next to the controller that fires it (e.g.

--- a/tests/controllers/devices/test_single_bulk_parity.py
+++ b/tests/controllers/devices/test_single_bulk_parity.py
@@ -1,0 +1,102 @@
+"""Single-vs-bulk parity for the devices delete/archive/set_labels command pairs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import ErrorCode
+
+from .conftest import MakeControllerFactory, attach_reloading_scanner
+
+
+async def test_delete_parity_missing_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Single raises NOT_FOUND; the bulk row carries the same message."""
+    single = make_controller(tmp_path)
+    bulk = make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await single.delete_device(configuration="ghost.yaml")
+    rows = await bulk.delete_bulk(configurations=["ghost.yaml"])
+
+    assert exc_info.value.code == ErrorCode.NOT_FOUND
+    assert rows == [
+        {"configuration": "ghost.yaml", "success": False, "error": exc_info.value.message}
+    ]
+
+
+async def test_delete_parity_existing_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    controller = make_controller(tmp_path)
+    for name in ("kitchen.yaml", "office.yaml"):
+        (tmp_path / name).write_text("esphome:\n  name: x\n")
+
+    await controller.delete_device(configuration="kitchen.yaml")
+    rows = await controller.delete_bulk(configurations=["office.yaml"])
+
+    assert rows == [{"configuration": "office.yaml", "success": True}]
+    assert not (tmp_path / "kitchen.yaml").exists()
+    assert not (tmp_path / "office.yaml").exists()
+
+
+async def test_archive_parity_traversal_name(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """Single rejects INVALID_ARGS; the bulk row carries the same message."""
+    single = make_controller(tmp_path)
+    bulk = make_controller(tmp_path)
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: x\n")
+
+    with pytest.raises(CommandError) as exc_info:
+        await single.archive_device(configuration="../evil.yaml")
+    rows = await bulk.archive_bulk(configurations=["../evil.yaml", "kitchen.yaml"])
+
+    assert exc_info.value.code == ErrorCode.INVALID_ARGS
+    assert rows[0] == {
+        "configuration": "../evil.yaml",
+        "success": False,
+        "error": exc_info.value.message,
+    }
+    # Unlike the firmware bulk verbs' atomic batch validation, devices
+    # bulk isolates the bad row — the good config still archives.
+    assert rows[1] == {"configuration": "kitchen.yaml", "success": True}
+    assert (tmp_path / "archive" / "kitchen.yaml").exists()
+
+
+async def test_archive_parity_missing_yaml(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    single = make_controller(tmp_path)
+    bulk = make_controller(tmp_path)
+
+    with pytest.raises(CommandError) as exc_info:
+        await single.archive_device(configuration="ghost.yaml")
+    rows = await bulk.archive_bulk(configurations=["ghost.yaml"])
+
+    assert exc_info.value.code == ErrorCode.NOT_FOUND
+    assert rows == [
+        {"configuration": "ghost.yaml", "success": False, "error": exc_info.value.message}
+    ]
+
+
+async def test_set_labels_parity_missing_device(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    single = make_controller(tmp_path)
+    bulk = make_controller(tmp_path)
+    attach_reloading_scanner(single, tmp_path, [])
+    attach_reloading_scanner(bulk, tmp_path, [])
+
+    with pytest.raises(CommandError) as exc_info:
+        await single.set_labels(configuration="ghost.yaml", label_ids=[])
+    rows = await bulk.set_labels_bulk(updates=[{"configuration": "ghost.yaml", "label_ids": []}])
+
+    assert exc_info.value.code == ErrorCode.NOT_FOUND
+    assert rows == [
+        {"configuration": "ghost.yaml", "success": False, "error": exc_info.value.message}
+    ]

--- a/tests/controllers/devices/test_single_bulk_parity.py
+++ b/tests/controllers/devices/test_single_bulk_parity.py
@@ -16,12 +16,11 @@ async def test_delete_parity_missing_yaml(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
     """Single raises NOT_FOUND; the bulk row carries the same message."""
-    single = make_controller(tmp_path)
-    bulk = make_controller(tmp_path)
+    controller = make_controller(tmp_path)
 
     with pytest.raises(CommandError) as exc_info:
-        await single.delete_device(configuration="ghost.yaml")
-    rows = await bulk.delete_bulk(configurations=["ghost.yaml"])
+        await controller.delete_device(configuration="ghost.yaml")
+    rows = await controller.delete_bulk(configurations=["ghost.yaml"])
 
     assert exc_info.value.code == ErrorCode.NOT_FOUND
     assert rows == [
@@ -29,32 +28,16 @@ async def test_delete_parity_missing_yaml(
     ]
 
 
-async def test_delete_parity_existing_yaml(
-    tmp_path: Path, make_controller: MakeControllerFactory
-) -> None:
-    controller = make_controller(tmp_path)
-    for name in ("kitchen.yaml", "office.yaml"):
-        (tmp_path / name).write_text("esphome:\n  name: x\n")
-
-    await controller.delete_device(configuration="kitchen.yaml")
-    rows = await controller.delete_bulk(configurations=["office.yaml"])
-
-    assert rows == [{"configuration": "office.yaml", "success": True}]
-    assert not (tmp_path / "kitchen.yaml").exists()
-    assert not (tmp_path / "office.yaml").exists()
-
-
 async def test_archive_parity_traversal_name(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
     """Single rejects INVALID_ARGS; the bulk row carries the same message."""
-    single = make_controller(tmp_path)
-    bulk = make_controller(tmp_path)
+    controller = make_controller(tmp_path)
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: x\n")
 
     with pytest.raises(CommandError) as exc_info:
-        await single.archive_device(configuration="../evil.yaml")
-    rows = await bulk.archive_bulk(configurations=["../evil.yaml", "kitchen.yaml"])
+        await controller.archive_device(configuration="../evil.yaml")
+    rows = await controller.archive_bulk(configurations=["../evil.yaml", "kitchen.yaml"])
 
     assert exc_info.value.code == ErrorCode.INVALID_ARGS
     assert rows[0] == {
@@ -71,12 +54,11 @@ async def test_archive_parity_traversal_name(
 async def test_archive_parity_missing_yaml(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    single = make_controller(tmp_path)
-    bulk = make_controller(tmp_path)
+    controller = make_controller(tmp_path)
 
     with pytest.raises(CommandError) as exc_info:
-        await single.archive_device(configuration="ghost.yaml")
-    rows = await bulk.archive_bulk(configurations=["ghost.yaml"])
+        await controller.archive_device(configuration="ghost.yaml")
+    rows = await controller.archive_bulk(configurations=["ghost.yaml"])
 
     assert exc_info.value.code == ErrorCode.NOT_FOUND
     assert rows == [
@@ -87,14 +69,14 @@ async def test_archive_parity_missing_yaml(
 async def test_set_labels_parity_missing_device(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:
-    single = make_controller(tmp_path)
-    bulk = make_controller(tmp_path)
-    attach_reloading_scanner(single, tmp_path, [])
-    attach_reloading_scanner(bulk, tmp_path, [])
+    controller = make_controller(tmp_path)
+    attach_reloading_scanner(controller, tmp_path, [])
 
     with pytest.raises(CommandError) as exc_info:
-        await single.set_labels(configuration="ghost.yaml", label_ids=[])
-    rows = await bulk.set_labels_bulk(updates=[{"configuration": "ghost.yaml", "label_ids": []}])
+        await controller.set_labels(configuration="ghost.yaml", label_ids=[])
+    rows = await controller.set_labels_bulk(
+        updates=[{"configuration": "ghost.yaml", "label_ids": []}]
+    )
 
     assert exc_info.value.code == ErrorCode.NOT_FOUND
     assert rows == [

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Iterator
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
@@ -408,12 +408,20 @@ def upload_of(controller: FirmwareController, compile_job: FirmwareJob) -> Firmw
 
 @dataclass
 class StubDevices:
-    """Narrow ``DevicesController`` stand-in returning empty cache args.
+    """Narrow ``DevicesController`` stand-in: empty cache args, optional device catalog.
 
     The runner's ``_build_cache_args`` calls ``get_address_cache_args`` /
     ``get_ota_address_cache_args`` on the install / upload / rename paths;
-    returning ``[]`` keeps the build command shape minimal.
+    returning ``[]`` keeps the build command shape minimal. ``devices``
+    backs ``get_devices`` / ``get_by_configuration`` for tests driving
+    the bulk ordering or the offline-deferral device lookup.
     """
+
+    devices: list[Any] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Build the configuration-keyed index, mirroring production's O(1) lookup."""
+        self._by_configuration = {d.configuration: d for d in self.devices}
 
     def get_address_cache_args(self, _configuration: str) -> list[str]:
         return []
@@ -421,14 +429,11 @@ class StubDevices:
     def get_ota_address_cache_args(self, _configuration: str, _port: str) -> list[str]:
         return []
 
-    def get_devices(self) -> list:
-        """Return an empty list to satisfy the offline queue discovery checks."""
-        return []
+    def get_devices(self) -> list[Any]:
+        return self.devices
 
     def get_by_configuration(self, configuration: str) -> Any | None:
-        """Test double for the O(1) shadow index lookup."""
-        # The stub holds no devices (get_devices returns []), so lookups safely yield None.
-        return None
+        return self._by_configuration.get(configuration)
 
 
 def wire_devices(controller: FirmwareController) -> None:

--- a/tests/controllers/firmware/test_bulk_order.py
+++ b/tests/controllers/firmware/test_bulk_order.py
@@ -5,18 +5,7 @@ from __future__ import annotations
 from esphome_device_builder.controllers.firmware.bulk import _esphome_version_sort_key
 from esphome_device_builder.models import Device, JobType
 from tests.conftest import make_device
-from tests.controllers.firmware.conftest import FirmwareControllerFactory
-
-
-class _DevicesController:
-    def __init__(self, devices: list[Device]) -> None:
-        self._devices = devices
-
-    def get_devices(self) -> list[Device]:
-        return self._devices
-
-    def get_by_configuration(self, configuration: str) -> Device | None:
-        return next((d for d in self._devices if d.configuration == configuration), None)
+from tests.controllers.firmware.conftest import FirmwareControllerFactory, StubDevices
 
 
 def _device(
@@ -44,7 +33,7 @@ async def test_install_bulk_queues_stale_devices_before_pending_changes(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device("current.yaml"),
             _device("pending.yaml", has_pending_changes=True),
@@ -87,7 +76,7 @@ async def test_bulk_order_preserves_tail_input_order(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device("current-a.yaml", deployed_version="2026.5.0"),
             _device("current-b.yaml", deployed_version="2026.5.0"),
@@ -119,7 +108,7 @@ async def test_bulk_order_keeps_newer_deployed_versions_in_tail(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device(
                 "newer.yaml",
@@ -149,7 +138,7 @@ async def test_bulk_order_uses_update_available_as_stale_gate(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device(
                 "behind-but-not-flagged.yaml",
@@ -177,7 +166,7 @@ async def test_bulk_order_sorts_prerelease_numbers_numerically(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device(
                 "beta-10.yaml",
@@ -203,7 +192,7 @@ async def test_bulk_order_keeps_missing_versions_out_of_stale_bucket(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device("missing-deployed.yaml", deployed_version="", update_available=True),
             _device(
@@ -238,7 +227,7 @@ async def test_bulk_order_treats_unknown_deployed_version_as_oldest_stale(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device(
                 "local-build.yaml",
@@ -262,7 +251,7 @@ async def test_compile_bulk_uses_stale_first_order(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     controller = firmware_controller_factory(with_queue=True)
-    controller._db.devices = _DevicesController(
+    controller._db.devices = StubDevices(
         [
             _device("fresh.yaml"),
             _device("old.yaml", deployed_version="2025.1.0", update_available=True),

--- a/tests/controllers/firmware/test_single_bulk_parity.py
+++ b/tests/controllers/firmware/test_single_bulk_parity.py
@@ -6,9 +6,15 @@ import pytest
 
 from esphome_device_builder.controllers.firmware.controller import FirmwareController
 from esphome_device_builder.helpers.api import CommandError
-from esphome_device_builder.models import DeviceState, ErrorCode, JobType
+from esphome_device_builder.models import DeviceState, ErrorCode, JobSource, JobType
 from tests.conftest import make_device
-from tests.controllers.firmware.conftest import FirmwareControllerFactory, StubDevices
+from tests.controllers.firmware.conftest import (
+    FirmwareControllerFactory,
+    StubDevices,
+    build_scheduler_inputs,
+    stub_offloader,
+    stub_pairing,
+)
 
 
 def _job_shapes(controller: FirmwareController) -> list[tuple]:
@@ -88,12 +94,25 @@ async def test_install_parity_traversal_rejected_from_both_entry_points(
 async def test_compile_parity_threads_force_local(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
+    """Both entry points stay LOCAL even when scheduler routing would pick REMOTE."""
     device = make_device("kitchen", state=DeviceState.ONLINE)
     single = _controller(firmware_controller_factory, device)
     bulk = _controller(firmware_controller_factory, device)
+    pin = "a" * 64
+    for controller in (single, bulk):
+        stub_offloader(
+            controller,
+            build_scheduler_inputs(
+                pairings=[stub_pairing(pin_sha256=pin)],
+                open_pins={pin},
+                idle_pins={pin},
+            ),
+        )
 
     await single.compile(configuration="kitchen.yaml", force_local=True)
     await bulk.compile_bulk(configurations=["kitchen.yaml"], force_local=True)
 
     assert _job_shapes(single) == _job_shapes(bulk)
-    assert [job.job_type for job in single.state.jobs.values()] == [JobType.COMPILE]
+    jobs = list(single.state.jobs.values())
+    assert [job.job_type for job in jobs] == [JobType.COMPILE]
+    assert jobs[0].source is JobSource.LOCAL

--- a/tests/controllers/firmware/test_single_bulk_parity.py
+++ b/tests/controllers/firmware/test_single_bulk_parity.py
@@ -1,0 +1,99 @@
+"""Single-vs-bulk parity for the firmware install/compile command pairs."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.firmware.controller import FirmwareController
+from esphome_device_builder.helpers.api import CommandError
+from esphome_device_builder.models import DeviceState, ErrorCode, JobType
+from tests.conftest import make_device
+from tests.controllers.firmware.conftest import FirmwareControllerFactory, StubDevices
+
+
+def _job_shapes(controller: FirmwareController) -> list[tuple]:
+    """Normalise queued jobs for cross-entry-point comparison."""
+    return sorted(
+        (
+            job.job_type,
+            job.configuration,
+            job.port,
+            bool(job.depends_on),
+            job.source,
+            job.is_deferred_install,
+        )
+        for job in controller.state.jobs.values()
+    )
+
+
+def _controller(factory: FirmwareControllerFactory, *devices) -> FirmwareController:
+    controller = factory(with_queue=True)
+    controller._db.devices = StubDevices(list(devices))
+    return controller
+
+
+async def test_install_parity_online_device_queues_the_same_chain(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    device = make_device("kitchen", state=DeviceState.ONLINE)
+    single = _controller(firmware_controller_factory, device)
+    bulk = _controller(firmware_controller_factory, device)
+
+    await single.install(configuration="kitchen.yaml")
+    await bulk.install_bulk(configurations=["kitchen.yaml"])
+
+    assert _job_shapes(single) == _job_shapes(bulk)
+    assert {job.job_type for job in single.state.jobs.values()} == {
+        JobType.COMPILE,
+        JobType.UPLOAD,
+    }
+
+
+async def test_install_parity_offline_device_defers_from_both_entry_points(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    device = make_device("kitchen", state=DeviceState.OFFLINE)
+    single = _controller(firmware_controller_factory, device)
+    bulk = _controller(firmware_controller_factory, device)
+
+    await single.install(configuration="kitchen.yaml")
+    await bulk.install_bulk(configurations=["kitchen.yaml"])
+
+    assert _job_shapes(single) == _job_shapes(bulk)
+    jobs = list(single.state.jobs.values())
+    assert [job.job_type for job in jobs] == [JobType.COMPILE]
+    assert jobs[0].is_deferred_install is True
+
+
+async def test_install_parity_traversal_rejected_from_both_entry_points(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """Both entry points reject with INVALID_ARGS; the batch check is atomic."""
+    single = _controller(firmware_controller_factory)
+    bulk = _controller(firmware_controller_factory)
+
+    with pytest.raises(CommandError) as single_exc:
+        await single.install(configuration="../evil.yaml")
+    with pytest.raises(CommandError) as bulk_exc:
+        await bulk.install_bulk(configurations=["kitchen.yaml", "../evil.yaml"])
+
+    assert single_exc.value.code == bulk_exc.value.code == ErrorCode.INVALID_ARGS
+    # The batched boundary validation fails the whole batch, so the
+    # good config is not queued either — the documented single/bulk
+    # difference for firmware verbs.
+    assert not single.state.jobs
+    assert not bulk.state.jobs
+
+
+async def test_compile_parity_threads_force_local(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    device = make_device("kitchen", state=DeviceState.ONLINE)
+    single = _controller(firmware_controller_factory, device)
+    bulk = _controller(firmware_controller_factory, device)
+
+    await single.compile(configuration="kitchen.yaml", force_local=True)
+    await bulk.compile_bulk(configurations=["kitchen.yaml"], force_local=True)
+
+    assert _job_shapes(single) == _job_shapes(bulk)
+    assert [job.job_type for job in single.state.jobs.values()] == [JobType.COMPILE]

--- a/tests/test_single_bulk_parity.py
+++ b/tests/test_single_bulk_parity.py
@@ -1,5 +1,5 @@
 """
-Inventory guard: every ``*_bulk`` WS command has a registered single twin.
+Inventory guards: every ``*_bulk`` WS command keeps a single twin and its keyword surface.
 
 Per-verb behavioral parity lives next to each controller's suite
 (``tests/controllers/firmware/test_single_bulk_parity.py``,
@@ -11,31 +11,46 @@ from __future__ import annotations
 import importlib
 import inspect
 import pkgutil
+from collections.abc import Callable
 
 import esphome_device_builder.controllers as controllers_pkg
+from esphome_device_builder.helpers.api import collect_api_commands
+
+# Keywords the single twin exposes that its bulk deliberately does not.
+# firmware/install_bulk: fleet-wide installs stay scheduler-routed OTA
+# app flashes; per-device overrides go through firmware/install.
+# devices/set_labels_bulk: label_ids rides inside each ``updates`` row.
+_INTENTIONAL_BULK_GAPS: dict[str, set[str]] = {
+    "firmware/install_bulk": {"force_local", "bootloader"},
+    "devices/set_labels_bulk": {"label_ids"},
+}
+
+# The per-item carrier differs by arity; strip it before comparing.
+_SINGLE_CARRIERS = {"configuration"}
+_BULK_CARRIERS = {"configurations", "updates"}
 
 
-def _registered_commands() -> set[str]:
-    """Collect every ``@api_command`` name declared under ``controllers/``."""
-    commands: set[str] = set()
+def _registered_handlers() -> dict[str, Callable]:
+    """Collect every ``@api_command`` handler declared under ``controllers/``."""
+    handlers: dict[str, Callable] = {}
     for modinfo in pkgutil.walk_packages(controllers_pkg.__path__, controllers_pkg.__name__ + "."):
         module = importlib.import_module(modinfo.name)
         for obj in vars(module).values():
-            command = getattr(obj, "_api_command", None)
-            if isinstance(command, str):
-                commands.add(command)
-            if not (inspect.isclass(obj) and obj.__module__ == module.__name__):
-                continue
-            for name in dir(obj):
-                attr = inspect.getattr_static(obj, name, None)
-                command = getattr(attr, "_api_command", None)
-                if isinstance(command, str):
-                    commands.add(command)
-    return commands
+            if inspect.isclass(obj) and obj.__module__ == module.__name__:
+                handlers.update(collect_api_commands(obj))
+    return handlers
+
+
+def _keyword_parameters(func: Callable) -> set[str]:
+    return {
+        name
+        for name, parameter in inspect.signature(func).parameters.items()
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    }
 
 
 def test_every_bulk_command_has_a_single_twin() -> None:
-    commands = _registered_commands()
+    commands = set(_registered_handlers())
     bulk_commands = {command for command in commands if command.endswith("_bulk")}
     # Canary that the walk found the surface at all — an import-path
     # regression must fail loudly, not report an empty-set pass.
@@ -44,3 +59,19 @@ def test_every_bulk_command_has_a_single_twin() -> None:
         command for command in bulk_commands if command.removesuffix("_bulk") not in commands
     }
     assert not missing, f"bulk commands without a single twin: {sorted(missing)}"
+
+
+def test_every_bulk_command_carries_its_single_twin_keywords() -> None:
+    """A keyword added to a single handler must reach its bulk twin or the gap allowlist."""
+    handlers = _registered_handlers()
+    bulk_names = sorted(name for name in handlers if name.endswith("_bulk"))
+    assert bulk_names
+    for bulk_name in bulk_names:
+        single_keywords = (
+            _keyword_parameters(handlers[bulk_name.removesuffix("_bulk")]) - _SINGLE_CARRIERS
+        )
+        bulk_keywords = _keyword_parameters(handlers[bulk_name]) - _BULK_CARRIERS
+        missing = single_keywords - bulk_keywords - _INTENTIONAL_BULK_GAPS.get(bulk_name, set())
+        assert not missing, (
+            f"{bulk_name} is missing keywords its single twin has: {sorted(missing)}"
+        )

--- a/tests/test_single_bulk_parity.py
+++ b/tests/test_single_bulk_parity.py
@@ -1,0 +1,46 @@
+"""
+Inventory guard: every ``*_bulk`` WS command has a registered single twin.
+
+Per-verb behavioral parity lives next to each controller's suite
+(``tests/controllers/firmware/test_single_bulk_parity.py``,
+``tests/controllers/devices/test_single_bulk_parity.py``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import esphome_device_builder.controllers as controllers_pkg
+
+
+def _registered_commands() -> set[str]:
+    """Collect every ``@api_command`` name declared under ``controllers/``."""
+    commands: set[str] = set()
+    for modinfo in pkgutil.walk_packages(controllers_pkg.__path__, controllers_pkg.__name__ + "."):
+        module = importlib.import_module(modinfo.name)
+        for obj in vars(module).values():
+            command = getattr(obj, "_api_command", None)
+            if isinstance(command, str):
+                commands.add(command)
+            if not (inspect.isclass(obj) and obj.__module__ == module.__name__):
+                continue
+            for name in dir(obj):
+                attr = inspect.getattr_static(obj, name, None)
+                command = getattr(attr, "_api_command", None)
+                if isinstance(command, str):
+                    commands.add(command)
+    return commands
+
+
+def test_every_bulk_command_has_a_single_twin() -> None:
+    commands = _registered_commands()
+    bulk_commands = {command for command in commands if command.endswith("_bulk")}
+    # Canary that the walk found the surface at all — an import-path
+    # regression must fail loudly, not report an empty-set pass.
+    assert {"firmware/install_bulk", "devices/delete_bulk"} <= bulk_commands
+    missing = {
+        command for command in bulk_commands if command.removesuffix("_bulk") not in commands
+    }
+    assert not missing, f"bulk commands without a single twin: {sorted(missing)}"


### PR DESCRIPTION
# What does this implement/fix?

Third and final part of the anti drift work from the #1928 audit. Two guard layers keep single and bulk WS commands from diverging again.

An inventory guard walks every `@api_command` under `controllers/` and asserts each `*_bulk` command has a registered single twin. Per verb parity scenarios then run the same situation through the single command and a one element bulk call and assert corresponding outcomes: install chains match for online devices, offline devices defer to the same compile only job from both entry points, compile threads force_local identically, delete and archive of a missing YAML produce the same not_found message as the bulk error row, set_labels of an unknown device likewise, and the two intentional differences are pinned explicitly (firmware batch validation is atomic while devices bulk isolates bad rows).

The firmware conftest `StubDevices` gains an optional device catalog with a configuration keyed O(1) index, replacing the private stub in test_bulk_order. CLAUDE.md's single/bulk convention bullet now points at the parity files.

Stacked on #1933.

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/device-builder/issues/1928

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
