### PR TITLE
Carry active_source through device rebuilds

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -11,7 +11,7 @@ from esphome.const import CONF_PACKAGES
 from esphome.core import EsphomeError
 from esphome.storage_json import StorageJSON
 
-from ...models import Device, DeviceState
+from ...models import Device, DeviceState, ReachabilitySource
 from ...models.boards import normalize_platform
 from ..mac_addresses import derive_interface_macs
 from ..storage_path import resolve_compiled_config_path, resolve_storage_path
@@ -202,7 +202,14 @@ def load_device_from_storage(
         deployed_version = previous.deployed_version
         api_encryption_active = previous.api_encryption_active
         queued_update = previous.queued_update
-    state = previous.state if previous else DeviceState.UNKNOWN
+    # ``active_source`` is runtime-only (never persisted); losing it on a
+    # rebuild hides the mDNS-gated dashboard dots until the next announce,
+    # since the monitor re-fires ``on_source_change`` only on a transition.
+    state, active_source = (
+        (previous.state, previous.active_source)
+        if previous
+        else (DeviceState.UNKNOWN, ReachabilitySource.UNKNOWN)
+    )
     ip_addresses = list(previous.ip_addresses) if previous else []
 
     has_pending = compute_has_pending_changes(
@@ -342,6 +349,7 @@ def load_device_from_storage(
         loaded_integrations=loaded_integrations,
         directly_referenced_integrations=directly_referenced_integrations,
         state=state,
+        active_source=active_source,
         has_pending_changes=has_pending,
         pending_changes_via_hash=pending_via_hash,
         update_available=update_available,

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -53,6 +53,7 @@ from esphome_device_builder.models import (
     DefaultComponent,
     Esp32Variant,
     Platform,
+    ReachabilitySource,
 )
 from tests._storage_fixtures import write_storage_json
 
@@ -2674,6 +2675,43 @@ def test_load_device_without_previous_defaults_api_encryption_active_to_none(
     device = load_device_from_storage(yaml_path)
 
     assert device.api_encryption_active is None
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_carries_active_source_from_previous(tmp_path: Path) -> None:
+    """Reload preserves the monitor-observed ``active_source``.
+
+    The frontend gates the update-available and modified dots on
+    ``active_source == "mdns"``, and the monitor re-fires
+    ``on_source_change`` only on a real transition. A rebuild that
+    resets the field to UNKNOWN (the post-compile ``scanner.reload``
+    in a bulk update was the reported shape, issue #1939) therefore
+    hides the dots until the device's next TTL re-announce.
+    """
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    previous = load_device_from_storage(yaml_path)
+    previous.active_source = ReachabilitySource.MDNS
+
+    reloaded = load_device_from_storage(yaml_path, previous=previous)
+
+    assert reloaded.active_source is ReachabilitySource.MDNS
+
+
+@pytest.mark.usefixtures("_redirect_ext_storage")
+def test_load_device_without_previous_defaults_active_source_to_unknown(
+    tmp_path: Path,
+) -> None:
+    """First load (no ``previous``) starts at the not-yet-observed sentinel."""
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    write_storage_json(tmp_path, "kitchen.yaml")
+
+    device = load_device_from_storage(yaml_path)
+
+    assert device.active_source is ReachabilitySource.UNKNOWN
 
 
 @pytest.mark.usefixtures("_redirect_ext_storage")


### PR DESCRIPTION
# What does this implement/fix?

Fixes the update available dot vanishing for devices whose queued bulk update was cancelled. `Device.active_source` is runtime only and was missing from `load_device_from_storage`'s carry forward, so any rebuild reset it to UNKNOWN; the post compile `scanner.reload` in a bulk update did exactly that for every device, and the frontend gates the update and modified dots on `active_source == "mdns"`. Flashed devices reboot and get re-claimed on their announce, cancelled ones sit dotless until the next mDNS TTL refresh, which is what the reporter saw. The monitor only re-fires `on_source_change` on a real transition, so nothing repaired the field in the meantime.

The fix carries `active_source` from the previous in-memory device, the same shape as `state`, `ip_addresses` and the `api_encryption_active` carry that fixed this class of wipe before. Reproduced end to end with fake mDNS announces plus a headless browser: before the fix the dot disappeared for the two devices whose compiles completed, after it all three keep the dot and `active_source` stays mdns through enqueue, cancel and upload.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1939

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
