### PR TITLE
Resolve mDNS first before pinging or flipping a device offline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,6 +548,24 @@ against legacy behaviour before assuming the simpler version suffices.
     skipped (a device broadcasting the API gets its identity from the
     esphomelib path). The level-triggered repair (`reconcile_from_cache`)
     reads both services' cached TXT.
+  - **Resolve-first sweep step** (`resolve_api_mdns_targets`, for ONLINE
+    API devices the ping sweep is about to ICMP). A targeted
+    `AsyncServiceInfo` resolve (cache first, wire fallback) is cheaper
+    than the ICMP it replaces; on success `_apply_service_info` claims
+    mdns and the device leaves the ping rotation — this repairs a ledger
+    stuck on `ping` after a missed browser resolve (#1993). Claims here
+    are **ownership repair, not liveness**: candidates must already be
+    ONLINE (never revive off the cache, #1776) and must have some cached
+    mDNS trace (an mDNS-dark deployment gains no multicast traffic). A
+    miss claims nothing; ICMP decides, same as the active-resolve path.
+    The browser `Removed` branch runs the same verify-resolve before
+    honouring the expiry, so a lossy-multicast PTR drop doesn't demote a
+    device that still answers. Latch guard: an mdns claim on an API
+    device **without a live PTR** (sweep / removed-verify resolves fetch
+    SRV/TXT/A, not PTR) has no `Removed` counterpart, so `should_ping`
+    keeps it sweep-eligible — the sweep is its offline-detection
+    substitute until the PTR returns and normal browser ownership
+    resumes.
 
   Don't add an OFFLINE branch to the active-resolve path without
   re-reading this. The asymmetry is the only way to get aggressive ONLINE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,23 +549,31 @@ against legacy behaviour before assuming the simpler version suffices.
     esphomelib path). The level-triggered repair (`reconcile_from_cache`)
     reads both services' cached TXT.
   - **Resolve-first sweep step** (`resolve_api_mdns_targets`, for ONLINE
-    API devices the ping sweep is about to ICMP). A targeted
-    `AsyncServiceInfo` resolve (cache first, wire fallback) is cheaper
-    than the ICMP it replaces; on success `_apply_service_info` claims
-    mdns and the device leaves the ping rotation — this repairs a ledger
-    stuck on `ping` after a missed browser resolve (#1993). Claims here
+    API devices the ping sweep is about to ICMP). Exists because the
+    zeroconf browser never re-asks: after its startup queries it only
+    refreshes PTRs it already holds (rescue window at 75–100% of the
+    TTL), and a `Removed` cancels that schedule — from then on
+    re-discovery rides solely on the device's few boot-time announces.
+    The ways in (dashboard host suspended past the rescue window so the
+    wake expires every PTR at once; an OTA / crash goodbye; an expiry
+    whose reconnect announces were lost) all end the same: the ledger
+    sticks on `ping` while the device answers every direct query
+    (#1993). The sweep is the solicited re-ask the browser doesn't do:
+    a targeted `AsyncServiceInfo` resolve (cache first, wire fallback),
+    cheaper than the ICMP it replaces; on success `_apply_service_info`
+    claims mdns and the device leaves the ping rotation. Claims here
     are **ownership repair, not liveness**: candidates must already be
     ONLINE (never revive off the cache, #1776) and must have some cached
     mDNS trace (an mDNS-dark deployment gains no multicast traffic). A
     miss claims nothing; ICMP decides, same as the active-resolve path.
     The browser `Removed` branch runs the same verify-resolve before
-    honouring the expiry, so a lossy-multicast PTR drop doesn't demote a
-    device that still answers. Latch guard: an mdns claim on an API
-    device **without a live PTR** (sweep / removed-verify resolves fetch
-    SRV/TXT/A, not PTR) has no `Removed` counterpart, so `should_ping`
-    keeps it sweep-eligible — the sweep is its offline-detection
-    substitute until the PTR returns and normal browser ownership
-    resumes.
+    honouring the event, demoting only on a **confirmed miss** — so a
+    wake-from-suspend `Removed` storm or an OTA reboot doesn't flip
+    live devices OFFLINE. Latch guard: an mdns claim on an API device
+    **without a live PTR** (these resolves fetch SRV/TXT/A, not PTR)
+    has no `Removed` counterpart, so `should_ping` keeps it
+    sweep-eligible — the sweep is its offline-detection substitute
+    until the PTR returns and normal browser ownership resumes.
 
   Don't add an OFFLINE branch to the active-resolve path without
   re-reading this. The asymmetry is the only way to get aggressive ONLINE

--- a/docs/API.md
+++ b/docs/API.md
@@ -143,7 +143,7 @@ Connections that arrive on the trusted ingress site (HA add-on supervisor proxy)
 `Device.has_pending_changes`: `true` = config changed since last compile, `false` = up to date, `null` = never compiled.
 `Device.pending_changes_via_hash`: `true` when `has_pending_changes` came from the mDNS-sourced config-hash compare (vs the local mtime fallback). The frontend gates only this case on a live mDNS, so a local YAML edit still cues "install" when mDNS is dark.
 `Device.update_available`: `true` = device was compiled with a different ESPHome version than the server.
-`Device.runtime_state.active_source`: `ReachabilitySource` — channel currently driving online state (`mdns` > `mqtt` > `ping`); `unknown` until a source claims it (also the transient default after a restart). The frontend gates the mDNS-sourced out-of-sync / update indicators on `active_source == "mdns"`, since `deployed_version` / `deployed_config_hash` come only from the mDNS broadcast.
+`Device.runtime_state.active_source`: `ReachabilitySource` — channel currently driving online state (`mdns` > `mqtt` > `ping`); `unknown` until a source claims it (also the transient default after a restart). The frontend gates the mDNS-sourced out-of-sync / update indicators on `active_source == "mdns"`, since `deployed_version` / `deployed_config_hash` come only from the mDNS broadcast. Ownership self-repairs: before each ICMP sweep the monitor retries a targeted mDNS resolve for ONLINE API devices ping owns, so a ledger stuck on `ping` while the device still answers mDNS returns to `mdns` within a sweep (~60s).
 
 ### Firmware
 

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -333,6 +333,10 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         """Read the truthful "last heard via mDNS" age + remaining TTL."""
         return self._mdns.get_mdns_cache_info(name)
 
+    def has_live_mdns_ptr(self, name: str) -> bool:
+        """Whether the cache holds an unexpired esphomelib PTR for *name*."""
+        return self._mdns.has_live_ptr(name)
+
     def apply_ip(self, name: str, ip: str) -> bool:
         """
         Record a single-IP observation. Empty string clears stored IPs.

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -333,10 +333,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         """Read the truthful "last heard via mDNS" age + remaining TTL."""
         return self._mdns.get_mdns_cache_info(name)
 
-    def has_live_mdns_ptr(self, name: str) -> bool:
-        """Whether the cache holds an unexpired esphomelib PTR for *name*."""
-        return self._mdns.has_live_ptr(name)
-
     def apply_ip(self, name: str, ip: str) -> bool:
         """
         Record a single-IP observation. Empty string clears stored IPs.

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from esphome.zeroconf import AsyncEsphomeZeroconf
 from zeroconf import (
     AddressResolver,
+    DNSRecord,
     IPVersion,
     ServiceStateChange,
     current_time_millis,
@@ -229,7 +230,7 @@ class MdnsSource:
         cache = self._zeroconf.zeroconf.cache
         service_name = f"{name}.{_ESPHOME_SERVICE_TYPE}"
         txt_dns_records = list(cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN))
-        records: list[Any] = [
+        records: list[DNSRecord] = [
             *self._get_address_records(name),
             *cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN),
             *txt_dns_records,
@@ -367,10 +368,14 @@ class MdnsSource:
         monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name))
 
     async def _resolve_and_apply(
-        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
+        self,
+        zeroconf: Any,
+        info: AsyncServiceInfo,
+        device_name: str,
+        apply: Callable[[str, AsyncServiceInfo], None] | None = None,
     ) -> None:
-        """Resolve a cache-miss esphomelib mDNS service and propagate its details."""
-        await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
+        """Resolve a cache-miss mDNS service and propagate its details (fire-and-forget shape)."""
+        await self._resolve_then(zeroconf, info, device_name, apply or self._apply_service_info)
 
     async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
         """Resolve before honouring a ``Removed``; only a failed resolve applies OFFLINE."""
@@ -509,7 +514,9 @@ class MdnsSource:
         if info.load_from_cache(zeroconf):
             self._apply_http_txt(device_name, info)
             return
-        monitor._track_task(self._resolve_then(zeroconf, info, device_name, self._apply_http_txt))
+        monitor._track_task(
+            self._resolve_and_apply(zeroconf, info, device_name, self._apply_http_txt)
+        )
 
     def _apply_http_txt(self, device_name: str, info: AsyncServiceInfo) -> None:
         """
@@ -521,7 +528,7 @@ class MdnsSource:
         """
         self._apply_identity_txt(device_name, info.decoded_properties)
 
-    def _cached_ptr(self, service_name: str) -> Any | None:
+    def _cached_ptr(self, service_name: str) -> DNSRecord | None:
         """
         Look up the cached esphomelib PTR for *service_name*, expired or not.
 
@@ -532,9 +539,10 @@ class MdnsSource:
         """
         if self._zeroconf is None:
             return None
-        return self._zeroconf.zeroconf.cache.current_entry_with_name_and_alias(
+        ptr: DNSRecord | None = self._zeroconf.zeroconf.cache.current_entry_with_name_and_alias(
             _ESPHOME_SERVICE_TYPE, service_name
         )
+        return ptr
 
     def _cached_txt_properties(self, zc: Any, service_name: str) -> dict[str, str]:
         """Decode the unexpired cached TXT records for *service_name*."""
@@ -546,7 +554,7 @@ class MdnsSource:
         ]
         return _decode_mdns_txt_records(records)
 
-    def _get_address_records(self, name: str) -> list[Any]:
+    def _get_address_records(self, name: str) -> list[DNSRecord]:
         """Return cached A and AAAA records for *name*, or ``[]``."""
         if self._zeroconf is None:
             return []

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -379,12 +379,19 @@ class MdnsSource:
 
     async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
         """Resolve before honouring a ``Removed``; only a confirmed miss applies OFFLINE."""
+        if name in self._inflight_resolves:
+            # A concurrent resolve decides; the sweep re-checks either way.
+            return
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, name)
         verdict = await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
-        if verdict is not False:
-            # Resolved (stays ONLINE) or no verdict (swallowed error, or a
-            # concurrent resolve owns the flight) — never demote on
-            # uncertainty; the sweep re-checks either way.
+        if verdict is None:
+            # Errored, not missed — never demote on uncertainty, and say
+            # so above DEBUG since this gates the browser's OFFLINE path.
+            _LOGGER.warning(
+                "Removed-verify resolve for %s errored; leaving state to the sweep", device_name
+            )
+            return
+        if verdict:
             return
         monitor = self._monitor
         monitor.apply(device_name, DeviceState.OFFLINE, "mdns")

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -49,6 +49,11 @@ _LOGGER = logging.getLogger(__name__)
 # wire inside the window, so a short one-shot silently drops their announce.
 _MDNS_RESOLVE_TIMEOUT_MS = 10_000
 
+# The ping sweep's resolve-first pass runs before the ICMP sweep it feeds, so
+# it gets the same 3s bound as the non-API active resolve — a slow node the
+# window misses is pinged this sweep and re-resolved next.
+_SWEEP_RESOLVE_TIMEOUT_MS = 3_000
+
 # Bound on the zeroconf close. ``async_close`` broadcasts mDNS goodbyes and can
 # hang on a wedged socket; shutdown must not block on it.
 _MDNS_CLOSE_TIMEOUT = 1.0
@@ -229,12 +234,7 @@ class MdnsSource:
             *cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN),
             *txt_dns_records,
         ]
