### PR TITLE
Opt the data-only fork checkout out of checkout v7's pwn-request guard

### DIFF
--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -112,6 +112,12 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          # checkout v7 refuses fork heads under pull_request_target by
+          # default (pwn-request guard). This checkout is the reviewed
+          # exception the opt-in exists for: nothing under pr/ is ever
+          # executed or imported — only the definitions data trees are
+          # consumed, behind the symlink gate below.
+          allow-unsafe-pr-checkout: true
 
       - name: Skip our own regen commit
         id: loop


### PR DESCRIPTION
# What does this implement/fix?

The dark-launch rehearsal caught this on the first fork PR (#2028): `actions/checkout` v7 refuses to fetch a fork's head inside a `pull_request_target` workflow unless the step opts in (`##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow…`), so #2017's fork path failed at the PR-head checkout. Same-repo PRs were unaffected (the #2024 and #2026 runs completed correctly).

This checkout is precisely the reviewed exception the opt-in exists for: nothing under `pr/` is ever executed or imported — only the two definitions data trees are consumed (CSafeLoader/orjson), behind the symlink gate and the code-touching skip guard. Added `allow-unsafe-pr-checkout: true` to that one step with the rationale inline.

Dry-run rehearsal state so far: same-repo in-sync PR (#2024) converges quietly; same-repo drift PR (#2026) computes the diff, uploads the patch artifact, and logs "would push" with zero writes. The fork case re-verifies once this merges (the workflow definition runs from main).

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
