### PR TITLE
Warn on hardware fields that break catalog conventions

### DIFF
--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -119,8 +119,7 @@ _BOARD_PIN_FEATURES = {
 
 # Usable RAM per chip as platformio's ``maximum_ram_size`` reports it — the
 # catalog convention for ``hardware.ram_size``. Datasheet SRAM figures differ
-# (esp32c3: 400KB SRAM vs 320KB usable) and are the recurring contributor
-# confusion this check catches.
+# (esp32c3: 400KB SRAM vs 320KB usable).
 _CHIP_MAX_RAM: dict[str, int] = {
     "esp32": 327680,
     "esp32s2": 327680,
@@ -224,8 +223,8 @@ def collect_hardware_warnings(board_id: str, data: dict) -> list[str]:
     """
     Best-effort convention checks on ``hardware`` — warnings, never errors.
 
-    esphome-table lookups skip silently when esphome isn't importable
-    (the pre-commit hook env), so full coverage runs in CI / update_board.
+    Checks needing the installed esphome's board tables skip silently
+    when esphome isn't importable.
     """
     esphome_cfg = data.get("esphome")
     hardware = data.get("hardware")
@@ -278,12 +277,12 @@ def _resolve_chip(esphome_cfg: dict) -> str | None:
     if platform == "esp8266":
         return "esp8266"
     if platform == "rp2040":
-        if (mcu := esphome_cfg.get("mcu")) is not None:
-            return mcu
-        if (tables := _esphome_boards_table("rp2040")) is not None:
+        mcu = esphome_cfg.get("mcu")
+        if mcu is None and (tables := _esphome_boards_table("rp2040")) is not None:
             meta = tables.get(esphome_cfg.get("board"))
             if isinstance(meta, dict):
-                return meta.get("mcu")
+                mcu = meta.get("mcu")
+        return mcu.lower() if isinstance(mcu, str) else None
     return None
 
 

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -164,21 +164,25 @@ def _validate_against_schema(data: dict, schema: dict | None, item_id: str) -> l
     return errors
 
 
-def validate_board(manifest: Path, components_index: dict | None = None) -> list[str]:
+def validate_board(
+    manifest: Path, components_index: dict | None = None, data: dict | None = None
+) -> list[str]:
     """
     Validate a board manifest. Returns list of error messages.
 
     *components_index* is the dict returned by :func:`_build_components_index`;
     when provided, featured-component cross-references are validated against
-    the live component catalog.
+    the live component catalog. *data* is the already-parsed manifest, to
+    save a caller that parsed it for other checks the second read.
     """
     errors: list[str] = []
     board_id = manifest.parent.name
 
-    try:
-        data = load_manifest_dict(manifest)
-    except ManifestError as exc:
-        return [f"{board_id}: {exc}"]
+    if data is None:
+        try:
+            data = load_manifest_dict(manifest)
+        except ManifestError as exc:
+            return [f"{board_id}: {exc}"]
 
     # JSON Schema validation
     errors.extend(_validate_against_schema(data, _BOARD_SCHEMA, board_id))
@@ -863,11 +867,12 @@ def main() -> int:
     # Validate boards
     boards_dir = DEFINITIONS_DIR / "boards"
     for manifest in sorted(boards_dir.glob("*/manifest.yaml")):
-        all_errors.extend(validate_board(manifest, components_index))
         try:
             data = load_manifest_dict(manifest)
-        except ManifestError:
-            continue  # already reported as an error above
+        except ManifestError as exc:
+            all_errors.append(f"{manifest.parent.name}: {exc}")
+            continue
+        all_errors.extend(validate_board(manifest, components_index, data))
         all_warnings.extend(collect_hardware_warnings(manifest.parent.name, data))
 
     # Validate components

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -326,11 +326,23 @@ def _flash_warning(board_id: str, esphome_cfg: dict, hardware: dict) -> str | No
 def _esphome_boards_table(platform: str) -> dict | None:
     """Return the installed esphome's ``BOARDS`` table for *platform*, or None when unimportable."""
     if platform not in _ESPHOME_BOARDS_CACHE:
+        # Broad except: warnings must never turn into a crash, even on a
+        # broken esphome install.
         try:
             module = __import__(f"esphome.components.{platform}.boards", fromlist=["BOARDS"])
-            _ESPHOME_BOARDS_CACHE[platform] = getattr(module, "BOARDS", None)
-        except ImportError:
+        except Exception:
             _ESPHOME_BOARDS_CACHE[platform] = None
+        else:
+            table = getattr(module, "BOARDS", None)
+            if table is None:
+                # esphome imports but the table moved: say so once, or an
+                # upstream refactor silently disables every table check.
+                print(
+                    f"WARNING: esphome.components.{platform}.boards has no BOARDS "
+                    "table; hardware convention checks that need it are skipped",
+                    file=sys.stderr,
+                )
+            _ESPHOME_BOARDS_CACHE[platform] = table
     return _ESPHOME_BOARDS_CACHE[platform]
 
 

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -117,6 +117,29 @@ _BOARD_PIN_FEATURES = {
     "boot_button",
 }
 
+# Usable RAM per chip as platformio's ``maximum_ram_size`` reports it — the
+# catalog convention for ``hardware.ram_size``. Datasheet SRAM figures differ
+# (esp32c3: 400KB SRAM vs 320KB usable) and are the recurring contributor
+# confusion this check catches.
+_CHIP_MAX_RAM: dict[str, int] = {
+    "esp32": 327680,
+    "esp32s2": 327680,
+    "esp32s3": 327680,
+    "esp32c3": 327680,
+    "esp32c5": 327680,
+    "esp32c6": 327680,
+    "esp32c61": 327680,
+    "esp32h2": 327680,
+    "esp8266": 81920,
+    "rp2040": 262144,
+    "rp2350": 524288,
+}
+
+# platformio declares PSRAM-inclusive maximum_ram_size for PSRAM boards
+# (m5stack-core2: 4521984); a manifest value at or above this follows that
+# convention deliberately, so only sub-threshold mismatches warn.
+_PSRAM_INCLUSIVE_MIN = 1024 * 1024
+
 # Load JSON schemas if jsonschema is available
 _BOARD_SCHEMA: dict | None = None
 _COMPONENT_SCHEMA: dict | None = None
@@ -195,6 +218,132 @@ def validate_board(manifest: Path, components_index: dict | None = None) -> list
     errors.extend(_validate_wifi_radio_claim(board_id, data))
 
     return errors
+
+
+def collect_hardware_warnings(board_id: str, data: dict) -> list[str]:
+    """
+    Best-effort convention checks on ``hardware`` — warnings, never errors.
+
+    esphome-table lookups skip silently when esphome isn't importable
+    (the pre-commit hook env), so full coverage runs in CI / update_board.
+    """
+    esphome_cfg = data.get("esphome")
+    hardware = data.get("hardware")
+    if not isinstance(esphome_cfg, dict) or not isinstance(hardware, dict):
+        return []
+    checks = (
+        _variant_warning(board_id, esphome_cfg),
+        _ram_warning(board_id, esphome_cfg, hardware),
+        _flash_warning(board_id, esphome_cfg, hardware),
+    )
+    return [warning for warning in checks if warning is not None]
+
+
+def _esp32_table_variant(esphome_cfg: dict) -> str | None:
+    """Return the installed esphome's variant for the manifest's esp32 board, if resolvable."""
+    if esphome_cfg.get("platform") != "esp32":
+        return None
+    if (tables := _esphome_boards_table("esp32")) is None:
+        return None
+    meta = tables.get(esphome_cfg.get("board"))
+    if isinstance(meta, dict) and isinstance(meta.get("variant"), str):
+        return meta["variant"].lower()
+    return None
+
+
+def _variant_warning(board_id: str, esphome_cfg: dict) -> str | None:
+    declared = esphome_cfg.get("variant")
+    table_variant = _esp32_table_variant(esphome_cfg)
+    if (
+        isinstance(declared, str)
+        and table_variant is not None
+        and declared.lower() != table_variant
+    ):
+        return (
+            f"{board_id}: esphome.variant '{declared}' does not match "
+            f"'{table_variant}' declared for board '{esphome_cfg.get('board')}' "
+            f"by the installed esphome"
+        )
+    return None
+
+
+def _resolve_chip(esphome_cfg: dict) -> str | None:
+    """Return the ``_CHIP_MAX_RAM`` key for the manifest's chip, or None."""
+    platform = esphome_cfg.get("platform")
+    if platform == "esp32":
+        declared = esphome_cfg.get("variant")
+        if isinstance(declared, str):
+            return declared.lower()
+        return _esp32_table_variant(esphome_cfg)
+    if platform == "esp8266":
+        return "esp8266"
+    if platform == "rp2040":
+        if (mcu := esphome_cfg.get("mcu")) is not None:
+            return mcu
+        if (tables := _esphome_boards_table("rp2040")) is not None:
+            meta = tables.get(esphome_cfg.get("board"))
+            if isinstance(meta, dict):
+                return meta.get("mcu")
+    return None
+
+
+def _ram_warning(board_id: str, esphome_cfg: dict, hardware: dict) -> str | None:
+    ram = hardware.get("ram_size")
+    chip = _resolve_chip(esphome_cfg)
+    if (
+        isinstance(ram, int)
+        and chip in _CHIP_MAX_RAM
+        and ram != _CHIP_MAX_RAM[chip]
+        and ram < _PSRAM_INCLUSIVE_MIN
+    ):
+        return (
+            f"{board_id}: ram_size {ram} differs from {chip}'s usable RAM "
+            f"{_CHIP_MAX_RAM[chip]} (platformio maximum_ram_size); datasheet "
+            f"SRAM figures don't belong here"
+        )
+    return None
+
+
+def _flash_warning(board_id: str, esphome_cfg: dict, hardware: dict) -> str | None:
+    flash = hardware.get("flash_size")
+    board = esphome_cfg.get("board")
+    if (
+        esphome_cfg.get("platform") == "esp8266"
+        and isinstance(flash, str)
+        and (flash_bytes := _flash_str_to_bytes(flash)) is not None
+        and (tables := _esphome_boards_table("esp8266")) is not None
+        and isinstance(meta := tables.get(board), dict)
+        and isinstance(meta.get("flash_size"), int)
+        and meta["flash_size"] != flash_bytes
+    ):
+        return (
+            f"{board_id}: flash_size {flash} ({flash_bytes} bytes) differs from "
+            f"{meta['flash_size']} bytes declared for board '{board}' by the "
+            f"installed esphome"
+        )
+    return None
+
+
+def _esphome_boards_table(platform: str) -> dict | None:
+    """Return the installed esphome's ``BOARDS`` table for *platform*, or None when unimportable."""
+    if platform not in _ESPHOME_BOARDS_CACHE:
+        try:
+            module = __import__(f"esphome.components.{platform}.boards", fromlist=["BOARDS"])
+            _ESPHOME_BOARDS_CACHE[platform] = getattr(module, "BOARDS", None)
+        except ImportError:
+            _ESPHOME_BOARDS_CACHE[platform] = None
+    return _ESPHOME_BOARDS_CACHE[platform]
+
+
+_ESPHOME_BOARDS_CACHE: dict[str, dict | None] = {}
+
+_FLASH_SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)MB$")
+
+
+def _flash_str_to_bytes(flash: str) -> int | None:
+    """``"4MB"`` / ``"0.5MB"`` in bytes, or None when unparseable."""
+    match = _FLASH_SIZE_RE.match(flash)
+    return int(float(match.group(1)) * 1024 * 1024) if match else None
 
 
 def _build_components_index() -> dict | None:
@@ -696,6 +845,7 @@ def main() -> int:
     args = parser.parse_args()
 
     all_errors: list[str] = []
+    all_warnings: list[str] = []
 
     components_index = _build_components_index()
 
@@ -703,6 +853,11 @@ def main() -> int:
     boards_dir = DEFINITIONS_DIR / "boards"
     for manifest in sorted(boards_dir.glob("*/manifest.yaml")):
         all_errors.extend(validate_board(manifest, components_index))
+        try:
+            data = load_manifest_dict(manifest)
+        except ManifestError:
+            continue  # already reported as an error above
+        all_warnings.extend(collect_hardware_warnings(manifest.parent.name, data))
 
     # Validate components
     components_dir = DEFINITIONS_DIR / "components"
@@ -711,6 +866,9 @@ def main() -> int:
 
     if args.check_images:
         all_errors.extend(check_board_images(boards_dir))
+
+    for warning in all_warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
 
     if all_errors:
         for error in all_errors:

--- a/tests/test_validate_hardware.py
+++ b/tests/test_validate_hardware.py
@@ -1,0 +1,87 @@
+"""Pin the best-effort hardware convention warnings."""
+
+from __future__ import annotations
+
+import script.validate_definitions as vd
+
+
+def _board(platform: str, board: str, **kwargs) -> dict:
+    esphome = {"platform": platform, "board": board}
+    if variant := kwargs.pop("variant", None):
+        esphome["variant"] = variant
+    if mcu := kwargs.pop("mcu", None):
+        esphome["mcu"] = mcu
+    return {"esphome": esphome, "hardware": kwargs}
+
+
+def test_ram_matching_chip_is_quiet():
+    data = _board("esp32", "esp32-c3-devkitm-1", variant="esp32c3", ram_size=327680)
+    assert vd.collect_hardware_warnings("b", data) == []
+
+
+def test_ram_datasheet_figure_warns():
+    data = _board("esp32", "esp32-c3-devkitm-1", variant="esp32c3", ram_size=393216)
+    warnings = vd.collect_hardware_warnings("b", data)
+    assert len(warnings) == 1
+    assert "327680" in warnings[0]
+
+
+def test_ram_psram_inclusive_is_quiet():
+    data = _board("esp32", "m5stack-core2", variant="esp32", ram_size=4521984)
+    assert vd.collect_hardware_warnings("b", data) == []
+
+
+def test_ram_per_chip_values():
+    for platform, board, chip_kw, ram in [
+        ("esp8266", "d1_mini", {}, 81920),
+        ("rp2040", "rpipico", {"mcu": "rp2040"}, 262144),
+        ("rp2040", "rpipico2", {"mcu": "rp2350"}, 524288),
+    ]:
+        data = _board(platform, board, ram_size=ram, **chip_kw)
+        assert vd.collect_hardware_warnings("b", data) == []
+        data = _board(platform, board, ram_size=ram + 1, **chip_kw)
+        assert len(vd.collect_hardware_warnings("b", data)) == 1
+
+
+def test_wrong_declared_esp32_variant_warns(monkeypatch):
+    monkeypatch.setitem(vd._ESPHOME_BOARDS_CACHE, "esp32", {"someboard": {"variant": "ESP32S3"}})
+    data = _board("esp32", "someboard", variant="esp32c3")
+    warnings = vd.collect_hardware_warnings("b", data)
+    assert len(warnings) == 1
+    assert "esp32s3" in warnings[0]
+
+
+def test_esp8266_flash_mismatch_warns(monkeypatch):
+    monkeypatch.setitem(vd._ESPHOME_BOARDS_CACHE, "esp8266", {"d1_mini": {"flash_size": 4194304}})
+    data = _board("esp8266", "d1_mini", flash_size="1MB")
+    warnings = vd.collect_hardware_warnings("b", data)
+    assert len(warnings) == 1
+    assert "4194304" in warnings[0]
+
+    data = _board("esp8266", "d1_mini", flash_size="4MB")
+    assert vd.collect_hardware_warnings("b", data) == []
+
+    data = _board("esp8266", "d1_mini", flash_size="not-a-size")
+    assert vd.collect_hardware_warnings("b", data) == []
+
+
+def test_no_esphome_tables_skips_table_checks(monkeypatch):
+    for platform in ("esp32", "esp8266", "rp2040"):
+        monkeypatch.setitem(vd._ESPHOME_BOARDS_CACHE, platform, None)
+    data = _board("esp8266", "d1_mini", flash_size="1MB", ram_size=81920)
+    assert vd.collect_hardware_warnings("b", data) == []
+    # The stdlib-only ram check still runs off the declared variant.
+    data = _board("esp32", "someboard", variant="esp32c3", ram_size=393216)
+    assert len(vd.collect_hardware_warnings("b", data)) == 1
+
+
+def test_unknown_chip_and_missing_hardware_are_quiet():
+    assert vd.collect_hardware_warnings("b", {"esphome": {"platform": "bk72xx"}}) == []
+    data = _board("bk72xx", "cb2s", ram_size=1)
+    assert vd.collect_hardware_warnings("b", data) == []
+
+
+def test_flash_str_to_bytes():
+    assert vd._flash_str_to_bytes("4MB") == 4194304
+    assert vd._flash_str_to_bytes("0.5MB") == 524288
+    assert vd._flash_str_to_bytes("512KB") is None

--- a/tests/test_validate_hardware.py
+++ b/tests/test_validate_hardware.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 import script.validate_definitions as vd
+
+
+@pytest.fixture(autouse=True)
+def _no_esphome_tables(monkeypatch):
+    """Pin the table cache to esphome-absent; table tests monkeypatch their own."""
+    for platform in ("esp32", "esp8266", "rp2040"):
+        monkeypatch.setitem(vd._ESPHOME_BOARDS_CACHE, platform, None)
 
 
 def _board(platform: str, board: str, **kwargs) -> dict:
@@ -65,9 +74,7 @@ def test_esp8266_flash_mismatch_warns(monkeypatch):
     assert vd.collect_hardware_warnings("b", data) == []
 
 
-def test_no_esphome_tables_skips_table_checks(monkeypatch):
-    for platform in ("esp32", "esp8266", "rp2040"):
-        monkeypatch.setitem(vd._ESPHOME_BOARDS_CACHE, platform, None)
+def test_no_esphome_tables_skips_table_checks():
     data = _board("esp8266", "d1_mini", flash_size="1MB", ram_size=81920)
     assert vd.collect_hardware_warnings("b", data) == []
     # The stdlib-only ram check still runs off the declared variant.
@@ -78,6 +85,15 @@ def test_no_esphome_tables_skips_table_checks(monkeypatch):
 def test_unknown_chip_and_missing_hardware_are_quiet():
     assert vd.collect_hardware_warnings("b", {"esphome": {"platform": "bk72xx"}}) == []
     data = _board("bk72xx", "cb2s", ram_size=1)
+    assert vd.collect_hardware_warnings("b", data) == []
+
+
+def test_malformed_manifest_values_stay_best_effort():
+    data = _board("rp2040", "rpipico", ram_size=262145)
+    data["esphome"]["mcu"] = {"not": "a string"}
+    assert vd.collect_hardware_warnings("b", data) == []
+    data = _board("esp32", "someboard", ram_size=262145)
+    data["esphome"]["variant"] = ["esp32c3"]
     assert vd.collect_hardware_warnings("b", data) == []
 
 


### PR DESCRIPTION
# What does this implement/fix?

Board-data conventions currently live in reviewer heads — #2002's `ram_size` confusion (datasheet 400KB-SRAM figure instead of platformio's 327680 `maximum_ram_size`) had to be caught and fixed by a maintainer. `validate_definitions.py` now emits best-effort **warnings** (never errors, exit code unaffected) for three of them:

- **`hardware.ram_size`** vs a curated per-chip table of platformio's `maximum_ram_size` (esp32-family 327680, esp8266 81920, rp2040 262144, rp2350 524288 — the installed esphome's board tables verifiably don't carry this value, hence curated). Values ≥ 1MB are skipped: platformio itself declares PSRAM-inclusive figures for PSRAM boards (m5stack-core2's own board json says 4521984), so those follow convention deliberately. This check is stdlib-only and runs even in the slim pre-commit hook env when the manifest declares its variant.
- **Declared `esphome.variant`** vs the installed esphome's `BOARDS[board]["variant"]` — a wrong declared variant ships silently today (`_backfill_esp32_variants` only fills missing ones).
- **esp8266 `hardware.flash_size`** vs `BOARDS[board]["flash_size"]`.

The esphome-table lookups skip silently when esphome isn't importable (the pre-commit hook env has only pyyaml+jsonschema), so full coverage runs where it matters: CI's validate step and `update_board.py`, both with the pinned esphome installed.

On the current tree this flags exactly one board — `waveshare_esp32_s3_nano` (`ram_size: 524288`, the S3's raw datasheet SRAM) — which I'll fix as a follow-up single-board sync rather than widen this PR's scope.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