-        # PTR is owned by the type-domain
-        # (``_esphomelib._tcp.local.``) and carries the
-        # service-instance as its ``alias``;
-        # ``current_entry_with_name_and_alias`` is the
-        # zeroconf-API-canonical way to look it up.
-        ptr = cache.current_entry_with_name_and_alias(_ESPHOME_SERVICE_TYPE, service_name)
+        ptr = self._cached_ptr(service_name)
         if ptr is not None:
             records.append(ptr)
         if not records:
@@ -313,28 +313,24 @@ class MdnsSource:
             self._apply_identity_txt(device_name, props)
 
     async def resolve_and_claim(self, device_name: str) -> None:
-        """
-        Resolve the esphomelib service (cache first, wire fallback) and claim mdns.
-
-        The ping sweep's resolve-first step for API devices: an mDNS answer
-        replaces the ICMP probe and repairs a ledger stuck on ``ping`` after
-        a missed browser resolve (#1993). A miss claims nothing — ICMP decides.
-        """
+        """Resolve the esphomelib service (cache first, wire fallback) and claim mdns on a hit."""
         if (zc := self._zeroconf) is None:
             return
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"{device_name}.{_ESPHOME_SERVICE_TYPE}")
         if info.load_from_cache(zc.zeroconf):
             self._apply_service_info(device_name, info)
             return
-        await self._resolve_then(zc.zeroconf, info, device_name, self._apply_service_info)
+        await self._resolve_then(
+            zc.zeroconf,
+            info,
+            device_name,
+            self._apply_service_info,
+            timeout_ms=_SWEEP_RESOLVE_TIMEOUT_MS,
+        )
 
     def has_live_ptr(self, device_name: str) -> bool:
         """Whether the cache holds an unexpired esphomelib PTR for *device_name*."""
-        if self._zeroconf is None:
-            return False
-        ptr = self._zeroconf.zeroconf.cache.current_entry_with_name_and_alias(
-            _ESPHOME_SERVICE_TYPE, f"{device_name}.{_ESPHOME_SERVICE_TYPE}"
-        )
+        ptr = self._cached_ptr(f"{device_name}.{_ESPHOME_SERVICE_TYPE}")
         return ptr is not None and not ptr.is_expired(current_time_millis())
 
     def _on_esphomelib_service_state_change(
@@ -377,25 +373,14 @@ class MdnsSource:
         await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
 
     async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
-        """
-        Resolve before honouring a ``Removed`` — an answering device stays ONLINE.
-
-        A lossy-multicast PTR expiry must not demote a reachable device
-        (the #1993 ping-takeover trigger); only a failed resolve applies
-        the OFFLINE and its cleanup. Also bridges the goodbye + reboot
-        gap of an OTA flash.
-        """
-        if name not in self._inflight_resolves:
-            self._inflight_resolves.add(name)
-            info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, name)
-            try:
-                if await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
-                    self._apply_service_info(device_name, info)
-                    return
-            except Exception:
-                _LOGGER.debug("mDNS removed-verify failed for %s", device_name, exc_info=True)
-            finally:
-                self._inflight_resolves.discard(name)
+        """Resolve before honouring a ``Removed``; only a failed resolve applies OFFLINE."""
+        if name in self._inflight_resolves:
+            # A concurrent resolve decides; a dead device demotes via the
+            # sweep (no live PTR keeps it sweep-eligible).
+            return
+        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, name)
+        if await self._resolve_then(zeroconf, info, device_name, self._apply_service_info):
+            return
         monitor = self._monitor
         monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
         monitor.apply_ip(device_name, "")
@@ -409,7 +394,9 @@ class MdnsSource:
         info: AsyncServiceInfo,
         device_name: str,
         apply: Callable[[str, AsyncServiceInfo], None],
-    ) -> None:
+        *,
+        timeout_ms: float = _MDNS_RESOLVE_TIMEOUT_MS,
+    ) -> bool:
         """
         Resolve a cache-miss service and hand the result to *apply*.
 
@@ -417,20 +404,22 @@ class MdnsSource:
         HTTP browser paths: spawn a task on cache miss,
         ``async_request`` the record, swallow exceptions to a
         debug log, dispatch to the per-type applier on success.
-        At most one resolve per service name is in flight.
+        At most one resolve per service name is in flight. Returns
+        True iff the service resolved and *apply* ran.
         """
         if info.name in self._inflight_resolves:
-            return
+            return False
         self._inflight_resolves.add(info.name)
         try:
-            if not await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
-                return
+            if not await info.async_request(zeroconf, timeout=timeout_ms):
+                return False
         except Exception:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
-            return
+            return False
         finally:
             self._inflight_resolves.discard(info.name)
         apply(device_name, info)
+        return True
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """
@@ -531,6 +520,21 @@ class MdnsSource:
         rule from the esphomelib path would stamp a false confirmation.
         """
         self._apply_identity_txt(device_name, info.decoded_properties)
