### PR TITLE
Stamp compile start/end wall-clocks on firmware jobs

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -121,6 +121,13 @@ _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "
 )
 
+# This compile-phase grammar is the authoritative copy: it stamps
+# ``compile_started_at`` / ``compile_ended_at`` on the persisted job. The
+# frontend mirrors these markers in ``src/util/compile-phase.ts`` only to drive
+# the live per-second timer before the stamped fields land over the stream —
+# keep the two in sync (word markers, bracket-percent, ninja counter, end
+# banner).
+#
 # Lines are ANSI-stripped before compile-phase matching: PlatformIO colourises
 # and repaints, so escapes land not only as a leading reset but *inside* tokens
 # — the summary banner is ``[<green><bold>SUCCESS<reset>] Took`` — which an

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -123,14 +123,23 @@ _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
 
 # Compile-phase word markers for stamping ``compile_started_at``. ``Compiling
 # <path>`` is emitted by PlatformIO for every framework (esp-idf, esp32-arduino,
-# esp8266, libretiny); the rest cover a cached build that jumps straight to
-# linking. The bracketed ninja / percent forms are already caught by progress
-# parsing, so they aren't repeated here. None of these appear in the download or
+# esp8266, libretiny) and is the universal one; the rest cover a cached build
+# that jumps straight to linking. None of these appear in the download or
 # CMake-configure phase, whose lines start with ``--`` / ``Tool Manager:`` /
 # ``Library Manager:`` / ``Executing`` / ``Running`` / ``INFO``.
 _COMPILE_PHASE_WORD_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*"
     r"(?:Compiling |Archiving |Linking |Indexing |Generating |Building in )"
+)
+
+# The arduino per-file gauge ``[ 17%] Compiling …`` — percent *inside* the
+# brackets. Kept distinct from the download ``Unpacking [----] 0%`` bar (percent
+# *outside* the brackets) and from esptool ``(45 %)`` / OTA ``Uploading … 45%``,
+# none of which mean "compiling". So a stray percentage during the download
+# never starts the clock — only these three compile-specific shapes do (the
+# ninja ``[N/M]`` counter below is the third).
+_COMPILE_BRACKET_PERCENT: re.Pattern[str] = re.compile(
+    r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*\d{1,3}\s*%\s*\]"
 )
 
 # PlatformIO closes each environment with ``===== [SUCCESS] Took N seconds =====``

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -121,15 +121,22 @@ _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "
 )
 
+# Lines are ANSI-stripped before compile-phase matching: PlatformIO colourises
+# and repaints, so escapes land not only as a leading reset but *inside* tokens
+# — the summary banner is ``[<green><bold>SUCCESS<reset>] Took`` — which an
+# anchored/literal match would miss.
+_ANSI_ESCAPE: re.Pattern[str] = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
 # Compile-phase word markers for stamping ``compile_started_at``. ``Compiling
-# <path>`` is emitted by PlatformIO for every framework (esp-idf, esp32-arduino,
-# esp8266, libretiny) and is the universal one; the rest cover a cached build
-# that jumps straight to linking. None of these appear in the download or
-# CMake-configure phase, whose lines start with ``--`` / ``Tool Manager:`` /
-# ``Library Manager:`` / ``Executing`` / ``Running`` / ``INFO``.
+# <path>`` is emitted by PlatformIO for every framework (esp32-arduino, esp8266,
+# libretiny, esp-idf-via-pio); ``Reading CMake configuration`` opens an esp-idf
+# build (the real start, after the download); the rest cover a cached build that
+# jumps straight to linking. None appear in the download phase, whose lines
+# start with ``Tool Manager:`` / ``Library Manager:`` / ``Unpacking`` /
+# ``Installing``.
 _COMPILE_PHASE_WORD_PATTERN: re.Pattern[str] = re.compile(
-    r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*"
-    r"(?:Compiling |Archiving |Linking |Indexing |Generating |Building in )"
+    r"^\s*(?:Compiling |Archiving |Linking |Indexing |Generating |Building in "
+    r"|Reading CMake configuration)"
 )
 
 # The arduino per-file gauge ``[ 17%] Compiling …`` — percent *inside* the
@@ -138,9 +145,7 @@ _COMPILE_PHASE_WORD_PATTERN: re.Pattern[str] = re.compile(
 # none of which mean "compiling". So a stray percentage during the download
 # never starts the clock — only these three compile-specific shapes do (the
 # ninja ``[N/M]`` counter below is the third).
-_COMPILE_BRACKET_PERCENT: re.Pattern[str] = re.compile(
-    r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*\d{1,3}\s*%\s*\]"
-)
+_COMPILE_BRACKET_PERCENT: re.Pattern[str] = re.compile(r"^\s*\[\s*\d{1,3}\s*%\s*\]")
 
 # PlatformIO closes each environment with ``===== [SUCCESS] Took N seconds =====``
 # (or ``[FAILED]``); marks ``compile_ended_at`` so an install's flash phase,

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -121,6 +121,23 @@ _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "
 )
 
