### PR TITLE
Drop "preview toggle" note from install-method options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -67,8 +67,8 @@ body:
         - PyPI
         - Wheel from a GitHub release
         - From source (script/setup)
-        - ESPHome container (preview toggle)
-        - Home Assistant App (preview toggle)
+        - ESPHome container
+        - Home Assistant App
         - Desktop app
         - Other / not sure
     validations:

--- a/.github/ISSUE_TEMPLATE/device_status.yml
+++ b/.github/ISSUE_TEMPLATE/device_status.yml
@@ -111,8 +111,8 @@ body:
         - PyPI
         - Wheel from a GitHub release
         - From source (script/setup)
-        - ESPHome container (preview toggle)
-        - Home Assistant App (preview toggle)
+        - ESPHome container
+        - Home Assistant App
         - Desktop app
         - Other / not sure
     validations:


### PR DESCRIPTION
# What does this implement/fix?

Removes the "(preview toggle)" qualifier from the "ESPHome container" and "Home Assistant App" options in the install-method dropdowns of the bug-report and device-status issue templates. The preview toggle is no longer how these installs are enabled, so the note is stale and confusing to reporters.

**Related issue or feature (if applicable):**

- N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.