### PR TITLE
Document the pre-commit stash loop when board catalog JSON is left unstaged

### DIFF
--- a/esphome_device_builder/definitions/README.md
+++ b/esphome_device_builder/definitions/README.md
@@ -72,6 +72,32 @@ everything against your installed ESPHome and re-stamps that version, so it does
 not check; still run it from the venv so you don't commit catalog-wide changes
 from a different ESPHome.
 
+### Troubleshooting: the pre-commit hook fails on every attempt
+
+The `sync-boards` pre-commit hook reruns the full sync whenever a commit
+touches a board manifest, so committing the manifest without the regenerated
+JSON fails once with `files were modified by this hook` — stage the generated
+files and retry. But if the regenerated JSON is sitting in your working tree
+*unstaged*, the failure loops forever:
+
+```
+[WARNING] Unstaged files detected.
+...
+regenerate boards.json from manifests....................................Failed
+- files were modified by this hook
+...
+[WARNING] Stashed changes conflicted with hook auto-fixes... Rolling back fixes...
+```
+
+pre-commit stashes your unstaged changes, the hook regenerates the same
+files, and restoring the stash conflicts with the hook's writes, so
+pre-commit rolls the hook's output back — every retry reproduces the
+identical failure. The fix is to leave nothing unstaged: run
+`python script/update_board.py`, then `git add` the manifest together with
+the files it prints (`boards.index.json`, `board_bodies/<id>.json`,
+`featured_components.index.json`) and commit again. With a clean working
+tree there is no stash, the hook regenerates the same bytes, and passes.
+
 ### Curated vs generated vs imported boards
 
 - **Curated** (most hand-written manifests): a `manifest.yaml` with no `source:`

--- a/esphome_device_builder/definitions/README.md
+++ b/esphome_device_builder/definitions/README.md
@@ -92,11 +92,13 @@ regenerate boards.json from manifests....................................Failed
 pre-commit stashes your unstaged changes, the hook regenerates the same
 files, and restoring the stash conflicts with the hook's writes, so
 pre-commit rolls the hook's output back — every retry reproduces the
-identical failure. The fix is to leave nothing unstaged: run
-`python script/update_board.py`, then `git add` the manifest together with
-the files it prints (`boards.index.json`, `board_bodies/<id>.json`,
-`featured_components.index.json`) and commit again. With a clean working
-tree there is no stash, the hook regenerates the same bytes, and passes.
+identical failure. Unrelated unstaged edits are stashed and restored
+cleanly; the loop needs the regenerated catalog files themselves to be
+unstaged. The fix is to stage them: run `python script/update_board.py`,
+then `git add` the manifest together with the files it prints
+(`boards.index.json`, `board_bodies/<id>.json`,
+`featured_components.index.json`) and commit again. With those staged the
+hook regenerates the same bytes, and passes.
 
 ### Curated vs generated vs imported boards
 
@@ -117,10 +119,7 @@ Create a new subfolder in `boards/` with a `manifest.yaml`:
 ```
 boards/
 └── my-awesome-board/
-    ├── manifest.yaml
-    └── images/           (optional)
-        ├── board-top.png
-        └── pinout.png
+    └── manifest.yaml
 ```
 
 ### Board Manifest Schema
@@ -159,11 +158,13 @@ docs_url: "https://esphome.io/components/esp32.html"
 product_url: "https://example.com/my-awesome-board"
 is_generic: false              # true only for generic fallback boards
 
-# Images; URLs or paths relative to this manifest (first = primary).
-# Prefer a bundled local asset over a hotlinked vendor URL, which can rot.
+# Images: hosted URLs (manufacturer product page), first = primary.
+# Don't commit image files — definitions/ ships in the PyPI wheel, so
+# binaries bloat every install (the generic chip SVGs are the one
+# exception). validate_definitions.py --check-images verifies the URLs.
 images:
-  - "images/board-top.png"
-  - "images/pinout.png"
+  - "https://example.com/media/my-awesome-board-top.jpg"
+  - "https://example.com/media/my-awesome-board-pinout.jpg"
 
 # Pin definitions (see below)
 pins:


### PR DESCRIPTION
# What does this implement/fix?

Adds a troubleshooting section to the definitions README for the pre-commit failure loop hit when the regenerated board catalog JSON sits unstaged in the working tree: pre-commit stashes it, the sync-boards hook rewrites the same files, and the stash restore conflicts and rolls the hook's output back, so every commit attempt fails identically. The note shows the failure signature and the fix, which is to run `script/update_board.py` and stage the manifest together with the regenerated files before committing.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1942

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
