### PR TITLE
Guard the full board sync against a mismatched ESPHome

### DIFF
--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -127,7 +127,10 @@ jobs:
         # version, so re-stamp boards against the same esphome the align step
         # pinned; otherwise the Test job's ``sync-boards`` pre-commit hook
         # re-stamps it and the opened PR lands red on every esphome patch.
-        run: python script/sync_boards.py
+        # ``--restamp`` because the installed esphome is the freshly-resolved
+        # one while the committed stamp is still the previous version — the
+        # one caller for which that mismatch is the point.
+        run: python script/sync_boards.py --restamp
 
       - name: Validate definitions
         # Re-validate every board (curated + imported) against the JSON Schema

--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -86,7 +86,9 @@ jobs:
       - name: Regenerate board catalog
         # The opened PR needs to ship the regenerated catalog
         # alongside the imported manifests — without this, a merge
-        # would land new YAMLs the dashboard never sees.
+        # would land new YAMLs the dashboard never sees. No --restamp:
+        # the pinned install above matches the committed stamp, so the
+        # full-sync guard doubles as a pin/stamp consistency check.
         run: python script/sync_boards.py
 
       - name: Detect device-catalog changes + summarise diff

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,12 +377,13 @@ against legacy behaviour before assuming the simpler version suffices.
   `script/update_board.py [board-id]` (auto-detects the edited board) to
   regenerate its JSON and validate in one step. It wraps
   `script/sync_boards.py <board-id>` (single board) / `sync_boards.py`
-  (all) + `validate_definitions.py`. Single-board mode refuses unless the
+  (all) + `validate_definitions.py`. Both modes refuse unless the
   installed `esphome` matches the `esphome_version` stamped in
