### PR TITLE
Lift every page dependency and validate imported full setups with ESPHome

### DIFF
--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -118,5 +118,7 @@ BUS_CATEGORIES: frozenset[str] = frozenset({"bus", "one_wire", "canbus"})
 # Catalog categories that never appear as featured components — they belong in
 # the dedicated "Add core configuration" dialog, not board recommendations.
 # Shared by the importer (which must not lift such a component as a dependency
-# hub) and the validator (which rejects manifests featuring one).
-FEATURED_EXCLUDED_CATEGORIES: frozenset[str] = frozenset({"core", "ota", "time", "update"})
+# hub) and the validator (which rejects manifests featuring one). ``time`` is
+# deliberately absent: a page's ``time:`` platform is a hard dependency of
+# leaves like ``sensor.total_daily_energy``, so imports must carry it.
+FEATURED_EXCLUDED_CATEGORIES: frozenset[str] = frozenset({"core", "ota", "update"})

--- a/script/_full_setup_gate.py
+++ b/script/_full_setup_gate.py
@@ -6,7 +6,7 @@ wizard's "all recommended" flow and run through the real
 ``esphome.config.load_config`` in a forked worker (ESPHome accumulates
 module-global state across validations, so every validation gets a fresh
 process — same isolation the slow e2e suite uses). A failing entry is
-dropped by mapping the error's ``@ data['<domain>'][i]`` path back to the
+dropped by mapping the error's structured config path back to the
 generated item's ``id``; the record revalidates until clean. Boards left
 featureless (or with an unmappable failure) are skipped entirely.
 """
@@ -16,16 +16,18 @@ from __future__ import annotations
 import logging
 import multiprocessing as mp
 import os
-import re
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
+if TYPE_CHECKING:
+    from esphome_device_builder.models import BoardCatalogEntry, ComponentCatalogEntry
+
 _LOGGER = logging.getLogger("sync_esphome_devices")
 
-_ERROR_PATH_RE = re.compile(r"@ data\['([a-z_0-9]+)'\](?:\[(\d+)\])?")
 # Each pass drops at least one entry per failing board; ESPHome often stops
 # at the first error per domain, so a page with many same-shaped broken
 # entries (one bad expander pin copied eight times) needs a pass per entry.
@@ -42,23 +44,28 @@ def apply_validation_gate(records: list[dict[str, Any]]) -> dict[str, str]:
     if "fork" not in mp.get_all_start_methods():
         _LOGGER.warning("Skipping full-setup validation: no fork start method")
         return {}
+    # Import once in the parent: every forked worker then inherits the
+    # clean pre-validation module state instead of re-importing esphome.
+    import esphome.config  # noqa: F401
+
     ctx = mp.get_context("fork")
     skipped: dict[str, str] = {}
     pending = list(records)
     for _ in range(_MAX_PASSES):
         if not pending:
             break
-        with ctx.Pool(processes=min(8, os.cpu_count() or 4), maxtasksperchild=1) as pool:
+        processes = min(8, os.cpu_count() or 4, len(pending))
+        with ctx.Pool(processes=processes, maxtasksperchild=1) as pool:
             results = pool.map(_validate_record, pending, chunksize=1)
         retry: list[dict[str, Any]] = []
         for record, outcome in zip(pending, results, strict=True):
-            if outcome is None or not outcome.drop_ids:
+            if outcome is None or not outcome.drops:
                 if outcome is not None and outcome.errors:
                     skipped[record["id"]] = f"full setup fails validation: {outcome.errors[0]}"
                 continue
-            for local_id, error in zip(outcome.drop_ids, outcome.drop_errors, strict=True):
+            for local_id, error in outcome.drops:
                 _LOGGER.info("%s: dropping %s — %s", record["id"], local_id, error)
-            _apply_drops(record, set(outcome.drop_ids))
+            _apply_drops(record, {local_id for local_id, _ in outcome.drops})
             if record.get("featured_components"):
                 retry.append(record)
             else:
@@ -70,20 +77,45 @@ def apply_validation_gate(records: list[dict[str, Any]]) -> dict[str, str]:
     return skipped
 
 
+def run_esphome_validation(
+    board_id: str,
+    board: BoardCatalogEntry,
+    defaults: list[tuple[ComponentCatalogEntry, dict[str, Any]]],
+) -> tuple[str, list[Any]]:
+    """
+    Generate *board*'s YAML with *defaults* and run real ESPHome validation.
+
+    Returns ``(yaml_text, errors)`` — errors are ``vol.Invalid`` (carrying a
+    structured ``.path``) or a single ``EsphomeError``. Shared with the slow
+    e2e boards suite; call from a fresh (forked) process only.
+    """
+    from esphome.config import load_config
+    from esphome.core import CORE, EsphomeError
+
+    from esphome_device_builder.helpers.device_yaml import generate_device_yaml
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Inline creds keep the YAML ``!secret``-free so it validates standalone.
+        yaml_path = Path(tmp) / f"{board_id}.yaml"
+        yaml_text = generate_device_yaml(
+            "repro", "Repro", board, ssid="ssid", psk="password", defaults=defaults
+        )
+        yaml_path.write_text(yaml_text, encoding="utf-8")
+        CORE.config_path = yaml_path
+        try:
+            return yaml_text, list(load_config({}, skip_external_update=True).errors)
+        except EsphomeError as err:
+            return yaml_text, [err]
+
+
+@dataclass(slots=True)
 class _Outcome:
     """One validation result: nothing set means the record validated clean."""
 
-    __slots__ = ("drop_errors", "drop_ids", "errors")
-
-    def __init__(
-        self,
-        drop_ids: list[str] | None = None,
-        drop_errors: list[str] | None = None,
-        errors: list[str] | None = None,
-    ) -> None:
-        self.drop_ids = drop_ids or []
-        self.drop_errors = drop_errors or []
-        self.errors = errors or []
+    # (local id, error text) per entry to drop.
+    drops: list[tuple[str, str]] = field(default_factory=list)
+    # Board-level failures no single entry can absorb.
+    errors: list[str] = field(default_factory=list)
 
 
 def _validate_record(record: dict[str, Any]) -> _Outcome | None:
@@ -93,9 +125,6 @@ def _validate_record(record: dict[str, Any]) -> _Outcome | None:
     Returns ``None`` when the gate doesn't apply (pin-conflict boards keep
     partial bundles, so no combined setup exists to validate).
     """
-    from esphome.config import load_config
-    from esphome.core import CORE, EsphomeError
-
     from esphome_device_builder.controllers.components import _load_body_from_disk
     from esphome_device_builder.definitions import (
         _load_component_multi_conf,
@@ -112,24 +141,12 @@ def _validate_record(record: dict[str, Any]) -> _Outcome | None:
     ]
     if not featured or _has_pin_conflict(featured):
         return None
-    esphome_cfg = _load_esphome_config(record["esphome"], record["id"])
-    if esphome_cfg.platform.value == "esp32" and esphome_cfg.variant is None:
-        # sync_boards backfills the variant from the PIO board id when it
-        # regenerates the catalog; without the same backfill an imported
-        # ``board:``-only manifest fails as "This board is unknown".
-        from esphome.components.esp32.boards import BOARDS
-
-        from esphome_device_builder.models.boards import Esp32Variant
-
-        meta = BOARDS.get(esphome_cfg.board)
-        if meta is not None:
-            esphome_cfg.variant = Esp32Variant(meta["variant"].lower())
     board = BoardCatalogEntry(
         id=record["id"],
         name=record["name"],
         description="",
         manufacturer="",
-        esphome=esphome_cfg,
+        esphome=_load_esphome_config(record["esphome"], record["id"]),
         featured_components=featured,
         full_config=True,
     )
@@ -141,57 +158,45 @@ def _validate_record(record: dict[str, Any]) -> _Outcome | None:
         defaults.append(
             (body, {key: p.value for key, p in fc.fields.items() if p.value is not None})
         )
-
-    from esphome_device_builder.helpers.device_yaml import generate_device_yaml
-
-    with tempfile.TemporaryDirectory() as tmp:
-        yaml_path = Path(tmp) / f"{record['id']}.yaml"
-        yaml_text = generate_device_yaml(
-            "repro", "Repro", board, ssid="ssid", psk="password", defaults=defaults
-        )
-        yaml_path.write_text(yaml_text, encoding="utf-8")
-        CORE.config_path = yaml_path
-        try:
-            errors = [str(err) for err in load_config({}, skip_external_update=True).errors]
-        except EsphomeError as err:
-            errors = [str(err)]
+    yaml_text, errors = run_esphome_validation(record["id"], board, defaults)
     if not errors:
         return _Outcome()
     return _map_errors(errors, yaml_text, record)
 
 
-def _map_errors(errors: list[str], yaml_text: str, record: dict[str, Any]) -> _Outcome:
-    """Map each error's config path to the featured entry that produced it."""
+def _map_errors(errors: list[Any], yaml_text: str, record: dict[str, Any]) -> _Outcome:
+    """Map each error's structured config path to the featured entry that produced it."""
     data = yaml.safe_load(yaml_text)
     entries = record.get("featured_components") or []
     local_ids = {entry["id"] for entry in entries}
-    drop_ids: list[str] = []
-    drop_errors: list[str] = []
+    drops: list[tuple[str, str]] = []
+    seen: set[str] = set()
     for error in errors:
-        match = _ERROR_PATH_RE.search(error)
-        local_id = _entry_for_path(match, data, entries, local_ids) if match else None
+        path = list(getattr(error, "path", None) or [])
+        local_id = _entry_for_path(path, data, entries, local_ids)
         if local_id is None:
             # An error we can't pin on one entry poisons the whole board.
-            return _Outcome(errors=[error])
-        if local_id not in drop_ids:
-            drop_ids.append(local_id)
-            drop_errors.append(error)
-    return _Outcome(drop_ids=drop_ids, drop_errors=drop_errors)
+            return _Outcome(errors=[str(error)])
+        if local_id not in seen:
+            seen.add(local_id)
+            drops.append((local_id, str(error)))
+    return _Outcome(drops=drops)
 
 
 def _entry_for_path(
-    match: re.Match[str],
+    path: list[Any],
     data: dict[str, Any],
     entries: list[dict[str, Any]],
     local_ids: set[str],
 ) -> str | None:
