### PR TITLE
Resolve page substitutions at import time so templated values extract

### DIFF
--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -225,10 +225,10 @@ _PLACEHOLDER_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"\byour[\s_-]+(key|address|token|id)\b", re.IGNORECASE),
 ]
 
-# Template substitutions like ``${friendly_name}`` that upstream pages
-# resolve at runtime via ``substitutions:``. We don't carry the
-# substitutions block forward, so anything still containing one is
-# unsafe to surface as a preset value or as an ``occupied_by`` label.
+# Template substitutions like ``${friendly_name}``. The page's own
+# ``substitutions:`` block is resolved in ``_resolve_page_substitutions``,
+# so anything still containing one is an undefined reference (or the pass
+# was skipped) — unsafe to surface as a preset value or ``occupied_by`` label.
 _TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]*\}")
 
 # Deprecated flat ``clk_mode: GPIO<n>_(IN|OUT)`` encodes the RMII clock
@@ -513,6 +513,8 @@ def _first_config_yaml(body: str, device_dir: Path) -> tuple[dict[str, Any], str
     """
     First parseable ``yaml`` config fence as ``(parsed, raw_text)``, following ``file=``.
 
+    *parsed* has the page's ``substitutions:`` block resolved over the tree.
+
     A device page often splits optional snippets across separate fences. The
     onboard ``ethernet:`` block (real hardware we lift) is sometimes a standalone
     fence after the base config, so fold just that one into the primary fence when
@@ -545,7 +547,7 @@ def _first_config_yaml(body: str, device_dir: Path) -> tuple[dict[str, Any], str
         # edits to it. An inline fence is already in *body* — leave it be.
         if ethernet_text is not None and ethernet_text not in body:
             text = f"{text}\n{ethernet_text}"
-    return parsed, text
+    return _resolve_page_substitutions(parsed, device_dir.name), text
 
 
 def _extract_local_images(body: str, device_dir: Path) -> list[str]:
@@ -585,11 +587,10 @@ def _resolve_page_substitutions(parsed: dict[str, Any], folder: str) -> dict[str
     """
     Resolve the page's own ``substitutions:`` block over the config tree.
 
-    Runs ESPHome's real substitution pass so ``pin: ${open_switch}``-style
-    values extract like literals. Unresolved references stay literal, and
-    any failure returns *parsed* unchanged.
+    Unresolved references stay literal; any failure returns *parsed* unchanged.
     """
-    if not isinstance(parsed.get("substitutions"), dict) or not parsed["substitutions"]:
+    subs = parsed.get("substitutions")
+    if not isinstance(subs, dict) or not subs:
         return parsed
     try:
         from esphome.components.substitutions import do_substitution_pass
@@ -642,11 +643,7 @@ def _iter_devices(repo: Path) -> Iterator[_DeviceSource]:
             frontmatter=frontmatter,
             body=body,
             content_hash=_hash_content(hash_src),
-            config_yaml=(
-                _resolve_page_substitutions(config[0], device_dir.name)
-                if config is not None
-                else None
-            ),
+            config_yaml=config[0] if config is not None else None,
             images=_extract_local_images(body, device_dir),
         )
 

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -231,6 +231,9 @@ _PLACEHOLDER_PATTERNS: list[re.Pattern[str]] = [
 # was skipped) — unsafe to surface as a preset value or ``occupied_by`` label.
 _TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]*\}")
 
+# A token with no letter or digit is placeholder noise ("***"), not a name.
+_ALNUM_RE = re.compile(r"[A-Za-z0-9]")
+
 # Deprecated flat ``clk_mode: GPIO<n>_(IN|OUT)`` encodes the RMII clock
 # pin and direction in the mode string; folded into nested ``clk``
 # ``{mode, pin}`` (upstream removal 2026.9.0).
@@ -1469,17 +1472,20 @@ def _clean_entity_name(inline_item: dict[str, Any]) -> str:
     """
     Pick a readable entity name from an inline-yaml item.
 
-    Returns the upstream ``name:`` / ``id:`` value with any
-    ``${...}`` template substitutions removed and surrounding
-    whitespace / separators trimmed. Returns an empty string when no
-    readable label remains — callers fall back to a derived default.
+    Returns the upstream ``name:`` / ``id:`` value with ``${...}``
+    template substitutions and symbol-only placeholder tokens (a
+    ``friendly_name: "***"`` fill-in resolving into the name) removed
+    and surrounding whitespace / separators trimmed. Returns an empty
+    string when no readable label remains — callers fall back to a
+    derived default.
     """
     for key in ("name", "id"):
         candidate = inline_item.get(key)
         if not isinstance(candidate, str):
             continue
-        cleaned = _TEMPLATE_VAR_RE.sub("", candidate).strip(" -_")
-        cleaned = re.sub(r"\s+", " ", cleaned)
+        cleaned = _TEMPLATE_VAR_RE.sub("", candidate)
+        tokens = [t for t in cleaned.split() if _ALNUM_RE.search(t)]
+        cleaned = " ".join(tokens).strip(" -_")
         if cleaned:
             return cleaned
     return ""

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -231,9 +231,11 @@ _PLACEHOLDER_PATTERNS: list[re.Pattern[str]] = [
 # was skipped) — unsafe to surface as a preset value or ``occupied_by`` label.
 _TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]*\}")
 
-# A token with no letter or digit (unicode-aware, so "Спот" survives) is
-# placeholder noise ("***"), not a name. Stripped from name edges only so
-# interior separators ("gosund_sp111 - Status") stay.
+# A leading token with no letter or digit (unicode-aware, so "Спот"
+# survives) is placeholder noise — a ``friendly_name: "***"`` fill-in
+# resolving into "*** Button". Only leading tokens are stripped: interior
+# separators ("gosund_sp111 - Status") and trailing symbols that
+# disambiguate ("Energy Meter kWh +" vs "Energy Meter kWh") are real.
 _ALNUM_RE = re.compile(r"[^\W_]")
 
 # Deprecated flat ``clk_mode: GPIO<n>_(IN|OUT)`` encodes the RMII clock
@@ -1475,10 +1477,9 @@ def _clean_entity_name(inline_item: dict[str, Any]) -> str:
     Pick a readable entity name from an inline-yaml item.
 
     Returns the upstream ``name:`` / ``id:`` value with ``${...}``
-    template substitutions and symbol-only placeholder tokens (a
-    ``friendly_name: "***"`` fill-in resolving into the name) removed
-    and surrounding whitespace / separators trimmed. Returns an empty
-    string when no readable label remains — callers fall back to a
+    template substitutions and leading symbol-only placeholder tokens
+    removed and surrounding whitespace / separators trimmed. Returns an
+    empty string when no readable label remains — callers fall back to a
     derived default.
     """
     for key in ("name", "id"):
@@ -1488,8 +1489,6 @@ def _clean_entity_name(inline_item: dict[str, Any]) -> str:
         tokens = _TEMPLATE_VAR_RE.sub("", candidate).split()
         while tokens and not _ALNUM_RE.search(tokens[0]):
             tokens.pop(0)
-        while tokens and not _ALNUM_RE.search(tokens[-1]):
-            tokens.pop()
         cleaned = " ".join(tokens).strip(" -_")
         if cleaned:
             return cleaned

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -231,8 +231,10 @@ _PLACEHOLDER_PATTERNS: list[re.Pattern[str]] = [
 # was skipped) — unsafe to surface as a preset value or ``occupied_by`` label.
 _TEMPLATE_VAR_RE = re.compile(r"\$\{[^}]*\}")
 
-# A token with no letter or digit is placeholder noise ("***"), not a name.
-_ALNUM_RE = re.compile(r"[A-Za-z0-9]")
+# A token with no letter or digit (unicode-aware, so "Спот" survives) is
+# placeholder noise ("***"), not a name. Stripped from name edges only so
+# interior separators ("gosund_sp111 - Status") stay.
+_ALNUM_RE = re.compile(r"[^\W_]")
 
 # Deprecated flat ``clk_mode: GPIO<n>_(IN|OUT)`` encodes the RMII clock
 # pin and direction in the mode string; folded into nested ``clk``
@@ -1483,8 +1485,11 @@ def _clean_entity_name(inline_item: dict[str, Any]) -> str:
         candidate = inline_item.get(key)
         if not isinstance(candidate, str):
             continue
-        cleaned = _TEMPLATE_VAR_RE.sub("", candidate)
-        tokens = [t for t in cleaned.split() if _ALNUM_RE.search(t)]
+        tokens = _TEMPLATE_VAR_RE.sub("", candidate).split()
+        while tokens and not _ALNUM_RE.search(tokens[0]):
+            tokens.pop(0)
+        while tokens and not _ALNUM_RE.search(tokens[-1]):
+            tokens.pop()
         cleaned = " ".join(tokens).strip(" -_")
         if cleaned:
             return cleaned

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -37,6 +37,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections import OrderedDict
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -580,6 +581,39 @@ def _hash_content(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def _resolve_page_substitutions(parsed: dict[str, Any], folder: str) -> dict[str, Any]:
+    """
+    Resolve the page's own ``substitutions:`` block over the config tree.
+
+    Runs ESPHome's real substitution pass so ``pin: ${open_switch}``-style
+    values extract like literals. Unresolved references stay literal, and
+    any failure returns *parsed* unchanged.
+    """
+    if not isinstance(parsed.get("substitutions"), dict) or not parsed["substitutions"]:
+        return parsed
+    try:
+        from esphome.components.substitutions import do_substitution_pass
+    except ImportError:
+        _LOGGER.debug("esphome unavailable; skipping substitution pass (%s)", folder)
+        return parsed
+    try:
+        resolved = do_substitution_pass(OrderedDict(parsed))
+    except Exception as err:
+        _LOGGER.warning("substitution pass failed for %s: %s", folder, err)
+        return parsed
+    resolved.pop("substitutions", None)
+    return _plain_tree(resolved)
+
+
+def _plain_tree(value: Any) -> Any:
+    """Rebuild dict/list subclasses (``substitute`` emits OrderedDict) as plain builtins."""
+    if isinstance(value, dict):
+        return {k: _plain_tree(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_plain_tree(v) for v in value]
+    return value
+
+
 def _iter_devices(repo: Path) -> Iterator[_DeviceSource]:
     """Walk *repo* and yield one record per usable device page."""
     devices_root = repo / _DEVICES_SUBDIR
@@ -608,7 +642,11 @@ def _iter_devices(repo: Path) -> Iterator[_DeviceSource]:
             frontmatter=frontmatter,
             body=body,
             content_hash=_hash_content(hash_src),
-            config_yaml=config[0] if config is not None else None,
+            config_yaml=(
+                _resolve_page_substitutions(config[0], device_dir.name)
+                if config is not None
+                else None
+            ),
             images=_extract_local_images(body, device_dir),
         )
 

--- a/tests/test_sync_esphome_devices_substitutions.py
+++ b/tests/test_sync_esphome_devices_substitutions.py
@@ -91,6 +91,19 @@ _INDEX: dict[str, dict[str, Any]] = {
 }
 
 
+def test_placeholder_substitution_value_is_dropped_from_names() -> None:
+    """A ``friendly_name: "***"`` fill-in resolves but never lands in a name or label."""
+    parsed: dict[str, Any] = {
+        "substitutions": {"friendly_name": "***"},
+        "binary_sensor": [{"platform": "gpio", "name": "${friendly_name} Button", "pin": 5}],
+    }
+    resolved = _resolve_page_substitutions(parsed, "board")
+    assert resolved["binary_sensor"][0]["name"] == "*** Button"
+    featured, _, occupancy = _extract_featured_components(resolved, _INDEX)
+    assert featured[0]["fields"]["name"] == "Button"
+    assert occupancy == {5: "Button"}
+
+
 def test_loratap_shaped_page_extracts_after_resolution() -> None:
     """The #1988 shape: substitution-valued pins and durations extract like literals."""
     parsed: dict[str, Any] = {

--- a/tests/test_sync_esphome_devices_substitutions.py
+++ b/tests/test_sync_esphome_devices_substitutions.py
@@ -104,6 +104,25 @@ def test_placeholder_substitution_value_is_dropped_from_names() -> None:
     assert occupancy == {5: "Button"}
 
 
+@pytest.mark.parametrize(
+    ("upstream", "expected"),
+    [
+        pytest.param("Спот", "Спот", id="unicode_kept"),
+        pytest.param("gosund_sp111 - Status", "gosund_sp111 - Status", id="interior_dash_kept"),
+        pytest.param("Energy Meter kWh +", "Energy Meter kWh", id="trailing_symbol_stripped"),
+    ],
+)
+def test_edge_symbol_tokens_only_are_stripped(upstream: str, expected: str) -> None:
+    parsed: dict[str, Any] = {
+        "substitutions": {"x": "y"},
+        "binary_sensor": [{"platform": "gpio", "name": upstream, "pin": 5}],
+    }
+    featured, _, _ = _extract_featured_components(
+        _resolve_page_substitutions(parsed, "board"), _INDEX
+    )
+    assert featured[0]["fields"]["name"] == expected
+
+
 def test_loratap_shaped_page_extracts_after_resolution() -> None:
     """The #1988 shape: substitution-valued pins and durations extract like literals."""
     parsed: dict[str, Any] = {

--- a/tests/test_sync_esphome_devices_substitutions.py
+++ b/tests/test_sync_esphome_devices_substitutions.py
@@ -15,48 +15,35 @@ from script.sync_esphome_devices import (  # type: ignore[import-not-found]
 pytest.importorskip("esphome")
 
 
-def test_whole_scalar_substitution_preserves_type() -> None:
+@pytest.mark.parametrize(
+    ("substitutions", "raw", "expected"),
+    [
+        pytest.param({"baud": 9600}, "${baud}", 9600, id="whole_scalar_keeps_type"),
+        pytest.param(
+            {"friendly_name": "Blind Switch"},
+            "${friendly_name} S1 input",
+            "Blind Switch S1 input",
+            id="interpolation",
+        ),
+        pytest.param({"open_switch": "P23"}, "$open_switch", "P23", id="bare_var"),
+        pytest.param(
+            {"base": "kitchen", "device_name": "${base}-light"},
+            "${device_name}",
+            "kitchen-light",
+            id="chained",
+        ),
+        pytest.param(
+            {"defined": "yes"}, "${not_defined} Uptime", "${not_defined} Uptime", id="undefined"
+        ),
+    ],
+)
+def test_reference_forms_resolve(substitutions: dict[str, Any], raw: str, expected: Any) -> None:
     parsed: dict[str, Any] = {
-        "substitutions": {"baud": 9600},
-        "uart": {"baud_rate": "${baud}"},
+        "substitutions": substitutions,
+        "sensor": [{"platform": "uptime", "update_interval": raw}],
     }
     resolved = _resolve_page_substitutions(parsed, "board")
-    assert resolved["uart"]["baud_rate"] == 9600
-
-
-def test_interpolation_and_bare_var_forms() -> None:
-    parsed: dict[str, Any] = {
-        "substitutions": {"friendly_name": "Blind Switch", "open_switch": "P23"},
-        "binary_sensor": [
-            {
-                "platform": "gpio",
-                "name": "${friendly_name} S1 switch input",
-                "pin": "$open_switch",
-            }
-        ],
-    }
-    resolved = _resolve_page_substitutions(parsed, "board")
-    item = resolved["binary_sensor"][0]
-    assert item["name"] == "Blind Switch S1 switch input"
-    assert item["pin"] == "P23"
-
-
-def test_substitution_referencing_another_substitution() -> None:
-    parsed: dict[str, Any] = {
-        "substitutions": {"base": "kitchen", "device_name": "${base}-light"},
-        "esphome": {"name": "${device_name}"},
-    }
-    resolved = _resolve_page_substitutions(parsed, "board")
-    assert resolved["esphome"]["name"] == "kitchen-light"
-
-
-def test_undefined_reference_stays_literal() -> None:
-    parsed: dict[str, Any] = {
-        "substitutions": {"defined": "yes"},
-        "sensor": [{"platform": "uptime", "name": "${not_defined} Uptime"}],
-    }
-    resolved = _resolve_page_substitutions(parsed, "board")
-    assert resolved["sensor"][0]["name"] == "${not_defined} Uptime"
+    assert resolved["sensor"][0]["update_interval"] == expected
 
 
 def test_substitutions_key_absent_from_result() -> None:

--- a/tests/test_sync_esphome_devices_substitutions.py
+++ b/tests/test_sync_esphome_devices_substitutions.py
@@ -109,10 +109,11 @@ def test_placeholder_substitution_value_is_dropped_from_names() -> None:
     [
         pytest.param("Спот", "Спот", id="unicode_kept"),
         pytest.param("gosund_sp111 - Status", "gosund_sp111 - Status", id="interior_dash_kept"),
-        pytest.param("Energy Meter kWh +", "Energy Meter kWh", id="trailing_symbol_stripped"),
+        pytest.param("Energy Meter kWh +", "Energy Meter kWh +", id="trailing_symbol_kept"),
+        pytest.param("- - *** Button", "Button", id="leading_run_stripped"),
     ],
 )
-def test_edge_symbol_tokens_only_are_stripped(upstream: str, expected: str) -> None:
+def test_leading_symbol_tokens_only_are_stripped(upstream: str, expected: str) -> None:
     parsed: dict[str, Any] = {
         "substitutions": {"x": "y"},
         "binary_sensor": [{"platform": "gpio", "name": upstream, "pin": 5}],

--- a/tests/test_sync_esphome_devices_substitutions.py
+++ b/tests/test_sync_esphome_devices_substitutions.py
@@ -1,0 +1,142 @@
+"""Page ``substitutions:`` blocks resolve over the config tree before extraction."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from script.sync_esphome_devices import (  # type: ignore[import-not-found]
+    _extract_featured_components,
+    _resolve_page_substitutions,
+)
+
+pytest.importorskip("esphome")
+
+
+def test_whole_scalar_substitution_preserves_type() -> None:
+    parsed: dict[str, Any] = {
+        "substitutions": {"baud": 9600},
+        "uart": {"baud_rate": "${baud}"},
+    }
+    resolved = _resolve_page_substitutions(parsed, "board")
+    assert resolved["uart"]["baud_rate"] == 9600
+
+
+def test_interpolation_and_bare_var_forms() -> None:
+    parsed: dict[str, Any] = {
+        "substitutions": {"friendly_name": "Blind Switch", "open_switch": "P23"},
+        "binary_sensor": [
+            {
+                "platform": "gpio",
+                "name": "${friendly_name} S1 switch input",
+                "pin": "$open_switch",
+            }
+        ],
+    }
+    resolved = _resolve_page_substitutions(parsed, "board")
+    item = resolved["binary_sensor"][0]
+    assert item["name"] == "Blind Switch S1 switch input"
+    assert item["pin"] == "P23"
+
+
+def test_substitution_referencing_another_substitution() -> None:
+    parsed: dict[str, Any] = {
+        "substitutions": {"base": "kitchen", "device_name": "${base}-light"},
+        "esphome": {"name": "${device_name}"},
+    }
+    resolved = _resolve_page_substitutions(parsed, "board")
+    assert resolved["esphome"]["name"] == "kitchen-light"
+
+
+def test_undefined_reference_stays_literal() -> None:
+    parsed: dict[str, Any] = {
+        "substitutions": {"defined": "yes"},
+        "sensor": [{"platform": "uptime", "name": "${not_defined} Uptime"}],
+    }
+    resolved = _resolve_page_substitutions(parsed, "board")
+    assert resolved["sensor"][0]["name"] == "${not_defined} Uptime"
+
+
+def test_substitutions_key_absent_from_result() -> None:
+    parsed: dict[str, Any] = {
+        "substitutions": {"pin": "GPIO4"},
+        "switch": [{"platform": "gpio", "pin": "${pin}"}],
+    }
+    assert "substitutions" not in _resolve_page_substitutions(parsed, "board")
+
+
+@pytest.mark.parametrize(
+    "parsed",
+    [
+        pytest.param({"switch": [{"platform": "gpio", "pin": 4}]}, id="absent"),
+        pytest.param({"substitutions": {}, "switch": []}, id="empty"),
+        pytest.param({"substitutions": ["not", "a", "map"], "switch": []}, id="non_mapping"),
+    ],
+)
+def test_unusable_substitutions_block_is_a_no_op(parsed: dict[str, Any]) -> None:
+    assert _resolve_page_substitutions(parsed, "board") is parsed
+
+
+def test_pass_failure_returns_parsed_unchanged(caplog: pytest.LogCaptureFixture) -> None:
+    """An invalid substitution key aborts the pass; the board imports as before."""
+    parsed: dict[str, Any] = {
+        "substitutions": {"bad key!": "x"},
+        "switch": [{"platform": "gpio", "pin": "${bad key!}"}],
+    }
+    with caplog.at_level(logging.WARNING):
+        assert _resolve_page_substitutions(parsed, "board") is parsed
+    assert "substitution pass failed for board" in caplog.text
+
+
+_INDEX: dict[str, dict[str, Any]] = {
+    "binary_sensor.gpio": {
+        "config_entries": [{"key": "pin", "type": "pin"}, {"key": "name", "type": "string"}]
+    },
+    "switch.gpio": {
+        "config_entries": [
+            {"key": "pin", "type": "pin"},
+            {"key": "interlock_wait_time", "type": "string"},
+            {"key": "name", "type": "string"},
+        ]
+    },
+}
+
+
+def test_loratap_shaped_page_extracts_after_resolution() -> None:
+    """The #1988 shape: substitution-valued pins and durations extract like literals."""
+    parsed: dict[str, Any] = {
+        "substitutions": {
+            "device_friendly_name": "Blind Switch",
+            "open_switch": "P23",
+            "open_relay": "P26",
+            "interlock_time": "200ms",
+        },
+        "binary_sensor": [
+            {
+                "platform": "gpio",
+                "name": "${device_friendly_name} S1 switch input",
+                "pin": "${open_switch}",
+                "id": "open_cover_switch",
+            }
+        ],
+        "switch": [
+            {
+                "platform": "gpio",
+                "pin": "${open_relay}",
+                "name": "Relay #1",
+                "id": "relay1",
+                "interlock_wait_time": "${interlock_time}",
+            }
+        ],
+    }
+    resolved = _resolve_page_substitutions(parsed, "loratap_sc411wsc")
+    featured, _, _ = _extract_featured_components(resolved, _INDEX)
+    by_cid = {entry["component_id"]: entry for entry in featured}
+    sensor = by_cid["binary_sensor.gpio"]
+    assert sensor["fields"]["pin"] == {"value": 23, "locked": True}
+    assert sensor["fields"]["name"] == "Blind Switch S1 switch input"
+    switch = by_cid["switch.gpio"]
+    assert switch["fields"]["pin"] == {"value": 26, "locked": True}
+    assert switch["fields"]["interlock_wait_time"] == "200ms"


### PR DESCRIPTION
# What does this implement/fix?

Fixes #1988 and #1984. The LoraTap SC411WSC page defines every featured candidate's pin as a `${open_switch}`-style reference to its own `substitutions:` block, so the required-field guard correctly refused each half-import and the board vanished with `no extractable featured components`. The Genvex page is the same theme with substitution-valued ids (`id: ${modbus_ctrl_id}`).

The importer now runs ESPHome's real substitution pass (`esphome.components.substitutions.do_substitution_pass`) over the parsed config fence before extraction, at the tail of `_first_config_yaml` so every consumer of the tree sees resolved values. Whole-scalar references keep their type, `$var` and `${var}` forms both resolve, inter-variable references chain, and jinja expressions like `${1/86400}` evaluate. The pass is non-strict: an undefined reference stays literal and the existing `$` rejection in `_is_simple_scalar` / `_TEMPLATE_VAR_RE` stripping remain the safety net for it, as they do when the pass fails or esphome is unavailable (the board then imports exactly as before). The resolved tree is rebuilt as plain builtins since `substitute()` emits OrderedDicts that neither the manifest SafeDumper nor the gate's `generate_device_yaml` path can represent.

355 of 772 upstream pages define a substitutions block, so the catalog regeneration (140 changed manifests plus the two returning boards, both passing the validation gate with all their featured entries) ships in a stacked follow-up PR. No new gate refusals; the three remaining refused boards (govee_h6086, iot_devices_ggreg20_v3, martin_jerry_rp_fc01) are the genuinely broken pages already tracked in their own issues.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1988
- fixes https://github.com/esphome/device-builder/issues/1984

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
