### PR TITLE
Rehome the sweep-loop base and adopt it in PingSource

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/_api_probe.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_api_probe.py
@@ -1,14 +1,12 @@
 """
-Plumbing shared by the Native API sources.
+Worker-dial plumbing shared by the Native API sources.
 
-The one-shot ``device_info`` probe helpers plus the presence-gated
-sweep-loop base both ``ApiInfoSource`` and ``ApiReviverSource`` run on.
+The one-shot ``device_info`` probe helpers both ``ApiInfoSource``
+and ``ApiReviverSource`` layer over the sweep-loop base.
 """
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import importlib.util
 import logging
 import sys
@@ -17,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from ...helpers.device_yaml import DEFAULT_API_PORT
 from ...helpers.json import JSONDecodeError, dumps, loads
 from ...helpers.subprocess import run_subprocess_capture
+from ._sweep_source import SweepSource
 
 if TYPE_CHECKING:
     from ...models import Device
@@ -26,7 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 
 _WORKER_MODULE = "esphome_device_builder.helpers.api_device_info"
 _SUBPROCESS_TIMEOUT = 15.0
-_INTERVAL = 60  # seconds between sweeps
 
 
 def api_worker_available() -> bool:
@@ -40,50 +38,8 @@ def api_worker_available() -> bool:
     return importlib.util.find_spec("aioesphomeapi") is not None
 
 
-class ApiSweepSource:
-    """Presence-gated fixed-interval sweep loop; subclasses supply ``_sweep``."""
-
-    # Names the source in the crash-continue log line.
-    _sweep_label: str
-    # Head start for the passive sources (mDNS browser, ping sweep) so
-    # the common case never reaches this source's heavier repair.
-    _bootstrap_delay: float
-
-    def __init__(self, monitor: DeviceStateMonitor) -> None:
-        self._monitor = monitor
-        # Cleared at the top of each iteration so a wake fired
-        # mid-sweep still triggers the next idle. The presence 0→1
-        # transition is multiplexed into the same event so a
-        # subscriber arriving mid-idle doesn't wait out the interval.
-        self._wake = asyncio.Event()
-        if monitor._presence is not None:
-            monitor._presence.add_subscriber_callback(self._wake.set)
-
-    async def run(self) -> None:
-        await asyncio.sleep(self._bootstrap_delay)
-        if not self._prepare():
-            return
-        monitor = self._monitor
-        # Strict pause when wired to a SubscriberPresence gate: only
-        # sweep while at least one dashboard client is subscribed.
-        while True:
-            if monitor._presence is not None:
-                await monitor._presence.wait_for_subscriber()
-            self._wake.clear()
-            try:
-                await self._sweep()
-            except Exception:
-                # A sweep failure must not kill the loop for the
-                # process lifetime; log it and try again next interval.
-                _LOGGER.exception("%s sweep failed; continuing", self._sweep_label)
-            await self._idle()
-
-    def _prepare(self) -> bool:
-        """One-shot gate after the bootstrap sleep; False disables the source."""
-        return True
-
-    async def _sweep(self) -> None:
-        raise NotImplementedError
+class ApiSweepSource(SweepSource):
+    """Sweep-loop base plus the budgeted ``device_info`` worker dial."""
 
     async def _probe(self, device: Device, addresses: list[str]) -> dict[str, Any] | None:
         """
@@ -101,10 +57,6 @@ class ApiSweepSource:
     async def _run_worker(self, device: Device, request: bytes) -> dict[str, Any] | None:
         """Instance seam over the shared worker runner (tests stub it here)."""
         return await run_worker(device.name, request)
-
-    async def _idle(self) -> None:
-        with contextlib.suppress(TimeoutError):
-            await asyncio.wait_for(self._wake.wait(), timeout=_INTERVAL)
 
 
 class ProbeError(Exception):

--- a/esphome_device_builder/controllers/_device_state_monitor/_api_probe.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_api_probe.py
@@ -1,7 +1,7 @@
 """
 Worker-dial plumbing shared by the Native API sources.
 
