### PR TITLE
Skip the release catalog sync for dev builds

### DIFF
--- a/.github/workflows/sync-on-esphome-release.yml
+++ b/.github/workflows/sync-on-esphome-release.yml
@@ -4,7 +4,8 @@ name: Sync component catalog on ESPHome release
 # for the new schema to publish, then dispatches the component catalog sync so
 # it refreshes immediately instead of waiting for the nightly. The device/board
 # catalog is sourced from devices.esphome.io plus curated manifests, so a
-# release doesn't change it; it stays on its own schedule.
+# release doesn't change it; it stays on its own schedule. Nightly dev builds
+# are dispatched too but skipped: they publish no schema bundle.
 
 on:
   workflow_dispatch:
@@ -26,7 +27,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Check the version is a stable or beta release
+        id: gate
+        # Nightly dev builds (2026.8.0-dev20260712) publish no schema bundle,
+        # so waiting for one just burns 20 minutes and fails; the downstream
+        # sync rejects them with this same pattern anyway.
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$'; then
+            echo "sync=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Skipping catalog sync for '$VERSION' - not a stable/beta release"
+            echo "sync=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Wait for the schema bundle to publish
+        if: steps.gate.outputs.sync == 'true'
         # The schema build (esphome-schema) and this run fan out from the same
         # release event, so the bundle can lag the release by a few minutes. The
         # component sync consumes it, so wait before kicking that off. ``version``
@@ -51,6 +69,7 @@ jobs:
           exit 1
 
       - name: Dispatch the component catalog sync
+        if: steps.gate.outputs.sync == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/sync-on-esphome-release.yml
+++ b/.github/workflows/sync-on-esphome-release.yml
@@ -24,6 +24,10 @@ concurrency:
 
 jobs:
   dispatch:
+    # Expressions can't regex-match, so this job-level check is just the cheap
+    # denylist that spares a nightly runner allocation for dev builds; the gate
+    # step below is the strict allowlist for every other dispatch input.
+    if: ${{ !contains(inputs.version, 'dev') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
# What does this implement/fix?

`esphome/version-notifier` dispatches `sync-on-esphome-release.yml` for every ESPHome release tag, including the nightly dev builds (`2026.8.0-dev20260712`). Dev builds never publish a schema bundle at `https://schema.esphome.io/<version>/schema.zip`, so the "Wait for the schema bundle to publish" loop 404s for 20 minutes and the run fails — every night at ~03:08 UTC (e.g. [run 29177790107](https://github.com/esphome/device-builder/actions/runs/29177790107)), burning ~25 runner-minutes and normalising red runs on this workflow.

This adds a gate step at the top of the `dispatch` job that validates the version against the same pattern the downstream `sync-component-catalog.yml` already enforces (`^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$` — stable and beta only). Anything else skips cleanly in seconds with a `::notice::` instead of waiting 20 minutes to fail; the wait and dispatch steps are gated on the check's output. The version flows through `env`, matching the existing injection-hardening pattern. The downstream sync's own validation stays as the second line of defense.

Verified locally: `2026.8.0` and `2026.8.0b1` pass the gate; `2026.8.0-dev20260712`, `2026.8.0.dev1`, and empty skip. Post-merge, tonight's version-notifier dispatch should come back green as a skip.

**Related issue or feature (if applicable):**

- no issue; prompted by the nightly failing dispatch runs (latest: [29177790107](https://github.com/esphome/device-builder/actions/runs/29177790107))

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