+# Compile-phase word markers for stamping ``compile_started_at``. ``Compiling
+# <path>`` is emitted by PlatformIO for every framework (esp-idf, esp32-arduino,
+# esp8266, libretiny); the rest cover a cached build that jumps straight to
+# linking. The bracketed ninja / percent forms are already caught by progress
+# parsing, so they aren't repeated here. None of these appear in the download or
+# CMake-configure phase, whose lines start with ``--`` / ``Tool Manager:`` /
+# ``Library Manager:`` / ``Executing`` / ``Running`` / ``INFO``.
+_COMPILE_PHASE_WORD_PATTERN: re.Pattern[str] = re.compile(
+    r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*"
+    r"(?:Compiling |Archiving |Linking |Indexing |Generating |Building in )"
+)
+
+# PlatformIO closes each environment with ``===== [SUCCESS] Took N seconds =====``
+# (or ``[FAILED]``); marks ``compile_ended_at`` so an install's flash phase,
+# which streams after, isn't counted.
+_COMPILE_END_PATTERN: re.Pattern[str] = re.compile(r"\[(?:SUCCESS|FAILED)\] Took ")
+
 # History retention.
 #   - "Primary" = COMPILE / UPLOAD / INSTALL: dedup'd to the most
 #     recent terminal job per device, then capped globally. The dedup

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -33,6 +33,7 @@ from ...models import (
 )
 from ...models.firmware import _now_iso
 from .constants import (
+    _COMPILE_BRACKET_PERCENT,
     _COMPILE_END_PATTERN,
     _COMPILE_PHASE_WORD_PATTERN,
     _INFLIGHT_TRIM_KEEP,
@@ -364,24 +365,39 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
         _trim_job_output(job, keep=_INFLIGHT_TRIM_KEEP)
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
+    _stamp_compile_phase(job, line)
     progress = _parse_progress(line)
-    _stamp_compile_phase(job, line, progress)
     if progress is None or progress <= (job.progress or 0):
         return
     _fire_job_progress(job, bus, progress)
 
 
-def _stamp_compile_phase(job: FirmwareJob, line: str, progress: int | None) -> None:
+def _is_compile_start_line(line: str) -> bool:
+    """
+    Whether *line* proves compilation has begun.
+
+    True for a PlatformIO ``Compiling`` / ``Linking`` / … word marker, an
+    arduino ``[ NN%]`` per-file gauge, or a ninja ``[N/M]`` counter (any total —
+    download always precedes ninja, so the first counter is the build start).
+    Deliberately *not* the esptool ``(45 %)`` / OTA / download percentages, so a
+    stray percent during the download can't start the clock.
+    """
+    return bool(
+        _COMPILE_PHASE_WORD_PATTERN.match(line)
+        or _COMPILE_BRACKET_PERCENT.match(line)
+        or _NINJA_PROGRESS_PATTERN.match(line)
+    )
+
+
+def _stamp_compile_phase(job: FirmwareJob, line: str) -> None:
     """
     Stamp the compile-phase wall-clocks off *line*.
 
-    Start on the first build line — a parseable progress percent (ninja /
-    esptool) or a compile-word marker (PlatformIO ``Compiling`` output, which
-    carries no percent) — and end on the summary banner, so the recorded span
+    Start on the first build line and end on the summary banner, so the span
     excludes the download and CMake configure and, for an install, the flash.
     """
     if job.compile_started_at is None:
-        if progress is not None or _COMPILE_PHASE_WORD_PATTERN.match(line):
+        if _is_compile_start_line(line):
             job.compile_started_at = _now_iso()
     elif job.compile_ended_at is None and _COMPILE_END_PATTERN.search(line):
         job.compile_ended_at = _now_iso()

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -33,6 +33,7 @@ from ...models import (
 )
 from ...models.firmware import _now_iso
 from .constants import (
+    _ANSI_ESCAPE,
     _COMPILE_BRACKET_PERCENT,
     _COMPILE_END_PATTERN,
     _COMPILE_PHASE_WORD_PATTERN,
@@ -394,12 +395,14 @@ def _stamp_compile_phase(job: FirmwareJob, line: str) -> None:
     Stamp the compile-phase wall-clocks off *line*.
 
     Start on the first build line and end on the summary banner, so the span
-    excludes the download and CMake configure and, for an install, the flash.
+    excludes the download and, for an install, the flash. ANSI is stripped
+    first — the ``[SUCCESS] Took`` banner colours *inside* the brackets.
     """
+    clean = _ANSI_ESCAPE.sub("", line)
     if job.compile_started_at is None:
-        if _is_compile_start_line(line):
+        if _is_compile_start_line(clean):
             job.compile_started_at = _now_iso()
-    elif job.compile_ended_at is None and _COMPILE_END_PATTERN.search(line):
+    elif job.compile_ended_at is None and _COMPILE_END_PATTERN.search(clean):
         job.compile_ended_at = _now_iso()
 
 

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -31,7 +31,10 @@ from ...models import (
     JobProgressData,
     JobType,
 )
+from ...models.firmware import _now_iso
 from .constants import (
+    _COMPILE_END_PATTERN,
+    _COMPILE_PHASE_WORD_PATTERN,
     _INFLIGHT_TRIM_KEEP,
     _MAX_OUTPUT_LINES_INFLIGHT,
     _MAX_OUTPUT_LINES_RETAINED,
@@ -362,9 +365,26 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     out_payload: JobOutputData = {"job_id": job.job_id, "line": line}
     bus.fire(EventType.JOB_OUTPUT, out_payload)
     progress = _parse_progress(line)
+    _stamp_compile_phase(job, line, progress)
     if progress is None or progress <= (job.progress or 0):
         return
     _fire_job_progress(job, bus, progress)
+
+
+def _stamp_compile_phase(job: FirmwareJob, line: str, progress: int | None) -> None:
+    """
+    Stamp the compile-phase wall-clocks off *line*.
+
+    Start on the first build line — a parseable progress percent (ninja /
+    esptool) or a compile-word marker (PlatformIO ``Compiling`` output, which
+    carries no percent) — and end on the summary banner, so the recorded span
+    excludes the download and CMake configure and, for an install, the flash.
+    """
+    if job.compile_started_at is None:
+        if progress is not None or _COMPILE_PHASE_WORD_PATTERN.match(line):
+            job.compile_started_at = _now_iso()
+    elif job.compile_ended_at is None and _COMPILE_END_PATTERN.search(line):
+        job.compile_ended_at = _now_iso()
 
 
 def _target_is_offline(controller: FirmwareController, configuration: str) -> bool:

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -396,13 +396,20 @@ def _stamp_compile_phase(job: FirmwareJob, line: str) -> None:
 
     Start on the first build line and end on the summary banner, so the span
     excludes the download and, for an install, the flash. ANSI is stripped
-    first — the ``[SUCCESS] Took`` banner colours *inside* the brackets.
+    first — the ``[SUCCESS] Took`` banner colours *inside* the brackets. Runs
+    per streamed line, so it short-circuits once both stamps are latched (an
+    install flashes long after the compile ends) and pre-filters the end scan
+    on a plain-text substring before paying for the ANSI strip + regex.
     """
-    clean = _ANSI_ESCAPE.sub("", line)
+    if job.compile_ended_at is not None:
+        return
     if job.compile_started_at is None:
-        if _is_compile_start_line(clean):
+        if _is_compile_start_line(_ANSI_ESCAPE.sub("", line)):
             job.compile_started_at = _now_iso()
-    elif job.compile_ended_at is None and _COMPILE_END_PATTERN.search(clean):
+        return
+    # ``Took `` is plain text in the banner (only the [SUCCESS]/[FAILED] token
+    # carries inline ANSI), so this skips the strip + regex on every other line.
+    if "Took " in line and _COMPILE_END_PATTERN.search(_ANSI_ESCAPE.sub("", line)):
         job.compile_ended_at = _now_iso()
 
 

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -173,10 +173,12 @@ class FirmwareJob(DashboardModel):
     created_at: str = ""  # ISO 8601
     started_at: str | None = None
     completed_at: str | None = None
-    # Wall-clocks bounding the compile phase, download and configure excluded.
+    # Wall-clocks bounding the compile phase. The dependency download is
+    # excluded; CMake configure counts (it's CPU+I/O work of the build).
     # ``compile_started_at`` is stamped on the first line that proves the
-    # toolchain is building (a parseable progress percent, or a ``Compiling`` /
-    # ninja build line); ``compile_ended_at`` on the PlatformIO summary banner.
+    # toolchain is building (a ``Compiling`` / ``Reading CMake configuration``
+    # word marker, an arduino ``[ NN%]`` gauge, or a ninja ``[N/M]`` counter);
+    # ``compile_ended_at`` on the PlatformIO summary banner.
     # Persisted + snapshotted so a client reconnecting after a page reload or a
     # restart shows the true compile elapsed, not a clock restarted from the
     # replayed buffer.

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -173,15 +173,10 @@ class FirmwareJob(DashboardModel):
     created_at: str = ""  # ISO 8601
     started_at: str | None = None
     completed_at: str | None = None
-    # Wall-clocks bounding the compile phase. The dependency download is
-    # excluded; CMake configure counts (it's CPU+I/O work of the build).
-    # ``compile_started_at`` is stamped on the first line that proves the
-    # toolchain is building (a ``Compiling`` / ``Reading CMake configuration``
-    # word marker, an arduino ``[ NN%]`` gauge, or a ninja ``[N/M]`` counter);
-    # ``compile_ended_at`` on the PlatformIO summary banner.
-    # Persisted + snapshotted so a client reconnecting after a page reload or a
-    # restart shows the true compile elapsed, not a clock restarted from the
-    # replayed buffer.
+    # Wall-clocks bounding the compile phase (dependency download excluded;
+    # CMake configure counts). Stamped from build-output markers in
+    # ``controllers.firmware.helpers._stamp_compile_phase``; the end stamp is
+    # the PlatformIO summary banner, so an install's flash isn't counted.
     compile_started_at: str | None = None
     compile_ended_at: str | None = None
     exit_code: int | None = None

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -173,6 +173,15 @@ class FirmwareJob(DashboardModel):
     created_at: str = ""  # ISO 8601
     started_at: str | None = None
     completed_at: str | None = None
+    # Wall-clocks bounding the compile phase, download and configure excluded.
+    # ``compile_started_at`` is stamped on the first line that proves the
+    # toolchain is building (a parseable progress percent, or a ``Compiling`` /
+    # ninja build line); ``compile_ended_at`` on the PlatformIO summary banner.
+    # Persisted + snapshotted so a client reconnecting after a page reload or a
+    # restart shows the true compile elapsed, not a clock restarted from the
+    # replayed buffer.
+    compile_started_at: str | None = None
+    compile_ended_at: str | None = None
     exit_code: int | None = None
     output: list[str] = field(default_factory=list)
     error: str | None = None
@@ -490,6 +499,8 @@ class FirmwareJob(DashboardModel):
         self.failure_reason = JobFailureReason.NONE
         self.started_at = None
         self.completed_at = None
+        self.compile_started_at = None
+        self.compile_ended_at = None
         self.exit_code = None
 
     def apply_build_source(self, build_source: JobBuildSource) -> None:

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -1,17 +1,23 @@
 """``compile_started_at`` / ``compile_ended_at`` stamping.
 
 The compile clock must count compilation only: it starts on the first line
-that proves the toolchain is building (a parseable progress percent, or a
-PlatformIO ``Compiling`` word marker the percent parser can't see), and stops
-on the summary banner — never during the dependency download or CMake
-configure, and never counting an install's flash phase.
+that proves the toolchain is building and stops on the summary banner — never
+during the dependency download or CMake configure, and never counting an
+install's flash phase. Two output shapes have to work: PlatformIO's
+``Compiling <path>`` word markers (arduino / esp8266 / libretiny, and esp-idf
+via the pio builder), which carry no percentage, and raw esp-idf ninja
+``[N/M] Building …`` counters (bluetooth-proxy / idf.py builds), which carry no
+``Compiling`` word — the real lines below come from a captured ninja build.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from esphome_device_builder.controllers.firmware.helpers import _stamp_compile_phase
+from esphome_device_builder.controllers.firmware.helpers import (
+    _parse_progress,
+    _stamp_compile_phase,
+)
 from esphome_device_builder.models.firmware import FirmwareJob, JobType
 
 
@@ -19,12 +25,21 @@ def _job() -> FirmwareJob:
     return FirmwareJob(job_id="j", configuration="c.yaml", job_type=JobType.COMPILE)
 
 
-class TestCompileStart:
+def _feed(job: FirmwareJob, line: str) -> None:
+    """Drive one line the way ``_ingest_output_line`` does: parse, then stamp."""
+    _stamp_compile_phase(job, line, _parse_progress(line))
+
+
+class TestPlatformIOWordMarkers:
+    """pio prints ``Compiling <path>`` with no percentage — the word starts it."""
+
     @pytest.mark.parametrize(
         "line",
         [
             "Compiling .pio/build/esp32dev/src/main.cpp.o",
             "Compiling .pioenvs/apy/esp_hw_support/cpu.c.o",
+            "Compiling .pio/build/nodemcuv2/core/core_esp8266_main.cpp.o",
+            "Compiling .pio/build/bk72xx/src/main.cpp.o",
             "Archiving .pio/build/nodemcuv2/libFrameworkArduino.a",
             "Linking .pio/build/bk72xx/firmware.elf",
             "Building in release mode",
@@ -32,16 +47,46 @@ class TestCompileStart:
     )
     def test_word_marker_starts_without_percent(self, line: str) -> None:
         job = _job()
-        _stamp_compile_phase(job, line, None)
+        _feed(job, line)
         assert job.compile_started_at is not None
 
-    def test_parsed_progress_starts_for_raw_ninja(self) -> None:
-        # esp-idf ninja prints no "Compiling" word; the counter is caught by
-        # progress parsing, which is the start signal here.
+
+class TestRawNinjaCounters:
+    """esp-idf ninja prints ``[N/M] Building …`` with no ``Compiling`` word."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Real captured lines (CR-split, trailing erase-to-eol escape).
+            "[1/1547] Generating project_elf_src_esp32s3.c\x1b[K",
+            "[6/1547] Building C object esp-idf/esp_adc/adc_cali.c.obj\x1b[K",
+            "[995/1547] Building C object esp-idf/bt/bta_hh_utils.c.obj",
+            "[1547/1547] Linking CXX executable btp.elf",
+        ],
+    )
+    def test_counter_starts_via_parsed_progress(self, line: str) -> None:
         job = _job()
