### PR TITLE
Align _resolve_images with the featured-image path traversal guard

### DIFF
--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -29,7 +29,7 @@ import orjson
 import yaml
 
 from ..constants import DEVICE_IMPORT_SOURCE_TYPE
-from ..helpers.lazy_catalog import is_unsafe_catalog_id
+from ..helpers.lazy_catalog import is_unsafe_catalog_id, is_unsafe_manifest_path
 from ..helpers.yaml import FastestSafeLoader
 from ..models import (
     BoardCatalogEntry,
@@ -95,7 +95,8 @@ def _resolve_images(board_dir: Path, manifest_images: list[str] | None) -> list[
 
     Local images are converted to relative URLs served by the
     /boards/images static route (e.g. /boards/images/esp32-devkit-v1/images/photo.png).
-    External URLs are kept as-is.
+    External URLs are kept as-is. An absolute path or a parent-dir
+    escape is dropped (logged), same as featured images.
     """
     images: list[str] = []
 
@@ -103,6 +104,12 @@ def _resolve_images(board_dir: Path, manifest_images: list[str] | None) -> list[
     for entry in manifest_images or []:
         if entry.startswith(("http://", "https://")):
             images.append(entry)
+        elif is_unsafe_manifest_path(entry):
+            _LOGGER.warning(
+                "Board %s: image %r must be a path inside the board dir; skipping",
+                board_dir.name,
+                entry,
+            )
         else:
             # Resolve relative path against board directory
             local = board_dir / entry
@@ -206,7 +213,7 @@ def _resolve_featured_image(raw: object, board_dir: Path) -> str:
         return ""
     if raw.startswith(("http://", "https://")):
         return raw
-    if Path(raw).is_absolute() or ".." in Path(raw).parts:
+    if is_unsafe_manifest_path(raw):
         _LOGGER.warning(
             "Board %s: featured image %r must be a path inside the board dir; skipping",
             board_dir.name,

--- a/esphome_device_builder/definitions/__init__.py
+++ b/esphome_device_builder/definitions/__init__.py
@@ -29,7 +29,11 @@ import orjson
 import yaml
 
 from ..constants import DEVICE_IMPORT_SOURCE_TYPE
-from ..helpers.lazy_catalog import is_unsafe_catalog_id, is_unsafe_manifest_path
+from ..helpers.lazy_catalog import (
+    is_external_image_url,
+    is_unsafe_catalog_id,
+    is_unsafe_manifest_path,
+)
 from ..helpers.yaml import FastestSafeLoader
 from ..models import (
     BoardCatalogEntry,
@@ -96,13 +100,13 @@ def _resolve_images(board_dir: Path, manifest_images: list[str] | None) -> list[
     Local images are converted to relative URLs served by the
     /boards/images static route (e.g. /boards/images/esp32-devkit-v1/images/photo.png).
     External URLs are kept as-is. An absolute path or a parent-dir
-    escape is dropped (logged), same as featured images.
+    escape is dropped (logged).
     """
     images: list[str] = []
 
     # First: explicit entries from manifest (URLs or relative paths)
     for entry in manifest_images or []:
-        if entry.startswith(("http://", "https://")):
+        if is_external_image_url(entry):
             images.append(entry)
         elif is_unsafe_manifest_path(entry):
             _LOGGER.warning(
@@ -211,7 +215,7 @@ def _resolve_featured_image(raw: object, board_dir: Path) -> str:
     """
     if not isinstance(raw, str) or not raw:
         return ""
-    if raw.startswith(("http://", "https://")):
+    if is_external_image_url(raw):
         return raw
     if is_unsafe_manifest_path(raw):
         _LOGGER.warning(

--- a/esphome_device_builder/helpers/lazy_catalog.py
+++ b/esphome_device_builder/helpers/lazy_catalog.py
@@ -53,9 +53,11 @@ def is_unsafe_manifest_path(raw: str) -> bool:
 
     Checked under both path flavours so the verdict is host-independent:
     ``anchor`` catches POSIX-absolute plus the Windows drive / rooted
-    forms (``C:x``, ``\x``) on any OS.
+    forms (``C:x``, ``\x``) on any OS. A NUL byte (reachable via a
+    YAML ``"\0"`` escape) is rejected rather than silently failing
+    every filesystem probe downstream.
     """
-    return any(
+    return "\x00" in raw or any(
         bool(path.anchor) or ".." in path.parts
         for path in (PurePosixPath(raw), PureWindowsPath(raw))
     )

--- a/esphome_device_builder/helpers/lazy_catalog.py
+++ b/esphome_device_builder/helpers/lazy_catalog.py
@@ -21,7 +21,7 @@ import asyncio
 from collections import OrderedDict
 from collections.abc import Callable
 from functools import lru_cache
-from pathlib import PurePath
+from pathlib import PurePosixPath, PureWindowsPath
 
 # LRU cap for ``is_unsafe_catalog_id`` (~5x a typical catalog size).
 # Bounded rather than ``@cache`` because the predicate sees external
@@ -42,15 +42,23 @@ def is_unsafe_catalog_id(catalog_id: str) -> bool:
     )
 
 
+def is_external_image_url(raw: str) -> bool:
+    """Return True when a manifest image entry is an external http(s) URL."""
+    return raw.startswith(("http://", "https://"))
+
+
 def is_unsafe_manifest_path(raw: str) -> bool:
     r"""
     Return True for a manifest-relative path that can escape its base dir.
 
+    Checked under both path flavours so the verdict is host-independent:
     ``anchor`` catches POSIX-absolute plus the Windows drive / rooted
-    forms (``C:x``, ``\x``) that ``is_absolute`` alone misses.
+    forms (``C:x``, ``\x``) on any OS.
     """
-    path = PurePath(raw)
-    return bool(path.anchor) or ".." in path.parts
+    return any(
+        bool(path.anchor) or ".." in path.parts
+        for path in (PurePosixPath(raw), PureWindowsPath(raw))
+    )
 
 
 class LazyBodyStore[BodyT]:

--- a/esphome_device_builder/helpers/lazy_catalog.py
+++ b/esphome_device_builder/helpers/lazy_catalog.py
@@ -21,6 +21,7 @@ import asyncio
 from collections import OrderedDict
 from collections.abc import Callable
 from functools import lru_cache
+from pathlib import PurePath
 
 # LRU cap for ``is_unsafe_catalog_id`` (~5x a typical catalog size).
 # Bounded rather than ``@cache`` because the predicate sees external
@@ -39,6 +40,17 @@ def is_unsafe_catalog_id(catalog_id: str) -> bool:
         or "\\" in catalog_id
         or "\x00" in catalog_id
     )
+
+
+def is_unsafe_manifest_path(raw: str) -> bool:
+    r"""
+    Return True for a manifest-relative path that can escape its base dir.
+
+    ``anchor`` catches POSIX-absolute plus the Windows drive / rooted
+    forms (``C:x``, ``\x``) that ``is_absolute`` alone misses.
+    """
+    path = PurePath(raw)
+    return bool(path.anchor) or ".." in path.parts
 
 
 class LazyBodyStore[BodyT]:

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -36,7 +36,10 @@ from esphome_device_builder.constants import (  # noqa: E402
     BUS_CATEGORIES,
     FEATURED_EXCLUDED_CATEGORIES,
 )
-from esphome_device_builder.helpers.lazy_catalog import is_unsafe_manifest_path  # noqa: E402
+from esphome_device_builder.helpers.lazy_catalog import (  # noqa: E402
+    is_external_image_url,
+    is_unsafe_manifest_path,
+)
 from script._component_catalog import load_component_catalog  # noqa: E402
 from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 
@@ -487,10 +490,7 @@ def _validate_image_paths(board_id: str, data: dict) -> list[str]:
     return [
         f"{board_id}: {label} '{raw}' must be a relative path inside the board dir"
         for label, raw in candidates
-        if isinstance(raw, str)
-        and raw
-        and not raw.startswith(("http://", "https://"))
-        and is_unsafe_manifest_path(raw)
+        if isinstance(raw, str) and not is_external_image_url(raw) and is_unsafe_manifest_path(raw)
     ]
 
 

--- a/script/validate_definitions.py
+++ b/script/validate_definitions.py
@@ -36,6 +36,7 @@ from esphome_device_builder.constants import (  # noqa: E402
     BUS_CATEGORIES,
     FEATURED_EXCLUDED_CATEGORIES,
 )
+from esphome_device_builder.helpers.lazy_catalog import is_unsafe_manifest_path  # noqa: E402
 from script._component_catalog import load_component_catalog  # noqa: E402
 from script._manifest import ManifestError, load_manifest_dict  # noqa: E402
 
@@ -219,6 +220,8 @@ def validate_board(
     errors.extend(_validate_featured(board_id, data, pins_by_gpio, components_index, is_imported))
 
     errors.extend(_validate_wifi_radio_claim(board_id, data))
+
+    errors.extend(_validate_image_paths(board_id, data))
 
     return errors
 
@@ -467,6 +470,27 @@ def _validate_wifi_radio_claim(board_id: str, data: dict) -> list[str]:
         f"'{variant}' without a default component providing a Wi-Fi radio "
         f"({', '.join(sorted(_WIFI_RADIO_COMPONENT_IDS))}) — the generator "
         "would emit a wifi block the chip cannot validate"
+    ]
+
+
+def _validate_image_paths(board_id: str, data: dict) -> list[str]:
+    """Reject local image paths that are absolute or escape the board dir."""
+    candidates: list[tuple[str, object]] = [
+        ("images entry", entry) for entry in data.get("images") or []
+    ]
+    for section in ("featured_components", "featured_bundles"):
+        candidates.extend(
+            (f"{section} image_url", item.get("image_url"))
+            for item in data.get(section) or []
+            if isinstance(item, dict)
+        )
+    return [
+        f"{board_id}: {label} '{raw}' must be a relative path inside the board dir"
+        for label, raw in candidates
+        if isinstance(raw, str)
+        and raw
+        and not raw.startswith(("http://", "https://"))
+        and is_unsafe_manifest_path(raw)
     ]
 
 

--- a/tests/helpers/test_lazy_catalog.py
+++ b/tests/helpers/test_lazy_catalog.py
@@ -18,6 +18,7 @@ import pytest
 from esphome_device_builder.helpers.lazy_catalog import (
     LazyBodyStore,
     is_unsafe_catalog_id,
+    is_unsafe_manifest_path,
 )
 
 
@@ -45,6 +46,24 @@ def test_is_unsafe_catalog_id_rejects_traversal_shapes(bad: str) -> None:
 @pytest.mark.parametrize("good", ["wifi", "sensor.dht", "sensor.bme280_i2c"])
 def test_is_unsafe_catalog_id_passes_flat_catalog_ids(good: str) -> None:
     assert is_unsafe_catalog_id(good) is False
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "/etc/passwd",
+        "../other-board/x.jpg",
+        "images/../../escape.png",
+        "..",
+    ],
+)
+def test_is_unsafe_manifest_path_rejects_escaping_shapes(bad: str) -> None:
+    assert is_unsafe_manifest_path(bad) is True
+
+
+@pytest.mark.parametrize("good", ["images/top.png", "photo.jpg", "images/sub/x.webp"])
+def test_is_unsafe_manifest_path_passes_board_relative_paths(good: str) -> None:
+    assert is_unsafe_manifest_path(good) is False
 
 
 async def test_get_caches_first_hit() -> None:

