### PR TITLE
Test: regen-board-catalog fork dry-run rehearsal (do not merge)

### DIFF
--- a/esphome_device_builder/definitions/boards/waveshare_esp32_c3_zero/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/waveshare_esp32_c3_zero/manifest.yaml
@@ -1,7 +1,7 @@
 id: waveshare_esp32_c3_zero
 name: Waveshare ESP32-C3-Zero
 description: >
-  Ultra-compact ESP32-C3 castellated module with castellated pads, 4MB onboard flash, USB-C connector and an onboard ceramic antenna.
+  Ultra-compact ESP32-C3 castellated module with castellated pads, 4 MB onboard flash, USB-C connector and an onboard ceramic antenna.
   No USB-UART bridge chip.
 manufacturer: Waveshare
 

--- a/esphome_device_builder/definitions/boards/waveshare_esp32_c3_zero/manifest.yaml
+++ b/esphome_device_builder/definitions/boards/waveshare_esp32_c3_zero/manifest.yaml
@@ -1,7 +1,7 @@
 id: waveshare_esp32_c3_zero
 name: Waveshare ESP32-C3-Zero
 description: >
-  Ultra-compact ESP32-C3 module with castellated pads, 4MB onboard flash, USB-C connector and an onboard ceramic antenna.
+  Ultra-compact ESP32-C3 castellated module with castellated pads, 4MB onboard flash, USB-C connector and an onboard ceramic antenna.
   No USB-UART bridge chip.
 manufacturer: Waveshare
 


### PR DESCRIPTION
Fork-side rehearsal for the #2017 dark launch: a cross-repo PR editing one manifest **without** regenerating.

Expected with BOARD_CATALOG_AUTOPUSH unset: the regen workflow detects the fork, computes the diff, uploads `board-catalog-regen.patch`, and logs the dry-run 'would post the fork instructions comment' notice — **no** comment, **no** push. After the flip, the same shape gets the sticky comment instead.

Will be closed unmerged.