-        _stamp_compile_phase(job, "[907/1424] Building C object foo.c.obj", 63)
+        _feed(job, line)
         assert job.compile_started_at is not None
 
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # CMake reconfigure + globbed-dir re-check: total under the ninja
+            # floor, so no percent parses and the compile hasn't started.
+            "[0/2] Re-checking globbed directories...\x1b[K",
+            "[1/2] Re-running CMake...\x1b[K",
+            "[0/4] Re-checking globbed directories...\x1b[K",
+            "[3/97] Performing build step for 'bootloader'",
+        ],
+    )
+    def test_configure_counters_do_not_start(self, line: str) -> None:
+        job = _job()
+        _feed(job, line)
+        assert job.compile_started_at is None
+
+
+class TestDownloadAndConfigureExcluded:
     @pytest.mark.parametrize(
         "line",
         [
@@ -49,21 +94,15 @@ class TestCompileStart:
             "Library Manager: Installing esphome/noise-c @ 0.1.11",
             "Unpacking [####################] 100%",
             "-- Configuring done (3.0s)",
+            "-- Building ESP-IDF components for target esp32s3",
             "Executing action: reconfigure",
-            "[1/2] Re-running CMake...",
+            "Running ninja in directory /data/build/btp/build",
         ],
     )
-    def test_download_and_configure_do_not_start(self, line: str) -> None:
+    def test_no_start(self, line: str) -> None:
         job = _job()