--- a/tests/helpers/test_lazy_catalog.py
+++ b/tests/helpers/test_lazy_catalog.py
@@ -59,6 +59,7 @@ def test_is_unsafe_catalog_id_passes_flat_catalog_ids(good: str) -> None:
         "C:evil.png",
         "\\rooted.png",
         "..\\other\\x.jpg",
+        "evil\x00.png",
     ],
 )
 def test_is_unsafe_manifest_path_rejects_escaping_shapes(bad: str) -> None:

--- a/tests/helpers/test_lazy_catalog.py
+++ b/tests/helpers/test_lazy_catalog.py
@@ -55,6 +55,10 @@ def test_is_unsafe_catalog_id_passes_flat_catalog_ids(good: str) -> None:
         "../other-board/x.jpg",
         "images/../../escape.png",
         "..",
+        "C:\\evil.png",
+        "C:evil.png",
+        "\\rooted.png",
+        "..\\other\\x.jpg",
     ],
 )
 def test_is_unsafe_manifest_path_rejects_escaping_shapes(bad: str) -> None:

--- a/tests/test_definitions_loader.py
+++ b/tests/test_definitions_loader.py
@@ -128,6 +128,32 @@ def test_parse_connectivity_logs_and_skips_unknown(
     )
 
 
+def test_resolve_images_drops_escaping_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Absolute / parent-dir image entries drop with a warning instead of raising."""
+    boards_dir = tmp_path / "boards"
+    board_dir = boards_dir / "my-board"
+    (board_dir / "images").mkdir(parents=True)
+    (board_dir / "images" / "top.png").write_bytes(b"x")
+    # A real file above the boards dir: resolving it used to raise
+    # ValueError out of ``_local_to_url``'s ``relative_to``.
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"x")
+    monkeypatch.setattr(defs, "_BOARDS_DIR", boards_dir)
+
+    with caplog.at_level(logging.WARNING):
+        images = defs._resolve_images(
+            board_dir, ["images/top.png", "../../outside.png", str(outside)]
+        )
+
+    assert images == ["/boards/images/my-board/images/top.png"]
+    dropped = [
+        rec for rec in caplog.records if "must be a path inside the board dir" in rec.getMessage()
+    ]
+    assert len(dropped) == 2
+
+
 def _write_fake_boards(root: Path) -> Path:
     """Create a minimal ``boards/`` tree with one good and one broken manifest."""
     fake_boards = root / "boards"

--- a/tests/test_validate_image_paths.py
+++ b/tests/test_validate_image_paths.py
@@ -28,15 +28,13 @@ def test_escaping_featured_image_url_rejected() -> None:
         "featured_bundles": [{"id": "b", "image_url": "/abs.png"}],
     }
     errors = _validate_image_paths("demo", data)
-    assert len(errors) == 2
-    assert any("featured_components image_url '../other/x.png'" in e for e in errors)
-    assert any("featured_bundles image_url '/abs.png'" in e for e in errors)
+    assert errors == [
+        "demo: featured_components image_url '../other/x.png' must be a relative "
+        "path inside the board dir",
+        "demo: featured_bundles image_url '/abs.png' must be a relative path inside the board dir",
+    ]
 
 
 def test_non_string_and_absent_values_ignored() -> None:
-    data = {
-        "images": [],
-        "featured_components": [{"id": "a"}, {"id": "b", "image_url": None}],
-        "featured_bundles": [],
-    }
+    data = {"featured_components": [{"id": "a"}, {"id": "b", "image_url": None}]}
     assert _validate_image_paths("demo", data) == []

--- a/tests/test_validate_image_paths.py
+++ b/tests/test_validate_image_paths.py
@@ -1,0 +1,42 @@
+"""Tests for the local image path guard in ``script/validate_definitions.py``."""
+
+from __future__ import annotations
+
+from script.validate_definitions import _validate_image_paths  # type: ignore[import-not-found]
+
+
+def test_clean_manifest_passes() -> None:
+    data = {
+        "images": ["images/top.png", "https://example.test/x.jpg"],
+        "featured_components": [{"id": "a", "image_url": "images/a.png"}],
+        "featured_bundles": [{"id": "b", "image_url": "https://example.test/b.jpg"}],
+    }
+    assert _validate_image_paths("demo", data) == []
+
+
+def test_escaping_images_entry_rejected() -> None:
+    errors = _validate_image_paths("demo", {"images": ["../../../script/x", "/etc/passwd"]})
+    assert errors == [
+        "demo: images entry '../../../script/x' must be a relative path inside the board dir",
+        "demo: images entry '/etc/passwd' must be a relative path inside the board dir",
+    ]
+
+
+def test_escaping_featured_image_url_rejected() -> None:
+    data = {
+        "featured_components": [{"id": "a", "image_url": "../other/x.png"}],
+        "featured_bundles": [{"id": "b", "image_url": "/abs.png"}],
+    }
+    errors = _validate_image_paths("demo", data)
+    assert len(errors) == 2
+    assert any("featured_components image_url '../other/x.png'" in e for e in errors)
+    assert any("featured_bundles image_url '/abs.png'" in e for e in errors)
+
+
+def test_non_string_and_absent_values_ignored() -> None:
+    data = {
+        "images": [],
+        "featured_components": [{"id": "a"}, {"id": "b", "image_url": None}],
+        "featured_bundles": [],
+    }
+    assert _validate_image_paths("demo", data) == []


### PR DESCRIPTION
# What does this implement/fix?

`_resolve_images` had no guard against absolute or parent-dir `images:` entries, so a manifest like `images: ["../../../script/x"]` made `_local_to_url`'s `relative_to` raise and crash the strict sync with a bare traceback. The featured-image resolver already rejected these shapes.

The check now lives in one shared helper, `is_unsafe_manifest_path` in `helpers/lazy_catalog.py` beside `is_unsafe_catalog_id`, and both resolvers use it; an escaping entry is dropped with the same per-board warning the featured path logs. It also catches Windows rooted and drive-relative forms via `anchor`, which the old `is_absolute` check missed.

`validate_definitions.py` gains the matching lint gate: a traversal-shaped `images:` entry or featured `image_url` now fails validation with a per-manifest error, so a broken or hostile manifest PR is rejected at lint time instead of surfacing as a sync crash.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2018

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
