### PR TITLE
Auto-regenerate the board catalog on manifest PRs

### DIFF
--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -132,8 +132,16 @@ jobs:
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
         # rm-then-copy so deletions and renames propagate. components/
         # comes along so featured-pin stamping sees the same catalog the
-        # PR tree does even when the PR base is stale.
+        # PR tree does even when the PR base is stale. Symlinks anywhere
+        # under the PR's definitions tree are refused: a symlinked
+        # manifest would make the trusted sync read — and a symlinked
+        # output dir make the copy-back write — arbitrary runner paths.
         run: |
+          if find pr/esphome_device_builder/definitions -type l | grep -q .; then
+            find pr/esphome_device_builder/definitions -type l
+            echo "::error::Symlinks under esphome_device_builder/definitions are not allowed."
+            exit 1
+          fi
           rm -rf base/esphome_device_builder/definitions/boards \
             base/esphome_device_builder/definitions/components
           cp -a pr/esphome_device_builder/definitions/boards \
@@ -204,6 +212,9 @@ jobs:
         if: >-
           steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
           && steps.stage.outputs.changed == 'true'
+        # The patch is a convenience; a flaky artifact store must not
+        # block the push.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: board-catalog-regen-${{ github.event.pull_request.number }}
@@ -249,7 +260,12 @@ jobs:
             -c user.name="${SLUG}[bot]" \
             -c user.email="${bot_id}+${SLUG}[bot]@users.noreply.github.com" \
             commit -m "Regenerate board catalog for ${BOARD_IDS} [board-catalog-regen]"
-          git -C pr push "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${HEAD_REF}"
+          # Credential via header, not URL — a URL-embedded token would
+          # echo into the log on push errors (masked, but keep it out
+          # entirely).
+          auth=$(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')
+          git -C pr -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth}" \
+            push "https://github.com/${REPO}.git" "HEAD:refs/heads/${HEAD_REF}"
 
       - name: Comment on fork PR (sticky)
         if: >-
@@ -259,7 +275,6 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           CHANGED: ${{ steps.stage.outputs.changed }}
-          BOARD_IDS: ${{ steps.inspect.outputs.board_ids }}
           PIN: ${{ steps.stage.outputs.pin }}
         with:
           script: |
@@ -267,7 +282,9 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const ids = process.env.BOARD_IDS.split(' ').filter(Boolean);
+            // Full sync, not per-id update_board.py: it handles deleted
+            // and renamed boards too, and mirrors what this run executed.
+            const pin = process.env.PIN || 'esphome';
             const body = process.env.CHANGED === 'true'
               ? [
                   marker,
@@ -277,8 +294,8 @@ jobs:
                   "what's committed. Forks can't receive an automated push, so run locally:",
                   '',
                   '```bash',
-                  `uv pip install '${process.env.PIN}'`,
-                  ...ids.map(id => `python script/update_board.py ${id}`),
+                  `uv pip install '${pin}'`,
+                  'python script/sync_boards.py',
                   'git add -A esphome_device_builder/definitions && git commit -m "Regenerate board catalog" && git push',
                   '```',
                   '',

--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -120,13 +120,15 @@ jobs:
         # retriggers this workflow; the marker check stops the loop one
         # run early (deterministic no-diff convergence is the backstop).
         run: |
-          subject=$(git -C pr log -1 --format=%s)
-          if [ "${subject#*"[board-catalog-regen]"}" != "$subject" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Head commit is our own regen; nothing to do."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          case "$(git -C pr log -1 --format=%s)" in
+            *"[board-catalog-regen]"*)
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Head commit is our own regen; nothing to do."
+              ;;
+            *)
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
       - name: Overlay PR manifests onto the base tree
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'