-        _stamp_compile_phase(job, line, None)
+        _feed(job, line)
         assert job.compile_started_at is None
-
-    def test_start_is_latched_once(self) -> None:
-        job = _job()
-        _stamp_compile_phase(job, "Compiling a.cpp.o", None)
-        first = job.compile_started_at
-        _stamp_compile_phase(job, "Compiling b.cpp.o", None)
-        assert job.compile_started_at == first
 
 
 class TestCompileEnd:
@@ -76,29 +115,49 @@ class TestCompileEnd:
     )
     def test_banner_ends_after_start(self, line: str) -> None:
         job = _job()
-        _stamp_compile_phase(job, "Compiling a.cpp.o", None)
-        _stamp_compile_phase(job, line, None)
+        _feed(job, "Compiling a.cpp.o")
+        _feed(job, line)
         assert job.compile_ended_at is not None
 
     def test_end_ignored_before_start(self) -> None:
         job = _job()
-        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds", None)
+        _feed(job, "[SUCCESS] Took 1.0 seconds")
         assert job.compile_started_at is None
         assert job.compile_ended_at is None
 
-    def test_end_is_latched_once(self) -> None:
+
+class TestLatching:
+    def test_start_latched_once(self) -> None:
         job = _job()
-        _stamp_compile_phase(job, "Compiling a.cpp.o", None)
-        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds", None)
+        _feed(job, "Compiling a.cpp.o")
+        first = job.compile_started_at
+        _feed(job, "[6/1547] Building C object b.c.obj")
+        assert job.compile_started_at == first
+
+    def test_end_latched_once(self) -> None:
+        job = _job()
+        _feed(job, "Compiling a.cpp.o")
+        _feed(job, "[SUCCESS] Took 1.0 seconds")
         first = job.compile_ended_at