-  `boards.index.json` by the last full sync (betas canonicalized to base, as
-  it rebuilds the shared index from every board); a full sync regenerates
-  everything from the installed esphome and re-stamps it, so it doesn't
-  check. Full contributor workflow: `definitions/README.md`.
+  `boards.index.json` by the last full sync (betas canonicalized to base);
+  `sync_boards.py --restamp` is the explicit opt-in to regenerate every
+  board against the installed esphome and re-stamp that version (the
+  catalog-sync workflows' esphome-bump path). Full contributor workflow:
+  `definitions/README.md`.
 - **Frontend handoff** for the catalog is documented inline in models
   (`ConfigEntry`, `ComponentCatalogEntry`). New `ConfigEntryType` values
   need a frontend update — coordinate.
@@ -767,7 +768,7 @@ When changing the sync script or catalog handling, watch for these:
 | `esphome_device_builder/definitions/platform_capabilities.index.json` | Generated; do not hand-edit. esphome platform metadata the long-lived process reads instead of importing `esphome.components.*` (download routing, wifi-inference no-wifi sets, static download-types). Loaded via `load_platform_capabilities_index`. |
 | `esphome_device_builder/helper_cli.py` (`device-builder-helper`) | Subprocess for `get_download_types` on build-dir-dependent platforms (libretiny/nrf52), so the child imports `esphome.components.<X>`, not the dashboard process. |
 | `script/update_board.py` | One-step contributor wrapper: regenerate one board's JSON (`sync_boards.py`) + validate (`validate_definitions.py`). Auto-detects the edited board, or takes an id. |
-| `script/sync_boards.py` | Regenerates the split board catalog from the manifests; stamps the generating `esphome_version` into `boards.index.json`. Takes an optional board id to regenerate just one (single-board mode guards installed `esphome` against that stamp). |
+| `script/sync_boards.py` | Regenerates the split board catalog from the manifests; stamps the generating `esphome_version` into `boards.index.json`. Takes an optional board id to regenerate just one. Both modes guard installed `esphome` against that stamp; `--restamp` opts a full sync out to regenerate against a new esphome. |
 | `script/sync_components.py` | Regenerates the component catalog + `platform_capabilities.index.json` |
 | `script/check_catalog.py` | Smoke test for popular components |
 | `script/check_import_time.py` | CI guard: fails if `import …device_builder` regresses past `script/import_time_budget.json` (e.g. a fresh eager `esphome.components.*` import) |

--- a/esphome_device_builder/definitions/README.md
+++ b/esphome_device_builder/definitions/README.md
@@ -62,15 +62,15 @@ source .venv/bin/activate    # or call .venv/bin/python directly
 python script/sync_boards.py my-board
 ```
 
-Single-board mode (and `update_board.py`) rewrites one body but rebuilds the
-shared index from every board, so the installed ESPHome must match the version
-the committed catalog was generated against (stamped as `esphome_version` in
-`boards.index.json` by the last full sync, betas canonicalized to their base
-release) or their index entries silently drift; it refuses on a mismatch and
-prints the version to install. A full `python script/sync_boards.py` regenerates
-everything against your installed ESPHome and re-stamps that version, so it does
-not check; still run it from the venv so you don't commit catalog-wide changes
-from a different ESPHome.
+The installed ESPHome must match the version the committed catalog was
+generated against (stamped as `esphome_version` in `boards.index.json` by the
+last full sync, betas canonicalized to their base release) or the derived data
+silently drifts — single-board mode rebuilds the shared index from every
+board, and a full sync rewrites every body. Both modes refuse on a mismatch
+and print the version to install. `python script/sync_boards.py --restamp` is
+the explicit opt-in to regenerate everything against your installed ESPHome
+and re-stamp that version — that's for a deliberate catalog-wide ESPHome bump,
+not a routine board edit.
 
 ### Troubleshooting: the pre-commit hook fails on every attempt
 

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -1396,10 +1396,14 @@ def _require_matching_esphome() -> None:
 
 
 def _require_matching_esphome_full() -> None:
-    """Abort a full sync on an ESPHome mismatch unless the stamp is missing (first sync)."""
+    """Abort a full sync on an ESPHome mismatch unless no stamp is readable (nothing to guard)."""
     expected = _committed_esphome_stamp()
     if expected is None:
-        _LOGGER.info("no esphome_version stamp in %s — first full sync, proceeding", _INDEX_FILE)
+        _LOGGER.info(
+            "no readable esphome_version stamp in %s (missing or corrupt index) — "
+            "nothing to guard against, regenerating from the installed ESPHome",
+            _INDEX_FILE,
+        )
         return
     assert_installed_esphome(
         expected,

--- a/script/sync_boards.py
+++ b/script/sync_boards.py
@@ -23,18 +23,21 @@ The YAML manifests under ``definitions/boards/<id>/manifest.yaml``
 remain the human-editable source of truth; this script is the only
 thing that writes the three artefacts.
 
-Single-board mode (``BOARD_ID``) must run against the same ESPHome the
-rest of the committed catalog was generated against (the
-``esphome_version`` a full sync stamps into ``boards.index.json``),
-since it rebuilds the shared index from every board; it refuses on a
-mismatch. A full sync regenerates everything from the installed ESPHome
-and re-stamps that version, so it does not check.
+Both modes must run against the same ESPHome the committed catalog was
+generated against (the ``esphome_version`` a full sync stamps into
+``boards.index.json``): single-board mode rebuilds the shared index from
+every board, and a full sync rewrites every body, so either drifts the
+whole catalog on a mismatch. Both refuse unless the versions match;
+``--restamp`` lets a full sync intentionally regenerate against the
+installed ESPHome and re-stamp that version (the catalog-sync workflows'
+esphome-bump path).
 
 Usage
 -----
 
     python script/sync_boards.py              # regenerate every board
     python script/sync_boards.py BOARD_ID     # regenerate only one board
+    python script/sync_boards.py --restamp    # regenerate against a new ESPHome
 """
 
 from __future__ import annotations
@@ -1205,12 +1208,24 @@ def main() -> int:
         help="Board id (the folder name under esphome_device_builder/definitions/boards/) "
         "to regenerate on its own. Omit to regenerate the whole catalog.",
     )
+    parser.add_argument(
+        "--restamp",
+        action="store_true",
+        help="Full sync only: regenerate every board against the installed ESPHome even "
+        "when it does not match the esphome_version stamped in boards.index.json, "
+        "re-stamping that version.",
+    )
     args = parser.parse_args()
 
-    # Only single-board mode needs the match: it rebuilds the shared index from
-    # every board, so a mismatched esphome drifts the others' index entries.
+    # Either mode drifts the whole catalog on a version mismatch: single-board
+    # rebuilds the shared index from every board, a full sync rewrites every
+    # body. --restamp is the explicit opt-in for the intentional full regen.
     if args.board:
+        if args.restamp:
+            parser.error("--restamp applies to the full sync only; drop the board id")
         _require_matching_esphome()
+    elif not args.restamp:
+        _require_matching_esphome_full()
 
     # Abort the sync on the first bad manifest — partial output here
     # would silently ship a board-shaped hole to every install.
@@ -1348,23 +1363,49 @@ def _write_index(full_payloads: list[dict[str, Any]]) -> None:
     next_index.replace(_INDEX_FILE)
 
 
+def _committed_esphome_stamp() -> str | None:
+    """Return the ``esphome_version`` stamped in boards.index.json, or None if unreadable."""
+    try:
+        stamp = orjson.loads(_INDEX_FILE.read_bytes())["esphome_version"]
+    except (OSError, orjson.JSONDecodeError, KeyError):
+        return None
+    return stamp if isinstance(stamp, str) else None
+
+
+_RESTAMP_ALT_FIX = (
+    "Or intentionally regenerate every board against your installed ESPHome\n"
+    "and re-stamp boards.index.json:\n"
+    "    python script/sync_boards.py --restamp"
+)
+
+
 def _require_matching_esphome() -> None:
     """Abort unless installed ESPHome matches the ``esphome_version`` boards.index.json was built with."""
-    try:
-        expected = orjson.loads(_INDEX_FILE.read_bytes())["esphome_version"]
-    except (OSError, orjson.JSONDecodeError, KeyError):
+    expected = _committed_esphome_stamp()
+    if expected is None:
         raise SystemExit(
             f"sync_boards: could not read esphome_version from {_INDEX_FILE}.\n"
-            f"To fix, regenerate the whole catalog first: python script/sync_boards.py"
-        ) from None
+            f"To fix, regenerate the whole catalog first: python script/sync_boards.py --restamp"
+        )
     assert_installed_esphome(
         expected,
         what="sync_boards single-board mode",
         normalize=_canonical_esphome_version,
-        alt_fix=(
-            "Or regenerate the whole catalog against your installed ESPHome instead:\n"
-            "    python script/sync_boards.py"
-        ),
+        alt_fix=_RESTAMP_ALT_FIX,
+    )
+
+
+def _require_matching_esphome_full() -> None:
+    """Abort a full sync on an ESPHome mismatch unless the stamp is missing (first sync)."""
+    expected = _committed_esphome_stamp()
+    if expected is None:
+        _LOGGER.info("no esphome_version stamp in %s — first full sync, proceeding", _INDEX_FILE)
+        return
+    assert_installed_esphome(
+        expected,
+        what="sync_boards full sync",
+        normalize=_canonical_esphome_version,
+        alt_fix=_RESTAMP_ALT_FIX,
     )
 
 

--- a/tests/test_sync_boards_single.py
+++ b/tests/test_sync_boards_single.py
@@ -93,3 +93,42 @@ def test_require_matching_esphome(monkeypatch, tmp_path):
     monkeypatch.setattr(esphome.const, "__version__", "2000.0.0")
     with pytest.raises(SystemExit, match=r"2099\.1\.1"):
         sb._require_matching_esphome()
+
+
+def test_require_matching_esphome_names_restamp(monkeypatch, tmp_path):
+    index = tmp_path / "boards.index.json"
+    index.write_bytes(orjson.dumps({"esphome_version": "2099.1.1", "boards": []}))
+    monkeypatch.setattr(sb, "_INDEX_FILE", index)
+    monkeypatch.setattr(esphome.const, "__version__", "2000.0.0")
+    with pytest.raises(SystemExit, match=r"--restamp"):
+        sb._require_matching_esphome()
+
+
+def test_require_matching_esphome_full(monkeypatch, tmp_path):
+    index = tmp_path / "boards.index.json"
+    index.write_bytes(orjson.dumps({"esphome_version": "2099.1.1", "boards": []}))
+    monkeypatch.setattr(sb, "_INDEX_FILE", index)
+
+    monkeypatch.setattr(esphome.const, "__version__", "2099.1.1b3")
+    sb._require_matching_esphome_full()  # beta canonicalizes to the base: no raise
+
+    monkeypatch.setattr(esphome.const, "__version__", "2000.0.0")
+    with pytest.raises(SystemExit, match=r"--restamp"):
+        sb._require_matching_esphome_full()
+
+
+def test_require_matching_esphome_full_missing_stamp_proceeds(monkeypatch, tmp_path):
+    monkeypatch.setattr(sb, "_INDEX_FILE", tmp_path / "boards.index.json")
+    monkeypatch.setattr(esphome.const, "__version__", "2000.0.0")
+    sb._require_matching_esphome_full()  # no index at all: first full sync
+
+    sb._INDEX_FILE.write_bytes(orjson.dumps({"boards": []}))
+    sb._require_matching_esphome_full()  # index without a stamp: same
+
+
+def test_restamp_with_board_id_is_an_argparse_error(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["sync_boards.py", "some_board", "--restamp"])
+    with pytest.raises(SystemExit) as excinfo:
+        sb.main()
+    assert excinfo.value.code == 2
+    assert "--restamp applies to the full sync only" in capsys.readouterr().err


### PR DESCRIPTION
# What does this implement/fix?

A bare `python script/sync_boards.py` (full sync) — including the `sync-boards` pre-commit hook — ran with **no ESPHome-version check**: it silently rewrote all 1041 board bodies and re-stamped `boards.index.json` from whatever esphome happened to be installed. That's the footgun that wrecked #2002: a contributor's full sync against a mismatched local esphome reverted a dozen unrelated boards, and a maintainer had to push the fix. The guard existed only on the single-board path — the one contributors are least likely to hit.

The full sync now refuses on a mismatch too, with the same install instructions single-board mode prints. The intentional catalog-wide regen against a new esphome is an explicit opt-in: `sync_boards.py --restamp` (rejected in single-board mode via `parser.error`). The one caller for which the mismatch is the point — `sync-component-catalog.yml`'s re-stamp step, which installs the freshly-resolved esphome before the stamp is bumped — passes `--restamp`. `sync-device-catalog.yml` deliberately does **not**: its install is pinned via `esphome-constraints.txt`, so the guard doubles as a pin/stamp consistency net there. CI's drift check and the pre-commit hook are unchanged — the hook failing loudly on a mismatched contributor venv is the fix.

A missing/unreadable stamp (first-ever sync) logs and proceeds. Docs updated: module docstring, `definitions/README.md` contributor guide, CLAUDE.md.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