--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -1,0 +1,310 @@
+name: Regenerate board catalog
+
+# Auto-regenerates the three generated board-catalog artefacts
+# (boards.index.json, board_bodies/<id>.json,
+# featured_components.index.json) on PRs that edit board manifests, so
+# contributors only ever hand-edit YAML. Same-repo PRs get the regen
+# pushed as a bot commit; fork PRs (no token can push to a fork — the
+# maintainer-edit grant applies to user credentials only) get a sticky
+# comment with the exact local commands plus a ready-to-apply patch
+# artifact. test.yml's drift gate stays as the enforcing backstop; this
+# workflow must never become a required check.
+#
+# Security model (pull_request_target => secrets reachable):
+# every executed script comes from the BASE checkout; the PR head is
+# checked out as *data only* and only its definitions/boards +
+# definitions/components trees are overlaid (parsed via CSafeLoader /
+# orjson — no code paths). The run skips entirely when the PR touches
+# anything that could influence execution (script/**, any *.py,
+# esphome-constraints.txt, pyproject.toml, workflows, pre-commit
+# config). The App token is minted only after all untrusted-data
+# processing, scoped to this repo with contents:write only, and the
+# commit is staged through a pathspec allowlist of the three generated
+# locations. PR-controlled strings (branch name, board ids) never reach
+# a shell uninterpolated: ids are validated against a strict slug
+# regex, the branch name travels via env.
+#
+# Rollout gate: mutating actions (push / comment) only run when the
+# repo variable BOARD_CATALOG_AUTOPUSH is 'true'; otherwise the run
+# computes, uploads the patch artifact, and logs what it would do.
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "esphome_device_builder/definitions/boards/**/manifest.yaml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: regen-board-catalog-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  regen:
+    name: Regenerate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Bot PRs (catalog syncs, dependabot) already carry their regen or
+    # never touch manifests; a null head repo is a fork deleted mid-flight.
+    if: >-
+      github.event.pull_request.head.repo != null
+      && github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Inspect PR files
+        id: inspect
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const paths = files.map(f => f.filename);
+            // Skip when the PR could influence what this workflow
+            // executes or installs — the drift gate covers those PRs.
+            const codePatterns = [
+              /^script\//,
+              /\.py$/,
+              /^esphome-constraints\.txt$/,
+              /^pyproject\.toml$/,
+              /^\.github\//,
+              /^\.pre-commit-config\.yaml$/,
+            ];
+            const touchy = paths.filter(p => codePatterns.some(re => re.test(p)));
+            if (touchy.length) {
+              core.notice(`Skipping auto-regen: PR also touches ${touchy.slice(0, 5).join(', ')}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            const idRe = /^esphome_device_builder\/definitions\/boards\/([^/]+)\/manifest\.yaml$/;
+            const ids = [...new Set(paths.map(p => idRe.exec(p)?.[1]).filter(Boolean))];
+            // Ids become commit-message / comment text and a suggested
+            // command line; anything outside the slug alphabet is not a
+            // board this catalog could contain — refuse rather than quote.
+            const slugRe = /^[A-Za-z0-9._-]+$/;
+            if (!ids.length || ids.some(id => !slugRe.test(id))) {
+              core.notice('Skipping auto-regen: no plainly-named board manifest in the diff.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+            const head = context.payload.pull_request.head;
+            core.setOutput('skip', 'false');
+            core.setOutput('board_ids', ids.join(' '));
+            core.setOutput('is_fork', String(head.repo.full_name !== `${owner}/${repo}`));
+
+      - name: Check out base (trusted, executed)
+        if: steps.inspect.outputs.skip != 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          path: base
+          persist-credentials: false
+
+      - name: Check out PR head (data only, never executed)
+        if: steps.inspect.outputs.skip != 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          path: pr
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Skip our own regen commit
+        id: loop
+        if: steps.inspect.outputs.skip != 'true'
+        # The paths filter sees the whole PR diff, so the bot's own push
+        # retriggers this workflow; the marker check stops the loop one
+        # run early (deterministic no-diff convergence is the backstop).
+        run: |
+          subject=$(git -C pr log -1 --format=%s)
+          if [ "${subject#*"[board-catalog-regen]"}" != "$subject" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Head commit is our own regen; nothing to do."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Overlay PR manifests onto the base tree
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        # rm-then-copy so deletions and renames propagate. components/
+        # comes along so featured-pin stamping sees the same catalog the
+        # PR tree does even when the PR base is stale.
+        run: |
+          rm -rf base/esphome_device_builder/definitions/boards \
+            base/esphome_device_builder/definitions/components
+          cp -a pr/esphome_device_builder/definitions/boards \
+            base/esphome_device_builder/definitions/boards
+          cp -a pr/esphome_device_builder/definitions/components \
+            base/esphome_device_builder/definitions/components
+
+      - name: Set up Python
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install package (base constraints)
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        working-directory: base
+        run: uv pip install --system -c esphome-constraints.txt -e '.[esphome,test]'
+
+      - name: Validate manifests
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        working-directory: base
+        run: python script/validate_definitions.py
+
+      - name: Regenerate catalog against the pinned esphome
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        working-directory: base
+        # Full sync: handles adds / deletes / multi-board edits and
+        # restores a whole-catalog clobber; --restamp is unnecessary
+        # (and undesired) because the pinned install matches the stamp.
+        run: python script/sync_boards.py
+
+      - name: Stage regenerated artefacts into the PR tree
+        id: stage
+        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+        # The git-add pathspec is the write allowlist: whatever the sync
+        # produced, only the three generated locations can reach a commit.
+        run: |
+          defs=esphome_device_builder/definitions
+          rsync -a --delete "base/$defs/board_bodies/" "pr/$defs/board_bodies/"
+          cp "base/$defs/boards.index.json" "base/$defs/featured_components.index.json" "pr/$defs/"
+          git -C pr add -A -- \
+            "$defs/boards.index.json" \
+            "$defs/board_bodies" \
+            "$defs/featured_components.index.json"
+          if git -C pr diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Committed catalog already matches the regenerated one."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git -C pr diff --cached --stat | tail -5
+          fi
+          pin=$(grep -oE 'esphome==[A-Za-z0-9.b-]+' base/esphome-constraints.txt | head -n1)
+          echo "pin=$pin" >> "$GITHUB_OUTPUT"
+
+      - name: Write regen patch
+        if: >-
+          steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+          && steps.stage.outputs.changed == 'true'
+        run: git -C pr diff --cached > board-catalog-regen.patch
+
+      - name: Upload regen patch
+        if: >-
+          steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+          && steps.stage.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: board-catalog-regen-${{ github.event.pull_request.number }}
+          path: board-catalog-regen.patch
+          retention-days: 14
+
+      - name: Mint App token
+        id: token
+        if: >-
+          steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+          && steps.stage.outputs.changed == 'true'
+          && steps.inspect.outputs.is_fork == 'false'
+          && vars.BOARD_CATALOG_AUTOPUSH == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: Push regen commit to the PR branch
+        if: steps.token.outcome == 'success'
+        env:
+          TOKEN: ${{ steps.token.outputs.token }}
+          SLUG: ${{ steps.token.outputs.app-slug }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BOARD_IDS: ${{ steps.inspect.outputs.board_ids }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The branch may have moved since this event fired; a push on a
+          # stale base would either fail (fine) or interleave — bail and
+          # let the new synchronize event's run handle it.
+          current=$(git ls-remote "https://github.com/${REPO}.git" "refs/heads/${HEAD_REF}" | cut -f1)
+          if [ "$current" != "$HEAD_SHA" ]; then
+            echo "::notice::Branch moved (${current}); the newer run takes over."
+            exit 0
+          fi
+          bot_id=$(gh api "/users/${SLUG}%5Bbot%5D" --jq .id)
+          git -C pr \
+            -c user.name="${SLUG}[bot]" \
+            -c user.email="${bot_id}+${SLUG}[bot]@users.noreply.github.com" \
+            commit -m "Regenerate board catalog for ${BOARD_IDS} [board-catalog-regen]"
+          git -C pr push "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${HEAD_REF}"
+
+      - name: Comment on fork PR (sticky)
+        if: >-
+          steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+          && steps.inspect.outputs.is_fork == 'true'
+          && vars.BOARD_CATALOG_AUTOPUSH == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          CHANGED: ${{ steps.stage.outputs.changed }}
+          BOARD_IDS: ${{ steps.inspect.outputs.board_ids }}
+          PIN: ${{ steps.stage.outputs.pin }}
+        with:
+          script: |
+            const marker = '<!-- board-catalog-regen -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const ids = process.env.BOARD_IDS.split(' ').filter(Boolean);
+            const body = process.env.CHANGED === 'true'
+              ? [
+                  marker,
+                  '### Board catalog needs regenerating',
+                  '',
+                  'CI regenerated the catalog JSON from your manifests and it differs from',
+                  "what's committed. Forks can't receive an automated push, so run locally:",
+                  '',
+                  '```bash',
+                  `uv pip install '${process.env.PIN}'`,
+                  ...ids.map(id => `python script/update_board.py ${id}`),
+                  'git add -A esphome_device_builder/definitions && git commit -m "Regenerate board catalog" && git push',
+                  '```',
+                  '',
+                  `Or download \`board-catalog-regen.patch\` from [this run](${runUrl}) and \`git apply\` it.`,
+                  'Details: `esphome_device_builder/definitions/README.md`.',
+                ].join('\n')
+              : `${marker}\n✅ Board catalog is in sync with the manifests.`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else if (process.env.CHANGED === 'true') {
+              // Never open a comment just to say everything is fine.
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Dry-run summary
+        if: >-
+          steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
+          && steps.stage.outputs.changed == 'true'
+          && vars.BOARD_CATALOG_AUTOPUSH != 'true'
+        env:
+          IS_FORK: ${{ steps.inspect.outputs.is_fork }}
+        run: |
+          action="push a regen commit to the PR branch"
+          [ "$IS_FORK" = "true" ] && action="post the fork instructions comment"
+          echo "::notice::Dry run (BOARD_CATALOG_AUTOPUSH unset): would $action. Patch uploaded as artifact."

--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -201,7 +201,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
             git -C pr diff --cached --stat | tail -5
           fi
-          pin=$(grep -oE 'esphome==[A-Za-z0-9.b-]+' base/esphome-constraints.txt | head -n1)
+          pin=$(grep -oE 'esphome==[A-Za-z0-9.]+' base/esphome-constraints.txt | head -n1 || true)
           echo "pin=$pin" >> "$GITHUB_OUTPUT"
 
       - name: Write regen patch
@@ -286,7 +286,11 @@ jobs:
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             // Full sync, not per-id update_board.py: it handles deleted
             // and renamed boards too, and mirrors what this run executed.
-            const pin = process.env.PIN || 'esphome';
+            // Constraints-file fallback stays version-correct even when
+            // no pin token was derivable.
+            const install = process.env.PIN
+              ? `uv pip install '${process.env.PIN}'`
+              : 'uv pip install -c esphome-constraints.txt esphome';
             const body = process.env.CHANGED === 'true'
               ? [
                   marker,
@@ -296,7 +300,7 @@ jobs:
                   "what's committed. Forks can't receive an automated push, so run locally:",
                   '',
                   '```bash',
-                  `uv pip install '${pin}'`,
+                  install,
                   'python script/sync_boards.py',
                   'git add -A esphome_device_builder/definitions && git commit -m "Regenerate board catalog" && git push',
                   '```',
@@ -308,7 +312,7 @@ jobs:
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number, per_page: 100,
             });
-            const existing = comments.find(c => c.body.includes(marker));
+            const existing = comments.find(c => c.body?.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             } else if (process.env.CHANGED === 'true') {

--- a/esphome_device_builder/definitions/README.md
+++ b/esphome_device_builder/definitions/README.md
@@ -51,6 +51,17 @@ compares every manifest against its generated body and fails CI on any drift.
 confirm it resolves (network, opt-in); the consistency test exempts `images`, so
 a broken image URL passes the sync but is caught here.
 
+### CI regenerates the catalog for you
+
+On PRs that edit a board manifest, CI reruns the regeneration against the
+pinned ESPHome (`.github/workflows/regen-board-catalog.yml`): same-repo
+branches get the regenerated JSON pushed back as a bot commit, and fork PRs
+get a sticky comment with the exact commands plus a ready-to-apply
+`board-catalog-regen.patch` artifact. So if you forget the local step — or
+regenerated against the wrong ESPHome — CI fixes or tells you exactly how to.
+Running `update_board.py` locally is still the fastest path (no CI round-trip)
+and the only one that also validates before you push.
+
 ### Run the sync with the project venv
 
 `sync_boards.py` imports ESPHome: it generates the boards no manifest covers


### PR DESCRIPTION
# What does this implement/fix?

Contributors keep tripping over the board-catalog regen step (#2002 needed maintainer pushes to fix a whole-catalog rewrite from a mismatched local esphome). This adds `.github/workflows/regen-board-catalog.yml`: on PRs that edit `definitions/boards/**/manifest.yaml`, CI regenerates the three generated artefacts **with base-branch code against the pinned esphome** and pushes the result to the PR as a bot commit — contributors only ever hand-edit YAML. Fork PRs (no token can push to a fork; the maintainer-edit grant applies to user credentials only) instead get a sticky comment with the exact pinned-install + full-sync commands and a downloadable `git apply` patch artifact, flipped to "✅ in sync" once resolved.

**Security model** (`pull_request_target`, so designed adversarially and reviewed by two independent adversarial passes before opening):

- Everything executed comes from the **base** checkout; the PR head is data only — just its `definitions/boards/` + `definitions/components/` trees are overlaid (consumed via CSafeLoader/orjson; nothing imported or executed).
- Hard skip when the PR touches anything execution-influencing: `script/**`, any `*.py` (matches nested paths), `esphome-constraints.txt`, `pyproject.toml`, `.github/**`, `.pre-commit-config.yaml`. Build backend is plain `setuptools.build_meta`, so the overlay cannot influence the install.
- **Symlinks anywhere under the PR's `definitions/` tree are refused** — a symlinked manifest would turn the trusted sync into an arbitrary runner-file read, and a symlinked output dir would let the copy-back write outside the tree.
- The App token is minted only after all untrusted-data processing, scoped to this repo with `contents: write` only, and passed to git via a URL-scoped `http.<url>.extraheader` rather than embedded in the push URL. The commit is staged through a pathspec allowlist of the three generated locations. No PR-controlled string is interpolated into a shell (`head.ref` travels via `env:`; board ids are validated against `^[A-Za-z0-9._-]+$`).
- Loop-safe: the bot commit carries a `[board-catalog-regen]` marker its own retrigger skips on, and regeneration is byte-deterministic so a second run converges to no-diff. Per-PR concurrency with cancel-in-progress; 20-minute timeout; `ls-remote` head-unchanged guard + non-force push for mid-run contributor pushes.

**Rollout is dark**: all mutating steps (push / comment) are additionally gated on the repo variable `BOARD_CATALOG_AUTOPUSH`; until it's set to `true` the workflow only computes, uploads the patch artifact, and logs what it would do. The flip is a separate deliberate action after rehearsal on test PRs (same-repo, fork, a #2002-style clobber drill, and a `script/`-touching skip-guard proof). test.yml's drift gate (sharpened in #2015) stays as the enforcing backstop; this workflow must **never** become a required check.

Rehearsed locally: split-checkout overlay + regen on a simulated PR that both edited a manifest and clobbered the catalog stamp — the staged result was scoped to exactly the edited board plus the stamp restore, with nothing outside the allowlist.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [x] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