-        _stamp_compile_phase(job, "[FAILED] Took 9.0 seconds", None)
+        _feed(job, "[FAILED] Took 9.0 seconds")
         assert job.compile_ended_at == first
 
+    def test_cleared_by_clear_run_state(self) -> None:
+        job = _job()
+        _feed(job, "Compiling a.cpp.o")
+        _feed(job, "[SUCCESS] Took 1.0 seconds")
+        job.clear_run_state()
+        assert job.compile_started_at is None
+        assert job.compile_ended_at is None
 
-def test_cleared_by_clear_run_state() -> None:
-    job = _job()
-    _stamp_compile_phase(job, "Compiling a.cpp.o", None)
-    _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds", None)
-    job.clear_run_state()
+
+def test_old_job_without_fields_deserializes_to_none() -> None:
+    """A job persisted before these fields existed loads with them unset."""
+    payload = {
+        "job_id": "old",
+        "configuration": "c.yaml",
+        "job_type": JobType.COMPILE.value,
+    }
+    job = FirmwareJob.from_dict(payload)
     assert job.compile_started_at is None
     assert job.compile_ended_at is None

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -56,6 +56,11 @@ class TestPlatformIOWordMarkers:
         _stamp_compile_phase(job, "[ 17%] Compiling .pio/build/uno/src/main.cpp.o")
         assert job.compile_started_at is not None
 
+    def test_reading_cmake_configuration_starts_esp_idf(self) -> None:
+        job = _job()
+        _stamp_compile_phase(job, "Reading CMake configuration...")
+        assert job.compile_started_at is not None
+
 
 class TestRawNinjaCounters:
     """esp-idf ninja prints ``[N/M]`` counters; the first one is the build start."""
@@ -153,6 +158,9 @@ class TestCompileEnd:
         [
             "===================== [SUCCESS] Took 15.36 seconds =====================",
             "===================== [FAILED] Took 4.10 seconds =====================",
+            # Real ANSI banner: colours sit *inside* the brackets.
+            "\x1b[0m===== [\x1b[32m\x1b[1mSUCCESS\x1b[0m] Took 14.73 seconds =====\x1b[0m",
+            "[\x1b[31m\x1b[1mFAILED\x1b[0m] Took 4.10 seconds",
         ],
     )
     def test_banner_ends_after_start(self, line: str) -> None:

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -1,22 +1,11 @@
-"""``compile_started_at`` / ``compile_ended_at`` stamping.
+"""
+``compile_started_at`` / ``compile_ended_at`` stamping.
 
