### PR TITLE
Test: regen-board-catalog dry-run rehearsal (do not merge)

### DIFF
--- a/esphome_device_builder/definitions/boards/waveshare_esp32_c3_zero/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/waveshare_esp32_c3_zero/manifest.yaml
@@ -2,7 +2,7 @@ id: waveshare_esp32_c3_zero
 name: Waveshare ESP32-C3-Zero
 description: >
   Ultra-compact ESP32-C3 module with castellated pads, 4MB onboard flash, USB-C connector and an onboard ceramic antenna.
-  No USB-UART bridge chip.
+  No USB-UART bridge chip onboard.
 manufacturer: Waveshare
 
 images:

--- a/script/update_board.py
+++ b/script/update_board.py
@@ -131,4 +131,3 @@ def _run(label: str, script: str, *script_args: str) -> bool:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/script/update_board.py
+++ b/script/update_board.py
@@ -131,3 +131,4 @@ def _run(label: str, script: str, *script_args: str) -> bool:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/script/update_board.py
+++ b/script/update_board.py
@@ -30,6 +30,7 @@ _BOARDS_REL = "esphome_device_builder/definitions/boards"
 _BOARDS_DIR = _REPO_ROOT / _BOARDS_REL
 
 
+# Rehearsal marker: proves the regen workflow skip-guard (removed with the test PR).
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Regenerate, validate, and report one board's catalog files."


### PR DESCRIPTION
Rehearsal PR for the #2017 dark launch: edits one manifest **without** regenerating, deliberately bypassing the pre-commit hook.

Expected:
1. `Regenerate board catalog` workflow: computes a diff, uploads `board-catalog-regen.patch`, logs the dry-run 'would push' notice (BOARD_CATALOG_AUTOPUSH unset ⇒ zero writes).
2. `Lint + smoke checks`: drift gate fails with the #2015 error naming `update_board.py waveshare_esp32_c3_zero` and the pinned esphome.

Will be closed unmerged; a follow-up push will touch `script/` to prove the skip guard.