-The one-shot ``device_info`` probe helpers both ``ApiInfoSource``
+The one-shot ``device_info`` probe helpers that ``ApiInfoSource``
 and ``ApiReviverSource`` layer over the sweep-loop base.
 """
 

--- a/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
@@ -1,0 +1,65 @@
+"""Presence-gated fixed-interval sweep-loop base for the monitor's sources."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .controller import DeviceStateMonitor
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SweepSource:
+    """Presence-gated fixed-interval sweep loop; subclasses supply ``_sweep``."""
+
+    # Names the source in the crash-continue log line.
+    _sweep_label: str
+    # Head start for the other sources (e.g. the mDNS browser) so the
+    # common case never reaches this source's heavier work.
+    _bootstrap_delay: float
+    # Seconds between sweeps.
+    _interval: float = 60
+
+    def __init__(self, monitor: DeviceStateMonitor) -> None:
+        self._monitor = monitor
+        # Cleared at the top of each iteration so a wake fired
+        # mid-sweep still triggers the next idle. The presence 0→1
+        # transition is multiplexed into the same event so a
+        # subscriber arriving mid-idle doesn't wait out the interval.
+        self._wake = asyncio.Event()
+        if monitor._presence is not None:
+            monitor._presence.add_subscriber_callback(self._wake.set)
+
+    async def run(self) -> None:
+        await asyncio.sleep(self._bootstrap_delay)
+        if not await self._prepare():
+            return
+        monitor = self._monitor
+        # Strict pause when wired to a SubscriberPresence gate: only
+        # sweep while at least one dashboard client is subscribed.
+        while True:
+            if monitor._presence is not None:
+                await monitor._presence.wait_for_subscriber()
+            self._wake.clear()
+            try:
+                await self._sweep()
+            except Exception:
+                # A sweep failure must not kill the loop for the
+                # process lifetime; log it and try again next interval.
+                _LOGGER.exception("%s sweep failed; continuing", self._sweep_label)
+            await self._idle()
+
+    async def _prepare(self) -> bool:
+        """One-shot gate after the bootstrap sleep; False disables the source."""
+        return True
+
+    async def _sweep(self) -> None:
+        raise NotImplementedError
+
+    async def _idle(self) -> None:
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(self._wake.wait(), timeout=self._interval)

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -75,7 +75,7 @@ class ApiInfoSource(ApiSweepSource):
         self._force_reprobe.add(name)
         self._wake.set()
 
-    def _prepare(self) -> bool:
+    async def _prepare(self) -> bool:
         # The sweep loop still runs without the worker library: the
         # mDNS-cache reconcile pass needs no API worker.
         self._api_available = api_worker_available()

--- a/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
@@ -97,7 +97,7 @@ class ApiReviverSource(ApiSweepSource):
         # identity verification; a fresh pair revives without a dial.
         self._verified: dict[str, tuple[str, float]] = {}
 
-    def _prepare(self) -> bool:
+    async def _prepare(self) -> bool:
         # Unlike api_info there is no lib-less work to do — identity
         # verification IS the dial.
         if not api_worker_available():

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -98,8 +98,8 @@ class PingSource(SweepSource):
     async def _sweep(self) -> None:
         # Disjoint candidate sets — resolve both concurrently so a
         # wire-miss in one doesn't delay the sweep behind the other.
