### PR TITLE
Name the exact fix in the board-catalog drift error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,10 +107,6 @@ jobs:
           if [ -n "$(git status --porcelain -- $paths)" ]; then
             git status --porcelain -- $paths
             git diff -- $paths
-            # Name the exact fix: the pinned esphome (a mismatched local
-            # install is the usual cause of a whole-catalog rewrite) and,
-            # when exactly one board's body drifted, its single-board
-            # update_board.py invocation.
             pin=$(grep -o 'esphome==.*' esphome-constraints.txt)
             ids=$(git status --porcelain -- esphome_device_builder/definitions/board_bodies/ \
               | grep 'board_bodies/' | sed -E 's|.*board_bodies/(.+)\.json.*|\1|' | sort -u || true)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,14 @@ jobs:
           if [ -n "$(git status --porcelain -- $paths)" ]; then
             git status --porcelain -- $paths
             git diff -- $paths
-            pin=$(grep -o 'esphome==.*' esphome-constraints.txt)
+            # || true everywhere: this branch runs under bash -e, and a
+            # no-match grep must not eat the ::error guidance below.
+            pin=$(grep -oE 'esphome==[A-Za-z0-9.]+' esphome-constraints.txt | head -n1 || true)
+            if [ -n "$pin" ]; then
+              install="uv pip install '$pin'"
+            else
+              install="uv pip install -c esphome-constraints.txt esphome"
+            fi
             ids=$(git status --porcelain -- esphome_device_builder/definitions/board_bodies/ \
               | grep 'board_bodies/' | sed -E 's|.*board_bodies/(.+)\.json.*|\1|' | sort -u || true)
             if [ "$(echo "$ids" | grep -c .)" = "1" ]; then
@@ -115,7 +122,7 @@ jobs:
             else
               fix="python script/sync_boards.py"
             fi
-            echo "::error::Board catalog is out of sync with manifests. Fix locally: uv pip install '$pin' && $fix — then commit the regenerated files (see definitions/README.md)."
+            echo "::error::Board catalog is out of sync with manifests. Fix locally: $install && $fix — then commit the regenerated files (see definitions/README.md)."
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,19 @@ jobs:
           if [ -n "$(git status --porcelain -- $paths)" ]; then
             git status --porcelain -- $paths
             git diff -- $paths
-            echo "::error::Board catalog is out of sync with manifests; run script/sync_boards.py and commit."
+            # Name the exact fix: the pinned esphome (a mismatched local
+            # install is the usual cause of a whole-catalog rewrite) and,
+            # when exactly one board's body drifted, its single-board
+            # update_board.py invocation.
+            pin=$(grep -o 'esphome==.*' esphome-constraints.txt)
+            ids=$(git status --porcelain -- esphome_device_builder/definitions/board_bodies/ \
+              | grep 'board_bodies/' | sed -E 's|.*board_bodies/(.+)\.json.*|\1|' | sort -u || true)
+            if [ "$(echo "$ids" | grep -c .)" = "1" ]; then
+              fix="python script/update_board.py $ids"
+            else
+              fix="python script/sync_boards.py"
+            fi
+            echo "::error::Board catalog is out of sync with manifests. Fix locally: uv pip install '$pin' && $fix — then commit the regenerated files (see definitions/README.md)."
             exit 1
           fi
 


### PR DESCRIPTION
# What does this implement/fix?

When the board-catalog drift gate fails, the error was a bare "run script/sync_boards.py and commit" — it never mentioned that the regen must run against the **pinned** esphome, which is the usual reason a contributor's local run rewrote the whole catalog in the first place (#2002). The step now derives the changed board ids from the porcelain output and the pin from `esphome-constraints.txt`, and emits the exact local fix:

- one drifted body → `uv pip install 'esphome==<pin>' && python script/update_board.py <id>`
- otherwise → the pin-qualified full-sync command

plus a pointer to `definitions/README.md`. The gate itself is unchanged; the id extraction is filtered to `board_bodies/` lines so index-only drift falls through to the full-sync message. Logic sandbox-tested against single-board, multi-board, and index-only porcelain shapes.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