+
+    def _cached_ptr(self, service_name: str) -> Any | None:
+        """
+        Look up the cached esphomelib PTR for *service_name*, expired or not.
+
+        PTR is owned by the type-domain (``_esphomelib._tcp.local.``) and
+        carries the service-instance as its ``alias``;
+        ``current_entry_with_name_and_alias`` is the zeroconf-API-canonical
+        way to look it up.
+        """
+        if self._zeroconf is None:
+            return None
+        return self._zeroconf.zeroconf.cache.current_entry_with_name_and_alias(
+            _ESPHOME_SERVICE_TYPE, service_name
+        )
 
     def _cached_txt_properties(self, zc: Any, service_name: str) -> dict[str, str]:
         """Decode the unexpired cached TXT records for *service_name*."""

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -378,13 +378,13 @@ class MdnsSource:
         await self._resolve_then(zeroconf, info, device_name, apply or self._apply_service_info)
 
     async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
-        """Resolve before honouring a ``Removed``; only a failed resolve applies OFFLINE."""
-        if name in self._inflight_resolves:
-            # A concurrent resolve decides; a dead device demotes via the
-            # sweep (no live PTR keeps it sweep-eligible).
-            return
+        """Resolve before honouring a ``Removed``; only a confirmed miss applies OFFLINE."""
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, name)
-        if await self._resolve_then(zeroconf, info, device_name, self._apply_service_info):
+        verdict = await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
+        if verdict is not False:
+            # Resolved (stays ONLINE) or no verdict (swallowed error, or a
+            # concurrent resolve owns the flight) — never demote on
+            # uncertainty; the sweep re-checks either way.
             return
         monitor = self._monitor
         monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
@@ -401,7 +401,7 @@ class MdnsSource:
         apply: Callable[[str, AsyncServiceInfo], None],
         *,
         timeout_ms: float = _MDNS_RESOLVE_TIMEOUT_MS,
-    ) -> bool:
+    ) -> bool | None:
         """
         Resolve a cache-miss service and hand the result to *apply*.
 
@@ -410,17 +410,19 @@ class MdnsSource:
         ``async_request`` the record, swallow exceptions to a
         debug log, dispatch to the per-type applier on success.
         At most one resolve per service name is in flight. Returns
-        True iff the service resolved and *apply* ran.
+        True when the service resolved and *apply* ran, False on a
+        confirmed miss, None when there is no verdict (a swallowed
+        error, or a resolve already in flight).
         """
         if info.name in self._inflight_resolves:
-            return False
+            return None
         self._inflight_resolves.add(info.name)
         try:
             if not await info.async_request(zeroconf, timeout=timeout_ms):
                 return False
         except Exception:
             _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
-            return False
+            return None
         finally:
             self._inflight_resolves.discard(info.name)
         apply(device_name, info)

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -312,6 +312,31 @@ class MdnsSource:
         if props := self._cached_txt_properties(zc, f"{device_name}.{_HTTP_SERVICE_TYPE}"):
             self._apply_identity_txt(device_name, props)
 
+    async def resolve_and_claim(self, device_name: str) -> None:
+        """
+        Resolve the esphomelib service (cache first, wire fallback) and claim mdns.
+
+        The ping sweep's resolve-first step for API devices: an mDNS answer
+        replaces the ICMP probe and repairs a ledger stuck on ``ping`` after
+        a missed browser resolve (#1993). A miss claims nothing — ICMP decides.
+        """
+        if (zc := self._zeroconf) is None:
+            return
+        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"{device_name}.{_ESPHOME_SERVICE_TYPE}")
+        if info.load_from_cache(zc.zeroconf):
+            self._apply_service_info(device_name, info)
+            return
+        await self._resolve_then(zc.zeroconf, info, device_name, self._apply_service_info)
+
+    def has_live_ptr(self, device_name: str) -> bool:
+        """Whether the cache holds an unexpired esphomelib PTR for *device_name*."""
+        if self._zeroconf is None:
+            return False
+        ptr = self._zeroconf.zeroconf.cache.current_entry_with_name_and_alias(
+            _ESPHOME_SERVICE_TYPE, f"{device_name}.{_ESPHOME_SERVICE_TYPE}"
+        )
+        return ptr is not None and not ptr.is_expired(current_time_millis())
+
     def _on_esphomelib_service_state_change(
         self, zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
     ) -> None:
@@ -329,11 +354,7 @@ class MdnsSource:
             return
 
         if state_change == ServiceStateChange.Removed:
-            monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
-            monitor.apply_ip(device_name, "")
-            monitor.forget(device_name)
-            if monitor.state.reachability is not None:
-                monitor.state.reachability.clear(device_name)
+            monitor._track_task(self._verify_removed(zeroconf, name, device_name))
             return
 
         # Don't claim ONLINE off a bare PTR — only once the service
@@ -354,6 +375,33 @@ class MdnsSource:
     ) -> None:
         """Resolve a cache-miss esphomelib mDNS service and propagate its details."""
         await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
+
+    async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
+        """
+        Resolve before honouring a ``Removed`` — an answering device stays ONLINE.
+
+        A lossy-multicast PTR expiry must not demote a reachable device
+        (the #1993 ping-takeover trigger); only a failed resolve applies
+        the OFFLINE and its cleanup. Also bridges the goodbye + reboot
+        gap of an OTA flash.
+        """
+        if name not in self._inflight_resolves:
+            self._inflight_resolves.add(name)
+            info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, name)
+            try:
+                if await info.async_request(zeroconf, timeout=_MDNS_RESOLVE_TIMEOUT_MS):
+                    self._apply_service_info(device_name, info)
+                    return
+            except Exception:
+                _LOGGER.debug("mDNS removed-verify failed for %s", device_name, exc_info=True)
+            finally:
+                self._inflight_resolves.discard(name)
+        monitor = self._monitor
+        monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
+        monitor.apply_ip(device_name, "")
+        monitor.forget(device_name)
+        if monitor.state.reachability is not None:
+            monitor.state.reachability.clear(device_name)
 
     async def _resolve_then(
         self,

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -108,10 +108,16 @@ class PingSource:
             self._wake.clear()
             # Disjoint candidate sets — resolve both concurrently so a
             # wire-miss in one doesn't delay the sweep behind the other.
-            await asyncio.gather(
+            # An unguarded raise here must not kill the loop for the
+            # process lifetime; log it and keep sweeping.
+            results = await asyncio.gather(
                 shared.resolve_non_api_mdns_targets(monitor),
                 shared.resolve_api_mdns_targets(monitor),
+                return_exceptions=True,
             )
+            for result in results:
+                if isinstance(result, BaseException):
+                    _LOGGER.warning("mDNS resolve step failed; continuing", exc_info=result)
             await self._ping_sweep()
             await self._idle()
 

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -107,6 +107,7 @@ class PingSource:
                 await monitor._presence.wait_for_subscriber()
             self._wake.clear()
             await shared.resolve_non_api_mdns_targets(monitor)
+            await shared.resolve_api_mdns_targets(monitor)
             await self._ping_sweep()
             await self._idle()
 

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -116,7 +116,10 @@ class PingSource:
                 return_exceptions=True,
             )
             for result in results:
-                if isinstance(result, BaseException):
+                if isinstance(result, BaseException) and not isinstance(result, Exception):
+                    # Never mask a cancellation as a benign step failure.
+                    raise result
+                if isinstance(result, Exception):
                     _LOGGER.warning("mDNS resolve step failed; continuing", exc_info=result)
             await self._ping_sweep()
             await self._idle()

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -106,8 +106,12 @@ class PingSource:
             if monitor._presence is not None:
                 await monitor._presence.wait_for_subscriber()
             self._wake.clear()
-            await shared.resolve_non_api_mdns_targets(monitor)
-            await shared.resolve_api_mdns_targets(monitor)
+            # Disjoint candidate sets — resolve both concurrently so a
+            # wire-miss in one doesn't delay the sweep behind the other.
+            await asyncio.gather(
+                shared.resolve_non_api_mdns_targets(monitor),
+                shared.resolve_api_mdns_targets(monitor),
+            )
             await self._ping_sweep()
             await self._idle()
 

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -8,6 +8,7 @@ monitor reaches sibling sources through ``state`` and through
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from ...helpers.hostname import is_local_hostname
@@ -15,6 +16,8 @@ from ...models import Device, DeviceState, ReachabilitySource
 
 if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # Source-precedence ledger. An observation can only override the
@@ -94,10 +97,20 @@ async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     ]
     if not candidates:
         return