-The compile clock counts compilation only. It starts on the first line that
-proves the toolchain is building and stops on the summary banner — never
-during the dependency download, and never counting an install's flash phase.
-
-Two output shapes must both work:
-
-* PlatformIO ``Compiling <path>`` word markers (esp8266 / esp32-arduino /
-  libretiny, and esp-idf via the pio builder), which carry no percentage.
-* raw esp-idf ninja ``[N/M] Building …`` counters (bluetooth-proxy / idf.py
-  builds), which carry no ``Compiling`` word.
-
-The lines below are captured from real ``platformio.log`` (esp8266) and
-``btp_compile.log`` (esp-idf ninja) builds. Because the download always
-precedes the first ninja counter, the first ``[N/M]`` starts the clock (no
-total floor). A stray percentage while downloading (esptool-style ``(45 %)``,
-an ``Unpacking`` bar) must *not* start it — only the three compile-specific
-shapes do.
+The clock starts on the first build line (PlatformIO ``Compiling`` word
+markers with no percentage, or raw esp-idf ninja ``[N/M]`` counters with no
+``Compiling`` word — both pinned from captured builds) and stops at the
+summary banner; the dependency download and an install's flash never count,
+and a stray download/flash percentage never starts it.
 """
 
 from __future__ import annotations

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -1,0 +1,104 @@
+"""``compile_started_at`` / ``compile_ended_at`` stamping.
+
+The compile clock must count compilation only: it starts on the first line
+that proves the toolchain is building (a parseable progress percent, or a
+PlatformIO ``Compiling`` word marker the percent parser can't see), and stops
+on the summary banner — never during the dependency download or CMake
+configure, and never counting an install's flash phase.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome_device_builder.controllers.firmware.helpers import _stamp_compile_phase
+from esphome_device_builder.models.firmware import FirmwareJob, JobType
+
+
+def _job() -> FirmwareJob:
+    return FirmwareJob(job_id="j", configuration="c.yaml", job_type=JobType.COMPILE)
+
+
+class TestCompileStart:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "Compiling .pio/build/esp32dev/src/main.cpp.o",
+            "Compiling .pioenvs/apy/esp_hw_support/cpu.c.o",
+            "Archiving .pio/build/nodemcuv2/libFrameworkArduino.a",
+            "Linking .pio/build/bk72xx/firmware.elf",
+            "Building in release mode",
+        ],
+    )
+    def test_word_marker_starts_without_percent(self, line: str) -> None:
+        job = _job()
+        _stamp_compile_phase(job, line, None)
+        assert job.compile_started_at is not None
+
+    def test_parsed_progress_starts_for_raw_ninja(self) -> None:
+        # esp-idf ninja prints no "Compiling" word; the counter is caught by
+        # progress parsing, which is the start signal here.
+        job = _job()
+        _stamp_compile_phase(job, "[907/1424] Building C object foo.c.obj", 63)
+        assert job.compile_started_at is not None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "Tool Manager: Installing framework-arduinoespressif32",
+            "Library Manager: Installing esphome/noise-c @ 0.1.11",
+            "Unpacking [####################] 100%",
+            "-- Configuring done (3.0s)",
+            "Executing action: reconfigure",
+            "[1/2] Re-running CMake...",
+        ],
+    )
+    def test_download_and_configure_do_not_start(self, line: str) -> None:
+        job = _job()
+        _stamp_compile_phase(job, line, None)
+        assert job.compile_started_at is None
+
+    def test_start_is_latched_once(self) -> None:
+        job = _job()
+        _stamp_compile_phase(job, "Compiling a.cpp.o", None)
+        first = job.compile_started_at
+        _stamp_compile_phase(job, "Compiling b.cpp.o", None)
+        assert job.compile_started_at == first
+
+
+class TestCompileEnd:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "===================== [SUCCESS] Took 15.36 seconds =====================",
+            "===================== [FAILED] Took 4.10 seconds =====================",
+        ],
+    )
+    def test_banner_ends_after_start(self, line: str) -> None:
+        job = _job()
+        _stamp_compile_phase(job, "Compiling a.cpp.o", None)
+        _stamp_compile_phase(job, line, None)
+        assert job.compile_ended_at is not None
+
+    def test_end_ignored_before_start(self) -> None:
+        job = _job()
+        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds", None)
+        assert job.compile_started_at is None
+        assert job.compile_ended_at is None
+
+    def test_end_is_latched_once(self) -> None:
+        job = _job()
+        _stamp_compile_phase(job, "Compiling a.cpp.o", None)
+        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds", None)
+        first = job.compile_ended_at
+        _stamp_compile_phase(job, "[FAILED] Took 9.0 seconds", None)
+        assert job.compile_ended_at == first
+
+
+def test_cleared_by_clear_run_state() -> None:
+    job = _job()
+    _stamp_compile_phase(job, "Compiling a.cpp.o", None)
+    _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds", None)
+    job.clear_run_state()
+    assert job.compile_started_at is None
+    assert job.compile_ended_at is None

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -110,7 +110,15 @@ class TestStrayPercentDoesNotStart:
         assert job.compile_started_at is None
 
 