-    """Resolve one ``data['<domain>'][i]`` path to a featured local id."""
-    domain, index = match.group(1), match.group(2)
+    """Resolve one structured config path to a featured local id."""
+    if not path or not isinstance(path[0], str):
+        return None
+    domain = path[0]
     block = data.get(domain)
     item: Any = None
-    if index is not None and isinstance(block, list):
-        i = int(index)
-        item = block[i] if i < len(block) else None
+    if len(path) > 1 and isinstance(path[1], int) and isinstance(block, list):
+        item = block[path[1]] if path[1] < len(block) else None
     elif isinstance(block, dict):
         item = block
     if isinstance(item, dict):

--- a/script/_full_setup_gate.py
+++ b/script/_full_setup_gate.py
@@ -41,14 +41,16 @@ def apply_validation_gate(records: list[dict[str, Any]]) -> dict[str, str]:
     Mutates *records* in place; returns ``{board_id: skip_reason}`` for
     boards that can't be repaired.
     """
-    if "fork" not in mp.get_all_start_methods():
-        _LOGGER.warning("Skipping full-setup validation: no fork start method")
-        return {}
     # Import once in the parent: every forked worker then inherits the
     # clean pre-validation module state instead of re-importing esphome.
     import esphome.config  # noqa: F401
 
-    ctx = mp.get_context("fork")
+    if "fork" in mp.get_all_start_methods():
+        ctx = mp.get_context("fork")
+    else:
+        # Windows: spawn re-imports esphome per worker (slower) but the
+        # fresh-process isolation is the same — never skip validation.
+        ctx = mp.get_context("spawn")
     skipped: dict[str, str] = {}
     pending = list(records)
     for _ in range(_MAX_PASSES):

--- a/script/_full_setup_gate.py
+++ b/script/_full_setup_gate.py
@@ -1,0 +1,234 @@
+"""
+Import-time validation gate: an imported board's full setup must validate.
+
+Each record's featured components are resolved exactly like the create
+wizard's "all recommended" flow and run through the real
+``esphome.config.load_config`` in a forked worker (ESPHome accumulates
+module-global state across validations, so every validation gets a fresh
+process — same isolation the slow e2e suite uses). A failing entry is
+dropped by mapping the error's ``@ data['<domain>'][i]`` path back to the
+generated item's ``id``; the record revalidates until clean. Boards left
+featureless (or with an unmappable failure) are skipped entirely.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_LOGGER = logging.getLogger("sync_esphome_devices")
+
+_ERROR_PATH_RE = re.compile(r"@ data\['([a-z_0-9]+)'\](?:\[(\d+)\])?")
+# Each pass drops at least one entry per failing board; ESPHome often stops
+# at the first error per domain, so a page with many same-shaped broken
+# entries (one bad expander pin copied eight times) needs a pass per entry.
+_MAX_PASSES = 12
+
+
+def apply_validation_gate(records: list[dict[str, Any]]) -> dict[str, str]:
+    """
+    Drop featured entries whose generated full setup fails ESPHome validation.
+
+    Mutates *records* in place; returns ``{board_id: skip_reason}`` for
+    boards that can't be repaired.
+    """
+    if "fork" not in mp.get_all_start_methods():
+        _LOGGER.warning("Skipping full-setup validation: no fork start method")
+        return {}
+    ctx = mp.get_context("fork")
+    skipped: dict[str, str] = {}
+    pending = list(records)
+    for _ in range(_MAX_PASSES):
+        if not pending:
+            break
+        with ctx.Pool(processes=min(8, os.cpu_count() or 4), maxtasksperchild=1) as pool:
+            results = pool.map(_validate_record, pending, chunksize=1)
+        retry: list[dict[str, Any]] = []
+        for record, outcome in zip(pending, results, strict=True):
+            if outcome is None or not outcome.drop_ids:
+                if outcome is not None and outcome.errors:
+                    skipped[record["id"]] = f"full setup fails validation: {outcome.errors[0]}"
+                continue
+            for local_id, error in zip(outcome.drop_ids, outcome.drop_errors, strict=True):
+                _LOGGER.info("%s: dropping %s — %s", record["id"], local_id, error)
+            _apply_drops(record, set(outcome.drop_ids))
+            if record.get("featured_components"):
+                retry.append(record)
+            else:
+                skipped[record["id"]] = "no featured component survives full-setup validation"
+        pending = retry
+    for record in pending:
+        # Still failing after the pass budget — refuse rather than emit.
+        skipped.setdefault(record["id"], "full setup still fails validation after repairs")
+    return skipped
+
+
+class _Outcome:
+    """One validation result: nothing set means the record validated clean."""
+
+    __slots__ = ("drop_errors", "drop_ids", "errors")
+
+    def __init__(
+        self,
+        drop_ids: list[str] | None = None,
+        drop_errors: list[str] | None = None,
+        errors: list[str] | None = None,
+    ) -> None:
+        self.drop_ids = drop_ids or []
+        self.drop_errors = drop_errors or []
+        self.errors = errors or []
+
+
+def _validate_record(record: dict[str, Any]) -> _Outcome | None:
+    """
+    Validate one record's full setup in this (forked) process.
+
+    Returns ``None`` when the gate doesn't apply (pin-conflict boards keep
+    partial bundles, so no combined setup exists to validate).
+    """
+    from esphome.config import load_config
+    from esphome.core import CORE, EsphomeError
+
+    from esphome_device_builder.controllers.components import _load_body_from_disk
+    from esphome_device_builder.definitions import (
+        _load_component_multi_conf,
+        _load_esphome_config,
+        _load_featured_component,
+    )
+    from esphome_device_builder.models import BoardCatalogEntry
+    from script.sync_boards import _has_pin_conflict
+
+    multi_conf = _load_component_multi_conf()
+    featured = [
+        _load_featured_component(fc, Path(), multi_conf)
+        for fc in record.get("featured_components") or []
+    ]
+    if not featured or _has_pin_conflict(featured):
+        return None
+    esphome_cfg = _load_esphome_config(record["esphome"], record["id"])
+    if esphome_cfg.platform.value == "esp32" and esphome_cfg.variant is None:
+        # sync_boards backfills the variant from the PIO board id when it
+        # regenerates the catalog; without the same backfill an imported
+        # ``board:``-only manifest fails as "This board is unknown".
+        from esphome.components.esp32.boards import BOARDS
+
+        from esphome_device_builder.models.boards import Esp32Variant
+
+        meta = BOARDS.get(esphome_cfg.board)
+        if meta is not None:
+            esphome_cfg.variant = Esp32Variant(meta["variant"].lower())
+    board = BoardCatalogEntry(
+        id=record["id"],
+        name=record["name"],
+        description="",
+        manufacturer="",
+        esphome=esphome_cfg,
+        featured_components=featured,
+        full_config=True,
+    )
+    defaults = []
+    for fc in featured:
+        body = _load_body_from_disk(fc.component_id)
+        if body is None:
+            return _Outcome(errors=[f"no catalog body for {fc.component_id}"])
+        defaults.append(
+            (body, {key: p.value for key, p in fc.fields.items() if p.value is not None})
+        )
+
+    from esphome_device_builder.helpers.device_yaml import generate_device_yaml
+
+    with tempfile.TemporaryDirectory() as tmp:
+        yaml_path = Path(tmp) / f"{record['id']}.yaml"
+        yaml_text = generate_device_yaml(
+            "repro", "Repro", board, ssid="ssid", psk="password", defaults=defaults
+        )
+        yaml_path.write_text(yaml_text, encoding="utf-8")
+        CORE.config_path = yaml_path
+        try:
+            errors = [str(err) for err in load_config({}, skip_external_update=True).errors]
+        except EsphomeError as err:
+            errors = [str(err)]
+    if not errors:
+        return _Outcome()
+    return _map_errors(errors, yaml_text, record)
+
+
+def _map_errors(errors: list[str], yaml_text: str, record: dict[str, Any]) -> _Outcome:
+    """Map each error's config path to the featured entry that produced it."""
+    data = yaml.safe_load(yaml_text)
+    entries = record.get("featured_components") or []
+    local_ids = {entry["id"] for entry in entries}
+    drop_ids: list[str] = []
+    drop_errors: list[str] = []
+    for error in errors:
+        match = _ERROR_PATH_RE.search(error)
+        local_id = _entry_for_path(match, data, entries, local_ids) if match else None
+        if local_id is None:
+            # An error we can't pin on one entry poisons the whole board.
+            return _Outcome(errors=[error])
+        if local_id not in drop_ids:
+            drop_ids.append(local_id)
+            drop_errors.append(error)
+    return _Outcome(drop_ids=drop_ids, drop_errors=drop_errors)
+
+
+def _entry_for_path(
+    match: re.Match[str],
+    data: dict[str, Any],
+    entries: list[dict[str, Any]],
+    local_ids: set[str],
+) -> str | None:
+    """Resolve one ``data['<domain>'][i]`` path to a featured local id."""
+    domain, index = match.group(1), match.group(2)
+    block = data.get(domain)
+    item: Any = None
+    if index is not None and isinstance(block, list):
+        i = int(index)
+        item = block[i] if i < len(block) else None
+    elif isinstance(block, dict):
+        item = block
+    if isinstance(item, dict):
+        item_id = item.get("id")
+        if isinstance(item_id, str) and item_id in local_ids:
+            return item_id
+    # Mapping-style hubs generate without their local id; fall back to the
+    # sole featured entry of the domain.
+    matches = [
+        entry["id"]
+        for entry in entries
+        if entry["component_id"] == domain or entry["component_id"].startswith(f"{domain}.")
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _apply_drops(record: dict[str, Any], drop_ids: set[str]) -> None:
+    """Remove *drop_ids* from the record's featured entries, bundles, and requires."""
+    record["featured_components"] = [
+        entry for entry in record.get("featured_components") or [] if entry["id"] not in drop_ids
+    ]
+    for entry in record["featured_components"]:
+        requires = [ref for ref in entry.get("requires") or [] if ref not in drop_ids]
+        if requires:
+            entry["requires"] = requires
+        elif "requires" in entry:
+            del entry["requires"]
+    bundles = [
+        bundle
+        for bundle in record.get("featured_bundles") or []
+        if [member for member in bundle["component_ids"] if member not in drop_ids]
+    ]
+    for bundle in bundles:
+        bundle["component_ids"] = [
+            member for member in bundle["component_ids"] if member not in drop_ids
+        ]
+    if bundles:
+        record["featured_bundles"] = bundles
+    elif "featured_bundles" in record:
+        del record["featured_bundles"]

--- a/script/_full_setup_gate.py
+++ b/script/_full_setup_gate.py
@@ -21,8 +21,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
-
 if TYPE_CHECKING:
     from esphome_device_builder.models import BoardCatalogEntry, ComponentCatalogEntry
 
@@ -127,6 +125,14 @@ def _validate_record(record: dict[str, Any]) -> _Outcome | None:
     Returns ``None`` when the gate doesn't apply (pin-conflict boards keep
     partial bundles, so no combined setup exists to validate).
     """
+    try:
+        return _validate_record_inner(record)
+    except Exception as exc:
+        return _Outcome(errors=[f"validation crashed: {exc!r}"])
+
+
+def _validate_record_inner(record: dict[str, Any]) -> _Outcome | None:
+    """See :func:`_validate_record`; separated so its crash guard stays total."""
     from esphome_device_builder.controllers.components import _load_body_from_disk
     from esphome_device_builder.definitions import (
         _load_component_multi_conf,
@@ -168,7 +174,13 @@ def _validate_record(record: dict[str, Any]) -> _Outcome | None:
 
 def _map_errors(errors: list[Any], yaml_text: str, record: dict[str, Any]) -> _Outcome:
     """Map each error's structured config path to the featured entry that produced it."""