-        # An unguarded raise here must not kill the loop for the
-        # process lifetime; log it and keep sweeping.
+        # A failing resolve step is logged and must not skip the
+        # sibling resolve or the ping pass for this interval.
         results = await asyncio.gather(
             shared.resolve_non_api_mdns_targets(self._monitor),
             shared.resolve_api_mdns_targets(self._monitor),

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -13,6 +12,7 @@ from icmplib.exceptions import ICMPLibError
 from ...helpers.hostname import is_local_hostname
 from ...models import Device, DeviceState
 from . import shared
+from ._sweep_source import SweepSource
 from .helpers import _pick_ipv4
 
 if TYPE_CHECKING:
@@ -24,14 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 def _format_devices(devices: list[Device]) -> str:
     """Render *devices* as ``"name (address), …"`` for log messages."""
     return ", ".join(f"{d.name} ({d.address})" for d in devices)
-
-
-_PING_INTERVAL = 60  # seconds between ping sweeps
-# Bootstrap delay gives the mDNS browser a head start so the
-# common case (everything announces) skips a redundant ping the
-# browser would have flipped ONLINE for free. 10s mirrors the
-# upstream dashboard's ``MDNS_BOOTSTRAP_TIME``.
-_PING_BOOTSTRAP_DELAY = 10
 
 
 async def _can_use_icmp_lib_with_privilege() -> bool | None:
@@ -54,14 +46,18 @@ async def _can_use_icmp_lib_with_privilege() -> bool | None:
     return True
 
 
-class PingSource:
+class PingSource(SweepSource):
     """ICMP ping loop owning the periodic sweep and the wake-on-add early trigger."""
 
+    _sweep_label = "ICMP ping"
+    # The mDNS browser's head start so the common case (everything
+    # announces) skips a redundant ping the browser would have flipped
+    # ONLINE for free. 10s mirrors the upstream dashboard's
+    # ``MDNS_BOOTSTRAP_TIME``.
+    _bootstrap_delay = 10
+
     def __init__(self, monitor: DeviceStateMonitor) -> None:
-        self._monitor = monitor
-        # Cleared at the top of each sweep so a wake fired mid-sweep
-        # still triggers the next idle.
-        self._wake = asyncio.Event()
+        super().__init__(monitor)
         # One in-flight budget for every ICMP consumer — the sweep and
         # the reviver's pre-filter share it so overlapping loops can't
         # exceed the icmplib reliability bound together.
@@ -72,21 +68,19 @@ class PingSource:
         # flicker (120s TTL vs 60s sweep) so the line only re-emits on
         # real membership change.
         self._last_logged_targets: tuple[tuple[str, str], ...] = ()
-        # Set in ``run`` once the privilege probe lands; the pre-
+        # Set in ``_prepare`` once the privilege probe lands; the pre-
         # ``run`` default is only seen by tests that mock ``icmp_ping``.
         self._privileged: bool = True
         # Privilege-probe outcome for siblings (the API reviver gates on
         # it): ``None`` until the probe lands, then True iff some ICMP
         # socket mode works and the sweep is running.
         self.icmp_available: bool | None = None
-        # 0→1 multiplexed into the same wake event so a subscriber
-        # arriving mid-idle gets fresh ICMP without waiting out the
-        # rest of the interval.
-        if monitor._presence is not None:
-            monitor._presence.add_subscriber_callback(self._wake.set)
 
-    async def run(self) -> None:
-        await asyncio.sleep(_PING_BOOTSTRAP_DELAY)
+    def wake(self) -> None:
+        """Bail the idle wait so the next sweep runs without waiting out the interval."""
+        self._wake.set()
+
+    async def _prepare(self) -> bool:
         privileged = await _can_use_icmp_lib_with_privilege()
         self.icmp_available = privileged is not None
         if privileged is None:
@@ -96,46 +90,28 @@ class PingSource:
                 "net.ipv4.ping_group_range covering this process's group); "
                 "device state will only update via mDNS"
             )
-            return
+            return False
         self._privileged = privileged
         _LOGGER.debug("Using icmplib in privileged=%s mode for the ICMP ping sweep", privileged)
-        # Strict pause when wired to a SubscriberPresence gate: only
-        # sweep while at least one dashboard client is subscribed,
-        # so a quiet network with no observers generates no ICMP
-        # traffic. The 0→1 transition wakes the loop immediately
-        # via ``wait_for_subscriber`` — mDNS keeps running
-        # unconditionally because it's passive.
-        monitor = self._monitor
-        while True:
-            if monitor._presence is not None:
-                await monitor._presence.wait_for_subscriber()
-            self._wake.clear()
-            # Disjoint candidate sets — resolve both concurrently so a
-            # wire-miss in one doesn't delay the sweep behind the other.
-            # An unguarded raise here must not kill the loop for the
-            # process lifetime; log it and keep sweeping.
-            results = await asyncio.gather(
-                shared.resolve_non_api_mdns_targets(monitor),
-                shared.resolve_api_mdns_targets(monitor),
-                return_exceptions=True,
-            )
-            for result in results:
-                if isinstance(result, BaseException) and not isinstance(result, Exception):
-                    # Never mask a cancellation as a benign step failure.
-                    raise result
-                if isinstance(result, Exception):
-                    _LOGGER.warning("mDNS resolve step failed; continuing", exc_info=result)
-            await self._ping_sweep()
-            await self._idle()
+        return True
 