-    await asyncio.gather(
+    results = await asyncio.gather(
         *(monitor._mdns.resolve_and_claim(d.name) for d in candidates),
         return_exceptions=True,
     )
+    for device, result in zip(candidates, results, strict=True):
+        if isinstance(result, BaseException):
+            # ``resolve_and_claim`` swallows resolve misses itself, so
+            # anything surfacing here is a real bug — don't mask it as
+            # a benign miss.
+            _LOGGER.warning(
+                "Resolve-first mDNS claim for %s raised unexpectedly",
+                device.name,
+                exc_info=result,
+            )
 
 
 async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -40,12 +40,21 @@ def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
     Skip the device only when it's already ONLINE *and* a
     higher-priority source (mDNS / MQTT) owns it. OFFLINE / UNKNOWN
     devices always get pinged so off-network hosts mDNS can't reach
-    have a path to come online via DNS + ping.
+    have a path to come online via DNS + ping. An mdns claim on an
+    API device without a live PTR (sweep / removed-verify resolve)
+    has no browser ``Removed`` counterpart, so it keeps sweep
+    eligibility — the sweep is its offline-detection substitute.
     """
     if device.runtime_state.state != DeviceState.ONLINE:
         return True
     source = monitor.state.state_source.get(device.name, ReachabilitySource.UNKNOWN)
-    return _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY[ReachabilitySource.PING]
+    if _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY[ReachabilitySource.PING]:
+        return True
+    return (
+        source == ReachabilitySource.MDNS
+        and device.api_enabled
+        and not monitor.has_live_mdns_ptr(device.name)
+    )
 
 
 def apply_resolved_addresses(
@@ -64,6 +73,34 @@ def apply_resolved_addresses(
     if isinstance(addresses, list) and addresses:
         monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
         monitor.apply_ip_addresses(name, addresses)
+
+
+async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
+    """
+    Resolve the esphomelib service for ONLINE API devices the sweep would ping.
+
+    An mDNS answer is cheaper than an ICMP probe and repairs a ledger
+    stuck on ``ping`` after a missed browser resolve (#1993); a miss
+    claims nothing and the ICMP sweep decides. Devices with no mDNS
+    trace in the cache are skipped so an mDNS-dark deployment
+    (Docker bridge) gains no multicast traffic.
+    """
+    if monitor._mdns.zeroconf is None:
+        return
+    candidates = [
+        d
+        for d in monitor._get_devices()
+        if d.api_enabled
+        and d.runtime_state.state is DeviceState.ONLINE
+        and should_ping(monitor, d)
+        and monitor.get_mdns_cache_info(d.name) is not None
+    ]
+    if not candidates:
+        return
+    await asyncio.gather(
+        *(monitor._mdns.resolve_and_claim(d.name) for d in candidates),
+        return_exceptions=True,
+    )
 
 
 async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -38,12 +38,11 @@ def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
     Decide whether *device* needs an ICMP probe this sweep.
 
     Skip the device only when it's already ONLINE *and* a
-    higher-priority source (mDNS / MQTT) owns it. OFFLINE / UNKNOWN
+    higher-priority source (mDNS / MQTT) owns it — except an
+    mdns-owned API device with no live PTR (no ``Removed`` will
+    fire for it), which stays sweep-eligible. OFFLINE / UNKNOWN
     devices always get pinged so off-network hosts mDNS can't reach
-    have a path to come online via DNS + ping. An mdns claim on an
-    API device without a live PTR (sweep / removed-verify resolve)
-    has no browser ``Removed`` counterpart, so it keeps sweep
-    eligibility — the sweep is its offline-detection substitute.
+    have a path to come online via DNS + ping.
     """
     if device.runtime_state.state != DeviceState.ONLINE:
         return True
@@ -53,7 +52,7 @@ def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
     return (
         source == ReachabilitySource.MDNS
         and device.api_enabled
-        and not monitor.has_live_mdns_ptr(device.name)
+        and not monitor._mdns.has_live_ptr(device.name)
     )
 
 
@@ -79,11 +78,9 @@ async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     """
     Resolve the esphomelib service for ONLINE API devices the sweep would ping.
 
-    An mDNS answer is cheaper than an ICMP probe and repairs a ledger
-    stuck on ``ping`` after a missed browser resolve (#1993); a miss
-    claims nothing and the ICMP sweep decides. Devices with no mDNS
-    trace in the cache are skipped so an mDNS-dark deployment
-    (Docker bridge) gains no multicast traffic.
+    A hit claims mdns and ends their ICMP eligibility; a miss claims
+    nothing and the ICMP sweep decides. Devices with no cached mDNS
+    trace at all are skipped.
     """
     if monitor._mdns.zeroconf is None:
         return

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -87,30 +87,19 @@ async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     """
     if monitor._mdns.zeroconf is None:
         return
-    candidates = [
-        d
+    claims = [
+        _resolve_and_claim_logged(monitor, d)
         for d in monitor._get_devices()
         if d.api_enabled
         and d.runtime_state.state is DeviceState.ONLINE
         and should_ping(monitor, d)
         and monitor.get_mdns_cache_info(d.name) is not None
     ]
-    if not candidates:
-        return
-    results = await asyncio.gather(
-        *(monitor._mdns.resolve_and_claim(d.name) for d in candidates),
-        return_exceptions=True,
-    )
-    for device, result in zip(candidates, results, strict=True):
-        if isinstance(result, BaseException):
-            # ``resolve_and_claim`` swallows resolve misses itself, so
-            # anything surfacing here is a real bug — don't mask it as
-            # a benign miss.
-            _LOGGER.warning(
-                "Resolve-first mDNS claim for %s raised unexpectedly",
-                device.name,
-                exc_info=result,
-            )
+    # The common case is a single stuck device — don't pay for a gather.
+    if len(claims) == 1:
+        await claims[0]
+    elif claims:
+        await asyncio.gather(*claims)
 
 
 async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
@@ -158,3 +147,16 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
         # subscription, so a miss conflates "device gone", "device
         # slow", and "transient packet loss"; let ICMP decide
         # instead.
+
+
+async def _resolve_and_claim_logged(monitor: DeviceStateMonitor, device: Device) -> None:
+    """Run one resolve-and-claim, surfacing unexpected errors."""
+    try:
+        await monitor._mdns.resolve_and_claim(device.name)
+    except Exception:
+        # ``resolve_and_claim`` swallows resolve misses itself, so
+        # anything surfacing here is a real bug — don't mask it as a
+        # benign miss.
+        _LOGGER.warning(
+            "Resolve-first mDNS claim for %s raised unexpectedly", device.name, exc_info=True
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ from esphome_device_builder.controllers._device_mqtt_coordinator import (
     DeviceMqttCoordinator,
 )
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers._device_state_monitor import mdns as _mdns_module
 from esphome_device_builder.controllers._device_state_monitor import ping as _ping_module
 from esphome_device_builder.controllers.boards import BoardCatalog
 from esphome_device_builder.controllers.components import ComponentCatalog
@@ -1003,6 +1004,25 @@ def make_online_api_device(name: str = "kitchen", **overrides: Any) -> Device:
     }
     base.update(overrides)
     return make_device(name, **base)
+
+
+def stub_async_service_info(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cached: bool = False,
+    resolved: bool = False,
+    addresses: tuple[str, ...] = ("192.168.1.50",),
+    properties: dict[str, str] | None = None,
+) -> MagicMock:
+    """Patch ``mdns.AsyncServiceInfo`` with a stub that hits the cache, the wire, or misses."""
+    info = MagicMock()
+    info.name = "kitchen._esphomelib._tcp.local."
+    info.load_from_cache.return_value = cached
+    info.async_request = AsyncMock(return_value=resolved)
+    info.parsed_scoped_addresses.return_value = list(addresses)
+    info.decoded_properties = properties if properties is not None else {"version": "2026.7.0"}
+    monkeypatch.setattr(_mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: info)
+    return info
 
 
 def make_peer_link_session(

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -220,6 +221,102 @@ def test_has_live_ptr_reads_the_browser_cache() -> None:
 
     monitor._mdns._zeroconf = None
     assert monitor._mdns.has_live_ptr("kitchen") is False
+
+
+def _gated_wire(info: MagicMock, *, result: bool) -> tuple[asyncio.Event, list[int]]:
+    """Hold the stub's wire resolve open until the returned event is set."""
+    gate = asyncio.Event()
+    calls: list[int] = []
+
+    async def _wire(*_args: Any, **_kwargs: Any) -> bool:
+        calls.append(1)
+        await gate.wait()
+        return result
+
+    info.async_request = _wire
+    return gate, calls
+
+
+async def test_added_during_removed_verify_keeps_device_online(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A device returning mid-verify (cache-hit ``Added``) stays ONLINE through both paths."""
+    device = make_online_api_device()
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    info = stub_async_service_info(monkeypatch, cached=True)
+    gate, _calls = _gated_wire(info, result=True)
+
+    verify = asyncio.create_task(
+        monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+    )
+    await asyncio.sleep(0)
+    assert _SERVICE_NAME in monitor._mdns._inflight_resolves
+
+    monitor._mdns._on_esphomelib_service_state_change(
+        MagicMock(), "_esphomelib._tcp.local.", _SERVICE_NAME, mdns_module.ServiceStateChange.Added
+    )
+    assert device.runtime_state.state == DeviceState.ONLINE
+
+    gate.set()
+    await verify
+    assert device.runtime_state.state == DeviceState.ONLINE
+    assert monitor.state.state_source["kitchen"] == ReachabilitySource.MDNS
+    assert callbacks.calls_for("on_state_change") == []
+
+
+async def test_added_resolve_during_verify_defers_to_the_inflight_verify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache-miss ``Added`` mid-verify spawns no second wire resolve; the verify decides."""
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    info = stub_async_service_info(monkeypatch)
+    gate, calls = _gated_wire(info, result=True)
+
+    verify = asyncio.create_task(
+        monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+    )
+    await asyncio.sleep(0)
+
+    monitor._mdns._on_esphomelib_service_state_change(
+        MagicMock(), "_esphomelib._tcp.local.", _SERVICE_NAME, mdns_module.ServiceStateChange.Added
+    )
+    gate.set()
+    await verify
+    while monitor._tasks:
+        await asyncio.gather(*list(monitor._tasks), return_exceptions=True)
+
+    assert len(calls) == 1
+    assert device.runtime_state.state == DeviceState.ONLINE
+    assert monitor.state.state_source["kitchen"] == ReachabilitySource.MDNS
+
+
+async def test_confirmed_wire_miss_outranks_a_stale_cache_added_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache-hit ``Added`` mid-verify can't save a device the wire says is gone."""
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    info = stub_async_service_info(monkeypatch, cached=True)
+    gate, _calls = _gated_wire(info, result=False)
+
+    verify = asyncio.create_task(
+        monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+    )
+    await asyncio.sleep(0)
+
+    monitor._mdns._on_esphomelib_service_state_change(
+        MagicMock(), "_esphomelib._tcp.local.", _SERVICE_NAME, mdns_module.ServiceStateChange.Added
+    )
+    assert device.runtime_state.state == DeviceState.ONLINE
+
+    gate.set()
+    await verify
+    assert device.runtime_state.state == DeviceState.OFFLINE
+    assert "kitchen" not in monitor.state.state_source
 
 
 async def test_verify_removed_keeps_online_on_a_swallowed_resolve_error(

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -1,0 +1,217 @@
+"""Tests for the ping sweep's resolve-first mDNS step (issue #1993)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor import mdns as mdns_module
+from esphome_device_builder.controllers._device_state_monitor import shared
+from esphome_device_builder.models import DeviceState, ReachabilitySource
+
+from .conftest import make_online_api_device, make_state_monitor_with_callbacks
+
+_SERVICE_NAME = "kitchen._esphomelib._tcp.local."
+
+
+def _stub_service_info(
+    monkeypatch: pytest.MonkeyPatch, *, cached: bool, resolved: bool = False
+) -> MagicMock:
+    """Stub ``AsyncServiceInfo`` so the resolve hits the cache, the wire, or misses."""
+    info = MagicMock()
+    info.name = _SERVICE_NAME
+    info.load_from_cache.return_value = cached
+    info.async_request = AsyncMock(return_value=resolved)
+    info.parsed_scoped_addresses.return_value = ["192.168.1.50"]
+    info.decoded_properties = {"version": "2026.7.0", "config_hash": "abcd1234"}
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: info)
+    return info
+
+
+def _prime_sweep(monitor: Any, *, cache_trace: bool = True, live_ptr: bool = False) -> None:
+    """Wire the fake zeroconf plus the two cache reads the sweep filter makes."""
+    monitor._mdns._zeroconf = MagicMock()
+    monitor.get_mdns_cache_info = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock() if cache_trace else None
+    )
+    monitor.has_live_mdns_ptr = MagicMock(return_value=live_ptr)  # type: ignore[method-assign]
+
+
+async def test_sweep_claims_mdns_for_ping_owned_online_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The #1993 repro: ping owns the ledger, the cache resolves → mdns reclaims, no wire."""
+    device = make_online_api_device()
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    _prime_sweep(monitor)
+    info = _stub_service_info(monkeypatch, cached=True)
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    assert monitor.state.state_source["kitchen"] == ReachabilitySource.MDNS
+    assert ("on_source_change", "kitchen", ReachabilitySource.MDNS) in callbacks.calls
+    assert device.runtime_state.deployed_version == "2026.7.0"
+    assert device.runtime_state.deployed_config_hash == "abcd1234"
+    assert device.runtime_state.state == DeviceState.ONLINE
+    info.async_request.assert_not_called()
+
+
+async def test_sweep_cache_miss_falls_back_to_wire_resolve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    _prime_sweep(monitor)
+    info = _stub_service_info(monkeypatch, cached=False, resolved=True)
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    info.async_request.assert_awaited_once()
+    assert monitor.state.state_source["kitchen"] == ReachabilitySource.MDNS
+
+
+async def test_sweep_resolve_miss_claims_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A miss leaves the ledger and state alone — ICMP decides, never the resolve."""
+    device = make_online_api_device()
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    _prime_sweep(monitor)
+    _stub_service_info(monkeypatch, cached=False, resolved=False)
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    assert monitor.state.state_source["kitchen"] == ReachabilitySource.PING
+    assert device.runtime_state.state == DeviceState.ONLINE
+    assert callbacks.calls_for("on_state_change") == []
+    assert shared.should_ping(monitor, device) is True
+
+
+@pytest.mark.parametrize("state", [DeviceState.OFFLINE, DeviceState.UNKNOWN])
+async def test_sweep_never_resolves_not_online_devices(state: DeviceState) -> None:
+    """Ownership repair only — a not-online device must not come online off the cache (#1776)."""
+    device = make_online_api_device(state=state)
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    _prime_sweep(monitor)
+    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    monitor._mdns.resolve_and_claim.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "source"),
+    [
+        pytest.param(
+            {"api_enabled": False, "loaded_integrations": ["mqtt", "wifi"]},
+            ReachabilitySource.PING,
+            id="non_api",
+        ),
+        pytest.param({}, ReachabilitySource.MQTT, id="mqtt_owned"),
+    ],
+)
+async def test_sweep_skips_ineligible_devices(
+    overrides: dict[str, Any], source: ReachabilitySource
+) -> None:
+    device = make_online_api_device(**overrides)
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = source
+    _prime_sweep(monitor)
+    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    monitor._mdns.resolve_and_claim.assert_not_called()
+
+
+async def test_sweep_skips_devices_with_no_cache_trace() -> None:
+    """mDNS-dark deployments (Docker bridge) must gain no multicast traffic."""
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    _prime_sweep(monitor, cache_trace=False)
+    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    monitor._mdns.resolve_and_claim.assert_not_called()
+
+
+async def test_sweep_without_zeroconf_is_a_noop() -> None:
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    monitor._mdns._zeroconf = None
+    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    monitor._mdns.resolve_and_claim.assert_not_called()
+
+
+async def test_sweep_rechecks_mdns_owned_device_without_live_ptr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A no-PTR mdns claim keeps sweep eligibility; a live PTR ends it (event-spam guard)."""
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    _prime_sweep(monitor, live_ptr=False)
+    resolve = AsyncMock()
+    monitor._mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
+
+    await shared.resolve_api_mdns_targets(monitor)
+    resolve.assert_awaited_once_with("kitchen")
+
+    monitor.has_live_mdns_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
+    await shared.resolve_api_mdns_targets(monitor)
+    resolve.assert_awaited_once()
+
+
+def test_should_ping_gates_mdns_ownership_on_live_ptr() -> None:
+    """An mdns claim with no live PTR has no ``Removed`` counterpart — keep sweeping it."""
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+
+    monitor.has_live_mdns_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
+    assert shared.should_ping(monitor, device) is True
+
+    monitor.has_live_mdns_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
+    assert shared.should_ping(monitor, device) is False
+
+
+def test_should_ping_non_api_mdns_ownership_unchanged() -> None:
+    """Non-API devices never publish a PTR; their active-resolve claim keeps the lockout."""
+    device = make_online_api_device(api_enabled=False, loaded_integrations=["mqtt", "wifi"])
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    monitor.has_live_mdns_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
+
+    assert shared.should_ping(monitor, device) is False
+
+
+def test_has_live_ptr_reads_the_browser_cache() -> None:
+    monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
+    fake_zeroconf = MagicMock()
+    monitor._mdns._zeroconf = fake_zeroconf
+    lookup = fake_zeroconf.zeroconf.cache.current_entry_with_name_and_alias
+
+    ptr = MagicMock()
+    ptr.is_expired.return_value = False
+    lookup.return_value = ptr
+    assert monitor.has_live_mdns_ptr("kitchen") is True
+    lookup.assert_called_with("_esphomelib._tcp.local.", _SERVICE_NAME)
+
+    ptr.is_expired.return_value = True
+    assert monitor.has_live_mdns_ptr("kitchen") is False
+
+    lookup.return_value = None
+    assert monitor.has_live_mdns_ptr("kitchen") is False
+
+    monitor._mdns._zeroconf = None
+    assert monitor.has_live_mdns_ptr("kitchen") is False

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -107,6 +108,24 @@ async def test_sweep_skips_ineligible_devices(
     await shared.resolve_api_mdns_targets(monitor)
 
     monitor._mdns.resolve_and_claim.assert_not_called()
+
+
+async def test_sweep_surfaces_unexpected_resolve_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising ``resolve_and_claim`` is logged as a bug, not masked as a benign miss."""
+    device = make_online_api_device()
+    monitor, _callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    _prime_sweep(monitor)
+    monitor._mdns.resolve_and_claim = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AttributeError("boom")
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await shared.resolve_api_mdns_targets(monitor)
+
+    assert "Resolve-first mDNS claim for kitchen raised unexpectedly" in caplog.text
 
 
 async def test_sweep_without_zeroconf_is_a_noop() -> None:

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -110,6 +110,20 @@ async def test_sweep_skips_ineligible_devices(
     monitor._mdns.resolve_and_claim.assert_not_called()
 
 
+async def test_sweep_resolves_multiple_candidates_concurrently() -> None:
+    devices = [make_online_api_device("kitchen"), make_online_api_device("porch")]
+    monitor, _callbacks = make_state_monitor_with_callbacks(devices)
+    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
+    monitor.state.state_source["porch"] = ReachabilitySource.PING
+    _prime_sweep(monitor)
+    resolve = AsyncMock()
+    monitor._mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
+
+    await shared.resolve_api_mdns_targets(monitor)
+
+    assert {call.args[0] for call in resolve.await_args_list} == {"kitchen", "porch"}
+
+
 async def test_sweep_surfaces_unexpected_resolve_errors(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -1,4 +1,4 @@
-"""Tests for the ping sweep's resolve-first mDNS step (issue #1993)."""
+"""Tests for the ping sweep's resolve-first mDNS step."""
 
 from __future__ import annotations
 
@@ -11,23 +11,13 @@ from esphome_device_builder.controllers._device_state_monitor import mdns as mdn
 from esphome_device_builder.controllers._device_state_monitor import shared
 from esphome_device_builder.models import DeviceState, ReachabilitySource
 
-from .conftest import make_online_api_device, make_state_monitor_with_callbacks
+from .conftest import (
+    make_online_api_device,
+    make_state_monitor_with_callbacks,
+    stub_async_service_info,
+)
 
 _SERVICE_NAME = "kitchen._esphomelib._tcp.local."
-
-
-def _stub_service_info(
-    monkeypatch: pytest.MonkeyPatch, *, cached: bool, resolved: bool = False
-) -> MagicMock:
-    """Stub ``AsyncServiceInfo`` so the resolve hits the cache, the wire, or misses."""
-    info = MagicMock()
-    info.name = _SERVICE_NAME
-    info.load_from_cache.return_value = cached
-    info.async_request = AsyncMock(return_value=resolved)
-    info.parsed_scoped_addresses.return_value = ["192.168.1.50"]
-    info.decoded_properties = {"version": "2026.7.0", "config_hash": "abcd1234"}
-    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: info)
-    return info
 
 
 def _prime_sweep(monitor: Any, *, cache_trace: bool = True, live_ptr: bool = False) -> None:
@@ -36,41 +26,41 @@ def _prime_sweep(monitor: Any, *, cache_trace: bool = True, live_ptr: bool = Fal
     monitor.get_mdns_cache_info = MagicMock(  # type: ignore[method-assign]
         return_value=MagicMock() if cache_trace else None
     )
-    monitor.has_live_mdns_ptr = MagicMock(return_value=live_ptr)  # type: ignore[method-assign]
+    monitor._mdns.has_live_ptr = MagicMock(return_value=live_ptr)  # type: ignore[method-assign]
 
 
 async def test_sweep_claims_mdns_for_ping_owned_online_device(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The #1993 repro: ping owns the ledger, the cache resolves → mdns reclaims, no wire."""
+    """Ping owns the ledger, the cache resolves → mdns reclaims without touching the wire."""
     device = make_online_api_device()
     monitor, callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
     _prime_sweep(monitor)
-    info = _stub_service_info(monkeypatch, cached=True)
+    info = stub_async_service_info(monkeypatch, cached=True)
 
     await shared.resolve_api_mdns_targets(monitor)
 
     assert monitor.state.state_source["kitchen"] == ReachabilitySource.MDNS
     assert ("on_source_change", "kitchen", ReachabilitySource.MDNS) in callbacks.calls
     assert device.runtime_state.deployed_version == "2026.7.0"
-    assert device.runtime_state.deployed_config_hash == "abcd1234"
-    assert device.runtime_state.state == DeviceState.ONLINE
     info.async_request.assert_not_called()
 
 
 async def test_sweep_cache_miss_falls_back_to_wire_resolve(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The wire fallback claims on an answer, bounded by the sweep-scoped timeout."""
     device = make_online_api_device()
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
     _prime_sweep(monitor)
-    info = _stub_service_info(monkeypatch, cached=False, resolved=True)
+    info = stub_async_service_info(monkeypatch, resolved=True)
 
     await shared.resolve_api_mdns_targets(monitor)
 
     info.async_request.assert_awaited_once()
+    assert info.async_request.await_args.kwargs["timeout"] == mdns_module._SWEEP_RESOLVE_TIMEOUT_MS
     assert monitor.state.state_source["kitchen"] == ReachabilitySource.MDNS
 
 
@@ -80,60 +70,38 @@ async def test_sweep_resolve_miss_claims_nothing(monkeypatch: pytest.MonkeyPatch
     monitor, callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
     _prime_sweep(monitor)
-    _stub_service_info(monkeypatch, cached=False, resolved=False)
+    stub_async_service_info(monkeypatch)
 
     await shared.resolve_api_mdns_targets(monitor)
 
     assert monitor.state.state_source["kitchen"] == ReachabilitySource.PING
-    assert device.runtime_state.state == DeviceState.ONLINE
     assert callbacks.calls_for("on_state_change") == []
-    assert shared.should_ping(monitor, device) is True
-
-
-@pytest.mark.parametrize("state", [DeviceState.OFFLINE, DeviceState.UNKNOWN])
-async def test_sweep_never_resolves_not_online_devices(state: DeviceState) -> None:
-    """Ownership repair only — a not-online device must not come online off the cache (#1776)."""
-    device = make_online_api_device(state=state)
-    monitor, _callbacks = make_state_monitor_with_callbacks([device])
-    _prime_sweep(monitor)
-    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
-
-    await shared.resolve_api_mdns_targets(monitor)
-
-    monitor._mdns.resolve_and_claim.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    ("overrides", "source"),
+    ("overrides", "source", "prime"),
     [
+        pytest.param({"state": DeviceState.OFFLINE}, ReachabilitySource.PING, {}, id="offline"),
+        pytest.param({"state": DeviceState.UNKNOWN}, ReachabilitySource.PING, {}, id="unknown"),
         pytest.param(
             {"api_enabled": False, "loaded_integrations": ["mqtt", "wifi"]},
             ReachabilitySource.PING,
+            {},
             id="non_api",
         ),
-        pytest.param({}, ReachabilitySource.MQTT, id="mqtt_owned"),
+        pytest.param({}, ReachabilitySource.MQTT, {}, id="mqtt_owned"),
+        pytest.param({}, ReachabilitySource.PING, {"cache_trace": False}, id="no_cache_trace"),
+        pytest.param({}, ReachabilitySource.MDNS, {"live_ptr": True}, id="mdns_owned_live_ptr"),
     ],
 )
 async def test_sweep_skips_ineligible_devices(
-    overrides: dict[str, Any], source: ReachabilitySource
+    overrides: dict[str, Any], source: ReachabilitySource, prime: dict[str, bool]
 ) -> None:
+    """Not-online, non-API, mqtt-owned, traceless, and browser-owned devices are never resolved."""
     device = make_online_api_device(**overrides)
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = source
-    _prime_sweep(monitor)
-    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
-
-    await shared.resolve_api_mdns_targets(monitor)
-
-    monitor._mdns.resolve_and_claim.assert_not_called()
-
-
-async def test_sweep_skips_devices_with_no_cache_trace() -> None:
-    """mDNS-dark deployments (Docker bridge) must gain no multicast traffic."""
-    device = make_online_api_device()
-    monitor, _callbacks = make_state_monitor_with_callbacks([device])
-    monitor.state.state_source["kitchen"] = ReachabilitySource.PING
-    _prime_sweep(monitor, cache_trace=False)
+    _prime_sweep(monitor, **prime)
     monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
 
     await shared.resolve_api_mdns_targets(monitor)
@@ -153,10 +121,8 @@ async def test_sweep_without_zeroconf_is_a_noop() -> None:
     monitor._mdns.resolve_and_claim.assert_not_called()
 
 
-async def test_sweep_rechecks_mdns_owned_device_without_live_ptr(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A no-PTR mdns claim keeps sweep eligibility; a live PTR ends it (event-spam guard)."""
+async def test_sweep_rechecks_mdns_owned_device_without_live_ptr() -> None:
+    """An mdns claim with no live PTR keeps sweep eligibility until the PTR returns."""
     device = make_online_api_device()
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
@@ -165,11 +131,17 @@ async def test_sweep_rechecks_mdns_owned_device_without_live_ptr(
     monitor._mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
 
     await shared.resolve_api_mdns_targets(monitor)
+
     resolve.assert_awaited_once_with("kitchen")
 
-    monitor.has_live_mdns_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
-    await shared.resolve_api_mdns_targets(monitor)
-    resolve.assert_awaited_once()
+
+async def test_resolve_and_claim_without_zeroconf_is_a_noop() -> None:
+    monitor, callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
+    monitor._mdns._zeroconf = None
+
+    await monitor._mdns.resolve_and_claim("kitchen")
+
+    assert callbacks.calls == []
 
 
 def test_should_ping_gates_mdns_ownership_on_live_ptr() -> None:
@@ -178,10 +150,10 @@ def test_should_ping_gates_mdns_ownership_on_live_ptr() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
 
-    monitor.has_live_mdns_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
+    monitor._mdns.has_live_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
     assert shared.should_ping(monitor, device) is True
 
-    monitor.has_live_mdns_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
+    monitor._mdns.has_live_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
     assert shared.should_ping(monitor, device) is False
 
 
@@ -190,7 +162,7 @@ def test_should_ping_non_api_mdns_ownership_unchanged() -> None:
     device = make_online_api_device(api_enabled=False, loaded_integrations=["mqtt", "wifi"])
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
-    monitor.has_live_mdns_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
+    monitor._mdns.has_live_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
 
     assert shared.should_ping(monitor, device) is False
 
@@ -204,14 +176,31 @@ def test_has_live_ptr_reads_the_browser_cache() -> None:
     ptr = MagicMock()
     ptr.is_expired.return_value = False
     lookup.return_value = ptr
-    assert monitor.has_live_mdns_ptr("kitchen") is True
+    assert monitor._mdns.has_live_ptr("kitchen") is True
     lookup.assert_called_with("_esphomelib._tcp.local.", _SERVICE_NAME)
 
     ptr.is_expired.return_value = True
-    assert monitor.has_live_mdns_ptr("kitchen") is False
+    assert monitor._mdns.has_live_ptr("kitchen") is False
 
     lookup.return_value = None
-    assert monitor.has_live_mdns_ptr("kitchen") is False
+    assert monitor._mdns.has_live_ptr("kitchen") is False
 
     monitor._mdns._zeroconf = None
-    assert monitor.has_live_mdns_ptr("kitchen") is False
+    assert monitor._mdns.has_live_ptr("kitchen") is False
+
+
+async def test_verify_removed_bails_when_a_resolve_is_inflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent resolve decides — the removed-verify must not demote without verifying."""
+    device = make_online_api_device()
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    monitor._mdns._inflight_resolves.add(_SERVICE_NAME)
+    info = stub_async_service_info(monkeypatch)
+
+    await monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+
+    info.async_request.assert_not_called()
+    assert device.runtime_state.state == DeviceState.ONLINE
+    assert callbacks.calls_for("on_state_change") == []

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -222,6 +222,22 @@ def test_has_live_ptr_reads_the_browser_cache() -> None:
     assert monitor._mdns.has_live_ptr("kitchen") is False
 
 
+async def test_verify_removed_keeps_online_on_a_swallowed_resolve_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An internal resolve error is not a confirmed miss — never demote on uncertainty."""
+    device = make_online_api_device()
+    monitor, callbacks = make_state_monitor_with_callbacks([device])
+    monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
+    info = stub_async_service_info(monkeypatch)
+    info.async_request.side_effect = OSError("socket gone")
+
+    await monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+
+    assert device.runtime_state.state == DeviceState.ONLINE
+    assert callbacks.calls_for("on_state_change") == []
+
+
 async def test_verify_removed_bails_when_a_resolve_is_inflight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -320,7 +320,7 @@ async def test_confirmed_wire_miss_outranks_a_stale_cache_added_claim(
 
 
 async def test_verify_removed_keeps_online_on_a_swallowed_resolve_error(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """An internal resolve error is not a confirmed miss — never demote on uncertainty."""
     device = make_online_api_device()
@@ -329,10 +329,12 @@ async def test_verify_removed_keeps_online_on_a_swallowed_resolve_error(
     info = stub_async_service_info(monkeypatch)
     info.async_request.side_effect = OSError("socket gone")
 
-    await monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+    with caplog.at_level(logging.WARNING):
+        await monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
 
     assert device.runtime_state.state == DeviceState.ONLINE
     assert callbacks.calls_for("on_state_change") == []
+    assert "Removed-verify resolve for kitchen errored" in caplog.text
 
 
 async def test_verify_removed_bails_when_a_resolve_is_inflight(

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -137,6 +137,26 @@ async def test_ping_loop_survives_a_raising_resolve_step(
     assert counts["sweeps"] >= 2
 
 
+async def test_ping_loop_does_not_mask_child_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled resolve step propagates instead of being logged as a step failure."""
+    monitor = _build_monitor(presence=None)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    async def _cancelled(_monitor: DeviceStateMonitor) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _cancelled)
+
+    task = asyncio.create_task(monitor._ping.run())
+    with contextlib.suppress(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=0.5)
+
+    assert task.done()
+    assert counts["sweeps"] == 0
+
+
 async def test_ping_loop_parks_until_first_subscriber(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -63,11 +63,12 @@ def _instrument_loop(
     async def _sweep() -> None:
         counts["sweeps"] += 1
 
-    # ``resolve_non_api_mdns_targets`` is a free function in ``shared``;
-    # patch the module attribute so ``PingSource.run``'s call sees the
-    # stub. ``_ping_sweep`` is a method on ``PingSource``; replace it
-    # on the per-test instance.
+    # The resolve steps are free functions in ``shared``; patch the
+    # module attributes so ``PingSource.run``'s calls see the stubs.
+    # ``_ping_sweep`` is a method on ``PingSource``; replace it on the
+    # per-test instance.
     monkeypatch.setattr(shared_module, "resolve_non_api_mdns_targets", _resolve)
+    monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _resolve)
     monitor._ping._ping_sweep = _sweep  # type: ignore[method-assign]
 
     # Skip the bootstrap delay; collapse the post-sweep idle wait

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -114,6 +114,29 @@ async def test_ping_loop_runs_unconditionally_without_presence(
     assert counts["resolves"] >= 2
 
 
+async def test_ping_loop_survives_a_raising_resolve_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising resolve step is logged and the loop keeps sweeping."""
+    monitor = _build_monitor(presence=None)
+    counts = _instrument_loop(monitor, monkeypatch)
+
+    async def _boom(_monitor: DeviceStateMonitor) -> None:
+        raise AttributeError("boom")
+
+    monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _boom)
+
+    task = asyncio.create_task(monitor._ping.run())
+    try:
+        await _drive_until(lambda: counts["sweeps"] >= 2)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert counts["sweeps"] >= 2
+
+
 async def test_ping_loop_parks_until_first_subscriber(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -458,14 +458,31 @@ async def test_start_continues_when_browser_construct_fails(
 # ---------------------------------------------------------------------------
 
 
+def _stub_removed_verify(monkeypatch: pytest.MonkeyPatch, *, resolved: bool) -> MagicMock:
+    """Stub the ``Removed`` branch's wire verify to hit or miss deterministically."""
+    info = MagicMock()
+    info.async_request = AsyncMock(return_value=resolved)
+    info.parsed_scoped_addresses.return_value = ["10.0.0.1"]
+    info.decoded_properties = {"version": "2026.7.0"}
+    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: info)
+    return info
+
+
+async def _drain_tracked_tasks(monitor: DeviceStateMonitor) -> None:
+    """Await the fire-and-forget tasks a dispatch spawned."""
+    while monitor._tasks:
+        await asyncio.gather(*list(monitor._tasks), return_exceptions=True)
+
+
 async def test_dispatch_removed_event_flips_offline_clears_ip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A ``Removed`` esphomelib event flips OFFLINE, clears IP, drops source slot."""
+    """A ``Removed`` whose verify-resolve misses flips OFFLINE, clears IP, drops source slot."""
     device = _device(state=DeviceState.ONLINE, ip="10.0.0.1")
     monitor, _callbacks = _make_monitor([device])
     monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    _stub_removed_verify(monkeypatch, resolved=False)
     try:
         dispatch(
             monitor._mdns._zeroconf.zeroconf,
@@ -473,9 +490,34 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
         )
+        await _drain_tracked_tasks(monitor)
         assert device.runtime_state.state == DeviceState.OFFLINE
         assert device.ip == ""
         assert "kitchen" not in monitor.state.state_source
+    finally:
+        await _stop_and_drain(monitor)
+
+
+async def test_dispatch_removed_event_stays_online_when_verify_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``Removed`` whose verify-resolve answers keeps the device ONLINE and mdns-owned."""
+    device = _device(state=DeviceState.ONLINE, ip="10.0.0.1")
+    monitor, _callbacks = _make_monitor([device])
+    monitor.state.state_source["kitchen"] = "mdns"
+    dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    _stub_removed_verify(monkeypatch, resolved=True)
+    try:
+        dispatch(
+            monitor._mdns._zeroconf.zeroconf,
+            ESPHOMELIB_SERVICE_TYPE,
+            f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
+            ServiceStateChange.Removed,
+        )
+        await _drain_tracked_tasks(monitor)
+        assert device.runtime_state.state == DeviceState.ONLINE
+        assert device.ip == "10.0.0.1"
+        assert monitor.state.state_source["kitchen"] == "mdns"
     finally:
         await _stop_and_drain(monitor)
 
@@ -500,6 +542,7 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
     tracker.observe("kitchen", "ping")
     monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
+    _stub_removed_verify(monkeypatch, resolved=False)
     try:
         dispatch(
             monitor._mdns._zeroconf.zeroconf,
@@ -507,6 +550,7 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
         )
+        await _drain_tracked_tasks(monitor)
         snap = tracker.snapshot(
             "kitchen", state=DeviceState.OFFLINE, active_source="unknown", ip=""
         )

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -40,7 +40,7 @@ from esphome_device_builder.controllers._device_state_monitor.ping import PingSo
 from esphome_device_builder.controllers._reachability_tracker import ReachabilityTracker
 from esphome_device_builder.models import RUNTIME_STATE_FIELD_NAMES, Device, DeviceState
 
-from .conftest import RecordingMonitorCallbacks
+from .conftest import RecordingMonitorCallbacks, stub_async_service_info
 from .conftest import make_device as _device
 
 # The service-type strings the production code uses; pinned here so
@@ -458,16 +458,6 @@ async def test_start_continues_when_browser_construct_fails(
 # ---------------------------------------------------------------------------
 
 
-def _stub_removed_verify(monkeypatch: pytest.MonkeyPatch, *, resolved: bool) -> MagicMock:
-    """Stub the ``Removed`` branch's wire verify to hit or miss deterministically."""
-    info = MagicMock()
-    info.async_request = AsyncMock(return_value=resolved)
-    info.parsed_scoped_addresses.return_value = ["10.0.0.1"]
-    info.decoded_properties = {"version": "2026.7.0"}
-    monkeypatch.setattr(mdns_module, "AsyncServiceInfo", lambda *_a, **_kw: info)
-    return info
-
-
 async def _drain_tracked_tasks(monitor: DeviceStateMonitor) -> None:
     """Await the fire-and-forget tasks a dispatch spawned."""
     while monitor._tasks:
@@ -482,7 +472,7 @@ async def test_dispatch_removed_event_flips_offline_clears_ip(
     monitor, _callbacks = _make_monitor([device])
     monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    _stub_removed_verify(monkeypatch, resolved=False)
+    stub_async_service_info(monkeypatch)
     try:
         dispatch(
             monitor._mdns._zeroconf.zeroconf,
@@ -506,7 +496,7 @@ async def test_dispatch_removed_event_stays_online_when_verify_resolves(
     monitor, _callbacks = _make_monitor([device])
     monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    _stub_removed_verify(monkeypatch, resolved=True)
+    stub_async_service_info(monkeypatch, resolved=True, addresses=("10.0.0.1",))
     try:
         dispatch(
             monitor._mdns._zeroconf.zeroconf,
@@ -542,7 +532,7 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
     tracker.observe("kitchen", "ping")
     monitor.state.state_source["kitchen"] = "mdns"
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
-    _stub_removed_verify(monkeypatch, resolved=False)
+    stub_async_service_info(monkeypatch)
     try:
         dispatch(
             monitor._mdns._zeroconf.zeroconf,


### PR DESCRIPTION
# What does this implement/fix?

Fixes the drawer showing Deployed Version as "Waiting for mDNS discovery…" while the Reachability section shows mDNS heard seconds ago: `active_source` sticks on `ping` even though the device answers every mDNS query, and the frontend hides the mDNS-sourced version and config hash whenever the ledger is not `mdns`.

The root cause is that the zeroconf browser never re-asks. After its startup queries it only sends refreshes for PTR records it already holds (the rescue window at 75 to 100 percent of the TTL), and a `Removed` cancels that schedule, so from that point re-discovery depends entirely on the device's few boot-time multicast announces. Every way into the state ends the same: the dashboard host suspends past the rescue window and the wake expires every PTR at once; an OTA or crash reboot sends a goodbye; or a PTR expires and the device's reconnect announces are lost in the reassociation window. Ping then revives the device within a sweep and takes the ledger, and nothing ever asks the device an mDNS question again, so the ledger never returns to `mdns` while the drawer's own A-record refresh loop keeps showing the cache as fresh.

The fix adds the solicited re-ask the browser deliberately does not do, at the two moments where mDNS should get a say before ICMP, since an `AsyncServiceInfo` resolve is cheaper than the probe it replaces:

Before each ping sweep, a new `resolve_api_mdns_targets` step resolves the esphomelib service (cache first, wire fallback with a sweep-scoped 3s bound) for ONLINE API devices the sweep was about to ping. On success the existing `_apply_service_info` path claims mdns and the device leaves the ping rotation; on a miss nothing is claimed and ICMP decides, mirroring the existing non-API active-resolve step. Candidates must already be ONLINE (this is ownership repair, never a liveness claim, so the #1776 latch stays impossible) and must have some cached mDNS trace, so an mDNS-dark deployment (Docker bridge) gains no multicast traffic.

The browser `Removed` branch now runs the same verify-resolve before honouring the event, and demotes only on a confirmed miss: a resolved device stays ONLINE, and a swallowed error or a concurrent resolve leaves state untouched for the sweep to re-check. That means a wake-from-suspend `Removed` storm or an OTA reboot no longer flips live devices OFFLINE, which prevents the ping takeover from ever starting.

Since these claims can land without a live PTR in the browser's view (the resolves fetch SRV/TXT/A, not PTR), there would be no `Removed` counterpart; `should_ping` therefore keeps an mdns-owned API device without a live PTR sweep-eligible, making the sweep its offline-detection substitute until the PTR returns and normal browser ownership resumes.

The frontend gate from esphome/device-builder-frontend#1037 is intentionally untouched; it becomes correct again once `active_source` tracks genuine mDNS liveness. Net traffic goes down for the affected segment (one resolve replaces recurring ICMP once it succeeds) and is unchanged for the happy browser-owned fleet and for mDNS-dark deployments.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/1993

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
