### PR TITLE
Reuse featured buses in lifts and prune dropped entries' pins

### DIFF
--- a/script/_full_setup_gate.py
+++ b/script/_full_setup_gate.py
@@ -228,7 +228,10 @@ def _entry_for_path(
 
 
 def _apply_drops(record: dict[str, Any], drop_ids: set[str]) -> None:
-    """Remove *drop_ids* from the record's featured entries, bundles, and requires."""
+    """Remove *drop_ids* from the record's featured entries, bundles, requires, and pins."""
+    dropped = [
+        entry for entry in record.get("featured_components") or [] if entry["id"] in drop_ids
+    ]
     record["featured_components"] = [
         entry for entry in record.get("featured_components") or [] if entry["id"] not in drop_ids
     ]
@@ -251,3 +254,66 @@ def _apply_drops(record: dict[str, Any], drop_ids: set[str]) -> None:
         record["featured_bundles"] = bundles
     elif "featured_bundles" in record:
         del record["featured_bundles"]
+    _prune_dropped_pins(record, dropped)
+
+
+def _prune_dropped_pins(record: dict[str, Any], dropped: list[dict[str, Any]]) -> None:
+    """
+    Drop pins owned by removed entries; relabel GPIOs a survivor still locks.
+
+    ``occupied_by`` carries either the local id or the entry's display name,
+    so match both — but a shared GPIO must stay declared or a surviving
+    entry's locked pin loses its board declaration.
+    """
+    labels = {entry["id"] for entry in dropped} | {
+        name
+        for entry in dropped
+        for name in (entry.get("name"), (entry.get("fields") or {}).get("name"))
+        if isinstance(name, str)
+    }
+    claimed = _surviving_gpio_labels(record["featured_components"])
+    pins = []
+    for pin in record.get("pins") or []:
+        if pin.get("occupied_by") not in labels:
+            pins.append(pin)
+        elif pin.get("gpio") in claimed:
+            pins.append({**pin, "occupied_by": claimed[pin["gpio"]]})
+    if pins:
+        record["pins"] = pins
+    elif "pins" in record:
+        del record["pins"]
+
+
+def _surviving_gpio_labels(entries: list[dict[str, Any]]) -> dict[int, str]:
+    """Map each GPIO a surviving entry locks to that entry's display label."""
+    from script.sync_esphome_devices import _PIN_TREE_FIELD_RE, _gpio_number
+
+    claimed: dict[int, str] = {}
+    for entry in entries:
+        fields = entry.get("fields") or {}
+        name = fields.get("name")
+        label = name if isinstance(name, str) else entry["id"]
+        for key, preset in fields.items():
+            if not _PIN_TREE_FIELD_RE.search(key):
+                continue
+            value = preset.get("value") if isinstance(preset, dict) else preset
+            _walk_gpio_leaves(value, label, _gpio_number, claimed)
+    return claimed
+
+
+def _walk_gpio_leaves(value: Any, label: str, gpio_number: Any, claimed: dict[int, str]) -> None:
+    """Record every GPIO leaf of a pin value (scalar, dict, or pin-group tree)."""
+    if isinstance(value, dict):
+        if "number" in value:
+            value = value["number"]
+        else:
+            for item in value.values():
+                _walk_gpio_leaves(item, label, gpio_number, claimed)
+            return
+    if isinstance(value, list):
+        for item in value:
+            _walk_gpio_leaves(item, label, gpio_number, claimed)
+        return
+    gpio = gpio_number(value)
+    if gpio is not None:
+        claimed.setdefault(gpio, label)

--- a/script/_full_setup_gate.py
+++ b/script/_full_setup_gate.py
@@ -32,7 +32,9 @@ _LOGGER = logging.getLogger("sync_esphome_devices")
 _MAX_PASSES = 12
 
 
-def apply_validation_gate(records: list[dict[str, Any]]) -> dict[str, str]:
+def apply_validation_gate(
+    records: list[dict[str, Any]], components_index: dict[str, dict[str, Any]]
+) -> dict[str, str]:
     """
     Drop featured entries whose generated full setup fails ESPHome validation.
 
@@ -65,7 +67,7 @@ def apply_validation_gate(records: list[dict[str, Any]]) -> dict[str, str]:
                 continue
             for local_id, error in outcome.drops:
                 _LOGGER.info("%s: dropping %s — %s", record["id"], local_id, error)
-            _apply_drops(record, {local_id for local_id, _ in outcome.drops})
+            _apply_drops(record, {local_id for local_id, _ in outcome.drops}, components_index)
             if record.get("featured_components"):
                 retry.append(record)
             else:
@@ -227,7 +229,9 @@ def _entry_for_path(
     return matches[0] if len(matches) == 1 else None
 
 
-def _apply_drops(record: dict[str, Any], drop_ids: set[str]) -> None:
+def _apply_drops(
+    record: dict[str, Any], drop_ids: set[str], components_index: dict[str, dict[str, Any]]
+) -> None:
     """Remove *drop_ids* from the record's featured entries, bundles, requires, and pins."""
     dropped = [
         entry for entry in record.get("featured_components") or [] if entry["id"] in drop_ids
@@ -254,24 +258,36 @@ def _apply_drops(record: dict[str, Any], drop_ids: set[str]) -> None:
         record["featured_bundles"] = bundles
     elif "featured_bundles" in record:
         del record["featured_bundles"]
-    _prune_dropped_pins(record, dropped)
+    _prune_dropped_pins(record, dropped, components_index)
 
 
-def _prune_dropped_pins(record: dict[str, Any], dropped: list[dict[str, Any]]) -> None:
+def _prune_dropped_pins(
+    record: dict[str, Any],
+    dropped: list[dict[str, Any]],
+    components_index: dict[str, dict[str, Any]],
+) -> None:
     """
     Drop pins owned by removed entries; relabel GPIOs a survivor still locks.
 
-    ``occupied_by`` carries either the local id or the entry's display name,
-    so match both — but a shared GPIO must stay declared or a surviving
+    ``occupied_by`` comes from ``_occupancy_label`` (cleaned upstream
+    name/id, else the component id), so match every label a dropped entry
+    can have produced — but a shared GPIO must stay declared or a surviving
     entry's locked pin loses its board declaration.
     """
-    labels = {entry["id"] for entry in dropped} | {
-        name
-        for entry in dropped
-        for name in (entry.get("name"), (entry.get("fields") or {}).get("name"))
-        if isinstance(name, str)
-    }
-    claimed = _surviving_gpio_labels(record["featured_components"])
+    labels: set[str] = set()
+    for entry in dropped:
+        labels.add(entry["id"])
+        labels.add(entry["component_id"])
+        fields = entry.get("fields") or {}
+        raw_id = fields.get("id")
+        for label in (
+            entry.get("name"),
+            fields.get("name"),
+            raw_id.get("value") if isinstance(raw_id, dict) else raw_id,
+        ):
+            if isinstance(label, str):
+                labels.add(label)
+    claimed = _surviving_gpio_labels(record["featured_components"], components_index)
     pins = []
     for pin in record.get("pins") or []:
         if pin.get("occupied_by") not in labels:
@@ -284,36 +300,54 @@ def _prune_dropped_pins(record: dict[str, Any], dropped: list[dict[str, Any]]) -
         del record["pins"]
 
 
-def _surviving_gpio_labels(entries: list[dict[str, Any]]) -> dict[int, str]:
-    """Map each GPIO a surviving entry locks to that entry's display label."""
-    from script.sync_esphome_devices import _PIN_TREE_FIELD_RE, _gpio_number
+def _surviving_gpio_labels(
+    entries: list[dict[str, Any]], components_index: dict[str, dict[str, Any]]
+) -> dict[int, str]:
+    """
+    Map each GPIO a surviving entry locks to that entry's display label.
+
+    Pin fields are detected by the catalog's ``type: "pin"`` (``sda``, ``clk``)
+    plus the pin-group name pattern (``data_pins``), matching how extraction
+    recorded occupancy in the first place.
+    """
+    from script.sync_esphome_devices import _PIN_TREE_FIELD_RE
 
     claimed: dict[int, str] = {}
     for entry in entries:
+        component = components_index.get(entry["component_id"]) or {}
+        pin_keys = {
+            ce["key"]
+            for ce in component.get("config_entries") or []
+            if ce.get("type") == "pin" and isinstance(ce.get("key"), str)
+        }
         fields = entry.get("fields") or {}
         name = fields.get("name")
         label = name if isinstance(name, str) else entry["id"]
         for key, preset in fields.items():
-            if not _PIN_TREE_FIELD_RE.search(key):
+            if key not in pin_keys and not _PIN_TREE_FIELD_RE.search(key):
                 continue
             value = preset.get("value") if isinstance(preset, dict) else preset
-            _walk_gpio_leaves(value, label, _gpio_number, claimed)
+            _walk_gpio_leaves(value, label, claimed)
     return claimed
 
 
-def _walk_gpio_leaves(value: Any, label: str, gpio_number: Any, claimed: dict[int, str]) -> None:
-    """Record every GPIO leaf of a pin value (scalar, dict, or pin-group tree)."""
+def _walk_gpio_leaves(value: Any, label: str, claimed: dict[int, str]) -> None:
+    """Record every board-GPIO leaf of a pin value (scalar, dict, or pin-group tree)."""
+    from script.sync_esphome_devices import _expander_keys, _gpio_number
+
     if isinstance(value, dict):
-        if "number" in value:
-            value = value["number"]
-        else:
-            for item in value.values():
-                _walk_gpio_leaves(item, label, gpio_number, claimed)
+        if _expander_keys(value):
+            # An expander channel's ``number`` is not a board GPIO.
             return
+        if "number" not in value:
+            for item in value.values():
+                _walk_gpio_leaves(item, label, claimed)
+            return
+        value = value["number"]
     if isinstance(value, list):
         for item in value:
-            _walk_gpio_leaves(item, label, gpio_number, claimed)
+            _walk_gpio_leaves(item, label, claimed)
         return
-    gpio = gpio_number(value)
+    gpio = _gpio_number(value)
     if gpio is not None:
         claimed.setdefault(gpio, label)

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -2674,7 +2674,7 @@ def main() -> int:
     # Static extraction can't see everything ESPHome enforces (pin modes,
     # cross-platform constraints, stale upstream pages) — validate every
     # record's full setup for real and repair or refuse before emitting.
-    gate_skips = apply_validation_gate([record for _, record in pending])
+    gate_skips = apply_validation_gate([record for _, record in pending], components_index)
 
     for src, record in pending:
         gate_reason = gate_skips.get(record["id"])

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -1815,6 +1815,33 @@ def _chain_bus_deps(
         bus_entry["requires"] = sub_ids
 
 
+def _seed_bus_local(
+    featured: list[dict[str, Any]], components_index: dict[str, dict[str, Any]]
+) -> dict[tuple[str, str | None], str]:
+    """
+    Map already-featured buses so later lifts reuse them instead of duplicating.
+
+    Keyed like ``_ensure_buses`` resolves deps: ``(domain, upstream id)`` for a
+    bus with a locked id, plus ``(domain, None)`` when it is the domain's sole
+    featured bus.
+    """
+    seeded: dict[tuple[str, str | None], str] = {}
+    by_domain: dict[str, list[str]] = {}
+    for entry in featured:
+        domain = entry["component_id"].partition(".")[0]
+        if not _is_bus_dep(domain, components_index):
+            continue
+        raw_id = (entry.get("fields") or {}).get("id")
+        instance = raw_id.get("value") if isinstance(raw_id, dict) else None
+        if isinstance(instance, str):
+            seeded[(domain, instance)] = entry["id"]
+        by_domain.setdefault(domain, []).append(entry["id"])
+    for domain, local_ids in by_domain.items():
+        if len(local_ids) == 1:
+            seeded.setdefault((domain, None), local_ids[0])
+    return seeded
+
+
 def _wire_consumer_requires(
     consumers: list[tuple[dict[str, Any], list[tuple[str, str | None]]]],
     hub_prereqs: dict[tuple[str, str | None], list[str]],
@@ -2003,7 +2030,12 @@ def _materialize_hubs(
     lift and drops a consumer whose hub didn't materialize.
     """
     used_ids = {entry["id"] for entry in featured}
-    state = _LiftState(config=config, components_index=components_index, used_ids=used_ids)
+    state = _LiftState(
+        config=config,
+        components_index=components_index,
+        used_ids=used_ids,
+        bus_local=_seed_bus_local(featured, components_index),
+    )
     # Each materialized hub keyed by its ref, carrying the local id + the bus
     # ids it needs — the ordered prerequisite chain a consumer references.
     hub_prereqs: dict[tuple[str, str | None], list[str]] = {}
@@ -2283,6 +2315,7 @@ def _extract_bus_deps(
         config=config,
         components_index=components_index,
         used_ids={entry["id"] for entry in featured},
+        bus_local=_seed_bus_local(featured, components_index),
     )
     for dep, instance in ordered_refs:
         bus_entry, local, bus_occ = _materialize_bus(dep, instance, state)

--- a/tests/test_sync_esphome_devices_dep_lifts.py
+++ b/tests/test_sync_esphome_devices_dep_lifts.py
@@ -132,6 +132,46 @@ def test_extract_drops_entry_missing_required_ref() -> None:
     assert featured == []
 
 
+def test_hub_reuses_already_featured_bus() -> None:
+    """A hub whose bus is already featured requires it instead of lifting a duplicate."""
+    components = dict(_COMPONENTS)
+    components["ads1115"] = {
+        "category": "misc",
+        "dependencies": ["i2c"],
+        "config_entries": [{"key": "address", "type": "integer"}, {"key": "i2c_id", "type": "id"}],
+    }
+    components["sensor.ads1115"] = {
+        "dependencies": ["ads1115"],
+        "config_entries": [{"key": "multiplexer", "type": "string"}],
+    }
+    components["i2c"] = {
+        "category": "bus",
+        "config_entries": [
+            {"key": "sda", "type": "pin"},
+            {"key": "scl", "type": "pin"},
+            {"key": "id", "type": "id"},
+        ],
+    }
+    featured = [
+        {
+            "id": "bus_a",
+            "component_id": "i2c",
+            "fields": {"id": {"value": "bus_a", "locked": True}},
+        },
+        {"id": "reader", "component_id": "sensor.ads1115", "fields": {"id": "reader"}},
+    ]
+    config = {
+        "i2c": [{"id": "bus_a", "sda": 4, "scl": 5}, {"id": "bus_b", "sda": 21, "scl": 22}],
+        "ads1115": {"address": 0x48, "i2c_id": "bus_a"},
+        "sensor": [{"platform": "ads1115", "multiplexer": "A0_GND"}],
+    }
+    extra, _ = _extract_driver_hubs(config, featured, components)
+    assert [entry["component_id"] for entry in extra] == ["ads1115"]
+    hub = extra[0]
+    assert hub["requires"] == ["bus_a"]
+    assert hub["fields"]["i2c_id"] == {"value": "bus_a", "locked": True}
+
+
 def test_materialize_bus_accepts_bare_mapping_key() -> None:
     """A bare ``modbus:`` key materializes fieldless via _select_bus_block."""
     components = {"modbus": {"category": "bus", "config_entries": [{"key": "id", "type": "id"}]}}

--- a/tests/test_sync_esphome_devices_gate.py
+++ b/tests/test_sync_esphome_devices_gate.py
@@ -131,6 +131,28 @@ def test_worker_crash_refuses_the_board_not_the_run(monkeypatch: pytest.MonkeyPa
     assert "boom" in outcome.errors[0]
 
 
+def test_apply_drops_prunes_dropped_entries_pins() -> None:
+    """Pins owned by a dropped entry leave the pins block, by id and by name."""
+    record = _record()
+    record["featured_components"][0]["fields"]["name"] = "Daily Energy"
+    record["pins"] = [
+        {"gpio": 4, "available": False, "occupied_by": "energy"},
+        {"gpio": 5, "available": False, "occupied_by": "Daily Energy"},
+        {"gpio": 6, "available": False, "occupied_by": "relay"},
+    ]
+    _apply_drops(record, {"energy"})
+    assert record["pins"] == [{"gpio": 6, "available": False, "occupied_by": "relay"}]
+
+
+def test_apply_drops_relabels_shared_pins_to_the_survivor() -> None:
+    """A GPIO a surviving entry still locks stays declared under the survivor's label."""
+    record = _record()
+    record["featured_components"][2]["fields"]["pin"] = {"value": 4, "locked": True}
+    record["pins"] = [{"gpio": 4, "available": False, "occupied_by": "energy"}]
+    _apply_drops(record, {"energy"})
+    assert record["pins"] == [{"gpio": 4, "available": False, "occupied_by": "relay"}]
+
+
 def test_apply_drops_removes_emptied_bundles() -> None:
     record = _record()
     record["featured_bundles"] = [{"id": "solo", "name": "Solo", "component_ids": ["energy"]}]

--- a/tests/test_sync_esphome_devices_gate.py
+++ b/tests/test_sync_esphome_devices_gate.py
@@ -103,7 +103,7 @@ def test_ambiguous_domain_fallback_poisons_the_board() -> None:
 def test_apply_drops_prunes_entries_bundles_and_requires() -> None:
     record = _record()
     record["featured_components"][2]["requires"] = ["modbus_bus", "energy"]
-    _apply_drops(record, {"energy"})
+    _apply_drops(record, {"energy"}, {})
     ids = [entry["id"] for entry in record["featured_components"]]
     assert ids == ["power", "relay", "modbus_bus"]
     assert record["featured_components"][1]["requires"] == ["modbus_bus"]
@@ -140,7 +140,7 @@ def test_apply_drops_prunes_dropped_entries_pins() -> None:
         {"gpio": 5, "available": False, "occupied_by": "Daily Energy"},
         {"gpio": 6, "available": False, "occupied_by": "relay"},
     ]
-    _apply_drops(record, {"energy"})
+    _apply_drops(record, {"energy"}, {})
     assert record["pins"] == [{"gpio": 6, "available": False, "occupied_by": "relay"}]
 
 
@@ -149,12 +149,38 @@ def test_apply_drops_relabels_shared_pins_to_the_survivor() -> None:
     record = _record()
     record["featured_components"][2]["fields"]["pin"] = {"value": 4, "locked": True}
     record["pins"] = [{"gpio": 4, "available": False, "occupied_by": "energy"}]
-    _apply_drops(record, {"energy"})
+    _apply_drops(record, {"energy"}, {})
     assert record["pins"] == [{"gpio": 4, "available": False, "occupied_by": "relay"}]
+
+
+def test_apply_drops_prunes_component_id_labeled_pins() -> None:
+    """A nameless dropped entry's pins carry its component id as the label."""
+    record = _record()
+    record["pins"] = [{"gpio": 4, "available": False, "occupied_by": "sensor.total_daily_energy"}]
+    _apply_drops(record, {"energy"}, {})
+    assert "pins" not in record
+
+
+def test_apply_drops_keeps_bus_pins_via_catalog_typing() -> None:
+    """A surviving bus claiming a shared GPIO through ``sda`` keeps the declaration."""
+    record = _record()
+    record["featured_components"].append(
+        {
+            "id": "bus",
+            "component_id": "i2c",
+            "fields": {"sda": {"value": 4, "locked": True}, "id": {"value": "bus"}},
+        }
+    )
+    record["pins"] = [{"gpio": 4, "available": False, "occupied_by": "energy"}]
+    components_index = {
+        "i2c": {"category": "bus", "config_entries": [{"key": "sda", "type": "pin"}]}
+    }
+    _apply_drops(record, {"energy"}, components_index)
+    assert record["pins"] == [{"gpio": 4, "available": False, "occupied_by": "bus"}]
 
 
 def test_apply_drops_removes_emptied_bundles() -> None:
     record = _record()
     record["featured_bundles"] = [{"id": "solo", "name": "Solo", "component_ids": ["energy"]}]
-    _apply_drops(record, {"energy"})
+    _apply_drops(record, {"energy"}, {})
     assert "featured_bundles" not in record


### PR DESCRIPTION
# What does this implement/fix?

Two importer defects found while regenerating the catalog (#1983), split out per review so the code lands on its own.

**Duplicate bus lifts.** The hub lift passes start with an empty bus map, so a hub whose bus was already featured (lifted by an earlier pass or extracted directly) materialized a second copy: on `hankerila_ea8` and the kincony boards the pcf8574/ads1115 hubs ended up with `i2c_id: bus_a` locked while `requires` pointed at a freshly minted `bus_a_2` duplicate of the same physical bus. CI caught exactly one of them (`test_committed_catalog_declares_every_reference` resolves references through a fields-id map, and the duplicate won the dict slot on every board except hankerila). `_seed_bus_local` now maps every already-featured bus into each pass's `_LiftState`, keyed the same way `_ensure_buses` resolves deps (`(domain, upstream id)` plus the sole-bus `(domain, None)` fallback), so lifts reuse instead of duplicating. Verified against the upstream KinCony pages: one physical `bus_a`, and the regenerated manifests now mirror it 1:1.

**Stale pins after gate drops.** When the validation gate drops an entry, its `pins[].occupied_by` labels survived, so GPIOs rendered as occupied by components the board no longer defines (esphbot's suggestion on #1983). `_apply_drops` now prunes pins owned by dropped entries and relabels shared GPIOs a surviving entry still locks. The reconstruction matches how extraction produced the data in the first place: the drop-match set covers every label `_occupancy_label` can emit (display name, upstream id, local id, component id fallback), and survivor pin fields are detected by the catalog's `type: "pin"` (so `sda`/`scl`/`clk` count) plus the pin-group name pattern, with expander channels excluded because extraction never records them as board GPIOs.

The catalog regeneration that exercises both fixes ships in #1983, which is based on this branch.

**Related issue or feature (if applicable):**

- follow-up to #1982; the regenerated catalog in #1983 depends on it

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
