### PR TITLE
Skip the catalog drift test on CI's Windows and macOS runners

### DIFF
--- a/tests/test_boards_json.py
+++ b/tests/test_boards_json.py
@@ -18,10 +18,13 @@ once at startup by the components controller). These tests pin:
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import orjson
+import pytest
 from esphome.components.esp32.boards import BOARDS as ESP32_BOARDS
 
 from esphome_device_builder.definitions import (
@@ -81,6 +84,11 @@ _BODY_ONLY_KEYS = frozenset(
 )
 
 
+@pytest.mark.skipif(
+    bool(os.environ.get("CI")) and sys.platform != "linux",
+    reason="CI's lint drift gate already regenerates and byte-compares the catalog; "
+    "re-deriving it on the slow Windows/macOS runners buys nothing",
+)
 def test_split_artefacts_match_manifests() -> None:
     """
     The committed artefacts reproduce what the manifests produce.


### PR DESCRIPTION
# What does this implement/fix?

`test_split_artefacts_match_manifests` re-derives the whole board catalog and byte-compares it against disk on **every** pytest runner — so a PR with catalog drift reds six jobs (five pytest runners + the lint drift gate) to report one fact, and pays the derivation on the slowest runners (Windows/macOS). Observed live on the #2017 rehearsal PR.

The test now skips under `CI` on non-Linux runners. What remains is non-redundant: the lint drift gate is the byte-level authority for the pinned esphome; the three Linux pytest runners each derive against a *different* esphome (stable-pinned 3.12, beta, dev — a dev-channel failure is the early warning that the next esphome bump moves the catalog, per the test's own docstring); and local `pytest` runs are unaffected.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
