### PR TITLE
Tolerate whitespace inside ticked Types-of-changes checkboxes

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -47,10 +47,8 @@ jobs:
             // Match `- [x] ... `<label>`` lines in the PR body. The
             // PR template puts the canonical label name in backticks
             // at the end of each "Types of changes" bullet. Interior
-            // whitespace around the x is tolerated — contributors tick
-            // as `[ X]` / `[x ]` often enough (#2002, #1689) that
-            // GitHub's own renderer accepting only `[x]` is the trap,
-            // not the intent. An `[ ]` box stays unticked.
+            // whitespace around the x is tolerated — contributors
+            // tick as `[ X]` / `[x ]`.
             const body = context.payload.pull_request.body || '';
             const re = /^\s*-\s*\[\s*x\s*\][^`\n]*`([^`]+)`/gim;
             const ticked = [];

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -47,10 +47,10 @@ jobs:
             // Match `- [x] ... `<label>`` lines in the PR body. The
             // PR template puts the canonical label name in backticks
             // at the end of each "Types of changes" bullet. Interior
-            // whitespace around the x is tolerated — contributors
+            // spaces/tabs around the x are tolerated — contributors
             // tick as `[ X]` / `[x ]`.
             const body = context.payload.pull_request.body || '';
-            const re = /^\s*-\s*\[\s*x\s*\][^`\n]*`([^`]+)`/gim;
+            const re = /^\s*-\s*\[[ \t]*x[ \t]*\][^`\n]*`([^`]+)`/gim;
             const ticked = [];
             for (const m of body.matchAll(re)) {
               const name = m[1];

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -46,9 +46,13 @@ jobs:
 
             // Match `- [x] ... `<label>`` lines in the PR body. The
             // PR template puts the canonical label name in backticks
-            // at the end of each "Types of changes" bullet.
+            // at the end of each "Types of changes" bullet. Interior
+            // whitespace around the x is tolerated — contributors tick
+            // as `[ X]` / `[x ]` often enough (#2002, #1689) that
+            // GitHub's own renderer accepting only `[x]` is the trap,
+            // not the intent. An `[ ]` box stays unticked.
             const body = context.payload.pull_request.body || '';
-            const re = /^\s*-\s*\[x\][^`\n]*`([^`]+)`/gim;
+            const re = /^\s*-\s*\[\s*x\s*\][^`\n]*`([^`]+)`/gim;
             const ticked = [];
             for (const m of body.matchAll(re)) {
               const name = m[1];


### PR DESCRIPTION
# What does this implement/fix?

The Types-of-changes checkbox parser required a byte-exact `[x]` / `[X]` — a stray space inside the brackets (`[ X]`, `[x ]`) made the "Apply" job fail with "No checkbox is ticked", which has bitten real contributor PRs twice (#2002, #1689) and needed a maintainer to edit the description. The regex now tolerates interior whitespace around the x (`\[\s*x\s*\]`); an unticked `[ ]` still doesn't match.

Sandbox-verified against `[x]`, `[X]`, `[ X]`, `[X ]`, `[ x ]` (all match) and `[ ]`, `[]`, `[xx]` (all rejected).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