-    def wake(self) -> None:
-        """Bail the idle wait so the next sweep runs without waiting on ``_PING_INTERVAL``."""
-        self._wake.set()
-
-    async def _idle(self) -> None:
-        """Sleep up to ``_PING_INTERVAL`` or until the wake event fires."""
-        with contextlib.suppress(TimeoutError):
-            await asyncio.wait_for(self._wake.wait(), timeout=_PING_INTERVAL)
+    async def _sweep(self) -> None:
+        # Disjoint candidate sets — resolve both concurrently so a
+        # wire-miss in one doesn't delay the sweep behind the other.
+        # An unguarded raise here must not kill the loop for the
+        # process lifetime; log it and keep sweeping.
+        results = await asyncio.gather(
+            shared.resolve_non_api_mdns_targets(self._monitor),
+            shared.resolve_api_mdns_targets(self._monitor),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, BaseException) and not isinstance(result, Exception):
+                # Never mask a cancellation as a benign step failure.
+                raise result
+            if isinstance(result, Exception):
+                _LOGGER.warning("mDNS resolve step failed; continuing", exc_info=result)
+        await self._ping_sweep()
 
     async def _ping_sweep(self) -> None:
         pingable, dns_failed = self._select_ping_targets()

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -31,7 +31,7 @@ _SOURCE_PRIORITY: dict[str, int] = {
 }
 
 # Per-sweep mDNS A-record resolve timeout — 3s keeps the whole