-class TestDownloadAndConfigureExcluded:
+class TestDownloadAndNarrationExcluded:
+    """Setup narration never starts the clock on its own.
+
+    In a real esp-idf build the clock is already running by the time these
+    lines stream ("Reading CMake configuration" starts it, since configure is
+    CPU+I/O work of the build); this pins that none of them is a start signal,
+    so a pio build's download phase stays out of the count.
+    """
+
     @pytest.mark.parametrize(
         "line",
         [

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -1,33 +1,34 @@
 """``compile_started_at`` / ``compile_ended_at`` stamping.
 
-The compile clock must count compilation only: it starts on the first line
-that proves the toolchain is building and stops on the summary banner — never
-during the dependency download or CMake configure, and never counting an
-install's flash phase. Two output shapes have to work: PlatformIO's
-``Compiling <path>`` word markers (arduino / esp8266 / libretiny, and esp-idf
-via the pio builder), which carry no percentage, and raw esp-idf ninja
-``[N/M] Building …`` counters (bluetooth-proxy / idf.py builds), which carry no
-``Compiling`` word — the real lines below come from a captured ninja build.
+The compile clock counts compilation only. It starts on the first line that
+proves the toolchain is building and stops on the summary banner — never
+during the dependency download, and never counting an install's flash phase.
+
+Two output shapes must both work:
+
+* PlatformIO ``Compiling <path>`` word markers (esp8266 / esp32-arduino /
+  libretiny, and esp-idf via the pio builder), which carry no percentage.
+* raw esp-idf ninja ``[N/M] Building …`` counters (bluetooth-proxy / idf.py
+  builds), which carry no ``Compiling`` word.
+
+The lines below are captured from real ``platformio.log`` (esp8266) and
+``btp_compile.log`` (esp-idf ninja) builds. Because the download always
+precedes the first ninja counter, the first ``[N/M]`` starts the clock (no
+total floor). A stray percentage while downloading (esptool-style ``(45 %)``,
+an ``Unpacking`` bar) must *not* start it — only the three compile-specific
+shapes do.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from esphome_device_builder.controllers.firmware.helpers import (
-    _parse_progress,
-    _stamp_compile_phase,
-)
+from esphome_device_builder.controllers.firmware.helpers import _stamp_compile_phase
 from esphome_device_builder.models.firmware import FirmwareJob, JobType
 
 
 def _job() -> FirmwareJob:
     return FirmwareJob(job_id="j", configuration="c.yaml", job_type=JobType.COMPILE)
-
-
-def _feed(job: FirmwareJob, line: str) -> None:
-    """Drive one line the way ``_ingest_output_line`` does: parse, then stamp."""
-    _stamp_compile_phase(job, line, _parse_progress(line))
 
 
 class TestPlatformIOWordMarkers:
@@ -36,53 +37,71 @@ class TestPlatformIOWordMarkers:
     @pytest.mark.parametrize(
         "line",
         [
+            # Real esp8266 platformio.log compile lines.
+            "Compiling .pioenvs/simple8266/src/esphome/components/api/api_server.cpp.o",
             "Compiling .pio/build/esp32dev/src/main.cpp.o",
-            "Compiling .pioenvs/apy/esp_hw_support/cpu.c.o",
-            "Compiling .pio/build/nodemcuv2/core/core_esp8266_main.cpp.o",
             "Compiling .pio/build/bk72xx/src/main.cpp.o",
-            "Archiving .pio/build/nodemcuv2/libFrameworkArduino.a",
-            "Linking .pio/build/bk72xx/firmware.elf",
+            "Indexing .pioenvs/simple8266/libFrameworkArduino.a",
+            "Linking .pioenvs/simple8266/firmware.elf",
             "Building in release mode",
         ],
     )
     def test_word_marker_starts_without_percent(self, line: str) -> None:
         job = _job()
-        _feed(job, line)
+        _stamp_compile_phase(job, line)
+        assert job.compile_started_at is not None
+
+    def test_arduino_bracket_percent_starts(self) -> None:
+        job = _job()
+        _stamp_compile_phase(job, "[ 17%] Compiling .pio/build/uno/src/main.cpp.o")
         assert job.compile_started_at is not None
 
 
 class TestRawNinjaCounters:
-    """esp-idf ninja prints ``[N/M] Building …`` with no ``Compiling`` word."""
+    """esp-idf ninja prints ``[N/M]`` counters; the first one is the build start."""
 
     @pytest.mark.parametrize(
         "line",
         [
-            # Real captured lines (CR-split, trailing erase-to-eol escape).
+            # Real captured btp_compile.log chunks (CR-split, trailing erase escape).
+            "[0/2] Re-checking globbed directories...\x1b[K",
+            "[1/2] Re-running CMake...\x1b[K",
             "[1/1547] Generating project_elf_src_esp32s3.c\x1b[K",
             "[6/1547] Building C object esp-idf/esp_adc/adc_cali.c.obj\x1b[K",
-            "[995/1547] Building C object esp-idf/bt/bta_hh_utils.c.obj",
+            "[3/97] Performing build step for 'bootloader'",
             "[1547/1547] Linking CXX executable btp.elf",
         ],
     )
-    def test_counter_starts_via_parsed_progress(self, line: str) -> None:
+    def test_any_counter_starts_the_clock(self, line: str) -> None:
         job = _job()
-        _feed(job, line)
+        _stamp_compile_phase(job, line)
         assert job.compile_started_at is not None
+
+
+class TestStrayPercentDoesNotStart:
+    """Download / flash / OTA percentages are not compilation."""
 
     @pytest.mark.parametrize(
         "line",
         [
-            # CMake reconfigure + globbed-dir re-check: total under the ninja
-            # floor, so no percent parses and the compile hasn't started.
-            "[0/2] Re-checking globbed directories...\x1b[K",
-            "[1/2] Re-running CMake...\x1b[K",
-            "[0/4] Re-checking globbed directories...\x1b[K",
-            "[3/97] Performing build step for 'bootloader'",
+            # Real esp8266 platformio.log download bar (percent outside brackets).
+            "Unpacking  [------------------------------------]    0%",
+            "Library Manager: Installing esphome/noise-c @ 0.1.11",
+            # esptool flash progress — parses as a percent, but it's the flash.
+            "Writing at 0x00010000... (45 %)",
+            "Writing at 0x000cf943 [=>  ]  84.8% 491520/579918 bytes...",
+            # ESPHome OTA upload.
+            "Uploading: [====      ] 35% ...",
+            # Memory-usage report at the end of link.
+            "RAM:   [====      ]  37.7% (used 30900 bytes from 81920 bytes)",
+            "Flash: [====      ]  41.8% (used 428199 bytes from 1023984 bytes)",
+            # A bare parenthesised percent anywhere.
+            "Downloading toolchain (45%)",
         ],
     )
-    def test_configure_counters_do_not_start(self, line: str) -> None:
+    def test_no_start(self, line: str) -> None:
         job = _job()
-        _feed(job, line)
+        _stamp_compile_phase(job, line)
         assert job.compile_started_at is None
 
 
@@ -91,18 +110,41 @@ class TestDownloadAndConfigureExcluded:
         "line",
         [
             "Tool Manager: Installing framework-arduinoespressif32",
-            "Library Manager: Installing esphome/noise-c @ 0.1.11",
-            "Unpacking [####################] 100%",
             "-- Configuring done (3.0s)",
             "-- Building ESP-IDF components for target esp32s3",
             "Executing action: reconfigure",
             "Running ninja in directory /data/build/btp/build",
+            "HARDWARE: ESP8266 80MHz, 80KB RAM, 1MB Flash",
         ],
     )
     def test_no_start(self, line: str) -> None:
         job = _job()
-        _feed(job, line)
+        _stamp_compile_phase(job, line)
         assert job.compile_started_at is None
+
+
+class TestFullSequences:
+    """End-to-end ordering: download first, then the build starts the clock."""
+
+    def test_esp8266_platformio(self) -> None:
+        job = _job()
+        for line in [
+            "Library Manager: Installing esphome/noise-c @ 0.1.11",
+            "Unpacking  [------------------------------------]    0%",
+            "HARDWARE: ESP8266 80MHz, 80KB RAM, 1MB Flash",
+            "Compiling .pioenvs/simple8266/src/esphome/components/api/api_server.cpp.o",
+        ]:
+            assert job.compile_started_at is None or line.startswith("Compiling")
+            _stamp_compile_phase(job, line)
+        assert job.compile_started_at is not None
+
+    def test_esp_idf_ninja_download_before_first_counter(self) -> None:
+        job = _job()
+        # A stray download percent lands before ninja and must not start it.
+        _stamp_compile_phase(job, "Downloading esp-idf tool (45%)")
+        assert job.compile_started_at is None
+        _stamp_compile_phase(job, "[0/2] Re-checking globbed directories...\x1b[K")
+        assert job.compile_started_at is not None
 
 
 class TestCompileEnd:
@@ -115,13 +157,13 @@ class TestCompileEnd:
     )
     def test_banner_ends_after_start(self, line: str) -> None:
         job = _job()
-        _feed(job, "Compiling a.cpp.o")
-        _feed(job, line)
+        _stamp_compile_phase(job, "Compiling a.cpp.o")
+        _stamp_compile_phase(job, line)
         assert job.compile_ended_at is not None
 
     def test_end_ignored_before_start(self) -> None:
         job = _job()
-        _feed(job, "[SUCCESS] Took 1.0 seconds")
+        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds")
         assert job.compile_started_at is None
         assert job.compile_ended_at is None
 
@@ -129,23 +171,23 @@ class TestCompileEnd:
 class TestLatching:
     def test_start_latched_once(self) -> None:
         job = _job()
-        _feed(job, "Compiling a.cpp.o")
+        _stamp_compile_phase(job, "Compiling a.cpp.o")
         first = job.compile_started_at
-        _feed(job, "[6/1547] Building C object b.c.obj")
+        _stamp_compile_phase(job, "[6/1547] Building C object b.c.obj")
         assert job.compile_started_at == first
 
     def test_end_latched_once(self) -> None:
         job = _job()
-        _feed(job, "Compiling a.cpp.o")
-        _feed(job, "[SUCCESS] Took 1.0 seconds")
+        _stamp_compile_phase(job, "Compiling a.cpp.o")
+        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds")
         first = job.compile_ended_at
-        _feed(job, "[FAILED] Took 9.0 seconds")
+        _stamp_compile_phase(job, "[FAILED] Took 9.0 seconds")
         assert job.compile_ended_at == first
 
     def test_cleared_by_clear_run_state(self) -> None:
         job = _job()
-        _feed(job, "Compiling a.cpp.o")
-        _feed(job, "[SUCCESS] Took 1.0 seconds")
+        _stamp_compile_phase(job, "Compiling a.cpp.o")
+        _stamp_compile_phase(job, "[SUCCESS] Took 1.0 seconds")
         job.clear_run_state()
         assert job.compile_started_at is None
         assert job.compile_ended_at is None


### PR DESCRIPTION
# What does this implement/fix?

The Device Builder dashboard shows a build timer during a compile/install. Its compile figure has to count the build itself — CMake configure included, since that is CPU and I/O intensive work — but not the Tool/Library Manager dependency download, and it has to stay correct when the user reloads the page or reopens the build window, or when the backend restarts mid-build. Deriving that on the client can't survive a reload, because reattaching to a running job replays the buffered output and would restart the clock from the replay.

This records the compile span on the persistent `FirmwareJob` itself, so it is authoritative and durable.

`compile_started_at` is stamped on the first line that proves the toolchain is building: a `Compiling` / `Archiving` / `Linking` / `Indexing` / `Generating` / `Building in <mode>` / `Reading CMake configuration` word marker, an arduino `[ NN%]` per-file gauge, or a ninja `[N/M]` counter (the download always precedes ninja, so the first counter — even the `[1/2] Re-running CMake` re-check — is the build start). Deliberately not any parseable percentage: a stray download or flash percent (Unpacking bars, esptool `Writing at`, OTA `Uploading`) never starts the clock. `compile_ended_at` is stamped on PlatformIO's `[SUCCESS]/[FAILED] Took N seconds` summary banner, so an install's flash phase (which streams after the compile) isn't counted. ANSI is stripped before matching, since PlatformIO colours the banner inside the brackets (`[<green><bold>SUCCESS<reset>] Took`).

Both are stamped in `_stamp_compile_phase`, called from the shared per-line `_ingest_output_line`, so local and remote (offloaded) builds get the same treatment. It short-circuits once both stamps are latched and pre-filters the end scan on a plain `Took ` substring, so the per-line hot path stays cheap through an install's flash. The fields serialize into the job like the existing `started_at` / `completed_at`, so the `firmware/follow_jobs` reconnect snapshot carries the true elapsed to a client that reloaded or reconnected, and they persist across a backend restart with the rest of the queue. `clear_run_state` resets them alongside the other per-run fields; a job persisted before these fields existed loads with them unset, and the frontend degrades gracefully.

Tests pin real captured output from an esp8266 PlatformIO build (`Compiling` word markers, no percentages) and an esp-idf ninja build (`[N/M]` counters, no `Compiling` word), plus the stray-percent exclusions, the ANSI-coloured banner, latching, and old-job deserialization.

**Related issue or feature (if applicable):**

- Supports the frontend build-timer / offload-discoverability work; no filed issue.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1183

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