-    data = yaml.safe_load(yaml_text)
+    # Function-level import: this module loads while sync_esphome_devices is
+    # still importing it, so a top-level import would be circular.
+    from script.sync_esphome_devices import _safe_load_yaml
+
+    # The generated YAML can carry ESPHome-only tags (``!lambda``) that the
+    # plain safe loader rejects.
+    data = _safe_load_yaml(yaml_text) or {}
     entries = record.get("featured_components") or []
     local_ids = {entry["id"] for entry in entries}
     drops: list[tuple[str, str]] = []

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -622,23 +622,29 @@ def _esp32_board_pins(generic: list[BoardPin], board_pins: dict[str, int] | None
     return out
 
 
+def esp32_variant_for_board(board_id: str) -> str | None:
+    """Variant name for a PIO board id from esphome's authoritative ``BOARDS`` map."""
+    module = importlib.import_module(_ESP32_BOARDS_MODULE)
+    board_list: dict[str, Any] = getattr(module, _ESP32_BOARDS_ATTR)
+    meta = board_list.get(board_id)
+    return meta["variant"].lower() if meta is not None else None
+
+
 def _backfill_esp32_variants(boards: list[BoardCatalogEntry]) -> None:
     """Fill ``esphome.variant`` from the PIO board id for esp32 boards missing it.
 
     Imported manifests sometimes carry only ``board:`` (no ``variant:``). Without
     a variant the generated ``esp32:`` block has neither key (the schema needs at
     least one) and the picker tags the board as bare ESP32 instead of its
-    sub-variant. ``BOARDS`` is the authoritative board -> variant map.
+    sub-variant.
     """
-    module = importlib.import_module(_ESP32_BOARDS_MODULE)
-    board_list: dict[str, Any] = getattr(module, _ESP32_BOARDS_ATTR)
     for board in boards:
         cfg = board.esphome
         if cfg.platform.value != "esp32" or cfg.variant is not None:
             continue
-        meta = board_list.get(cfg.board)
-        if meta is not None:
-            cfg.variant = Esp32Variant(meta["variant"].lower())
+        variant = esp32_variant_for_board(cfg.board)
+        if variant is not None:
+            cfg.variant = Esp32Variant(variant)
 
 
 def _augment_esp32_boards(boards: list[BoardCatalogEntry]) -> None:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -56,6 +56,7 @@ from esphome_device_builder.constants import (  # noqa: E402
 from esphome_device_builder.helpers.pin_gpio import parse_board_gpio  # noqa: E402
 from esphome_device_builder.models.boards import Esp32Variant  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
+from script._full_setup_gate import apply_validation_gate  # noqa: E402
 from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 from script._repo_cache import ensure_shallow_git_repo  # noqa: E402
 
@@ -2139,6 +2140,11 @@ def _hub_block_for(config: dict[str, Any], hub_cid: str) -> dict[str, Any] | Non
     return _sole_hub_block(raw)
 
 
+def _dep_already_featured(dep: str, existing_cids: set[str]) -> bool:
+    """Whether *dep* is met by a featured entry, exactly or as ``<dep>.<platform>``."""
+    return dep in existing_cids or any(cid.startswith(f"{dep}.") for cid in existing_cids)
+
+
 def _collect_driver_hub_refs(
     config: dict[str, Any],
     featured: list[dict[str, Any]],
@@ -2161,7 +2167,7 @@ def _collect_driver_hub_refs(
             continue
         refs: list[tuple[str, str | None]] = []
         for dep in component.get("dependencies") or []:
-            if not isinstance(dep, str) or dep in existing_cids:
+            if not isinstance(dep, str) or _dep_already_featured(dep, existing_cids):
                 continue
             hub = components_index.get(dep)
             if hub is None or not _is_driver_hub(hub):
@@ -2291,7 +2297,7 @@ def _collect_bus_dep_refs(
         block = source_block or _find_consumer_block(config, entry)
         refs: list[tuple[str, str | None]] = []
         for dep in component.get("dependencies") or []:
-            if not isinstance(dep, str) or dep in existing_cids:
+            if not isinstance(dep, str) or _dep_already_featured(dep, existing_cids):
                 continue
             if not _is_bus_dep(dep, components_index):
                 continue
@@ -2688,6 +2694,44 @@ def main() -> int:
     report = _SyncReport()
     active_remote_ids: set[str] = set()
 
+    pending = _collect_records(repo, args, components_index, revision, report)
+
+    # Static extraction can't see everything ESPHome enforces (pin modes,
+    # cross-platform constraints, stale upstream pages) — validate every
+    # record's full setup for real and repair or refuse before emitting.
+    gate_skips = apply_validation_gate([record for _, record in pending])
+
+    for src, record in pending:
+        gate_reason = gate_skips.get(record["id"])
+        if gate_reason is not None:
+            report.skipped.append(_SkippedDevice(src.folder_name, gate_reason))
+            continue
+        if not args.dry_run and _emit_manifest(record, src) is None:
+            report.skipped.append(
+                _SkippedDevice(src.folder_name, "slug collides with hand-curated board")
+            )
+            continue
+        active_remote_ids.add(src.folder_name)
+        report.imported.append(record["id"])
+
+    # Pruning is dangerous when --limit / --device is in effect, since
+    # we haven't actually visited the rest of the upstream tree.
+    if not args.dry_run and args.limit is None and args.device is None:
+        report.removed = _prune_removed(active_remote_ids)
+
+    _print_report(report, args.verbose)
+    return 0
+
+
+def _collect_records(
+    repo: Path,
+    args: argparse.Namespace,
+    components_index: dict[str, dict[str, Any]],
+    revision: str,
+    report: _SyncReport,
+) -> list[tuple[_DeviceSource, dict[str, Any]]]:
+    """Build the record for every accepted upstream page, honoring the CLI filters."""
+    pending: list[tuple[_DeviceSource, dict[str, Any]]] = []
     for src in _iter_devices(repo):
         if args.device and src.folder_name != args.device:
             continue
@@ -2697,23 +2741,10 @@ def main() -> int:
             if args.verbose:
                 _LOGGER.debug("skip %s: %s", src.folder_name, skip_reason)
             continue
-        if not args.dry_run and _emit_manifest(record, src) is None:
-            report.skipped.append(
-                _SkippedDevice(src.folder_name, "slug collides with hand-curated board")
-            )
-            continue
-        active_remote_ids.add(src.folder_name)
-        report.imported.append(record["id"])
-        if args.limit is not None and len(report.imported) >= args.limit:
+        pending.append((src, record))
+        if args.limit is not None and len(pending) >= args.limit:
             break
-
-    # Pruning is dangerous when --limit / --device is in effect, since
-    # we haven't actually visited the rest of the upstream tree.
-    if not args.dry_run and args.limit is None and args.device is None:
-        report.removed = _prune_removed(active_remote_ids)
-
-    _print_report(report, args.verbose)
-    return 0
+    return pending
 
 
 def _print_report(report: _SyncReport, verbose: bool) -> None:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -728,11 +728,16 @@ def _resolve_board_and_variant(
 
     if soc == "esp32":
         if board and not variant:
-            # Import-time resolver (connectivity is frozen here from the variant);
-            # the catalog's authoritative ``_backfill_esp32_variants`` runs later
-            # and only fixes ``esphome.variant``, not ``hardware.connectivity``.
             match = _ESP32_BOARD_VARIANT_RE.search(board.lower())
             variant = f"esp32{match.group(1)}" if match else None
+            if variant is None:
+                # PIO board ids that don't encode the variant (``esp32s3box``)
+                # resolve through esphome's authoritative board map — the
+                # manifest must carry the variant or the generated ``esp32:``
+                # block reads as an unknown board.
+                from script.sync_boards import esp32_variant_for_board
+
+                variant = esp32_variant_for_board(board)
         elif not board and variant:
             board = _ESP32_VARIANT_DEFAULT_BOARD.get(variant)
 
@@ -1800,7 +1805,7 @@ def _chain_bus_deps(
     Without the chain the lifted bus fails ESPHome's dependency validation.
     """
     bus_component = state.components_index.get(bus_entry["component_id"])
-    bus_block = _select_bus_block(state.config, bus_domain, instance_id)
+    bus_block = _select_block(state.config, bus_domain, instance_id)
     if bus_component is None or bus_block is None:
         return
     sub_ids, sub_refs = _ensure_buses(bus_component, bus_block, state)
@@ -1877,17 +1882,17 @@ def _block_platform(bus_domain: str, block: dict[str, Any]) -> str | None:
     return platform if isinstance(platform, str) and platform else None
 
 
-def _select_bus_block(
-    config: dict[str, Any], bus_domain: str, instance_id: str | None
+def _select_block(
+    config: dict[str, Any], domain: str, instance_id: str | None
 ) -> dict[str, Any] | None:
     """
-    Select the page block a bus lift reads: the ``id``-matched, else the sole block.
+    Select the page block a bus/hub lift reads: the ``id``-matched, else the sole block.
 
-    A bare key (``modbus:`` with a null body) selects as an empty block.
+    A bare key (``modbus:`` / ``tuya:`` with a null body) selects as an empty block.
     """
-    raw = config.get(bus_domain)
+    raw = config.get(domain)
     if raw is None:
-        return {} if bus_domain in config and instance_id is None else None
+        return {} if domain in config and instance_id is None else None
     blocks = _block_mappings(raw)
     if instance_id is not None:
         return next((b for b in blocks if b.get("id") == instance_id), None)
@@ -1912,7 +1917,7 @@ def _materialize_bus(
     when the bus is absent, ambiguous (no ``*_id`` and more than one bus), or a
     platform-style block has no resolvable ``platform:``.
     """
-    block = _select_bus_block(state.config, bus_domain, instance_id)
+    block = _select_block(state.config, bus_domain, instance_id)
     if block is None:
         return None, "", {}
     component = state.components_index.get(bus_domain)
@@ -2063,49 +2068,6 @@ def _required_pin_keys(component: dict[str, Any]) -> set[str]:
     }
 
 
-def _drop_unsatisfiable_consumers(
-    featured: list[dict[str, Any]],
-    bundles: list[dict[str, Any]],
-    components_index: dict[str, dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """
-    Drop featured leaves depending on a featured-excluded domain (``time``).
-
-    Such a dep can never appear in a manifest, so the leaf fails ESPHome's
-    dependency validation in every bundle it joins. Anything subtler (a hub
-    absent from the page, auto-loaded platform deps like ``libretiny``) is
-    left for real validation to decide. Prunes dropped ids from *bundles*.
-    """
-    kept: list[dict[str, Any]] = []
-    dropped_ids: set[str] = set()
-    for entry in featured:
-        component = components_index.get(entry["component_id"]) or {}
-        unsatisfiable = next(
-            (
-                dep
-                for dep in component.get("dependencies") or []
-                if isinstance(dep, str) and dep in FEATURED_EXCLUDED_CATEGORIES
-            ),
-            None,
-        )
-        if unsatisfiable is None:
-            kept.append(entry)
-            continue
-        _LOGGER.info(
-            "Dropping %s: hard dependency %r can't be featured",
-            entry["component_id"],
-            unsatisfiable,
-        )
-        dropped_ids.add(entry["id"])
-    if dropped_ids:
-        for bundle in bundles:
-            bundle["component_ids"] = [
-                member for member in bundle["component_ids"] if member not in dropped_ids
-            ]
-        bundles[:] = [bundle for bundle in bundles if bundle["component_ids"]]
-    return kept
-
-
 def _is_driver_hub(component: dict[str, Any]) -> bool:
     """
     Return True for a hub a consumer binds by catalog dependency.
@@ -2119,25 +2081,6 @@ def _is_driver_hub(component: dict[str, Any]) -> bool:
     """
     category = component.get("category")
     return category not in BUS_CATEGORIES and category not in FEATURED_EXCLUDED_CATEGORIES
-
-
-def _sole_hub_block(raw: Any) -> dict[str, Any] | None:
-    """Return the single top-level hub mapping, or ``None`` if absent/ambiguous."""
-    blocks = _block_mappings(raw)
-    return blocks[0] if len(blocks) == 1 else None
-
-
-def _hub_block_for(config: dict[str, Any], hub_cid: str) -> dict[str, Any] | None:
-    """
-    Resolve a dependency hub's top-level block, accepting the bare-key form.
-
-    ``tuya:`` with a null body is the common upstream shape for hubs whose
-    bus auto-binds; it lifts fieldless.
-    """
-    raw = config.get(hub_cid)
-    if raw is None:
-        return {} if hub_cid in config else None
-    return _sole_hub_block(raw)
 
 
 def _dep_already_featured(dep: str, existing_cids: set[str]) -> bool:
@@ -2172,7 +2115,7 @@ def _collect_driver_hub_refs(
             hub = components_index.get(dep)
             if hub is None or not _is_driver_hub(hub):
                 continue
-            block = _hub_block_for(config, dep)
+            block = _select_block(config, dep, None)
             if block is None:
                 continue
             instance_id = block.get("id") if isinstance(block.get("id"), str) else None
@@ -2215,7 +2158,7 @@ def _extract_driver_hubs(
         components_index,
         consumers,
         ordered_refs,
-        resolve_block=lambda cid, _instance_id: _hub_block_for(config, cid),
+        resolve_block=lambda cid, _instance_id: _select_block(config, cid, None),
         driver=True,
     )
 
@@ -2412,7 +2355,6 @@ def _make_record(  # noqa: C901, PLR0911, PLR0912 — distinct skip reasons each
         if lift_entries:
             featured = [*lift_entries, *featured]
             gpio_occupancy = {**lift_occupancy, **gpio_occupancy}
-    featured = _drop_unsatisfiable_consumers(featured, bundles, components_index)
     # The per-consumer bundle is built from id references before hubs are
     # lifted, so fold each member's ``requires`` (bus/hub) back in — otherwise a
     # "full setup" lands the light + outputs without the driver hub they need.

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -794,9 +794,30 @@ def _extract_featured_components(
 
     survivors = _select_survivors(candidates)
     id_map = _build_id_map(survivors)
-    featured = [_finalize_entry(c, id_map) for c in survivors]
-    bundles = _build_bundles(survivors, id_map)
+    finalized = [(c, _finalize_entry(c, id_map)) for c in survivors]
+    kept: list[tuple[_Candidate, dict[str, Any]]] = []
+    for candidate, entry in finalized:
+        missing = _missing_required_ref(candidate.component, entry["fields"])
+        if missing is None:
+            kept.append((candidate, entry))
+            continue
+        # The ref target didn't survive (or points at a nested sub-entity id
+        # we can't carry) — without it the entry fails ESPHome validation.
+        _LOGGER.info(
+            "Dropping %s: required reference %r is unresolvable", candidate.component_id, missing
+        )
+    featured = [entry for _, entry in kept]
+    bundles = _build_bundles([candidate for candidate, _ in kept], id_map)
     return featured, bundles, gpio_occupancy
+
+
+def _missing_required_ref(component: dict[str, Any], fields: dict[str, Any]) -> str | None:
+    """Key of a required ``type: "id"`` config entry absent from *fields*, or ``None``."""
+    for ce in component.get("config_entries") or []:
+        key = ce.get("key")
+        if ce.get("type") == "id" and ce.get("required") and key and key not in fields:
+            return key
+    return None
 
 
 def _select_survivors(candidates: list[_Candidate]) -> list[_Candidate]:
@@ -1255,6 +1276,10 @@ def _coerce_field_preset(  # noqa: PLR0911 — distinct field shapes each get th
             return {"value": normalized, "locked": True}
         gpio = _gpio_number(normalized)
         if gpio is None:
+            if isinstance(normalized, str) and _NAMED_PIN_RE.fullmatch(normalized):
+                # Board pin aliases (``TX1``, ``D5``, ``A0``) are valid values
+                # ESPHome resolves per-board; no board GPIO to mark occupied.
+                return {"value": normalized, "locked": True}
             # Reference-style pins or lambdas — skip silently.
             return None
         label = _occupancy_label(inline_item, component_id)
@@ -1304,6 +1329,11 @@ def _coerce_pin_list(
 # Field names whose nested value is a group of board pins (``data_pins``);
 # porches / dimensions / init sequences don't match.
 _PIN_TREE_FIELD_RE = re.compile(r"(?:^|_)pins?$")
+
+# Board pin alias names (``TX1``, ``D5``, ``A0``, ``SCL``): short uppercase
+# tokens — id references and lambdas are lowercase / longer, substitutions
+# start with ``$``, and numeric GPIO forms parse before this is consulted.
+_NAMED_PIN_RE = re.compile(r"[A-Z][A-Z0-9]{0,7}")
 
 
 def _coerce_data_tree(
@@ -1426,9 +1456,10 @@ def _is_simple_scalar(value: Any) -> bool:
     if value is None or isinstance(value, bool | int | float):
         return True
     if isinstance(value, str):
-        # Keep things short — long strings are usually templated names
-        # we don't want to lock the user into.
-        return "${" not in value and "\n" not in value and len(value) <= 80
+        # Keep things short — long strings are usually templated names we
+        # don't want to lock the user into. ``$`` covers both substitution
+        # forms (``${var}`` and bare ``$var``).
+        return "$" not in value and "\n" not in value and len(value) <= 80
     return False
 
 
@@ -1704,15 +1735,25 @@ def _collect_expander_refs(
     return consumers, ordered_refs
 
 
+@dataclass(frozen=True)
+class _LiftState:
+    """Shared state threaded through the bus / hub lift passes.
+
+    The holder is frozen; the containers inside mutate as lifts accumulate.
+    """
+
+    config: dict[str, Any]
+    components_index: dict[str, dict[str, Any]]
+    used_ids: set[str]
+    bus_local: dict[tuple[str, str | None], str] = field(default_factory=dict)
+    occupancy: dict[int, str] = field(default_factory=dict)
+    extra: list[dict[str, Any]] = field(default_factory=list)
+
+
 def _ensure_buses(
     hub_component: dict[str, Any],
     hub_block: dict[str, Any],
-    config: dict[str, Any],
-    components_index: dict[str, dict[str, Any]],
-    used_ids: set[str],
-    bus_local: dict[tuple[str, str | None], str],
-    occupancy: dict[int, str],
-    extra: list[dict[str, Any]],
+    state: _LiftState,
 ) -> tuple[list[str], dict[str, str]]:
     """
     Materialize (once) the bus each hub dependency resolves to.
@@ -1729,22 +1770,43 @@ def _ensure_buses(
         instance = hub_block.get(ref_field)
         instance = instance if isinstance(instance, str) and instance else None
         key = (dep, instance)
-        local = bus_local.get(key)
+        local = state.bus_local.get(key)
         if local is None:
-            bus_entry, local, bus_occ = _materialize_bus(
-                dep, instance, config, components_index, used_ids
-            )
+            bus_entry, local, bus_occ = _materialize_bus(dep, instance, state)
             if bus_entry is None:
                 continue
-            used_ids.add(local)
-            bus_local[key] = local
-            occupancy.update(bus_occ)
-            extra.append(bus_entry)
+            state.used_ids.add(local)
+            state.bus_local[key] = local
+            state.occupancy.update(bus_occ)
+            state.extra.append(bus_entry)
+            _chain_bus_deps(bus_entry, dep, instance, state)
         if local not in bus_ids:
             bus_ids.append(local)
         if instance is not None:
             bus_refs[ref_field] = instance
     return bus_ids, bus_refs
+
+
+def _chain_bus_deps(
+    bus_entry: dict[str, Any],
+    bus_domain: str,
+    instance_id: str | None,
+    state: _LiftState,
+) -> None:
+    """
+    Chain a freshly lifted bus's own bus deps (``modbus`` rides ``uart``).
+
+    Without the chain the lifted bus fails ESPHome's dependency validation.
+    """
+    bus_component = state.components_index.get(bus_entry["component_id"])
+    bus_block = _select_bus_block(state.config, bus_domain, instance_id)
+    if bus_component is None or bus_block is None:
+        return
+    sub_ids, sub_refs = _ensure_buses(bus_component, bus_block, state)
+    for sub_field, sub_instance in sub_refs.items():
+        bus_entry["fields"][sub_field] = {"value": sub_instance, "locked": True}
+    if sub_ids:
+        bus_entry["requires"] = sub_ids
 
 
 def _wire_consumer_requires(
@@ -1814,12 +1876,27 @@ def _block_platform(bus_domain: str, block: dict[str, Any]) -> str | None:
     return platform if isinstance(platform, str) and platform else None
 
 
+def _select_bus_block(
+    config: dict[str, Any], bus_domain: str, instance_id: str | None
+) -> dict[str, Any] | None:
+    """
+    Select the page block a bus lift reads: the ``id``-matched, else the sole block.
+
+    A bare key (``modbus:`` with a null body) selects as an empty block.
+    """
+    raw = config.get(bus_domain)
+    if raw is None:
+        return {} if bus_domain in config and instance_id is None else None
+    blocks = _block_mappings(raw)
+    if instance_id is not None:
+        return next((b for b in blocks if b.get("id") == instance_id), None)
+    return blocks[0] if len(blocks) == 1 else None
+
+
 def _materialize_bus(
     bus_domain: str,
     instance_id: str | None,
-    config: dict[str, Any],
-    components_index: dict[str, dict[str, Any]],
-    used_ids: set[str],
+    state: _LiftState,
 ) -> tuple[dict[str, Any] | None, str, dict[int, str]]:
     """
     Lift the bus a consumer depends on into a featured entry, both bus shapes.
@@ -1834,16 +1911,10 @@ def _materialize_bus(
     when the bus is absent, ambiguous (no ``*_id`` and more than one bus), or a
     platform-style block has no resolvable ``platform:``.
     """
-    blocks = _block_mappings(config.get(bus_domain))
-    if instance_id is not None:
-        block = next((b for b in blocks if b.get("id") == instance_id), None)
-    elif len(blocks) == 1:
-        block = blocks[0]
-    else:
-        block = None
+    block = _select_bus_block(state.config, bus_domain, instance_id)
     if block is None:
         return None, "", {}
-    component = components_index.get(bus_domain)
+    component = state.components_index.get(bus_domain)
     if component is not None:
         component_id = bus_domain
     else:
@@ -1851,12 +1922,14 @@ def _materialize_bus(
         if platform is None:
             return None, "", {}
         component_id = f"{bus_domain}.{platform}"
-        component = components_index.get(component_id)
+        component = state.components_index.get(component_id)
         if component is None:
             return None, "", {}
     # A hub binds several deps and ``_ensure_buses`` calls this for each, so confirm
-    # the resolved component is a bus (the id was never the filter).
-    if not _is_bus_category(component):
+    # the resolved component is a bus — or a platform-style provider whose
+    # category equals its domain (``time.homeassistant`` -> ``time``), the same
+    # convention one_wire/canbus use (the id was never the filter).
+    if not _is_bus_category(component) and component.get("category") != bus_domain:
         return None, "", {}
     bus_inst = block.get("id")
     bus_inst = bus_inst if isinstance(bus_inst, str) and bus_inst else None
@@ -1866,7 +1939,9 @@ def _materialize_bus(
         return None, "", {}
     if bus_inst:
         fields["id"] = {"value": bus_inst, "locked": True}
-    local_id = _unique_local_id(_sanitize_local_id(bus_inst or ""), used_ids, f"{bus_domain}_bus")
+    local_id = _unique_local_id(
+        _sanitize_local_id(bus_inst or ""), state.used_ids, f"{bus_domain}_bus"
+    )
     return {"id": local_id, "component_id": component_id, "fields": fields}, local_id, occupancy
 
 
@@ -1922,9 +1997,7 @@ def _materialize_hubs(
     lift and drops a consumer whose hub didn't materialize.
     """
     used_ids = {entry["id"] for entry in featured}
-    extra: list[dict[str, Any]] = []
-    occupancy: dict[int, str] = {}
-    bus_local: dict[tuple[str, str | None], str] = {}
+    state = _LiftState(config=config, components_index=components_index, used_ids=used_ids)
     # Each materialized hub keyed by its ref, carrying the local id + the bus
     # ids it needs — the ordered prerequisite chain a consumer references.
     hub_prereqs: dict[tuple[str, str | None], list[str]] = {}
@@ -1934,23 +2007,29 @@ def _materialize_hubs(
         block = resolve_block(hub_cid, instance_id)
         if hub_component is None or block is None:
             continue
+        # A platform-carrying block (``time: platform: homeassistant``) is a
+        # platform-style hub: the schema and the emitted component id live at
+        # ``<domain>.<platform>``, not the bare domain.
+        component_cid = hub_cid
+        platform = block.get("platform")
+        if isinstance(platform, str) and f"{hub_cid}.{platform}" in components_index:
+            component_cid = f"{hub_cid}.{platform}"
+            hub_component = components_index[component_cid]
         # Record the hub's own pin occupancy locally and merge only on success:
         # a shift-register hub puts board GPIOs (data/clock/latch) here, and a
         # placeholder field part-way through the block must not leave those pins
         # marked occupied for a hub we then drop.
         hub_occ: dict[int, str] = {}
-        fields = _extract_fields(block, hub_component, hub_occ, hub_cid)
-        if fields is None or (driver and not fields):
+        fields = _extract_fields(block, hub_component, hub_occ, component_cid)
+        if fields is None:
             continue
         if driver and not _required_pin_keys(hub_component) <= fields.keys():
             # A required pin didn't parse (lambda / reference): skip the hub and
             # leave ``requires`` unstamped so the dep banner covers it, rather than
             # ship a pinless hub that compiles into an invalid config.
             continue
-        occupancy.update(hub_occ)
-        bus_ids, bus_refs = _ensure_buses(
-            hub_component, block, config, components_index, used_ids, bus_local, occupancy, extra
-        )
+        state.occupancy.update(hub_occ)
+        bus_ids, bus_refs = _ensure_buses(hub_component, block, state)
         base = _sanitize_local_id(instance_id) if instance_id else ""
         hub_id = _unique_local_id(base, used_ids, f"{hub_cid}{'_hub' if driver else ''}")
         used_ids.add(hub_id)
@@ -1962,16 +2041,16 @@ def _materialize_hubs(
         # doesn't fall back to esphome's default i2c pins.
         for ref_field, bus_inst in bus_refs.items():
             fields[ref_field] = {"value": bus_inst, "locked": True}
-        hub_entry: dict[str, Any] = {"id": hub_id, "component_id": hub_cid, "fields": fields}
+        hub_entry: dict[str, Any] = {"id": hub_id, "component_id": component_cid, "fields": fields}
         if bus_ids:
             hub_entry["requires"] = bus_ids
-        extra.append(hub_entry)
+        state.extra.append(hub_entry)
         hub_prereqs[(hub_cid, instance_id)] = [*bus_ids, hub_id]
 
     if not driver:
         _drop_unresolved_consumers(featured, consumers, hub_prereqs)
     _wire_consumer_requires(consumers, hub_prereqs)
-    return extra, occupancy
+    return state.extra, state.occupancy
 
 
 def _required_pin_keys(component: dict[str, Any]) -> set[str]:
@@ -1981,6 +2060,49 @@ def _required_pin_keys(component: dict[str, Any]) -> set[str]:
         for ce in component.get("config_entries") or []
         if ce.get("type") == "pin" and ce.get("required") and isinstance(ce.get("key"), str)
     }
+
+
+def _drop_unsatisfiable_consumers(
+    featured: list[dict[str, Any]],
+    bundles: list[dict[str, Any]],
+    components_index: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Drop featured leaves depending on a featured-excluded domain (``time``).
+
+    Such a dep can never appear in a manifest, so the leaf fails ESPHome's
+    dependency validation in every bundle it joins. Anything subtler (a hub
+    absent from the page, auto-loaded platform deps like ``libretiny``) is
+    left for real validation to decide. Prunes dropped ids from *bundles*.
+    """
+    kept: list[dict[str, Any]] = []
+    dropped_ids: set[str] = set()
+    for entry in featured:
+        component = components_index.get(entry["component_id"]) or {}
+        unsatisfiable = next(
+            (
+                dep
+                for dep in component.get("dependencies") or []
+                if isinstance(dep, str) and dep in FEATURED_EXCLUDED_CATEGORIES
+            ),
+            None,
+        )
+        if unsatisfiable is None:
+            kept.append(entry)
+            continue
+        _LOGGER.info(
+            "Dropping %s: hard dependency %r can't be featured",
+            entry["component_id"],
+            unsatisfiable,
+        )
+        dropped_ids.add(entry["id"])
+    if dropped_ids:
+        for bundle in bundles:
+            bundle["component_ids"] = [
+                member for member in bundle["component_ids"] if member not in dropped_ids
+            ]
+        bundles[:] = [bundle for bundle in bundles if bundle["component_ids"]]
+    return kept
 
 
 def _is_driver_hub(component: dict[str, Any]) -> bool:
@@ -2002,6 +2124,19 @@ def _sole_hub_block(raw: Any) -> dict[str, Any] | None:
     """Return the single top-level hub mapping, or ``None`` if absent/ambiguous."""
     blocks = _block_mappings(raw)
     return blocks[0] if len(blocks) == 1 else None
+
+
+def _hub_block_for(config: dict[str, Any], hub_cid: str) -> dict[str, Any] | None:
+    """
+    Resolve a dependency hub's top-level block, accepting the bare-key form.
+
+    ``tuya:`` with a null body is the common upstream shape for hubs whose
+    bus auto-binds; it lifts fieldless.
+    """
+    raw = config.get(hub_cid)
+    if raw is None:
+        return {} if hub_cid in config else None
+    return _sole_hub_block(raw)
 
 
 def _collect_driver_hub_refs(
@@ -2031,7 +2166,7 @@ def _collect_driver_hub_refs(
             hub = components_index.get(dep)
             if hub is None or not _is_driver_hub(hub):
                 continue
-            block = _sole_hub_block(config.get(dep))
+            block = _hub_block_for(config, dep)
             if block is None:
                 continue
             instance_id = block.get("id") if isinstance(block.get("id"), str) else None
@@ -2074,7 +2209,7 @@ def _extract_driver_hubs(
         components_index,
         consumers,
         ordered_refs,
-        resolve_block=lambda cid, _instance_id: _sole_hub_block(config.get(cid)),
+        resolve_block=lambda cid, _instance_id: _hub_block_for(config, cid),
         driver=True,
     )
 
@@ -2109,14 +2244,16 @@ def _is_bus_dep(dep: str, components_index: dict[str, dict[str, Any]]) -> bool:
     Whether *dep* names one of ESPHome's buses, mapping- or platform-style.
 
     Mapping-style buses (i2c/spi/uart/modbus) resolve to a top-level component
-    whose category is ``"bus"``. Platform-style buses (one_wire/canbus) have no
-    top-level component; their schema lives under ``<dep>.<platform>`` and the
-    dep name itself equals the bus category, so it is matched against the set.
+    whose category is ``"bus"``. Platform-style deps (one_wire/canbus, and
+    non-bus providers like ``time``) have no top-level component; their schema
+    lives under ``<dep>.<platform>``, so any component-less dep is a
+    materialization candidate — ``_materialize_bus`` still requires a
+    platform-resolvable page block, so a stray dep name lifts nothing.
     """
     component = components_index.get(dep)
     if component is not None:
         return _is_bus_category(component)
-    return dep in BUS_CATEGORIES
+    return True
 
 
 def _collect_bus_dep_refs(
@@ -2193,22 +2330,28 @@ def _extract_bus_deps(
     consumers, ordered_refs = _collect_bus_dep_refs(config, featured, components_index)
     if not ordered_refs:
         return [], {}
-    used_ids = {entry["id"] for entry in featured}
-    extra: list[dict[str, Any]] = []
-    occupancy: dict[int, str] = {}
-    bus_local: dict[tuple[str, str | None], str] = {}
+    state = _LiftState(
+        config=config,
+        components_index=components_index,
+        used_ids={entry["id"] for entry in featured},
+    )
     for dep, instance in ordered_refs:
-        bus_entry, local, bus_occ = _materialize_bus(
-            dep, instance, config, components_index, used_ids
-        )
+        bus_entry, local, bus_occ = _materialize_bus(dep, instance, state)
         if bus_entry is None:
             continue
-        used_ids.add(local)
-        bus_local[(dep, instance)] = local
-        occupancy.update(bus_occ)
-        extra.append(bus_entry)
-    _wire_consumer_requires(consumers, {ref: [local] for ref, local in bus_local.items()})
-    return extra, occupancy
+        state.used_ids.add(local)
+        state.bus_local[(dep, instance)] = local
+        state.occupancy.update(bus_occ)
+        state.extra.append(bus_entry)
+        _chain_bus_deps(bus_entry, dep, instance, state)
+    # Lock each consumer onto the specific bus it named upstream — on a
+    # multi-bus board the generated ``<bus>_id`` is otherwise ambiguous.
+    for entry, refs in consumers:
+        for dep, instance in refs:
+            if instance is not None and (dep, instance) in state.bus_local:
+                entry["fields"][f"{dep}_id"] = {"value": instance, "locked": True}
+    _wire_consumer_requires(consumers, {ref: [local] for ref, local in state.bus_local.items()})
+    return state.extra, state.occupancy
 
 
 def _make_record(  # noqa: C901, PLR0911, PLR0912 — distinct skip reasons each get their own early exit
@@ -2263,6 +2406,7 @@ def _make_record(  # noqa: C901, PLR0911, PLR0912 — distinct skip reasons each
         if lift_entries:
             featured = [*lift_entries, *featured]
             gpio_occupancy = {**lift_occupancy, **gpio_occupancy}
+    featured = _drop_unsatisfiable_consumers(featured, bundles, components_index)
     # The per-consumer bundle is built from id references before hubs are
     # lifted, so fold each member's ``requires`` (bus/hub) back in — otherwise a
     # "full setup" lands the light + outputs without the driver hub they need.

--- a/tests/test_sync_esphome_devices_bus_dep.py
+++ b/tests/test_sync_esphome_devices_bus_dep.py
@@ -11,6 +11,7 @@ from script.sync_esphome_devices import (  # type: ignore[import-not-found]
     _find_consumer_block,
     _fold_requires_into_bundles,
     _is_bus_dep,
+    _LiftState,
     _materialize_bus,
 )
 
@@ -351,7 +352,8 @@ def test_list_pin_field_locks_and_records_occupancy() -> None:
 
 def test_octal_spi_materializes_both_clk_and_data_pins() -> None:
     """End-to-end guard: an octal spi block locks clk_pin and the data_pins list."""
-    entry, local, occ = _materialize_bus("spi", None, {"spi": _spi_block()}, _COMPONENTS, set())
+    state = _LiftState(config={"spi": _spi_block()}, components_index=_COMPONENTS, used_ids=set())
+    entry, local, occ = _materialize_bus("spi", None, state)
     assert entry is not None
     assert local == "display_spi"
     assert entry["fields"]["clk_pin"] == {"value": 21, "locked": True}
@@ -379,16 +381,20 @@ def test_lifts_mapping_bus_without_id() -> None:
 
 def test_materialize_bus_rejects_non_bus_component() -> None:
     """A non-bus dep (a hub also lists, e.g. esp32/output) is never lifted as a bus."""
-    entry, _, _ = _materialize_bus("output", None, {"output": {"x": "y"}}, _COMPONENTS, set())
+    state = _LiftState(config={"output": {"x": "y"}}, components_index=_COMPONENTS, used_ids=set())
+    entry, _, _ = _materialize_bus("output", None, state)
     assert entry is None
 
 
 def test_is_bus_dep_matches_all_known_buses() -> None:
-    """All six ESPHome buses match, both styles; non-bus deps do not."""
+    """Buses and component-less platform-style deps match; catalog non-buses don't."""
     for dep in ("i2c", "spi", "uart", "modbus", "one_wire", "canbus"):
         assert _is_bus_dep(dep, _COMPONENTS) is True
-    for dep in ("output", "esp32", "sensor"):
-        assert _is_bus_dep(dep, _COMPONENTS) is False
+    # In-catalog, non-bus components are hub territory, not bus lifts.
+    assert _is_bus_dep("output", _COMPONENTS) is False
+    # A dep with no top-level component (``time``) may resolve via a
+    # ``<dep>.<platform>`` page block; materialization filters the rest.
+    assert _is_bus_dep("time", _COMPONENTS) is True
 
 
 def test_lifts_platform_style_one_wire_without_id() -> None:
@@ -480,9 +486,12 @@ def test_lifts_platform_style_canbus() -> None:
 
 def test_materialize_platform_bus_direct() -> None:
     """Direct call: an id-less one_wire gpio block resolves the platform component."""
-    entry, local, occ = _materialize_bus(
-        "one_wire", None, {"one_wire": [{"platform": "gpio", "pin": "GPIO4"}]}, _COMPONENTS, set()
+    state = _LiftState(
+        config={"one_wire": [{"platform": "gpio", "pin": "GPIO4"}]},
+        components_index=_COMPONENTS,
+        used_ids=set(),
     )
+    entry, local, occ = _materialize_bus("one_wire", None, state)
     assert entry is not None
     assert entry["component_id"] == "one_wire.gpio"
     assert local == "one_wire_bus"

--- a/tests/test_sync_esphome_devices_dep_lifts.py
+++ b/tests/test_sync_esphome_devices_dep_lifts.py
@@ -7,16 +7,15 @@ from typing import Any
 from script.sync_esphome_devices import (  # type: ignore[import-not-found]
     _coerce_field_preset,
     _dep_already_featured,
-    _drop_unsatisfiable_consumers,
     _extract_bus_deps,
     _extract_driver_hubs,
     _extract_featured_components,
-    _hub_block_for,
     _is_driver_hub,
     _is_simple_scalar,
     _LiftState,
     _materialize_bus,
     _missing_required_ref,
+    _select_block,
 )
 
 _COMPONENTS: dict[str, dict[str, Any]] = {
@@ -56,11 +55,11 @@ def test_is_driver_hub_accepts_pinless_bus_attached_hubs() -> None:
     assert _is_driver_hub({"category": "core"}) is False
 
 
-def test_hub_block_for_accepts_bare_key() -> None:
-    """``tuya:`` with a null body lifts as an empty block; an absent key doesn't."""
-    assert _hub_block_for({"tuya": None}, "tuya") == {}
-    assert _hub_block_for({}, "tuya") is None
-    assert _hub_block_for({"tuya": {"uart_id": "bus"}}, "tuya") == {"uart_id": "bus"}
+def test_select_block_accepts_bare_key() -> None:
+    """``tuya:`` with a null body selects as an empty block; an absent key doesn't."""
+    assert _select_block({"tuya": None}, "tuya", None) == {}
+    assert _select_block({}, "tuya", None) is None
+    assert _select_block({"tuya": {"uart_id": "bus"}}, "tuya", None) == {"uart_id": "bus"}
 
 
 def test_bare_tuya_hub_lifts_and_chains_its_uart() -> None:
@@ -131,22 +130,6 @@ def test_extract_drops_entry_missing_required_ref() -> None:
     inline = {"sensor": [{"platform": "total_daily_energy", "power_id": "nested_sub_id"}]}
     featured, _, _ = _extract_featured_components(inline, _COMPONENTS)
     assert featured == []
-
-
-def test_drop_unsatisfiable_consumers_only_fires_on_excluded_domains() -> None:
-    """An ``ota``-dep leaf drops; unknown deps are left for the validation gate."""
-    components = {
-        "button.safe_mode": {"dependencies": ["ota"], "config_entries": []},
-        "output.libretiny_pwm": {"dependencies": ["libretiny"], "config_entries": []},
-    }
-    featured = [
-        {"id": "reboot", "component_id": "button.safe_mode", "fields": {}},
-        {"id": "pwm", "component_id": "output.libretiny_pwm", "fields": {}},
-    ]
-    bundles = [{"id": "all", "name": "All", "component_ids": ["reboot", "pwm"]}]
-    kept = _drop_unsatisfiable_consumers(featured, bundles, components)
-    assert [entry["id"] for entry in kept] == ["pwm"]
-    assert bundles[0]["component_ids"] == ["pwm"]
 
 
 def test_materialize_bus_accepts_bare_mapping_key() -> None:

--- a/tests/test_sync_esphome_devices_dep_lifts.py
+++ b/tests/test_sync_esphome_devices_dep_lifts.py
@@ -1,0 +1,159 @@
+"""Pin the dependency-lift repairs: bare hubs, platform hubs, chained buses, named pins."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from script.sync_esphome_devices import (  # type: ignore[import-not-found]
+    _coerce_field_preset,
+    _dep_already_featured,
+    _drop_unsatisfiable_consumers,
+    _extract_bus_deps,
+    _extract_driver_hubs,
+    _extract_featured_components,
+    _hub_block_for,
+    _is_driver_hub,
+    _is_simple_scalar,
+    _LiftState,
+    _materialize_bus,
+    _missing_required_ref,
+)
+
+_COMPONENTS: dict[str, dict[str, Any]] = {
+    "switch.tuya": {
+        "dependencies": ["tuya"],
+        "config_entries": [{"key": "switch_datapoint", "type": "integer"}],
+    },
+    "tuya": {
+        "category": "misc",
+        "config_entries": [{"key": "uart_id", "type": "id"}],
+        "dependencies": ["uart"],
+    },
+    "uart": {
+        "category": "bus",
+        "config_entries": [
+            {"key": "tx_pin", "type": "pin"},
+            {"key": "rx_pin", "type": "pin"},
+            {"key": "baud_rate", "type": "integer"},
+            {"key": "id", "type": "id"},
+        ],
+    },
+    "sensor.total_daily_energy": {
+        "dependencies": ["time"],
+        "config_entries": [{"key": "power_id", "type": "id", "required": True}],
+    },
+    "time.homeassistant": {
+        "category": "time",
+        "config_entries": [{"key": "id", "type": "id"}],
+    },
+}
+
+
+def test_is_driver_hub_accepts_pinless_bus_attached_hubs() -> None:
+    """A hub qualifies by category, not by owning a pin; buses and core stay out."""
+    assert _is_driver_hub({"category": "misc", "config_entries": []}) is True
+    assert _is_driver_hub({"category": "bus"}) is False
+    assert _is_driver_hub({"category": "core"}) is False
+
+
+def test_hub_block_for_accepts_bare_key() -> None:
+    """``tuya:`` with a null body lifts as an empty block; an absent key doesn't."""
+    assert _hub_block_for({"tuya": None}, "tuya") == {}
+    assert _hub_block_for({}, "tuya") is None
+    assert _hub_block_for({"tuya": {"uart_id": "bus"}}, "tuya") == {"uart_id": "bus"}
+
+
+def test_bare_tuya_hub_lifts_and_chains_its_uart() -> None:
+    """A bare ``tuya:`` hub materializes fieldless and pulls its uart bus along."""
+    featured = [{"id": "sw", "component_id": "switch.tuya", "fields": {"id": "sw"}}]
+    config = {
+        "tuya": None,
+        "uart": {"tx_pin": 1, "rx_pin": 3, "baud_rate": 9600},
+        "switch": [{"platform": "tuya", "switch_datapoint": 1}],
+    }
+    extra, _ = _extract_driver_hubs(config, featured, _COMPONENTS)
+    by_cid = {entry["component_id"]: entry for entry in extra}
+    assert set(by_cid) == {"tuya", "uart"}
+    assert by_cid["tuya"]["requires"] == [by_cid["uart"]["id"]]
+    assert featured[0]["requires"][-1] == by_cid["tuya"]["id"]
+
+
+def test_platform_style_dep_resolves_platform_component() -> None:
+    """``time: platform: homeassistant`` lifts as ``time.homeassistant``, not bare ``time``."""
+    featured = [
+        {
+            "id": "energy",
+            "component_id": "sensor.total_daily_energy",
+            "fields": {"id": "energy", "power_id": "power"},
+        }
+    ]
+    config = {
+        "time": {"platform": "homeassistant"},
+        "sensor": [{"platform": "total_daily_energy", "power_id": "power"}],
+    }
+    extra, _ = _extract_bus_deps(config, featured, _COMPONENTS)
+    assert [entry["component_id"] for entry in extra] == ["time.homeassistant"]
+    assert featured[0]["requires"] == [extra[0]["id"]]
+
+
+def test_named_pin_alias_locks_without_occupancy() -> None:
+    """``TX1``-style aliases lock verbatim; lowercase refs still skip."""
+    occupancy: dict[int, str] = {}
+    ce = {"key": "tx_pin", "type": "pin"}
+    assert _coerce_field_preset(ce, "TX1", "tx_pin", {}, occupancy, "uart") == {
+        "value": "TX1",
+        "locked": True,
+    }
+    assert occupancy == {}
+    assert _coerce_field_preset(ce, "my_pin_ref", "tx_pin", {}, occupancy, "uart") is None
+
+
+def test_bare_substitution_is_not_a_simple_scalar() -> None:
+    assert _is_simple_scalar("$update_interval") is False
+    assert _is_simple_scalar("${update_interval}") is False
+    assert _is_simple_scalar("60s") is True
+
+
+def test_dep_already_featured_matches_platform_style() -> None:
+    assert _dep_already_featured("touchscreen", {"touchscreen.ft63x6"}) is True
+    assert _dep_already_featured("uart", {"uart"}) is True
+    assert _dep_already_featured("uart", {"uart_bus.something"}) is False
+
+
+def test_missing_required_ref_flags_absent_required_id() -> None:
+    component = {"config_entries": [{"key": "output", "type": "id", "required": True}]}
+    assert _missing_required_ref(component, {"id": "fan"}) == "output"
+    assert _missing_required_ref(component, {"id": "fan", "output": "out1"}) is None
+
+
+def test_extract_drops_entry_missing_required_ref() -> None:
+    """A consumer whose required ref points at a nested sub-id we can't carry is dropped."""
+    inline = {"sensor": [{"platform": "total_daily_energy", "power_id": "nested_sub_id"}]}
+    featured, _, _ = _extract_featured_components(inline, _COMPONENTS)
+    assert featured == []
+
+
+def test_drop_unsatisfiable_consumers_only_fires_on_excluded_domains() -> None:
+    """An ``ota``-dep leaf drops; unknown deps are left for the validation gate."""
+    components = {
+        "button.safe_mode": {"dependencies": ["ota"], "config_entries": []},
+        "output.libretiny_pwm": {"dependencies": ["libretiny"], "config_entries": []},
+    }
+    featured = [
+        {"id": "reboot", "component_id": "button.safe_mode", "fields": {}},
+        {"id": "pwm", "component_id": "output.libretiny_pwm", "fields": {}},
+    ]
+    bundles = [{"id": "all", "name": "All", "component_ids": ["reboot", "pwm"]}]
+    kept = _drop_unsatisfiable_consumers(featured, bundles, components)
+    assert [entry["id"] for entry in kept] == ["pwm"]
+    assert bundles[0]["component_ids"] == ["pwm"]
+
+
+def test_materialize_bus_accepts_bare_mapping_key() -> None:
+    """A bare ``modbus:`` key materializes fieldless via _select_bus_block."""
+    components = {"modbus": {"category": "bus", "config_entries": [{"key": "id", "type": "id"}]}}
+    state = _LiftState(config={"modbus": None}, components_index=components, used_ids=set())
+    entry, local, _ = _materialize_bus("modbus", None, state)
+    assert entry is not None
+    assert entry["component_id"] == "modbus"
+    assert local == "modbus_bus"

--- a/tests/test_sync_esphome_devices_gate.py
+++ b/tests/test_sync_esphome_devices_gate.py
@@ -1,0 +1,103 @@
+"""Pin the full-setup validation gate's error mapping and drop application."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from script._full_setup_gate import (  # type: ignore[import-not-found]
+    _apply_drops,
+    _map_errors,
+)
+
+_YAML = """
+esphome:
+  name: repro
+sensor:
+  - platform: total_daily_energy
+    id: energy
+  - platform: hlw8012
+    id: power
+switch:
+  - platform: gpio
+    id: relay
+modbus:
+  id: modbus_bus
+"""
+
+
+def _record() -> dict[str, Any]:
+    return {
+        "id": "board",
+        "featured_components": [
+            {"id": "energy", "component_id": "sensor.total_daily_energy", "fields": {}},
+            {"id": "power", "component_id": "sensor.hlw8012", "fields": {}},
+            {"id": "relay", "component_id": "switch.gpio", "fields": {}},
+            {"id": "modbus_bus", "component_id": "modbus", "fields": {}},
+        ],
+        "featured_bundles": [
+            {"id": "all", "name": "All", "component_ids": ["energy", "power", "relay"]},
+        ],
+    }
+
+
+def test_maps_indexed_path_to_item_id() -> None:
+    """``data['sensor'][0]`` resolves through the generated item's ``id``."""
+    outcome = _map_errors(
+        ["Component sensor.total_daily_energy requires component time @ data['sensor'][0]"],
+        _YAML,
+        _record(),
+    )
+    assert outcome.drop_ids == ["energy"]
+    assert outcome.errors == []
+
+
+def test_maps_mapping_path_to_sole_domain_entry() -> None:
+    """A top-level mapping path (``data['modbus']``) falls back to the domain's sole entry."""
+    outcome = _map_errors(
+        ["Component modbus requires component uart @ data['modbus']"], _YAML, _record()
+    )
+    assert outcome.drop_ids == ["modbus_bus"]
+
+
+def test_two_errors_one_entry_dedupes() -> None:
+    outcome = _map_errors(
+        [
+            "bad pin @ data['switch'][0]['pin']",
+            "bad mode @ data['switch'][0]['pin']['mode']",
+        ],
+        _YAML,
+        _record(),
+    )
+    assert outcome.drop_ids == ["relay"]
+
+
+def test_unmappable_error_poisons_the_board() -> None:
+    """An error with no config path (or an unknown target) maps to a board-level failure."""
+    outcome = _map_errors(["something exploded, no path"], _YAML, _record())
+    assert outcome.drop_ids == []
+    assert outcome.errors == ["something exploded, no path"]
+
+
+def test_ambiguous_domain_fallback_poisons_the_board() -> None:
+    """A path whose item id is unknown and whose domain has several entries can't map."""
+    yaml_text = _YAML.replace("id: power", "id: not_featured")
+    outcome = _map_errors(["boom @ data['sensor'][1]"], yaml_text, _record())
+    assert outcome.drop_ids == []
+    assert outcome.errors == ["boom @ data['sensor'][1]"]
+
+
+def test_apply_drops_prunes_entries_bundles_and_requires() -> None:
+    record = _record()
+    record["featured_components"][2]["requires"] = ["modbus_bus", "energy"]
+    _apply_drops(record, {"energy"})
+    ids = [entry["id"] for entry in record["featured_components"]]
+    assert ids == ["power", "relay", "modbus_bus"]
+    assert record["featured_components"][1]["requires"] == ["modbus_bus"]
+    assert record["featured_bundles"][0]["component_ids"] == ["power", "relay"]
+
+
+def test_apply_drops_removes_emptied_bundles() -> None:
+    record = _record()
+    record["featured_bundles"] = [{"id": "solo", "name": "Solo", "component_ids": ["energy"]}]
+    _apply_drops(record, {"energy"})
+    assert "featured_bundles" not in record

--- a/tests/test_sync_esphome_devices_gate.py
+++ b/tests/test_sync_esphome_devices_gate.py
@@ -9,6 +9,18 @@ from script._full_setup_gate import (  # type: ignore[import-not-found]
     _map_errors,
 )
 
+
+class _Err:
+    """Stand-in for ``vol.Invalid``: a structured path plus a message."""
+
+    def __init__(self, message: str, path: list[Any] | None = None) -> None:
+        self._message = message
+        self.path = path or []
+
+    def __str__(self) -> str:
+        return self._message
+
+
 _YAML = """
 esphome:
   name: repro
@@ -41,49 +53,47 @@ def _record() -> dict[str, Any]:
 
 
 def test_maps_indexed_path_to_item_id() -> None:
-    """``data['sensor'][0]`` resolves through the generated item's ``id``."""
+    """A ``['sensor', 0]`` path resolves through the generated item's ``id``."""
     outcome = _map_errors(
-        ["Component sensor.total_daily_energy requires component time @ data['sensor'][0]"],
+        [_Err("requires component time", ["sensor", 0])],
         _YAML,
         _record(),
     )
-    assert outcome.drop_ids == ["energy"]
+    assert [local_id for local_id, _ in outcome.drops] == ["energy"]
     assert outcome.errors == []
 
 
 def test_maps_mapping_path_to_sole_domain_entry() -> None:
-    """A top-level mapping path (``data['modbus']``) falls back to the domain's sole entry."""
-    outcome = _map_errors(
-        ["Component modbus requires component uart @ data['modbus']"], _YAML, _record()
-    )
-    assert outcome.drop_ids == ["modbus_bus"]
+    """A top-level mapping path (``['modbus']``) falls back to the domain's sole entry."""
+    outcome = _map_errors([_Err("requires component uart", ["modbus"])], _YAML, _record())
+    assert [local_id for local_id, _ in outcome.drops] == ["modbus_bus"]
 
 
 def test_two_errors_one_entry_dedupes() -> None:
     outcome = _map_errors(
         [
-            "bad pin @ data['switch'][0]['pin']",
-            "bad mode @ data['switch'][0]['pin']['mode']",
+            _Err("bad pin", ["switch", 0, "pin"]),
+            _Err("bad mode", ["switch", 0, "pin", "mode"]),
         ],
         _YAML,
         _record(),
     )
-    assert outcome.drop_ids == ["relay"]
+    assert [local_id for local_id, _ in outcome.drops] == ["relay"]
 
 
 def test_unmappable_error_poisons_the_board() -> None:
     """An error with no config path (or an unknown target) maps to a board-level failure."""
-    outcome = _map_errors(["something exploded, no path"], _YAML, _record())
-    assert outcome.drop_ids == []
+    outcome = _map_errors([_Err("something exploded, no path")], _YAML, _record())
+    assert outcome.drops == []
     assert outcome.errors == ["something exploded, no path"]
 
 
 def test_ambiguous_domain_fallback_poisons_the_board() -> None:
     """A path whose item id is unknown and whose domain has several entries can't map."""
     yaml_text = _YAML.replace("id: power", "id: not_featured")
-    outcome = _map_errors(["boom @ data['sensor'][1]"], yaml_text, _record())
-    assert outcome.drop_ids == []
-    assert outcome.errors == ["boom @ data['sensor'][1]"]
+    outcome = _map_errors([_Err("boom", ["sensor", 1])], yaml_text, _record())
+    assert outcome.drops == []
+    assert outcome.errors == ["boom"]
 
 
 def test_apply_drops_prunes_entries_bundles_and_requires() -> None:

--- a/tests/test_sync_esphome_devices_gate.py
+++ b/tests/test_sync_esphome_devices_gate.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+import script._full_setup_gate as gate  # type: ignore[import-not-found]
 from script._full_setup_gate import (  # type: ignore[import-not-found]
     _apply_drops,
     _map_errors,
+    _validate_record,
 )
 
 
@@ -104,6 +108,27 @@ def test_apply_drops_prunes_entries_bundles_and_requires() -> None:
     assert ids == ["power", "relay", "modbus_bus"]
     assert record["featured_components"][1]["requires"] == ["modbus_bus"]
     assert record["featured_bundles"][0]["component_ids"] == ["power", "relay"]
+
+
+def test_map_errors_tolerates_esphome_tags() -> None:
+    """Generated YAML with ``!lambda`` values still parses for path mapping."""
+    yaml_text = _YAML.replace(
+        "    id: energy\n",
+        "    id: energy\n    filters:\n      - lambda: !lambda 'return x;'\n",
+    )
+    outcome = _map_errors([_Err("bad filter", ["sensor", 0])], yaml_text, _record())
+    assert [local_id for local_id, _ in outcome.drops] == ["energy"]
+
+
+def test_worker_crash_refuses_the_board_not_the_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unexpected worker exception becomes a board-level refusal."""
+    monkeypatch.setattr(
+        gate, "_validate_record_inner", lambda record: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    outcome = _validate_record({"id": "board"})
+    assert outcome is not None
+    assert outcome.drops == []
+    assert "boom" in outcome.errors[0]
 
 
 def test_apply_drops_removes_emptied_bundles() -> None:

--- a/tests/test_sync_esphome_devices_variant.py
+++ b/tests/test_sync_esphome_devices_variant.py
@@ -19,8 +19,11 @@ from script.sync_esphome_devices import (  # type: ignore[import-not-found]
         ("esp32_s3_zero", "esp32s3"),
         ("esp32-c61-devkitc1", "esp32c61"),  # longest-first: c61, not c6
         ("esp32-s3-devkitc-1", "esp32s3"),
-        ("esp32dev", None),  # classic esp32 — no variant suffix
-        ("esp32-poe", None),
+        # No variant suffix in the id: the authoritative BOARDS map resolves
+        # these (classic esp32), matching what sync_boards stamps later.
+        ("esp32dev", "esp32"),
+        ("esp32-poe", "esp32"),
+        ("not-a-real-board-id", None),  # unknown everywhere stays unset
     ],
 )
 def test_infers_variant_from_board_id(board: str, expected: str | None) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #1979: with the nested presets restored, an inventory run of every imported board's "all recommended" setup through real ESPHome validation still failed for 111 boards. The devices.esphome.io pages are valid configs, so every failure was something the importer dropped or mangled. This PR makes the importer carry everything the page satisfies and then proves each import against ESPHome itself.

Static lift repairs in `sync_esphome_devices.py`:

- `_is_driver_hub` widens to any non-bus, non-featured-excluded dependency hub, so bus-attached hubs (`tuya`, `ads1115`, `modbus_controller`, DAC hubs, `i2s_audio`) lift with their consumers. Bare hub keys (`tuya:` with a null body) lift fieldless, and a platform-carrying block (`time: platform: homeassistant`) resolves to its `<domain>.<platform>` component. `time` leaves `FEATURED_EXCLUDED_CATEGORIES` (now shared from `constants.py` with `validate_definitions.py`) since pages' time platforms are hard deps of leaves like `total_daily_energy`.
- `_chain_bus_deps` chains a lifted bus's own bus deps (`modbus` rides `uart`), and consumers on multi-bus boards get their upstream `<bus>_id` locked so the generated reference isn't ambiguous.
- Board pin aliases (`TX1`, `D5`) pass through as locked presets; bare `$var` substitutions are rejected everywhere (`_is_simple_scalar` previously only caught `${var}`); entries whose catalog-required id reference can't resolve are dropped; `_dep_already_featured` stops a dep from re-lifting beside its already-featured `<dep>.<platform>` entry; the esp32 variant now resolves through esphome's authoritative `BOARDS` map at record build (shared with `sync_boards`' backfill), so `board:`-only manifests carry the variant. The lift passes thread one frozen `_LiftState` instead of six positional args.

The backstop is a new import-time validation gate (`script/_full_setup_gate.py`): each record's full setup is generated exactly like the create wizard's recommended add and run through `esphome.config.load_config` in a forked worker (fresh process per validation, mirroring the slow e2e suite's isolation). A failing entry is located through the error's structured config path and dropped with a logged reason; the record revalidates until clean. Boards left featureless or with an unmappable failure are refused with the real ESPHome error in the skip report, so a broken upstream page can never ship a broken recommended setup. The slow e2e suite reuses the gate's validation helper, so the gate and the test agree by construction.

Result on the live corpus: 419 of 427 candidate pages import with full setups that validate clean; the 8 refusals are genuine page defects (templated ids, platform-mismatched components, invalid pin modes), each logged. The catalog regeneration lands in a follow-up PR so it stays reviewable; its `test_full_config_boards_validate_full_setup` e2e extension passes with zero failures and no skip lists.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1975

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