-# pass under one ``_PING_INTERVAL`` even if every target misses
+# pass under one sweep interval even if every target misses
 # the cache.
 _MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def _core_skip_external_update_default(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def _stub_icmp_privilege_probe(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bypass ``PingSource.run``'s ICMP socket privilege probe.
+    """Bypass ``PingSource._prepare``'s ICMP socket privilege probe.
 
     The real probe opens ``SOCK_RAW`` / ``SOCK_DGRAM`` against
     ``127.0.0.1``; on CI runners and locked-down dev machines

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -27,7 +27,6 @@ from esphome_device_builder.controllers._device_state_monitor import (
 )
 from esphome_device_builder.controllers._device_state_monitor import api_info as api_info_module
 from esphome_device_builder.controllers._device_state_monitor._api_probe import ProbeError
-from esphome_device_builder.controllers._device_state_monitor._sweep_source import SweepSource
 from esphome_device_builder.controllers._device_state_monitor.api_info import ApiInfoSource
 from esphome_device_builder.helpers import api_device_info
 from esphome_device_builder.helpers.async_ import log_task_exit
@@ -525,20 +524,6 @@ async def test_run_waits_for_subscriber_when_presence_wired(monkeypatch: Any) ->
     assert swept == [1]
 
 
-async def test_idle_returns_immediately_when_woken() -> None:
-    """A set wake event short-circuits the idle wait."""
-    monitor, _ = make_state_monitor_with_callbacks([])
-    monitor._api_info._wake.set()
-    await monitor._api_info._idle()
-
-
-async def test_idle_times_out_when_not_woken(monkeypatch: Any) -> None:
-    """With no wake, the idle wait expires after the interval and returns."""
-    monkeypatch.setattr(ApiInfoSource, "_interval", 0.01)
-    monitor, _ = make_state_monitor_with_callbacks([])
-    await monitor._api_info._idle()
-
-
 # ----------------------------------------------------------------------
 # _sweep — serial, one probe at a time
 # ----------------------------------------------------------------------
@@ -810,16 +795,6 @@ async def test_run_worker_logs_worker_reported_error(monkeypatch: Any, caplog: A
     with caplog.at_level(logging.DEBUG):
         assert await monitor._api_info._run_worker(make_device(), b"{}") is None
     assert "connection refused" in caplog.text
-
-
-async def test_sweep_source_base_defaults() -> None:
-    """The base runs unconditionally by default and demands a ``_sweep``."""
-    monitor, _ = make_state_monitor_with_callbacks([])
-    base = SweepSource(monitor)
-
-    assert await base._prepare() is True
-    with pytest.raises(NotImplementedError):
-        await base._sweep()
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -27,6 +27,7 @@ from esphome_device_builder.controllers._device_state_monitor import (
 )
 from esphome_device_builder.controllers._device_state_monitor import api_info as api_info_module
 from esphome_device_builder.controllers._device_state_monitor._api_probe import ProbeError
+from esphome_device_builder.controllers._device_state_monitor._sweep_source import SweepSource
 from esphome_device_builder.controllers._device_state_monitor.api_info import ApiInfoSource
 from esphome_device_builder.helpers import api_device_info
 from esphome_device_builder.helpers.async_ import log_task_exit
@@ -533,7 +534,7 @@ async def test_idle_returns_immediately_when_woken() -> None:
 
 async def test_idle_times_out_when_not_woken(monkeypatch: Any) -> None:
     """With no wake, the idle wait expires after the interval and returns."""
-    monkeypatch.setattr(api_probe_module, "_INTERVAL", 0.01)
+    monkeypatch.setattr(ApiInfoSource, "_interval", 0.01)
     monitor, _ = make_state_monitor_with_callbacks([])
     await monitor._api_info._idle()
 
@@ -814,9 +815,9 @@ async def test_run_worker_logs_worker_reported_error(monkeypatch: Any, caplog: A
 async def test_sweep_source_base_defaults() -> None:
     """The base runs unconditionally by default and demands a ``_sweep``."""
     monitor, _ = make_state_monitor_with_callbacks([])
-    base = api_probe_module.ApiSweepSource(monitor)
+    base = SweepSource(monitor)
 
-    assert base._prepare() is True
+    assert await base._prepare() is True
     with pytest.raises(NotImplementedError):
         await base._sweep()
 

--- a/tests/test_api_reviver.py
+++ b/tests/test_api_reviver.py
@@ -170,20 +170,20 @@ async def test_run_exits_when_icmp_is_unavailable(
     monitor._ping.ping_once.assert_not_called()
 
 
-def test_prepare_requires_the_worker_library(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_prepare_requires_the_worker_library(monkeypatch: pytest.MonkeyPatch) -> None:
     """No aioesphomeapi means no identity dial — the source disables itself."""
     device = make_stuck_offline_device()
     _monitor, _callbacks, src = _reviver([device])
     monkeypatch.setattr(api_reviver_module, "api_worker_available", lambda: False)
 
-    assert src._prepare() is False
+    assert await src._prepare() is False
 
 
-def test_prepare_passes_with_worker_and_icmp() -> None:
+async def test_prepare_passes_with_worker_and_icmp() -> None:
     device = make_stuck_offline_device()
     _monitor, _callbacks, src = _reviver([device])
 
-    assert src._prepare() is True
+    assert await src._prepare() is True
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -11,7 +11,7 @@ sweeping unconditionally — bug). Pins:
 * with a wired ``SubscriberPresence``, ``_ping_loop`` parks
   before the sweep until the first subscriber arrives
 * the 0→1 subscriber transition wakes the loop within one
-  scheduling tick — no waiting for ``_PING_INTERVAL``
+  scheduling tick — no waiting out the sweep interval
 * the 1→0 transition lets the next iteration park again so a
   burst of disconnects doesn't keep ICMP looping
 """
@@ -28,7 +28,6 @@ import pytest
 
 from esphome_device_builder import device_builder as device_builder_module
 from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
-from esphome_device_builder.controllers._device_state_monitor import ping as ping_module
 from esphome_device_builder.controllers._device_state_monitor import shared as shared_module
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
@@ -74,8 +73,8 @@ def _instrument_loop(
     # Skip the bootstrap delay; collapse the post-sweep idle wait
     # so the loop ticks fast enough for an asyncio.sleep(0)-driven
     # spin. Tests cancel the task to exit cleanly.
-    monkeypatch.setattr(ping_module, "_PING_BOOTSTRAP_DELAY", 0)
-    monkeypatch.setattr(ping_module, "_PING_INTERVAL", 0.001)
+    monkeypatch.setattr(PingSource, "_bootstrap_delay", 0)
+    monkeypatch.setattr(PingSource, "_interval", 0.001)
     return counts
 
 
@@ -135,6 +134,33 @@ async def test_ping_loop_survives_a_raising_resolve_step(
             await task
 
     assert counts["sweeps"] >= 2
+
+
+async def test_ping_loop_survives_a_raising_ping_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crashing sweep body is logged and the loop keeps sweeping."""
+    monitor = _build_monitor(presence=None)
+    counts = _instrument_loop(monitor, monkeypatch)
+    calls = {"n": 0}
+
+    async def _flaky_sweep() -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("boom")
+        counts["sweeps"] += 1
+
+    monitor._ping._ping_sweep = _flaky_sweep  # type: ignore[method-assign]
+
+    task = asyncio.create_task(monitor._ping.run())
+    try:
+        await _drive_until(lambda: counts["sweeps"] >= 2)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert calls["n"] >= 3
 
 
 async def test_ping_loop_does_not_mask_child_cancellation(
@@ -268,7 +294,7 @@ async def test_subscriber_arrival_mid_idle_bails_within_a_tick(
 ) -> None:
     """A subscriber arriving while the loop is in idle drives the next sweep promptly.
 
-    With ``_PING_INTERVAL`` re-stretched to 60s, anything beyond a
+    With the sweep interval re-stretched to 60s, anything beyond a
     handful of scheduling ticks for the second sweep means the
     0→1 wake didn't fire — the loop sat through the rest of the
     interval instead.
@@ -276,7 +302,7 @@ async def test_subscriber_arrival_mid_idle_bails_within_a_tick(
     presence = SubscriberPresence()
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
-    monkeypatch.setattr(ping_module, "_PING_INTERVAL", 60)
+    monkeypatch.setattr(PingSource, "_interval", 60)
 
     task = asyncio.create_task(monitor._ping.run())
     try:

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -142,13 +142,11 @@ async def test_ping_loop_survives_a_raising_ping_sweep(
     """A crashing sweep body is logged and the loop keeps sweeping."""
     monitor = _build_monitor(presence=None)
     counts = _instrument_loop(monitor, monkeypatch)
-    calls = {"n": 0}
 
     async def _flaky_sweep() -> None:
-        calls["n"] += 1
-        if calls["n"] == 1:
-            raise RuntimeError("boom")
         counts["sweeps"] += 1
+        if counts["sweeps"] == 1:
+            raise RuntimeError("boom")
 
     monitor._ping._ping_sweep = _flaky_sweep  # type: ignore[method-assign]
 
@@ -160,7 +158,7 @@ async def test_ping_loop_survives_a_raising_ping_sweep(
         with contextlib.suppress(asyncio.CancelledError):
             await task
 
-    assert calls["n"] >= 3
+    assert counts["sweeps"] >= 2
 
 
 async def test_ping_loop_does_not_mask_child_cancellation(

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -63,8 +63,8 @@ def _install_sweep_probe(
 
 def _patch_loop_for_wake_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Skip bootstrap and stretch the interval so only wakes can drive a second sweep."""
-    monkeypatch.setattr(ping_module, "_PING_BOOTSTRAP_DELAY", 0)
-    monkeypatch.setattr(ping_module, "_PING_INTERVAL", 3600)
+    monkeypatch.setattr(ping_module.PingSource, "_bootstrap_delay", 0)
+    monkeypatch.setattr(ping_module.PingSource, "_interval", 3600)
 
     async def _noop_resolve(_monitor: object) -> None:
         return None
@@ -160,7 +160,7 @@ def test_probe_device_ping_herd_collapses_to_single_set() -> None:
 
 
 async def test_wake_bails_idle_wait_early(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A wake fired during the idle wait re-runs the sweep without paying ``_PING_INTERVAL``."""
+    """A wake fired during the idle wait re-runs the sweep without paying the interval."""
     _patch_loop_for_wake_tests(monkeypatch)
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     sweeps = _install_sweep_probe(monkeypatch)

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1416,8 +1416,8 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
 
 def _shrink_ping_intervals(monkeypatch: pytest.MonkeyPatch) -> None:
     """Collapse the bootstrap delay + interval so ``_let_ping_loop_run_briefly`` sees sweeps."""
-    monkeypatch.setattr(ping_module, "_PING_BOOTSTRAP_DELAY", 0)
-    monkeypatch.setattr(ping_module, "_PING_INTERVAL", 0.001)
+    monkeypatch.setattr(ping_module.PingSource, "_bootstrap_delay", 0)
+    monkeypatch.setattr(ping_module.PingSource, "_interval", 0.001)
 
 
 async def test_start_drives_ping_pipeline_to_online_state(
@@ -1573,7 +1573,7 @@ async def test_repeat_sweep_with_unchanged_targets_logs_once(
 ) -> None:
     """``Pinging N devices`` only fires once when the target set is stable.
 
-    Without this dedup the line re-emits every ``_PING_INTERVAL``
+    Without this dedup the line re-emits every sweep interval
     forever on a steady fleet, spamming DEBUG-enabled logs with
     identical content. New devices, mDNS claims, or removals
     re-surface the line.

--- a/tests/test_subscriber_presence.py
+++ b/tests/test_subscriber_presence.py
@@ -175,7 +175,7 @@ async def test_wait_for_no_subscribers_wakes_on_drop_to_zero() -> None:
     This is the contract the ICMP ping loop's interruptible idle
     wait depends on — when the last subscriber leaves mid-sleep,
     the loop's ``asyncio.wait_for(presence.wait_for_no_subscribers
-    (), timeout=_PING_INTERVAL)`` must fire promptly so the next
+    (), timeout=<sweep interval>)`` must fire promptly so the next
     subscriber's first sweep doesn't wait out the rest of the
     interval.
     """

--- a/tests/test_sweep_source.py
+++ b/tests/test_sweep_source.py
@@ -1,0 +1,36 @@
+"""Contract tests for the neutral sweep-loop base."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from esphome_device_builder.controllers._device_state_monitor._sweep_source import SweepSource
+
+from .conftest import make_state_monitor_with_callbacks
+
+
+async def test_sweep_source_base_defaults() -> None:
+    """The base runs unconditionally by default and demands a ``_sweep``."""
+    monitor, _ = make_state_monitor_with_callbacks([])
+    base = SweepSource(monitor)
+
+    assert await base._prepare() is True
+    with pytest.raises(NotImplementedError):
+        await base._sweep()
+
+
+async def test_idle_returns_immediately_when_woken() -> None:
+    """A set wake event short-circuits the idle wait."""
+    monitor, _ = make_state_monitor_with_callbacks([])
+    base = SweepSource(monitor)
+    base._wake.set()
+    await base._idle()
+
+
+async def test_idle_times_out_when_not_woken(monkeypatch: Any) -> None:
+    """With no wake, the idle wait expires after the interval and returns."""
+    monkeypatch.setattr(SweepSource, "_interval", 0.01)
+    monitor, _ = make_state_monitor_with_callbacks([])
+    await SweepSource(monitor)._idle()


### PR DESCRIPTION
# What does this implement/fix?

PR #2014 extracted the presence gated sweep loop into `_api_probe.py`, where `ApiInfoSource` and `ApiReviverSource` run on it while `PingSource` still hand rolled the identical loop. This moves the loop base to a neutral `_sweep_source.py` (`SweepSource`), keeps the budgeted worker dial and its `_run_worker` test seam in `_api_probe.py` as a thin `ApiSweepSource(SweepSource)` layer, and migrates `PingSource` onto the base. The privilege probe made `_prepare` async on the base; ping's resolve gather step keeps its bespoke exception handling inside its `_sweep`. Interval and bootstrap delay are now class attrs on the base, so the ping test seams patch `PingSource._bootstrap_delay` / `_interval` like the API sources already did.

One behavior change worth naming: the ping sweep body now gets the template's crash continue, so a raising `_ping_sweep` logs and retries next interval instead of killing the loop task for the process lifetime; a new test pins it. Cancellation still propagates.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2020

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
