### PR TITLE
Expose DeviceStateMonitor sources as public seams and drop the PLR0904 grandfather

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,7 +498,7 @@ against legacy behaviour before assuming the simpler version suffices.
   is dark in some deployments (Docker-bridge), so `refresh_after_job`
   also arms a `loop.call_later` timer (`_schedule_version_reprobe`,
   tracked in `_reprobe_timers`, cancelled in `stop()`) that ~60s later
-  forces one Native-API version probe via `request_version_reprobe` —
+  forces one Native-API version probe via `api_info.request_reprobe` —
   the only signal of a rollback / failed boot where the announce never
   arrives. The forced probe still honours `_is_due`'s `priority_for !=
   MDNS` guard, so a device already seen over mDNS is skipped.

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -152,7 +152,7 @@ class ApiInfoSource(ApiSweepSource):
             )
         }
         for name in sorted(names):
-            monitor.reconcile_from_mdns_cache(name)
+            monitor.mdns.reconcile_from_cache(name)
 
     def _is_due(self, device: Device) -> bool:
         """

--- a/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
@@ -107,7 +107,7 @@ class ApiReviverSource(ApiSweepSource):
         # still-undecided outcome means the probe never ran; either way
         # the negative pre-filter can't be trusted, and availability
         # can't change within a process.
-        if self._monitor._ping.icmp_available is not True:
+        if self._monitor.ping.icmp_available is not True:
             _LOGGER.warning(
                 "API revival disabled: ICMP is unavailable, so the persisted-IP "
                 "pre-filter can't run and a verified ONLINE could never demote"
@@ -186,8 +186,8 @@ class ApiReviverSource(ApiSweepSource):
         # Ping's own semaphore, not a second one: the in-flight ICMP
         # budget is global, so an overlapping sweep and pre-filter
         # can't exceed the icmplib reliability bound together.
-        async with self._monitor._ping.icmp_concurrency:
-            rtt = await self._monitor._ping.ping_once(ip, retry=True)
+        async with self._monitor.ping.icmp_concurrency:
+            rtt = await self._monitor.ping.ping_once(ip, retry=True)
         if rtt is None:
             self._cool_down((device.name, ip), _ICMP_SILENT_COOLDOWN)
         return rtt
@@ -235,8 +235,7 @@ class ApiReviverSource(ApiSweepSource):
             # invalidation callback is wired; the cleared IP then drops
             # the device from the cohort entirely.
             self._record_dial_failure(key)
-            if monitor._on_persisted_ip_invalidated is not None:
-                monitor._on_persisted_ip_invalidated(device.name, ip)
+            monitor.invalidate_persisted_ip(device.name, ip)
             return
         mac = _normalize_mac(info.get("mac_address", ""))
         persisted_mac = _normalize_mac(device.mac_address)

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -28,8 +28,6 @@ from collections.abc import Awaitable, Callable
 from functools import partial
 from typing import Any
 
-from esphome.zeroconf import AsyncEsphomeZeroconf
-
 from ...helpers.async_ import create_eager_task, drain_tasks, log_task_exit
 from ...helpers.subscriber_presence import SubscriberPresence
 from ...models import (
@@ -39,7 +37,7 @@ from ...models import (
     DeviceState,
     ReachabilitySource,
 )
-from .._reachability_tracker import MdnsCacheInfo, ReachabilityTracker
+from .._reachability_tracker import ReachabilityTracker
 from .._task_controller_base import TaskControllerBase
 from ._state import MonitorState
 from .api_info import ApiInfoSource
@@ -119,13 +117,18 @@ ApiConnectionResolver = Callable[[str], Awaitable[tuple[str, int]]]
 PersistedIpInvalidatedCallback = Callable[[str, str], None]
 
 
-class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
+class DeviceStateMonitor(TaskControllerBase):
     """
     Drive device state from mDNS broadcasts plus periodic ICMP pings.
 
     Only one source can own a device's state at a time. mDNS always
     wins; ping only writes when mDNS hasn't already resolved the
     device. :meth:`priority_for` lets callers query the active source.
+
+    The public source attributes (``mdns``, ``ping``, ``importable``,
+    ``api_info``, ``api_reviver``) are the sanctioned seams for
+    per-source queries and nudges; the monitor keeps only the
+    cross-source core (lifecycle, the precedence ledger, ``apply_*``).
     """
 
     def __init__(
@@ -182,24 +185,24 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # ``None`` means "always run the loop" so existing tests
         # without a presence gate keep working.
         self._presence = presence
-        self._importable = ImportableDiscovery(self)
+        self.importable = ImportableDiscovery(self)
         # One Native API worker dial at a time across every API source
         # (api_info + reviver): each dial spawns an interpreter and
         # occupies one of a device's scarce API connection slots.
         self._api_dial_budget = asyncio.Semaphore(1)
-        self._mdns = MdnsSource(self)
-        self._ping = PingSource(self)
-        self._api_info = ApiInfoSource(self)
-        self._api_reviver = ApiReviverSource(self)
+        self.mdns = MdnsSource(self)
+        self.ping = PingSource(self)
+        self.api_info = ApiInfoSource(self)
+        self.api_reviver = ApiReviverSource(self)
 
     async def start(self) -> None:
         """Start the mDNS browser, the ping sweep, the API info fallback, and the reviver."""
-        await self._mdns.start()
-        self._ping_task = asyncio.create_task(self._ping.run())
+        await self.mdns.start()
+        self._ping_task = asyncio.create_task(self.ping.run())
         self._ping_task.add_done_callback(partial(log_task_exit, "Ping sweep"))
-        self._api_info_task = asyncio.create_task(self._api_info.run())
+        self._api_info_task = asyncio.create_task(self.api_info.run())
         self._api_info_task.add_done_callback(partial(log_task_exit, "API info fallback"))
-        self._api_reviver_task = asyncio.create_task(self._api_reviver.run())
+        self._api_reviver_task = asyncio.create_task(self.api_reviver.run())
         self._api_reviver_task.add_done_callback(partial(log_task_exit, "API reviver"))
 
     async def stop(self) -> None:
@@ -218,11 +221,11 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         # Cancel the browser FIRST so it stops dispatching new mDNS
         # callbacks; otherwise the drain below would race against
         # newly-spawned resolve tasks the browser is still firing.
-        await self._mdns.cancel_browser()
+        await self.mdns.cancel_browser()
         drain.extend(self._tasks)
         self._tasks.clear()
         # Close zeroconf eagerly so 5353 frees now, overlapping the task drain.
-        close = create_eager_task(self._mdns.close_zeroconf())
+        close = create_eager_task(self.mdns.close_zeroconf())
         if drain:
             # Drain bounded here so the cancelled tasks don't leak to aiohttp's
             # unbounded terminal sweep.
@@ -230,25 +233,13 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
                 await asyncio.wait_for(drain_tasks(drain), _STOP_DRAIN_TIMEOUT)
         await close
 
-    @property
-    def zeroconf(self) -> AsyncEsphomeZeroconf | None:
-        """
-        The mDNS responder powering device discovery, or ``None``.
-
-        Exposed so the dashboard's own ``_esphomebuilder._tcp.local.``
-        advertiser can reuse the same instance instead of opening a
-        second responder. ``None`` when zeroconf failed to start
-        (port held by avahi / ``mDNSResponder``).
-        """
-        return self._mdns.zeroconf
-
     def set_reachability(self, tracker: ReachabilityTracker) -> None:
         """
         Wire (or rewire) the per-signal freshness tracker.
 
         :class:`DevicesController` builds the monitor first so the
-        tracker can take ``get_mdns_cache_info`` as its mDNS cache
-        reader; this setter completes the wire-back.
+        tracker can take ``mdns.get_mdns_cache_info`` as its mDNS
+        cache reader; this setter completes the wire-back.
         """
         self.state.reachability = tracker
 
@@ -335,18 +326,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._on_state_change(name, state, source)
         return True
 
-    async def refresh_mdns(self, name: str) -> None:
-        """Re-query a device's mDNS A/AAAA records via the wire."""
-        await self._mdns.refresh_mdns(name)
-
-    def get_mdns_a_record_ttl_remaining(self, name: str) -> float | None:
-        """Return the minimum remaining TTL across cached A/AAAA records."""
-        return self._mdns.get_mdns_a_record_ttl_remaining(name)
-
-    def get_mdns_cache_info(self, name: str) -> MdnsCacheInfo | None:
-        """Read the truthful "last heard via mDNS" age + remaining TTL."""
-        return self._mdns.get_mdns_cache_info(name)
-
     def apply_ip(self, name: str, ip: str) -> bool:
         """
         Record a single-IP observation. Empty string clears the resolved set.
@@ -406,10 +385,6 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             return False
         self._on_ip_change(name, primary, addresses)
         return True
-
-    def request_version_reprobe(self, name: str) -> None:
-        """Force one Native-API version probe of *name*, ignoring the mac+version guard."""
-        self._api_info.request_reprobe(name)
 
     def apply_version(self, name: str, version: str) -> bool:
         """Record a firmware version observation; True iff forwarded."""
@@ -501,17 +476,10 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
             for device in self._get_devices_by_name(name)
         )
 
-    def get_cached_addresses(self, host_name: str) -> list[str] | None:
-        """Return all zeroconf-cached IPs for *host_name* without issuing a query."""
-        return self._mdns.get_cached_addresses(host_name)
-
-    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
-        """Eagerly resolve a device's ``_esphomelib._tcp.local.`` service."""
-        self._importable.probe_device(device_name, service_name)
-
-    def reconcile_from_mdns_cache(self, device_name: str) -> None:
-        """Re-apply the zeroconf-cached TXT payload; never claims state or IP."""
-        self._mdns.reconcile_from_cache(device_name)
+    def invalidate_persisted_ip(self, name: str, stale_ip: str) -> None:
+        """Tell the owner *name*'s persisted *stale_ip* is proven stale; no-op when unwired."""
+        if self._on_persisted_ip_invalidated is not None:
+            self._on_persisted_ip_invalidated(name, stale_ip)
 
     def probe_device_ping(self, device_name: str) -> None:
         """
@@ -524,33 +492,12 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         """
         devices = self._get_devices_by_name(device_name)
         if not devices or any(should_ping(self, d) for d in devices):
-            self._ping.wake()
+            self.ping.wake()
 
     def probe_reachability(self, device_name: str) -> None:
         """Full reachability nudge: eager mDNS resolve + ICMP sweep wake for *device_name*."""
-        self.probe_device(device_name)
+        self.importable.probe_device(device_name)
         self.probe_device_ping(device_name)
-
-    def revisit_importable(self, device_name: str) -> None:
-        """Re-fire ``on_importable_added`` for *device_name* if upstream still has it cached."""
-        self._importable.revisit_importable(device_name)
-
-    def revisit_all_importables(self) -> None:
-        """Re-fire ``on_importable_added`` for every cached importable."""
-        self._importable.revisit_all_importables()
-
-    def get_importable_devices(self) -> list[AdoptableDevice]:
-        """Snapshot of devices currently advertising as importable."""
-        return self._importable.get_importable_devices()
-
-    def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
-        """
-        Return DNS-cached IPs for *host_name* without issuing a lookup.
-
-        Populated by the ping sweep's pre-resolution pass; ``None``
-        on cache miss or expired entry.
-        """
-        return self.state.dns_cache.get_cached_addresses(host_name)
 
     # ------------------------------------------------------------------
     # Internals

--- a/esphome_device_builder/controllers/_device_state_monitor/importable.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/importable.py
@@ -54,16 +54,16 @@ class ImportableDiscovery:
         the apply still keys to the configured name.
         """
         monitor = self._monitor
-        if (zc := monitor._mdns.zeroconf) is None:
+        if (zc := monitor.mdns.zeroconf) is None:
             return
         zeroconf = zc.zeroconf
         broadcast = service_name or device_name
         full_service = f"{broadcast}.{_ESPHOME_SERVICE_TYPE}"
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, full_service)
         if info.load_from_cache(zeroconf):
-            monitor._mdns._apply_service_info(device_name, info)
+            monitor.mdns._apply_service_info(device_name, info)
             return
-        monitor._track_task(monitor._mdns._resolve_and_apply(zeroconf, info, device_name))
+        monitor._track_task(monitor.mdns._resolve_and_apply(zeroconf, info, device_name))
 
     def revisit_importable(self, device_name: str) -> None:
         """
@@ -150,7 +150,7 @@ class ImportableDiscovery:
         self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
     ) -> None:
         """Resolve a cache-miss HTTP service and store its URL."""
-        await self._monitor._mdns._resolve_then(
+        await self._monitor.mdns._resolve_then(
             zeroconf, info, device_name, self._apply_http_service_info
         )
 
@@ -200,7 +200,7 @@ class ImportableDiscovery:
         ``on_importable_added``.
         """
         monitor = self._monitor
-        if (zc := monitor._mdns.zeroconf) is None or monitor.state.http_urls.get(device_name):
+        if (zc := monitor.mdns.zeroconf) is None or monitor.state.http_urls.get(device_name):
             return
         info = AsyncServiceInfo(_HTTP_SERVICE_TYPE, f"{device_name}.{_HTTP_SERVICE_TYPE}")
         if not info.load_from_cache(zc.zeroconf):

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -268,8 +268,7 @@ class MdnsSource:
         Both IPv4 and IPv6 (scoped) entries are included — the
         OTA address-cache args need every IP we know so the
         runtime can try them in turn. mDNS-only; non-``.local``
-        hostnames go through
-        :meth:`DeviceStateMonitor.get_cached_dns_addresses`.
+        hostnames go through ``state.dns_cache.get_cached_addresses``.
         """
         if self._zeroconf is None:
             return None

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -93,7 +93,7 @@ class MdnsSource:
             return
 
         monitor = self._monitor
-        importable = monitor._importable
+        importable = monitor.importable
         importable.setup()
 
         def _dispatch(

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -184,7 +184,7 @@ class PingSource(SweepSource):
                 # cache, kept fresh by the ``AsyncServiceBrowser``, rather than
                 # giving up — but ping still decides liveness, so a stale or
                 # reflected entry demotes instead of latching ONLINE (#1776).
-                addresses = monitor.get_cached_addresses(device.address)
+                addresses = monitor.mdns.get_cached_addresses(device.address)
             if not addresses:
                 # mDNS-less devices: the ``.local`` won't resolve but a
                 # prior MQTT/DNS observation left a usable IP. Ping that so

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -1,8 +1,8 @@
 """Cross-cutting helpers shared by the mDNS browser path and the ping source.
 
-Each free function takes the monitor as its first argument; the
-monitor reaches sibling sources through ``state`` and through
-``_mdns`` / ``_ping`` / ``_importable`` attributes.
+Each free function takes the monitor as its first argument; sibling
+sources are reached through ``state`` and the monitor's public
+``mdns`` / ``ping`` / ``importable`` attributes.
 """
 
 from __future__ import annotations
@@ -61,7 +61,7 @@ def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
     return (
         source == ReachabilitySource.MDNS
         and device.api_enabled
-        and not monitor._mdns.has_live_ptr(device.name)
+        and not monitor.mdns.has_live_ptr(device.name)
     )
 
 
@@ -83,7 +83,7 @@ def address_resolution_exhausted(monitor: DeviceStateMonitor, address: str) -> b
     """
     if not address:
         return True
-    if is_local_hostname(address) and monitor.get_cached_addresses(address):
+    if is_local_hostname(address) and monitor.mdns.get_cached_addresses(address):
         return False
     return monitor.state.dns_cache.has_cached_failure(address)
 
@@ -114,7 +114,7 @@ async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     nothing and the ICMP sweep decides. Devices with no cached mDNS
     trace at all are skipped.
     """
-    if monitor._mdns.zeroconf is None:
+    if monitor.mdns.zeroconf is None:
         return
     claims = [
         _resolve_and_claim_logged(monitor, d)
@@ -122,7 +122,7 @@ async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
         if d.api_enabled
         and d.runtime_state.state is DeviceState.ONLINE
         and should_ping(monitor, d)
-        and monitor.get_mdns_cache_info(d.name) is not None
+        and monitor.mdns.get_mdns_cache_info(d.name) is not None
     ]
     # The common case is a single stuck device — don't pay for a gather.
     if len(claims) == 1:
@@ -143,7 +143,7 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     resolve for each such device every sweep so the indicator
     catches up. No-op when zeroconf failed to start.
     """
-    zeroconf = monitor._mdns.zeroconf
+    zeroconf = monitor.mdns.zeroconf
     if zeroconf is None:
         return
     candidates = [
@@ -181,7 +181,7 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
 async def _resolve_and_claim_logged(monitor: DeviceStateMonitor, device: Device) -> None:
     """Run one resolve-and-claim, surfacing unexpected errors."""
     try:
-        await monitor._mdns.resolve_and_claim(device.name)
+        await monitor.mdns.resolve_and_claim(device.name)
     except Exception:
         # ``resolve_and_claim`` swallows resolve misses itself, so
         # anything surfacing here is a real bug — don't mask it as a

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -221,7 +221,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         # state monitor.
         self._reachability = ReachabilityTracker(
             on_observation=self._on_reachability_observation,
-            mdns_cache_reader=self._state_monitor.get_mdns_cache_info,
+            mdns_cache_reader=self._state_monitor.mdns.get_mdns_cache_info,
         )
         self._state_monitor.set_reachability(self._reachability)
         # MQTT routes its observations through the same state monitor so
@@ -243,7 +243,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         up a second responder. ``None`` when zeroconf failed to start —
         callers skip their advertise.
         """
-        return self._state_monitor.zeroconf
+        return self._state_monitor.mdns.zeroconf
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -226,7 +226,7 @@ def _fire_version_reprobe(controller: DevicesController, configuration: str) -> 
     controller._reprobe_timers.pop(configuration, None)
     device = controller._scanner.get_by_configuration(configuration)
     if device is not None:
-        controller._state_monitor.request_version_reprobe(device.name)
+        controller._state_monitor.api_info.request_reprobe(device.name)
 
 
 def _read_compiled_esphome_version(configuration: str) -> str:

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -438,9 +438,9 @@ def _build_address_cache_args(device: Device, monitor: DeviceStateMonitor | None
     addresses: list[str] = []
     if monitor is not None:
         cached = (
-            monitor.get_cached_addresses(address)
+            monitor.mdns.get_cached_addresses(address)
             if is_local
-            else monitor.get_cached_dns_addresses(address)
+            else monitor.state.dns_cache.get_cached_addresses(address)
         )
         if cached:
             addresses = list(cached)

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -133,7 +133,7 @@ async def import_device(
     # the next ping sweep. Probe esphomelib too so version /
     # config_hash / api_encryption land alongside the IP.
     controller._state_monitor.apply(name, DeviceState.ONLINE, "mdns", claim=True)
-    cached = controller._state_monitor.get_cached_addresses(f"{mdns_name}.local")
+    cached = controller._state_monitor.mdns.get_cached_addresses(f"{mdns_name}.local")
     if cached:
         controller._state_monitor.apply_ip_addresses(name, cached)
     # Look up the service by ``mdns_name`` (factory firmware is
@@ -141,7 +141,7 @@ async def import_device(
     # chosen ``name``. The scan-change handler probes too but
     # only knows the YAML name, which has no broadcast yet for
     # the rename-during-adopt case.
-    controller._state_monitor.probe_device(name, service_name=mdns_name)
+    controller._state_monitor.importable.probe_device(name, service_name=mdns_name)
     return {"configuration": configuration}
 
 

--- a/esphome_device_builder/controllers/devices/reachability.py
+++ b/esphome_device_builder/controllers/devices/reachability.py
@@ -102,7 +102,8 @@ async def refresh_loop(controller: DevicesController, device_name: str) -> None:
         # Use the A/AAAA-specific TTL; the union-of-types
         # ``get_mdns_cache_info`` includes PTR's 4500s TTL and
         # would never wake up to refresh A.
-        a_ttl_remaining = controller._state_monitor.get_mdns_a_record_ttl_remaining(device_name)
+        mdns = controller._state_monitor.mdns
+        a_ttl_remaining = mdns.get_mdns_a_record_ttl_remaining(device_name)
         if a_ttl_remaining is not None and a_ttl_remaining > 0:
             # A still alive; sleep until just past expiry, then
             # re-check (an unrelated announce during the sleep
@@ -157,4 +158,4 @@ def on_observation(controller: DevicesController, name: str) -> None:
 
 async def refresh_device_mdns(controller: DevicesController, name: str) -> None:
     """Force-refresh a device's mDNS A record. No-op if zeroconf is down."""
-    await controller._state_monitor.refresh_mdns(name)
+    await controller._state_monitor.mdns.refresh_mdns(name)

--- a/esphome_device_builder/controllers/devices/scan_change.py
+++ b/esphome_device_builder/controllers/devices/scan_change.py
@@ -100,7 +100,7 @@ def on_scan_change(
         # the discovered hostname; ``_on_import_update`` already
         # filters configured + ignored entries so re-emitting
         # the full set is cheap.
-        controller._state_monitor.revisit_all_importables()
+        controller._state_monitor.importable.revisit_all_importables()
         # Drop the monitor's per-name state. Both the reachability
         # history and the source-precedence ledger would otherwise
         # accumulate one entry per device that's ever lived in the

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Protocol
 from unittest.mock import AsyncMock, MagicMock
 
@@ -39,37 +40,25 @@ from tests._storage_fixtures import write_storage_json
 from tests.conftest import make_device, wire_secrets_writer
 
 
-class _RecordingMdnsSource:
-    """Typed fake for the monitor's public ``mdns`` source attribute."""
+class _RecordingAddressCache:
+    """
+    Typed fake for a hostname→addresses read surface.
 
-    def __init__(self, calls: list[tuple[Any, ...]], cached: dict[str, list[str]]) -> None:
+    Backs both ``monitor.mdns`` and ``monitor.state.dns_cache``;
+    *record_as* keeps the two caches' call tuples distinct so
+    assertions can tell which cache answered.
+    """
+
+    def __init__(
+        self, calls: list[tuple[Any, ...]], cached: dict[str, list[str]], record_as: str
+    ) -> None:
         self._calls = calls
         self._cached = cached
+        self._record_as = record_as
 
     def get_cached_addresses(self, host_name: str) -> list[str] | None:
-        self._calls.append(("get_cached_addresses", host_name))
+        self._calls.append((self._record_as, host_name))
         return self._cached.get(normalize_hostname(host_name))
-
-
-class _RecordingDnsCache:
-    """Typed fake for ``monitor.state.dns_cache``'s sync read surface."""
-
-    def __init__(self, calls: list[tuple[Any, ...]], cached: dict[str, list[str]]) -> None:
-        self._calls = calls
-        self._cached = cached
-
-    def get_cached_addresses(self, host_name: str) -> list[str] | None:
-        # Tuple name kept distinct from the mDNS read so assertions
-        # can tell which cache answered.
-        self._calls.append(("get_cached_dns_addresses", host_name))
-        return self._cached.get(normalize_hostname(host_name))
-
-
-class _RecordingMonitorState:
-    """Typed fake for the monitor's public ``state`` attribute."""
-
-    def __init__(self, dns_cache: _RecordingDnsCache) -> None:
-        self.dns_cache = dns_cache
 
 
 class _RecordingImportableSource:
@@ -155,14 +144,16 @@ class RecordingStateMonitor:
     ) -> None:
         self.calls: list[tuple[Any, ...]] = []
         self._priority = priority_map or {}
-        self.mdns = _RecordingMdnsSource(
+        self.mdns = _RecordingAddressCache(
             self.calls,
             {normalize_hostname(k): v for k, v in (cached_addresses or {}).items()},
+            record_as="get_cached_addresses",
         )
-        self.state = _RecordingMonitorState(
-            _RecordingDnsCache(
+        self.state = SimpleNamespace(
+            dns_cache=_RecordingAddressCache(
                 self.calls,
                 {normalize_hostname(k): v for k, v in (cached_dns_addresses or {}).items()},
+                record_as="get_cached_dns_addresses",
             )
         )
         self.importable = _RecordingImportableSource(self.calls, list(importable_devices or []))

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -39,22 +39,85 @@ from tests._storage_fixtures import write_storage_json
 from tests.conftest import make_device, wire_secrets_writer
 
 
+class _RecordingMdnsSource:
+    """Typed fake for the monitor's public ``mdns`` source attribute."""
+
+    def __init__(self, calls: list[tuple[Any, ...]], cached: dict[str, list[str]]) -> None:
+        self._calls = calls
+        self._cached = cached
+
+    def get_cached_addresses(self, host_name: str) -> list[str] | None:
+        self._calls.append(("get_cached_addresses", host_name))
+        return self._cached.get(normalize_hostname(host_name))
+
+
+class _RecordingDnsCache:
+    """Typed fake for ``monitor.state.dns_cache``'s sync read surface."""
+
+    def __init__(self, calls: list[tuple[Any, ...]], cached: dict[str, list[str]]) -> None:
+        self._calls = calls
+        self._cached = cached
+
+    def get_cached_addresses(self, host_name: str) -> list[str] | None:
+        # Tuple name kept distinct from the mDNS read so assertions
+        # can tell which cache answered.
+        self._calls.append(("get_cached_dns_addresses", host_name))
+        return self._cached.get(normalize_hostname(host_name))
+
+
+class _RecordingMonitorState:
+    """Typed fake for the monitor's public ``state`` attribute."""
+
+    def __init__(self, dns_cache: _RecordingDnsCache) -> None:
+        self.dns_cache = dns_cache
+
+
+class _RecordingImportableSource:
+    """Typed fake for the monitor's public ``importable`` source attribute."""
+
+    def __init__(self, calls: list[tuple[Any, ...]], importable: list[AdoptableDevice]) -> None:
+        self._calls = calls
+        self._importable = importable
+
+    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
+        self._calls.append(("probe_device", device_name, service_name))
+
+    def revisit_importable(self, device_name: str) -> None:
+        self._calls.append(("revisit_importable", device_name))
+
+    def revisit_all_importables(self) -> None:
+        self._calls.append(("revisit_all_importables",))
+
+    def get_importable_devices(self) -> list[AdoptableDevice]:
+        self._calls.append(("get_importable_devices",))
+        return list(self._importable)
+
+
+class _RecordingApiInfoSource:
+    """Typed fake for the monitor's public ``api_info`` source attribute."""
+
+    def __init__(self, calls: list[tuple[Any, ...]]) -> None:
+        self._calls = calls
+
+    def request_reprobe(self, name: str) -> None:
+        self._calls.append(("request_reprobe", name))
+
+
 class RecordingStateMonitor:
     """Test fake for ``DeviceStateMonitor`` that captures every call.
 
-    Mirrors every public method on the production
-    ``DeviceStateMonitor`` (``apply`` / ``apply_ip`` /
-    ``apply_version`` / ``apply_api_encryption`` /
-    ``apply_config_hash`` / ``get_cached_addresses`` /
-    ``get_cached_dns_addresses`` / ``probe_device`` /
-    ``probe_device_ping`` / ``priority_for`` /
-    ``revisit_importable`` /
-    ``revisit_all_importables`` / ``get_importable_devices``)
-    without any of the real monitor's I/O. Calls land in
-    ``self.calls`` as flat tuples ``(method_name, *args)`` —
-    assertion-time comparisons read like
-    ``calls == [("apply", "kitchen", ONLINE, "mdns", True), ...]``
-    instead of three scattered ``MagicMock.assert_called_*`` lines.
+    Mirrors the production monitor's public surface — the core
+    methods (``apply`` / ``apply_ip`` / ``apply_version`` /
+    ``apply_api_encryption`` / ``apply_config_hash`` /
+    ``probe_device_ping`` / ``probe_reachability`` /
+    ``priority_for`` / ``forget``) plus the public source
+    attributes (``mdns`` / ``importable`` / ``api_info``) and
+    ``state.dns_cache`` — without any of the real monitor's I/O.
+    Calls land in the single shared ``self.calls`` list as flat
+    tuples ``(method_name, *args)`` — assertion-time comparisons
+    read like ``calls == [("apply", "kitchen", ONLINE, "mdns",
+    True), ...]`` instead of three scattered
+    ``MagicMock.assert_called_*`` lines.
 
     Why a typed fake rather than ``MagicMock``: a typo (e.g.
     ``probe_devicee.assert_called_once``) silently passes against a
@@ -62,11 +125,12 @@ class RecordingStateMonitor:
     refactor renaming a real method (``apply_ip`` → ``set_ip``)
     similarly breaks the contract without breaking the assertion.
     Pinning the surface here means both classes of drift surface as
-    ``AttributeError`` immediately. Mirroring the *full* public
-    surface (rather than just what the first batch of tests
-    needed) means a controller path like ``_on_scan_change(…,
-    REMOVED)`` that calls ``revisit_importable`` won't blow up
-    against the fake just because no earlier test exercised it.
+    ``AttributeError`` immediately. Mirroring the *full* surface the
+    devices controller touches (rather than just what the first
+    batch of tests needed) means a controller path like
+    ``_on_scan_change(…, REMOVED)`` that calls
+    ``importable.revisit_importable`` won't blow up against the
+    fake just because no earlier test exercised it.
 
     ``cached_addresses`` and ``cached_dns_addresses`` accept
     ``hostname → [ips]`` maps. Lookup keys are normalised through
@@ -74,7 +138,7 @@ class RecordingStateMonitor:
     inputs like ``Kitchen.local.`` and still hit the seeded entry.
 
     ``importable_devices`` lets tests pre-seed a list returned by
-    ``get_importable_devices``; defaults to ``[]``.
+    ``importable.get_importable_devices``; defaults to ``[]``.
 
     ``priority_map`` lets tests override the per-source priority
     returned by ``priority_for``; lookup falls back to ``"unknown"``
@@ -90,12 +154,19 @@ class RecordingStateMonitor:
         priority_map: dict[str, str] | None = None,
     ) -> None:
         self.calls: list[tuple[Any, ...]] = []
-        self._cached = {normalize_hostname(k): v for k, v in (cached_addresses or {}).items()}
-        self._cached_dns = {
-            normalize_hostname(k): v for k, v in (cached_dns_addresses or {}).items()
-        }
-        self._importable = list(importable_devices or [])
         self._priority = priority_map or {}
+        self.mdns = _RecordingMdnsSource(
+            self.calls,
+            {normalize_hostname(k): v for k, v in (cached_addresses or {}).items()},
+        )
+        self.state = _RecordingMonitorState(
+            _RecordingDnsCache(
+                self.calls,
+                {normalize_hostname(k): v for k, v in (cached_dns_addresses or {}).items()},
+            )
+        )
+        self.importable = _RecordingImportableSource(self.calls, list(importable_devices or []))
+        self.api_info = _RecordingApiInfoSource(self.calls)
 
     def apply(self, name: str, state: DeviceState, source: str, *, claim: bool = False) -> bool:
         self.calls.append(("apply", name, state, source, claim))
@@ -121,42 +192,21 @@ class RecordingStateMonitor:
         self.calls.append(("apply_config_hash", name, config_hash))
         return True
 
-    def get_cached_addresses(self, host_name: str) -> list[str] | None:
-        self.calls.append(("get_cached_addresses", host_name))
-        return self._cached.get(normalize_hostname(host_name))
-
-    def get_cached_dns_addresses(self, host_name: str) -> list[str] | None:
-        self.calls.append(("get_cached_dns_addresses", host_name))
-        return self._cached_dns.get(normalize_hostname(host_name))
-
-    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
-        self.calls.append(("probe_device", device_name, service_name))
-
     def probe_device_ping(self, device_name: str) -> None:
         self.calls.append(("probe_device_ping", device_name))
 
     def probe_reachability(self, device_name: str) -> None:
         # Delegates like production so callers' per-probe call tuples
         # keep matching regardless of which entry point they used.
-        self.probe_device(device_name)
+        self.importable.probe_device(device_name)
         self.probe_device_ping(device_name)
 
     def priority_for(self, name: str) -> str:
         self.calls.append(("priority_for", name))
         return self._priority.get(name, "unknown")
 
-    def revisit_importable(self, device_name: str) -> None:
-        self.calls.append(("revisit_importable", device_name))
-
-    def revisit_all_importables(self) -> None:
-        self.calls.append(("revisit_all_importables",))
-
     def forget(self, name: str) -> None:
         self.calls.append(("forget", name))
-
-    def get_importable_devices(self) -> list[AdoptableDevice]:
-        self.calls.append(("get_importable_devices",))
-        return list(self._importable)
 
 
 def _make_board_stub(board_id: str) -> MagicMock:

--- a/tests/controllers/devices/test_subscribe_reachability.py
+++ b/tests/controllers/devices/test_subscribe_reachability.py
@@ -115,13 +115,13 @@ def _wire_reachability(
     # path is what we want covered for most tests).
     state_monitor = MagicMock()
     state_monitor.priority_for = MagicMock(return_value=ReachabilitySource.PING)
-    state_monitor.refresh_mdns = AsyncMock()
+    state_monitor.mdns.refresh_mdns = AsyncMock()
     # The refresh loop reads ``get_mdns_a_record_ttl_remaining``
     # to decide how long to sleep before the next probe.
     # Returning ``None`` makes it sleep just the padding (~1s);
     # a default MagicMock would raise ``TypeError`` on the ``+``
     # arithmetic.
-    state_monitor.get_mdns_a_record_ttl_remaining = MagicMock(return_value=None)
+    state_monitor.mdns.get_mdns_a_record_ttl_remaining = MagicMock(return_value=None)
     controller._state_monitor = state_monitor
     return tracker
 
@@ -463,7 +463,7 @@ def test_scan_change_removed_clears_tracker(
     # Stub ``revisit_all_importables`` (called on REMOVED) so we
     # don't have to hand-build an import_discovery. The tracker
     # clear is what we're pinning down.
-    controller._state_monitor.revisit_all_importables = MagicMock()
+    controller._state_monitor.importable.revisit_all_importables = MagicMock()
     controller.state.regenerate_failed = set()
 
     controller._on_scan_change(ScanChange.REMOVED, device)
@@ -513,8 +513,8 @@ async def test_refresh_loop_only_calls_resolve_when_source_is_mdns(
     # Second iteration: sleep, then source = mdns → one refresh.
     # Third iteration: sleep raises CancelledError before the
     # priority probe runs. Total: 1 refresh across two ticks.
-    assert state_monitor.refresh_mdns.await_count == 1
-    state_monitor.refresh_mdns.assert_awaited_with("kitchen")
+    assert state_monitor.mdns.refresh_mdns.await_count == 1
+    state_monitor.mdns.refresh_mdns.assert_awaited_with("kitchen")
 
 
 async def test_refresh_loop_sleeps_until_cache_expiry(
@@ -539,7 +539,7 @@ async def test_refresh_loop_sleeps_until_cache_expiry(
     # Two A-TTL reads cover the two iterations: first fresh
     # (90s remaining), then expired (None — typical post-refresh
     # state if the device didn't respond).
-    state_monitor.get_mdns_a_record_ttl_remaining.side_effect = [90.0, None]
+    state_monitor.mdns.get_mdns_a_record_ttl_remaining.side_effect = [90.0, None]
     state_monitor.priority_for.return_value = ReachabilitySource.MDNS
 
     sleep_durations: list[float] = []
@@ -589,7 +589,7 @@ async def test_refresh_loop_skips_wire_query_when_recheck_finds_fresh_cache(
     state_monitor.priority_for.return_value = ReachabilitySource.MDNS
     # Three A-TTL reads: fresh (90s) → fresh again (60s, an
     # announce arrived) → empty (cache evicted).
-    state_monitor.get_mdns_a_record_ttl_remaining.side_effect = [90.0, 60.0, None]
+    state_monitor.mdns.get_mdns_a_record_ttl_remaining.side_effect = [90.0, 60.0, None]
 
     sleep_count = 0
 
@@ -609,4 +609,4 @@ async def test_refresh_loop_skips_wire_query_when_recheck_finds_fresh_cache(
         m.setattr("asyncio.sleep", fast_sleep)
         await controller._reachability_refresh_loop("kitchen")
 
-    state_monitor.refresh_mdns.assert_not_awaited()
+    state_monitor.mdns.refresh_mdns.assert_not_awaited()

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -582,7 +582,7 @@ async def test_schedule_version_reprobe_fires_and_requests(monkeypatch: Any) -> 
     controller._schedule_version_reprobe("kitchen.yaml")
     await asyncio.sleep(0.01)  # let the call_later(0) timer fire
 
-    controller._state_monitor.request_version_reprobe.assert_called_once_with(device.name)
+    controller._state_monitor.api_info.request_reprobe.assert_called_once_with(device.name)
     assert controller._reprobe_timers == {}  # consumed
 
 
@@ -592,7 +592,7 @@ async def test_fire_version_reprobe_unknown_configuration_is_noop() -> None:
 
     firmware_sync._fire_version_reprobe(controller, "kitchen.yaml")
 
-    controller._state_monitor.request_version_reprobe.assert_not_called()
+    controller._state_monitor.api_info.request_reprobe.assert_not_called()
 
 
 async def test_schedule_version_reprobe_reschedule_cancels_previous(monkeypatch: Any) -> None:

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -44,49 +44,49 @@ def test_select_targets_picks_online_api_device_missing_fields() -> None:
     """The target case: ONLINE, API-capable, blank mac+version, routable IP."""
     devices = [make_online_api_device()]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
 
 
 def test_select_targets_picks_when_only_one_field_missing() -> None:
     """A device with a MAC but no version still needs a fetch."""
     devices = [make_online_api_device(mac_address="94:C9:60:1F:8C:F1")]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
 
 
 def test_select_targets_skips_when_both_fields_present() -> None:
     """MDNS already supplied both → never connect."""
     devices = [make_online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert monitor._api_info._select_targets() == []
+    assert monitor.api_info._select_targets() == []
 
 
 def test_select_targets_skips_offline_device() -> None:
     """Only ONLINE devices are probed."""
     devices = [make_online_api_device(state=DeviceState.OFFLINE)]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert monitor._api_info._select_targets() == []
+    assert monitor.api_info._select_targets() == []
 
 
 def test_select_targets_skips_non_api_device() -> None:
     """A device that exposes no Native API can't be reached over it."""
     devices = [make_online_api_device(api_enabled=False, loaded_integrations=["web_server"])]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert monitor._api_info._select_targets() == []
+    assert monitor.api_info._select_targets() == []
 
 
 def test_select_targets_picks_uncompiled_online_api_device() -> None:
     """An online ``api:`` device never compiled here (empty loaded_integrations) is still probed."""
     devices = [make_online_api_device(loaded_integrations=[])]  # api_enabled set from YAML scan
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
 
 
 def test_select_targets_skips_when_only_local_hostname_known() -> None:
     """No IP and only a ``.local`` address → unresolvable when mDNS is down."""
     devices = [make_online_api_device(ip="", ip_addresses=[], address="kitchen.local")]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    assert monitor._api_info._select_targets() == []
+    assert monitor.api_info._select_targets() == []
 
 
 def test_select_targets_picks_mdns_owned_device_missing_fields() -> None:
@@ -94,7 +94,7 @@ def test_select_targets_picks_mdns_owned_device_missing_fields() -> None:
     devices = [make_online_api_device()]
     monitor, _ = make_state_monitor_with_callbacks(devices)
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
 
 
 def test_select_targets_skips_forced_reprobe_when_mdns_owns_state() -> None:
@@ -102,8 +102,8 @@ def test_select_targets_skips_forced_reprobe_when_mdns_owns_state() -> None:
     devices = [make_online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")]
     monitor, _ = make_state_monitor_with_callbacks(devices)
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
-    monitor._api_info.request_reprobe("kitchen")
-    assert monitor._api_info._select_targets() == []
+    monitor.api_info.request_reprobe("kitchen")
+    assert monitor.api_info._select_targets() == []
 
 
 def test_select_targets_picks_forced_reprobe_when_ping_owned() -> None:
@@ -111,8 +111,8 @@ def test_select_targets_picks_forced_reprobe_when_ping_owned() -> None:
     devices = [make_online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")]
     monitor, _ = make_state_monitor_with_callbacks(devices)
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
-    monitor._api_info.request_reprobe("kitchen")
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
+    monitor.api_info.request_reprobe("kitchen")
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
 
 
 def test_select_targets_picks_when_online_via_ping_not_mdns() -> None:
@@ -120,7 +120,7 @@ def test_select_targets_picks_when_online_via_ping_not_mdns() -> None:
     devices = [make_online_api_device()]
     monitor, _ = make_state_monitor_with_callbacks(devices)
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
 
 
 # ----------------------------------------------------------------------
@@ -157,11 +157,11 @@ async def test_fetch_applies_mac_and_version() -> None:
     """A worker hit writes the normalized MAC and the version through the monitor."""
     device = make_online_api_device(address="")
     monitor, callbacks = make_state_monitor_with_callbacks([device])
-    monitor._api_info._run_worker = AsyncMock(  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(  # type: ignore[method-assign]
         return_value={"mac_address": "94c9601f8cf1", "esphome_version": "2026.6.1"}
     )
 
-    await monitor._api_info._fetch(device)
+    await monitor.api_info._fetch(device)
 
     assert device.mac_address == "94:C9:60:1F:8C:F1"
     assert device.runtime_state.deployed_version == "2026.6.1"
@@ -173,11 +173,11 @@ async def test_fetch_failure_sets_cooldown_and_skips_next_select() -> None:
     """A failed fetch parks the device so the next sweep doesn't reconnect it."""
     device = make_online_api_device()
     monitor, _ = make_state_monitor_with_callbacks([device])
-    monitor._api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    assert [d.name for d in monitor._api_info._select_targets()] == ["kitchen"]
-    await monitor._api_info._fetch(device)
-    assert monitor._api_info._select_targets() == []
+    assert [d.name for d in monitor.api_info._select_targets()] == ["kitchen"]
+    await monitor.api_info._fetch(device)
+    assert monitor.api_info._select_targets() == []
 
 
 async def test_fetch_passes_resolved_key_and_port_to_worker() -> None:
@@ -189,11 +189,11 @@ async def test_fetch_passes_resolved_key_and_port_to_worker() -> None:
         on_ip_change=lambda *_: None,
         resolve_api_connection=AsyncMock(return_value=("s3cr3t-psk", 6055)),
     )
-    monitor._api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    await monitor._api_info._fetch(device)
+    await monitor.api_info._fetch(device)
 
-    request = json.loads(monitor._api_info._run_worker.call_args.args[1])
+    request = json.loads(monitor.api_info._run_worker.call_args.args[1])
     assert request["noise_psk"] == "s3cr3t-psk"
     assert request["port"] == 6055
     assert request["address"] == "192.168.1.50"
@@ -204,11 +204,11 @@ async def test_fetch_uses_plaintext_default_port_when_no_resolver() -> None:
     """Unwired resolver → empty PSK (plaintext) and the default 6053 port."""
     device = make_online_api_device(address="")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    monitor._api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    await monitor._api_info._fetch(device)
+    await monitor.api_info._fetch(device)
 
-    request = json.loads(monitor._api_info._run_worker.call_args.args[1])
+    request = json.loads(monitor.api_info._run_worker.call_args.args[1])
     assert request["noise_psk"] == ""
     assert request["port"] == 6053
 
@@ -217,20 +217,20 @@ async def test_fetch_connected_but_empty_sets_cooldown() -> None:
     """A probe that connects but returns no data still backs off (no every-sweep reconnect)."""
     device = make_online_api_device()
     monitor, _ = make_state_monitor_with_callbacks([device])
-    monitor._api_info._run_worker = AsyncMock(  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(  # type: ignore[method-assign]
         return_value={"mac_address": "", "esphome_version": ""}
     )
 
-    await monitor._api_info._fetch(device)
+    await monitor.api_info._fetch(device)
 
-    assert monitor._api_info._select_targets() == []
+    assert monitor.api_info._select_targets() == []
 
 
 async def test_fetch_partial_fill_is_progress_not_failure() -> None:
     """A probe that fills only the MAC isn't cooled down and stays eligible for the rest."""
     device = make_online_api_device(address="")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src._run_worker = AsyncMock(  # type: ignore[method-assign]
         return_value={"mac_address": "94c9601f8cf1", "esphome_version": ""}
     )
@@ -247,7 +247,7 @@ async def test_fetch_no_new_fill_is_a_failure() -> None:
     """Re-sending an already-known MAC with no version is a miss (cooldown)."""
     device = make_online_api_device(mac_address="94:C9:60:1F:8C:F1", address="")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src._run_worker = AsyncMock(  # type: ignore[method-assign]
         return_value={"mac_address": "94c9601f8cf1", "esphome_version": ""}
     )
@@ -266,12 +266,12 @@ async def test_fetch_resolver_failure_is_a_recorded_miss() -> None:
         on_ip_change=lambda *_: None,
         resolve_api_connection=AsyncMock(side_effect=RuntimeError("resolve boom")),
     )
-    monitor._api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    await monitor._api_info._fetch(device)
+    await monitor.api_info._fetch(device)
 
-    monitor._api_info._run_worker.assert_not_called()
-    assert "kitchen" in monitor._api_info._cooldown
+    monitor.api_info._run_worker.assert_not_called()
+    assert "kitchen" in monitor.api_info._cooldown
 
 
 async def test_fetch_skips_encrypted_device_without_key() -> None:
@@ -283,24 +283,24 @@ async def test_fetch_skips_encrypted_device_without_key() -> None:
         on_ip_change=lambda *_: None,
         resolve_api_connection=AsyncMock(return_value=("", 6053)),  # encrypted, key empty
     )
-    monitor._api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    await monitor._api_info._fetch(device)
+    await monitor.api_info._fetch(device)
 
-    monitor._api_info._run_worker.assert_not_called()
-    assert "kitchen" in monitor._api_info._cooldown
+    monitor.api_info._run_worker.assert_not_called()
+    assert "kitchen" in monitor.api_info._cooldown
 
 
 async def test_fetch_skips_when_addresses_emptied_after_select() -> None:
     """A select→fetch TOCTOU (no addresses left) is a recorded miss, not an IndexError."""
     device = make_online_api_device(ip="", ip_addresses=[], address="kitchen.local")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    monitor._api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    monitor.api_info._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
-    await monitor._api_info._fetch(device)  # must not raise IndexError
+    await monitor.api_info._fetch(device)  # must not raise IndexError
 
-    monitor._api_info._run_worker.assert_not_called()
-    assert "kitchen" in monitor._api_info._cooldown
+    monitor.api_info._run_worker.assert_not_called()
+    assert "kitchen" in monitor.api_info._cooldown
 
 
 async def test_systemic_warning_fires_once_when_many_devices_failing(
@@ -310,7 +310,7 @@ async def test_systemic_warning_fires_once_when_many_devices_failing(
     monkeypatch.setattr(api_info_module, "_MAX_PROBES_PER_SWEEP", 20)  # probe all in one sweep
     devices = [make_online_api_device(f"dev{i}") for i in range(10)]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    src = monitor._api_info
+    src = monitor.api_info
     src._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     with caplog.at_level(logging.WARNING):
@@ -329,7 +329,7 @@ async def test_systemic_warning_not_masked_by_one_healthy_device(
     devices = [make_online_api_device(f"bad{i}") for i in range(10)]
     healthy = make_online_api_device("good")
     monitor, _ = make_state_monitor_with_callbacks([*devices, healthy])
-    src = monitor._api_info
+    src = monitor.api_info
 
     async def _run_worker(device: Device, _request: bytes) -> dict[str, str] | None:
         if device.name == "good":
@@ -349,7 +349,7 @@ async def test_systemic_warning_rearms_after_recovery(monkeypatch: Any) -> None:
     monkeypatch.setattr(api_info_module, "_MAX_PROBES_PER_SWEEP", 20)
     devices = [make_online_api_device(f"dev{i}") for i in range(10)]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    src = monitor._api_info
+    src = monitor.api_info
     src._run_worker = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     await src._sweep()
@@ -367,7 +367,7 @@ async def test_sweep_prunes_cooldown_for_removed_devices() -> None:
     """A cooldown entry for a device no longer in the catalog is dropped."""
     device = make_online_api_device()
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src._cooldown.set("ghost", 1e18)
     src._cooldown.set("kitchen", 1e18)
     src._fetch = AsyncMock()  # type: ignore[method-assign]
@@ -386,7 +386,7 @@ async def test_sweep_prunes_cooldown_for_removed_devices() -> None:
 async def test_run_without_aioesphomeapi_still_sweeps(monkeypatch: Any) -> None:
     """No aioesphomeapi installed → the loop still runs (the cache reconcile needs no worker)."""
     monitor, _ = make_state_monitor_with_callbacks([make_online_api_device()])
-    src = monitor._api_info
+    src = monitor.api_info
     monkeypatch.setattr(
         "esphome_device_builder.controllers._device_state_monitor._api_probe.importlib.util.find_spec",
         lambda _name: None,
@@ -410,10 +410,10 @@ async def test_run_without_aioesphomeapi_still_sweeps(monkeypatch: Any) -> None:
 async def test_sweep_without_aioesphomeapi_reconciles_but_never_connects() -> None:
     """The API-connect stage is gated on aioesphomeapi; the cache reconcile is not."""
     monitor, _ = make_state_monitor_with_callbacks([make_online_api_device()])
-    src = monitor._api_info
+    src = monitor.api_info
     src._api_available = False
     reconciled: list[str] = []
-    monitor.reconcile_from_mdns_cache = reconciled.append  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = reconciled.append  # type: ignore[method-assign]
     src._fetch = AsyncMock()  # type: ignore[method-assign]
 
     await src._sweep()
@@ -432,10 +432,10 @@ async def test_sweep_reconciles_non_api_device_missing_identity() -> None:
     )
     monitor, _ = make_state_monitor_with_callbacks([device])
     reconciled: list[str] = []
-    monitor.reconcile_from_mdns_cache = reconciled.append  # type: ignore[method-assign]
-    monitor._api_info._fetch = AsyncMock()  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = reconciled.append  # type: ignore[method-assign]
+    monitor.api_info._fetch = AsyncMock()  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert reconciled == ["kitchen"]
 
@@ -443,7 +443,7 @@ async def test_sweep_reconciles_non_api_device_missing_identity() -> None:
 async def test_run_sweeps_then_idles(monkeypatch: Any) -> None:
     """With aioesphomeapi present the loop bootstraps, sweeps, then idles each cycle."""
     monitor, _ = make_state_monitor_with_callbacks([])
-    src = monitor._api_info
+    src = monitor.api_info
     monkeypatch.setattr(ApiInfoSource, "_bootstrap_delay", 0)
     swept: list[int] = []
 
@@ -464,7 +464,7 @@ async def test_run_sweeps_then_idles(monkeypatch: Any) -> None:
 async def test_run_survives_a_sweep_error(monkeypatch: Any) -> None:
     """An unexpected error from a sweep is logged and the loop keeps going."""
     monitor, _ = make_state_monitor_with_callbacks([])
-    src = monitor._api_info
+    src = monitor.api_info
     monkeypatch.setattr(ApiInfoSource, "_bootstrap_delay", 0)
     reached_idle: list[int] = []
 
@@ -506,7 +506,7 @@ async def test_run_waits_for_subscriber_when_presence_wired(monkeypatch: Any) ->
         presence=presence,
     )
     assert presence.callbacks  # ApiInfoSource registered its wake on construction
-    src = monitor._api_info
+    src = monitor.api_info
     monkeypatch.setattr(ApiInfoSource, "_bootstrap_delay", 0)
     swept: list[int] = []
 
@@ -539,17 +539,17 @@ async def test_sweep_fetches_each_selected_target() -> None:
     async def _fetch(device: Device) -> None:
         fetched.append(device.name)
 
-    monitor._api_info._fetch = _fetch  # type: ignore[method-assign]
-    await monitor._api_info._sweep()
+    monitor.api_info._fetch = _fetch  # type: ignore[method-assign]
+    await monitor.api_info._sweep()
     assert sorted(fetched) == ["alpha", "beta"]
 
 
 async def test_sweep_noop_when_no_targets() -> None:
     """An empty target set spawns nothing."""
     monitor, _ = make_state_monitor_with_callbacks([])
-    monitor._api_info._fetch = AsyncMock()  # type: ignore[method-assign]
-    await monitor._api_info._sweep()
-    monitor._api_info._fetch.assert_not_called()
+    monitor.api_info._fetch = AsyncMock()  # type: ignore[method-assign]
+    await monitor.api_info._sweep()
+    monitor.api_info._fetch.assert_not_called()
 
 
 async def test_sweep_skips_api_probe_when_cache_reconcile_fills_fields() -> None:
@@ -562,23 +562,23 @@ async def test_sweep_skips_api_probe_when_cache_reconcile_fills_fields() -> None
         device.runtime_state.deployed_version = "2026.6.4"
         device.runtime_state.deployed_config_hash = "abcd1234"
 
-    monitor.reconcile_from_mdns_cache = _fill  # type: ignore[method-assign]
-    monitor._api_info._fetch = AsyncMock()  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = _fill  # type: ignore[method-assign]
+    monitor.api_info._fetch = AsyncMock()  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
-    monitor._api_info._fetch.assert_not_called()
+    monitor.api_info._fetch.assert_not_called()
 
 
 async def test_sweep_probes_when_cache_reconcile_cannot_fill() -> None:
     """A cache miss leaves the device due; the API-connect stage still runs."""
     monitor, _ = make_state_monitor_with_callbacks([make_online_api_device()])
     reconciled: list[str] = []
-    monitor.reconcile_from_mdns_cache = reconciled.append  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = reconciled.append  # type: ignore[method-assign]
     fetch = AsyncMock()
-    monitor._api_info._fetch = fetch  # type: ignore[method-assign]
+    monitor.api_info._fetch = fetch  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert reconciled == ["kitchen"]
     fetch.assert_called_once()
@@ -607,10 +607,10 @@ async def test_sweep_reconciles_only_blank_online_devices() -> None:
     blank = make_online_api_device("blank")
     monitor, _ = make_state_monitor_with_callbacks([populated, offline, no_api, blank])
     reconciled: list[str] = []
-    monitor.reconcile_from_mdns_cache = reconciled.append  # type: ignore[method-assign]
-    monitor._api_info._fetch = AsyncMock()  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = reconciled.append  # type: ignore[method-assign]
+    monitor.api_info._fetch = AsyncMock()  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert reconciled == ["blank"]
 
@@ -625,11 +625,11 @@ async def test_sweep_reconciles_unknown_encryption_state_even_when_fields_full()
     assert device.runtime_state.api_encryption_active is None
     monitor, _ = make_state_monitor_with_callbacks([device])
     reconciled: list[str] = []
-    monitor.reconcile_from_mdns_cache = reconciled.append  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = reconciled.append  # type: ignore[method-assign]
     fetch = AsyncMock()
-    monitor._api_info._fetch = fetch  # type: ignore[method-assign]
+    monitor.api_info._fetch = fetch  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert reconciled == ["kitchen"]
     fetch.assert_not_called()
@@ -642,11 +642,11 @@ async def test_sweep_reconciles_missing_config_hash_even_when_not_api_due() -> N
     )
     monitor, _ = make_state_monitor_with_callbacks([device])
     reconciled: list[str] = []
-    monitor.reconcile_from_mdns_cache = reconciled.append  # type: ignore[method-assign]
+    monitor.mdns.reconcile_from_cache = reconciled.append  # type: ignore[method-assign]
     fetch = AsyncMock()
-    monitor._api_info._fetch = fetch  # type: ignore[method-assign]
+    monitor.api_info._fetch = fetch  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert reconciled == ["kitchen"]
     fetch.assert_not_called()
@@ -662,8 +662,8 @@ async def test_sweep_caps_probes_per_sweep(monkeypatch: Any) -> None:
     async def _fetch(device: Device) -> None:
         fetched.append(device.name)
 
-    monitor._api_info._fetch = _fetch  # type: ignore[method-assign]
-    await monitor._api_info._sweep()
+    monitor.api_info._fetch = _fetch  # type: ignore[method-assign]
+    await monitor.api_info._sweep()
     assert len(fetched) == 3
 
 
@@ -671,7 +671,7 @@ async def test_sweep_isolates_a_failing_fetch() -> None:
     """One device whose fetch raises is cooled down; the sweep finishes the rest."""
     a, b = make_online_api_device("a"), make_online_api_device("b")
     monitor, _ = make_state_monitor_with_callbacks([a, b])
-    src = monitor._api_info
+    src = monitor.api_info
     fetched: list[str] = []
 
     async def _fetch(device: Device) -> None:
@@ -693,7 +693,7 @@ async def test_sweep_exceptions_cool_down_and_count_as_failing(
     monkeypatch.setattr(api_info_module, "_MAX_PROBES_PER_SWEEP", 20)
     devices = [make_online_api_device(f"dev{i}") for i in range(10)]
     monitor, _ = make_state_monitor_with_callbacks(devices)
-    src = monitor._api_info
+    src = monitor.api_info
 
     async def _boom(_device: Device) -> None:
         raise RuntimeError("kaboom")
@@ -736,7 +736,7 @@ def _patch_capture(
 async def test_run_worker_parses_json_payload(monkeypatch: Any) -> None:
     monitor, _ = make_state_monitor_with_callbacks([])
     _patch_capture(monkeypatch, stdout=b'{"mac_address": "aa", "esphome_version": "1"}')
-    result = await monitor._api_info._run_worker(make_device(), b"{}")
+    result = await monitor.api_info._run_worker(make_device(), b"{}")
     assert result == {"mac_address": "aa", "esphome_version": "1"}
 
 
@@ -744,7 +744,7 @@ async def test_run_worker_feeds_request_over_stdin_with_stderr_discarded(monkeyp
     """The request goes to the child as stdin and stderr is dropped (clean stdout)."""
     monitor, _ = make_state_monitor_with_callbacks([])
     mock = _patch_capture(monkeypatch, stdout=b'{"mac_address": "aa", "esphome_version": "1"}')
-    await monitor._api_info._run_worker(make_device(), b"REQUEST-BYTES")
+    await monitor.api_info._run_worker(make_device(), b"REQUEST-BYTES")
     _, kwargs = mock.call_args
     assert kwargs["stdin_data"] == b"REQUEST-BYTES"
     assert kwargs["merge_stderr"] is False
@@ -754,7 +754,7 @@ async def test_run_worker_returns_none_on_device_side_miss(monkeypatch: Any) -> 
     """A worker that ran its protocol but got refused maps to ``None``."""
     monitor, _ = make_state_monitor_with_callbacks([])
     _patch_capture(monkeypatch, returncode=1, stdout=b"{}")
-    assert await monitor._api_info._run_worker(make_device(), b"{}") is None
+    assert await monitor.api_info._run_worker(make_device(), b"{}") is None
 
 
 @pytest.mark.parametrize(
@@ -774,7 +774,7 @@ async def test_run_worker_raises_transient_on_host_side_miss(
     monitor, _ = make_state_monitor_with_callbacks([])
     _patch_capture(monkeypatch, **capture_kwargs)
     with pytest.raises(ProbeError) as excinfo:
-        await monitor._api_info._run_worker(make_device(), b"{}")
+        await monitor.api_info._run_worker(make_device(), b"{}")
     assert excinfo.value.transient
 
 
@@ -783,7 +783,7 @@ async def test_run_worker_propagates_cancellation(monkeypatch: Any) -> None:
     monitor, _ = make_state_monitor_with_callbacks([])
     _patch_capture(monkeypatch, error=asyncio.CancelledError())
     with pytest.raises(asyncio.CancelledError):
-        await monitor._api_info._run_worker(make_device(), b"{}")
+        await monitor.api_info._run_worker(make_device(), b"{}")
 
 
 async def test_run_worker_logs_worker_reported_error(monkeypatch: Any, caplog: Any) -> None:
@@ -793,7 +793,7 @@ async def test_run_worker_logs_worker_reported_error(monkeypatch: Any, caplog: A
         monkeypatch, returncode=1, stdout=b'{"error": "APIConnectionError: connection refused"}'
     )
     with caplog.at_level(logging.DEBUG):
-        assert await monitor._api_info._run_worker(make_device(), b"{}") is None
+        assert await monitor.api_info._run_worker(make_device(), b"{}") is None
     assert "connection refused" in caplog.text
 
 
@@ -916,7 +916,7 @@ def test_request_reprobe_makes_filled_device_due() -> None:
     """A forced re-probe overrides the mac+version guard that would skip the device."""
     device = make_online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     assert src._select_targets() == []  # both fields present → normally skipped
     src.request_reprobe("kitchen")
     assert [d.name for d in src._select_targets()] == ["kitchen"]
@@ -926,7 +926,7 @@ def test_request_reprobe_bypasses_cooldown() -> None:
     """A forced re-probe is deliberate — it ignores the per-device failure cooldown."""
     device = make_online_api_device()
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src._cooldown.set("kitchen", 600)
     assert src._select_targets() == []  # parked on cooldown
     src.request_reprobe("kitchen")
@@ -937,7 +937,7 @@ async def test_forced_reprobe_probes_then_clears_itself() -> None:
     """The forced probe runs even with both fields set, then the flag is consumed."""
     device = make_online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.1")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src.request_reprobe("kitchen")
     src._run_worker = AsyncMock(  # type: ignore[method-assign]
         return_value={"esphome_version": "2026.6.2"}
@@ -954,7 +954,7 @@ async def test_forced_reprobe_confirming_existing_version_is_not_a_failure() -> 
     """A forced probe that connected and confirmed the version isn't cooled down."""
     device = make_online_api_device(mac_address="94:C9:60:1F:8C:F1", deployed_version="2026.6.2")
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src.request_reprobe("kitchen")
     src._run_worker = AsyncMock(  # type: ignore[method-assign]
         return_value={"mac_address": "94c9601f8cf1", "esphome_version": "2026.6.2"}
@@ -970,7 +970,7 @@ async def test_sweep_prunes_force_reprobe_for_dead_devices() -> None:
     """A force flag for a device that's no longer present is dropped on the next sweep."""
     device = make_online_api_device()
     monitor, _ = make_state_monitor_with_callbacks([device])
-    src = monitor._api_info
+    src = monitor.api_info
     src.request_reprobe("ghost")  # not a live device
     src._fetch = AsyncMock()  # type: ignore[method-assign]
 
@@ -983,5 +983,5 @@ def test_monitor_request_version_reprobe_forwards_to_api_info() -> None:
     """The monitor facade forwards a version re-probe request to the API source."""
     device = make_online_api_device()
     monitor, _ = make_state_monitor_with_callbacks([device])
-    monitor.request_version_reprobe("kitchen")
-    assert "kitchen" in monitor._api_info._force_reprobe
+    monitor.api_info.request_reprobe("kitchen")
+    assert "kitchen" in monitor.api_info._force_reprobe

--- a/tests/test_api_info_fallback.py
+++ b/tests/test_api_info_fallback.py
@@ -977,11 +977,3 @@ async def test_sweep_prunes_force_reprobe_for_dead_devices() -> None:
     await src._sweep()
 
     assert "ghost" not in src._force_reprobe
-
-
-def test_monitor_request_version_reprobe_forwards_to_api_info() -> None:
-    """The monitor facade forwards a version re-probe request to the API source."""
-    device = make_online_api_device()
-    monitor, _ = make_state_monitor_with_callbacks([device])
-    monitor.api_info.request_reprobe("kitchen")
-    assert "kitchen" in monitor.api_info._force_reprobe

--- a/tests/test_api_reviver.py
+++ b/tests/test_api_reviver.py
@@ -56,9 +56,9 @@ def _reviver(
     monitor, callbacks = make_state_monitor_with_callbacks(devices)
     monitor.state.dns_cache = MagicMock()
     monitor.state.dns_cache.has_cached_failure.return_value = True
-    monitor._ping.icmp_available = True
-    monitor._ping.ping_once = AsyncMock(return_value=rtt)  # type: ignore[method-assign]
-    src = monitor._api_reviver
+    monitor.ping.icmp_available = True
+    monitor.ping.ping_once = AsyncMock(return_value=rtt)  # type: ignore[method-assign]
+    src = monitor.api_reviver
     src._run_worker = AsyncMock(return_value=worker_result)  # type: ignore[method-assign]
     return monitor, callbacks, src
 
@@ -87,7 +87,7 @@ async def test_match_revives_online_under_ping() -> None:
     assert monitor.priority_for("kitchen") is ReachabilitySource.PING
     verified_ip, _verified_at = src._verified["kitchen"]
     assert verified_ip == "192.168.1.50"
-    assert monitor._ping._wake.is_set()
+    assert monitor.ping._wake.is_set()
 
 
 async def test_match_applies_mac_and_version_from_the_same_dial() -> None:
@@ -160,14 +160,14 @@ async def test_run_exits_when_icmp_is_unavailable(
     """Without a trustworthy negative pre-filter the reviver refuses to run at all."""
     device = make_stuck_offline_device()
     monitor, _callbacks, src = _reviver([device])
-    monitor._ping.icmp_available = icmp_available
+    monitor.ping.icmp_available = icmp_available
     monkeypatch.setattr(ApiReviverSource, "_bootstrap_delay", 0)
 
     with caplog.at_level(logging.WARNING):
         await asyncio.wait_for(src.run(), timeout=1)
 
     assert "API revival disabled" in caplog.text
-    monitor._ping.ping_once.assert_not_called()
+    monitor.ping.ping_once.assert_not_called()
 
 
 async def test_prepare_requires_the_worker_library(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -206,7 +206,7 @@ async def test_cohort_skips(overrides: dict[str, Any]) -> None:
 
     await src._sweep()
 
-    monitor._ping.ping_once.assert_not_called()
+    monitor.ping.ping_once.assert_not_called()
     src._run_worker.assert_not_called()
 
 
@@ -241,7 +241,7 @@ async def test_cohort_skips_without_a_cached_dns_failure() -> None:
 
     await src._sweep()
 
-    monitor._ping.ping_once.assert_not_called()
+    monitor.ping.ping_once.assert_not_called()
 
 
 async def test_cohort_skips_when_zeroconf_cache_has_addresses(
@@ -249,11 +249,11 @@ async def test_cohort_skips_when_zeroconf_cache_has_addresses(
 ) -> None:
     device = make_stuck_offline_device()
     monitor, _callbacks, src = _reviver([device])
-    monkeypatch.setattr(monitor, "get_cached_addresses", lambda _host: ["192.168.1.50"])
+    monkeypatch.setattr(monitor.mdns, "get_cached_addresses", lambda _host: ["192.168.1.50"])
 
     await src._sweep()
 
-    monitor._ping.ping_once.assert_not_called()
+    monitor.ping.ping_once.assert_not_called()
 
 
 async def test_cohort_includes_device_with_blank_address() -> None:
@@ -263,7 +263,7 @@ async def test_cohort_includes_device_with_blank_address() -> None:
 
     await src._sweep()
 
-    monitor._ping.ping_once.assert_awaited_once_with("192.168.1.50", retry=True)
+    monitor.ping.ping_once.assert_awaited_once_with("192.168.1.50", retry=True)
 
 
 async def test_post_revival_flap_is_pings_to_demote_and_keep() -> None:
@@ -272,13 +272,13 @@ async def test_post_revival_flap_is_pings_to_demote_and_keep() -> None:
     monitor, _callbacks, src = _reviver([device])
     await src._sweep()
     src._run_worker.reset_mock()
-    monitor._ping.ping_once.reset_mock()
+    monitor.ping.ping_once.reset_mock()
 
     monitor.apply("kitchen", DeviceState.OFFLINE, "ping")
     assert device.runtime_state.ip_addresses == ["192.168.1.50"]
     await src._sweep()
 
-    monitor._ping.ping_once.assert_not_called()
+    monitor.ping.ping_once.assert_not_called()
     src._run_worker.assert_not_called()
 
 
@@ -356,9 +356,9 @@ async def test_name_mismatch_invalidates_the_persisted_ip() -> None:
 
     # The cleared IP fails the cohort gate: no re-dial next sweep.
     src._run_worker.reset_mock()
-    monitor._ping.ping_once.reset_mock()
+    monitor.ping.ping_once.reset_mock()
     await src._sweep()
-    monitor._ping.ping_once.assert_not_called()
+    monitor.ping.ping_once.assert_not_called()
     src._run_worker.assert_not_called()
 
 
@@ -473,7 +473,7 @@ async def test_pair_mutated_between_prefilter_and_dial_is_skipped() -> None:
         device.ip = ""
         return 12.5
 
-    monitor._ping.ping_once = clear_ip  # type: ignore[method-assign]
+    monitor.ping.ping_once = clear_ip  # type: ignore[method-assign]
     await src._sweep()
 
     src._run_worker.assert_not_called()
@@ -512,11 +512,11 @@ async def test_worker_dials_share_one_monitor_wide_slot() -> None:
         in_flight -= 1
 
     src._run_worker = slow_worker  # type: ignore[method-assign]
-    monitor._api_info._run_worker = slow_worker  # type: ignore[method-assign]
+    monitor.api_info._run_worker = slow_worker  # type: ignore[method-assign]
 
     await asyncio.gather(
         src._probe(device, [device.ip]),
-        monitor._api_info._probe(device, [device.ip]),
+        monitor.api_info._probe(device, [device.ip]),
     )
 
     assert peak == 1

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from esphome_device_builder import device_builder as db_module
-from esphome_device_builder.controllers._device_state_monitor import DeviceStateMonitor
+from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.device_builder import DeviceBuilder
 from esphome_device_builder.helpers import dashboard_advertise
 from esphome_device_builder.helpers.dashboard_advertise import (
@@ -1002,7 +1002,7 @@ async def test_device_builder_advertises_in_ha_addon_mode(
             instances.append(self)
 
     monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
-    monkeypatch.setattr(DeviceStateMonitor, "zeroconf", property(lambda self: fake_zc))
+    monkeypatch.setattr(MdnsSource, "zeroconf", property(lambda self: fake_zc))
 
     settings = make_settings(with_core_path=True)
     settings.on_ha_addon = True
@@ -1051,7 +1051,7 @@ async def test_device_builder_constructs_advertiser_when_zeroconf_present(
             instances.append(self)
 
     monkeypatch.setattr(db_module, "DashboardAdvertiser", _FakeAdvertiser)
-    monkeypatch.setattr(DeviceStateMonitor, "zeroconf", property(lambda self: fake_zc))
+    monkeypatch.setattr(MdnsSource, "zeroconf", property(lambda self: fake_zc))
 
     settings = make_settings(with_core_path=True)
     settings.on_ha_addon = False

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -252,13 +252,13 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert pinged == ["10.0.0.1"]
     assert ip_changes == [("kitchen", "10.0.0.1", ["10.0.0.1"])]
     # DNS cache is now warm — ``get_cached_dns_addresses`` should hit
     # without triggering another resolver call.
-    assert monitor.get_cached_dns_addresses("esp.example.com") == ["10.0.0.1"]
+    assert monitor.state.dns_cache.get_cached_addresses("esp.example.com") == ["10.0.0.1"]
 
 
 async def test_ping_sweep_applies_ip_for_local_hosts(fake_resolver) -> None:
@@ -294,7 +294,7 @@ async def test_ping_sweep_applies_ip_for_local_hosts(fake_resolver) -> None:
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert ip_changes == [("kitchen", "192.168.1.50", ["192.168.1.50"])]
 
@@ -331,7 +331,7 @@ async def test_ping_sweep_targets_ipv4_primary_over_scoped_v6(
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert pinged == ["10.0.0.5"]
     assert ip_changes[0] == ("winefridge", "10.0.0.5", ["fe80::1%en0", "10.0.0.5"])
@@ -366,11 +366,11 @@ async def test_ping_sweep_prefers_system_resolver_over_zeroconf_cache(
         return _R()
 
     with (
-        patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(monitor.mdns, "get_cached_addresses", lambda host: ["192.168.213.11"]),
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert pinged == ["10.0.0.7"]
     assert ip_changes[0] == ("winefridge", "10.0.0.7", ["10.0.0.7"])
@@ -404,11 +404,11 @@ async def test_ping_sweep_falls_back_to_zeroconf_cache_when_resolver_fails(
         return _R()
 
     with (
-        patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(monitor.mdns, "get_cached_addresses", lambda host: ["192.168.213.11"]),
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert pinged == ["192.168.213.11"]
     assert state_changes[-1] == ("winefridge", DeviceState.ONLINE, "ping")
@@ -445,11 +445,11 @@ async def test_ping_sweep_demotes_dead_zeroconf_cached_local(
         return _R()
 
     with (
-        patch.object(monitor, "get_cached_addresses", lambda host: ["192.168.213.11"]),
+        patch.object(monitor.mdns, "get_cached_addresses", lambda host: ["192.168.213.11"]),
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert pinged and set(pinged) == {"192.168.213.11"}
     assert state_changes[-1] == ("winefridge", DeviceState.OFFLINE, "ping")
@@ -488,7 +488,7 @@ async def test_ping_sweep_marks_offline_directly_on_dns_failure(fake_resolver) -
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     # Crucially: ``icmp_ping`` was NOT called. The resolution failure
     # was enough to declare the device offline.
@@ -530,7 +530,7 @@ async def test_ping_sweep_skips_devices_with_cached_dns_failure(fake_resolver) -
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", fake_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert pinged == []
     assert resolver.calls == []
@@ -564,7 +564,7 @@ async def test_ping_marks_offline_when_icmp_raises(fake_resolver) -> None:
         patch.object(dns_cache_mod, "async_resolve", resolver),
         patch.object(ping_module, "icmp_ping", raising_ping),
     ):
-        await monitor._ping._ping_sweep()
+        await monitor.ping._ping_sweep()
 
     assert state_changes == [("kitchen", DeviceState.OFFLINE, "ping")]
 

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -256,8 +256,8 @@ async def test_ping_sweep_pre_resolves_via_dns_cache(fake_resolver) -> None:
 
     assert pinged == ["10.0.0.1"]
     assert ip_changes == [("kitchen", "10.0.0.1", ["10.0.0.1"])]
-    # DNS cache is now warm — ``get_cached_dns_addresses`` should hit
-    # without triggering another resolver call.
+    # DNS cache is now warm — ``state.dns_cache.get_cached_addresses``
+    # should hit without triggering another resolver call.
     assert monitor.state.dns_cache.get_cached_addresses("esp.example.com") == ["10.0.0.1"]
 
 

--- a/tests/test_importable_discovery.py
+++ b/tests/test_importable_discovery.py
@@ -45,7 +45,7 @@ def _removed(callbacks) -> list[str]:
 def test_on_import_update_translates_to_adoptable_device() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([])
 
-    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    monitor.importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
 
     assert _added(callbacks) == [
         AdoptableDevice(
@@ -63,7 +63,7 @@ def test_on_import_update_translates_to_adoptable_device() -> None:
 def test_on_import_update_emits_removed_with_device_name() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([])
 
-    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", None)
+    monitor.importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", None)
 
     # The mDNS service name is sliced down to the device-name label so
     # the dashboard can index ``import_result`` by ``device.name``.
@@ -74,7 +74,7 @@ def test_on_import_update_skips_already_configured_devices() -> None:
     """Configured devices never surface as importable."""
     monitor, callbacks = make_state_monitor_with_callbacks([_device("kitchen-1a2b3c")])
 
-    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    monitor.importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
     assert _added(callbacks) == []
 
 
@@ -84,7 +84,7 @@ def test_on_import_update_threads_ignored_flag() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([])
     monitor._is_ignored = ignored.__contains__
 
-    monitor._importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
+    monitor.importable._on_import_update("kitchen-1a2b3c._esphomelib._tcp.local.", _discovered())
     added = _added(callbacks)
     assert len(added) == 1 and added[0].ignored is True
 
@@ -101,7 +101,7 @@ def test_on_import_update_friendly_name_none_becomes_empty_string() -> None:
         project_version="1.0",
         network="wifi",
     )
-    monitor._importable._on_import_update("kitchen._esphomelib._tcp.local.", discovered)
+    monitor.importable._on_import_update("kitchen._esphomelib._tcp.local.", discovered)
 
     assert _added(callbacks)[0].friendly_name == ""
 
@@ -111,13 +111,13 @@ def test_get_importable_devices_filters_configured() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([_device("garage")])
     # Stand in for a started DashboardImportDiscovery — populate its
     # ``import_state`` directly so we don't have to spin up zeroconf.
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
         "garage._esphomelib._tcp.local.": _discovered("garage"),
     }
 
-    snapshot = monitor.get_importable_devices()
+    snapshot = monitor.importable.get_importable_devices()
 
     names = sorted(d.name for d in snapshot)
     assert names == ["kitchen"]
@@ -126,7 +126,7 @@ def test_get_importable_devices_filters_configured() -> None:
 def test_get_importable_devices_returns_empty_before_browser_start() -> None:
     """Without a started browser the snapshot is just empty (no crash)."""
     monitor, _callbacks = make_state_monitor_with_callbacks([])
-    assert monitor.get_importable_devices() == []
+    assert monitor.importable.get_importable_devices() == []
 
 
 def test_revisit_importable_refires_added_when_cached() -> None:
@@ -138,12 +138,12 @@ def test_revisit_importable_refires_added_when_cached() -> None:
     fires; we have to nudge the cache ourselves.
     """
     monitor, callbacks = make_state_monitor_with_callbacks([])  # device just got deleted
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {
         "kitchen-1a2b3c._esphomelib._tcp.local.": _discovered("kitchen-1a2b3c"),
     }
 
-    monitor.revisit_importable("kitchen-1a2b3c")
+    monitor.importable.revisit_importable("kitchen-1a2b3c")
 
     added = _added(callbacks)
     assert len(added) == 1
@@ -153,10 +153,10 @@ def test_revisit_importable_refires_added_when_cached() -> None:
 def test_revisit_importable_noop_for_unknown_name() -> None:
     """No cached entry → no callback fires (and no crash)."""
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {}
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {}
 
-    monitor.revisit_importable("unknown")
+    monitor.importable.revisit_importable("unknown")
 
     assert _added(callbacks) == []
 
@@ -164,7 +164,7 @@ def test_revisit_importable_noop_for_unknown_name() -> None:
 def test_revisit_importable_noop_when_browser_not_started() -> None:
     """No browser → silent skip (no crash on the optional attr)."""
     monitor, _callbacks = make_state_monitor_with_callbacks([])
-    monitor.revisit_importable("kitchen")  # must not raise
+    monitor.importable.revisit_importable("kitchen")  # must not raise
 
 
 def test_apply_http_service_info_populates_web_url_and_refires() -> None:
@@ -176,8 +176,8 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
     card's Visit-web-UI link in place.
     """
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
     }
 
@@ -185,7 +185,7 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
     info.server = "kitchen.local."
     info.port = 80
 
-    monitor._importable._apply_http_service_info("kitchen", info)
+    monitor.importable._apply_http_service_info("kitchen", info)
 
     assert monitor.state.http_urls == {"kitchen": "http://kitchen.local"}
     added = _added(callbacks)
@@ -196,8 +196,8 @@ def test_apply_http_service_info_populates_web_url_and_refires() -> None:
 def test_apply_http_service_info_includes_non_default_port() -> None:
     """Non-port-80 services build URLs with the explicit ``:port`` suffix."""
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
     }
 
@@ -205,15 +205,15 @@ def test_apply_http_service_info_includes_non_default_port() -> None:
     info.server = "kitchen.local."
     info.port = 8080
 
-    monitor._importable._apply_http_service_info("kitchen", info)
+    monitor.importable._apply_http_service_info("kitchen", info)
     assert _added(callbacks)[0].web_url == "http://kitchen.local:8080"
 
 
 def test_apply_http_service_info_skips_when_unchanged() -> None:
     """Repeat announcements for the same URL don't re-fire ADDED."""
     monitor, callbacks = make_state_monitor_with_callbacks([])
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {
         "kitchen._esphomelib._tcp.local.": _discovered("kitchen"),
     }
 
@@ -221,8 +221,8 @@ def test_apply_http_service_info_skips_when_unchanged() -> None:
     info.server = "kitchen.local."
     info.port = 80
 
-    monitor._importable._apply_http_service_info("kitchen", info)
-    monitor._importable._apply_http_service_info("kitchen", info)
+    monitor.importable._apply_http_service_info("kitchen", info)
+    monitor.importable._apply_http_service_info("kitchen", info)
 
     # Single fire — duplicate calls are deduped by URL equality.
     assert len(_added(callbacks)) == 1
@@ -238,11 +238,11 @@ def test_revisit_importable_skips_ignored_devices() -> None:
     ignored = {"kitchen-1a2b3c"}
     monitor, callbacks = make_state_monitor_with_callbacks([])
     monitor._is_ignored = ignored.__contains__
-    monitor._importable._import_discovery = DashboardImportDiscovery()
-    monitor._importable._import_discovery.import_state = {
+    monitor.importable._import_discovery = DashboardImportDiscovery()
+    monitor.importable._import_discovery.import_state = {
         "kitchen-1a2b3c._esphomelib._tcp.local.": _discovered("kitchen-1a2b3c"),
     }
 
-    monitor.revisit_importable("kitchen-1a2b3c")
+    monitor.importable.revisit_importable("kitchen-1a2b3c")
 
     assert _added(callbacks) == []

--- a/tests/test_mdns_cache_reconcile.py
+++ b/tests/test_mdns_cache_reconcile.py
@@ -45,7 +45,7 @@ def _seed_txt_cache(monitor: Any, records: list[DNSText]) -> None:
     fake_zeroconf.zeroconf.cache.get_all_by_details = MagicMock(
         side_effect=lambda name, *_a: [r for r in records if r.name == name]
     )
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
 
 
 def test_reconcile_applies_txt_fields_without_claiming() -> None:
@@ -67,7 +67,7 @@ def test_reconcile_applies_txt_fields_without_claiming() -> None:
         ],
     )
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert ("on_version_change", "kitchen", "2026.6.4") in callbacks.calls
     assert ("on_config_hash_change", "kitchen", "abcd1234") in callbacks.calls
@@ -93,7 +93,7 @@ def test_reconcile_works_without_a_cached_address_record() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     _seed_txt_cache(monitor, [_txt_record({"version": "2026.6.4"}, age_ms=600_000)])
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert device.runtime_state.deployed_version == "2026.6.4"
 
@@ -104,7 +104,7 @@ def test_reconcile_never_flips_an_offline_device_online() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([device])
     _seed_txt_cache(monitor, [_txt_record({"version": "2026.6.4"})])
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert device.runtime_state.state == DeviceState.OFFLINE
     assert callbacks.calls_for("on_state_change") == []
@@ -115,7 +115,7 @@ def test_reconcile_skips_expired_txt_records() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
     _seed_txt_cache(monitor, [_txt_record({"version": "2026.6.4"}, age_ms=5_000_000, ttl=4500)])
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert callbacks.calls == []
 
@@ -125,7 +125,7 @@ def test_reconcile_cache_miss_is_a_noop() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
     _seed_txt_cache(monitor, [])
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert callbacks.calls == []
 
@@ -150,7 +150,7 @@ def test_reconcile_reads_http_identity_txt_for_non_api_device() -> None:
         ],
     )
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert ("on_version_change", "kitchen", "2026.8.0") in callbacks.calls
     assert ("on_config_hash_change", "kitchen", "abcd1234") in callbacks.calls
@@ -168,7 +168,7 @@ def test_reconcile_http_txt_old_firmware_version_only() -> None:
         monitor, [_txt_record({"version": "2026.6.4"}, service_name=_HTTP_SERVICE_NAME)]
     )
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert device.runtime_state.deployed_version == "2026.6.4"
     assert callbacks.calls_for("on_config_hash_change") == []
@@ -178,9 +178,9 @@ def test_reconcile_http_txt_old_firmware_version_only() -> None:
 def test_reconcile_without_zeroconf_is_a_noop() -> None:
     """Zeroconf failed to start → nothing to read; don't raise."""
     monitor, callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
-    monitor._mdns._zeroconf = None
+    monitor.mdns._zeroconf = None
 
-    monitor.reconcile_from_mdns_cache("kitchen")
+    monitor.mdns.reconcile_from_cache("kitchen")
 
     assert callbacks.calls == []
 
@@ -195,9 +195,9 @@ async def test_sweep_heals_blank_device_from_cache_end_to_end() -> None:
         [_txt_record({"version": "2026.6.4", "config_hash": "abcd1234", "mac": "94c9601f8cf1"})],
     )
     fetch = MagicMock()
-    monitor._api_info._fetch = fetch  # type: ignore[method-assign]
+    monitor.api_info._fetch = fetch  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert device.runtime_state.deployed_version == "2026.6.4"
     assert device.runtime_state.deployed_config_hash == "abcd1234"
@@ -222,9 +222,9 @@ async def test_sweep_heals_blank_non_api_device_from_http_cache() -> None:
         ],
     )
     fetch = MagicMock()
-    monitor._api_info._fetch = fetch  # type: ignore[method-assign]
+    monitor.api_info._fetch = fetch  # type: ignore[method-assign]
 
-    await monitor._api_info._sweep()
+    await monitor.api_info._sweep()
 
     assert device.runtime_state.deployed_version == "2026.8.0"
     assert device.runtime_state.deployed_config_hash == "abcd1234"
@@ -235,7 +235,7 @@ async def test_sweep_heals_blank_non_api_device_from_http_cache() -> None:
 async def test_resolve_then_dedupes_inflight_service_names() -> None:
     """A second resolve for a service already being resolved is dropped, not stacked."""
     monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
-    source = monitor._mdns
+    source = monitor.mdns
     source._inflight_resolves.add(_SERVICE_NAME)
     info = MagicMock()
     info.name = _SERVICE_NAME
@@ -253,7 +253,7 @@ async def test_resolve_then_dedupes_inflight_service_names() -> None:
 async def test_resolve_then_clears_inflight_after_completion() -> None:
     """The in-flight guard releases once the resolve finishes, so retries stay possible."""
     monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
-    source = monitor._mdns
+    source = monitor.mdns
     info = MagicMock()
     info.name = _SERVICE_NAME
     info.async_request = AsyncMock(return_value=True)

--- a/tests/test_mdns_http_txt.py
+++ b/tests/test_mdns_http_txt.py
@@ -28,12 +28,12 @@ _HTTP = "_http._tcp.local."
 def _make_monitor(*devices: Device) -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
     monitor.state = MonitorState()
-    monitor._importable = ImportableDiscovery(monitor)
-    monitor._mdns = MdnsSource(monitor)
+    monitor.importable = ImportableDiscovery(monitor)
+    monitor.mdns = MdnsSource(monitor)
     monitor._presence = None
-    monitor._ping = PingSource(monitor)
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor.ping = PingSource(monitor)
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
     monitor._tasks = set()
     monitor.state.reachability = None
     monitor._get_devices = lambda: list(devices)
@@ -56,7 +56,7 @@ def _mqtt_device(**overrides: Any) -> Device:
 def _capture_apply(monitor: DeviceStateMonitor, monkeypatch: pytest.MonkeyPatch) -> list[tuple]:
     calls: list[tuple] = []
     monkeypatch.setattr(
-        monitor._mdns, "_apply_http_txt", lambda name, info: calls.append((name, info))
+        monitor.mdns, "_apply_http_txt", lambda name, info: calls.append((name, info))
     )
     return calls
 
@@ -84,7 +84,7 @@ def test_http_cache_hit_applies_identity_for_non_api_device(
     calls = _capture_apply(monitor, monkeypatch)
     info = _cached_info(monkeypatch, cached=True)
 
-    monitor._mdns._on_http_service_state_change(
+    monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"klo.{_HTTP}", ServiceStateChange.Added
     )
 
@@ -101,9 +101,9 @@ async def test_http_cache_miss_spawns_resolve_task(monkeypatch: pytest.MonkeyPat
     async def fake_resolve(*_args, **_kw) -> None:
         return None
 
-    monkeypatch.setattr(monitor._mdns, "_resolve_then", fake_resolve)
+    monkeypatch.setattr(monitor.mdns, "_resolve_then", fake_resolve)
 
-    monitor._mdns._on_http_service_state_change(
+    monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"klo.{_HTTP}", ServiceStateChange.Added
     )
 
@@ -118,7 +118,7 @@ def test_http_skips_all_api_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _capture_apply(monitor, monkeypatch)
     _cached_info(monkeypatch, cached=True)
 
-    monitor._mdns._on_http_service_state_change(
+    monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"klo.{_HTTP}", ServiceStateChange.Added
     )
 
@@ -134,7 +134,7 @@ def test_http_applies_when_bucket_has_a_non_api_sibling(monkeypatch: pytest.Monk
     calls = _capture_apply(monitor, monkeypatch)
     info = _cached_info(monkeypatch, cached=True)
 
-    monitor._mdns._on_http_service_state_change(
+    monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"klo.{_HTTP}", ServiceStateChange.Added
     )
 
@@ -147,7 +147,7 @@ def test_http_skips_unconfigured_device(monkeypatch: pytest.MonkeyPatch) -> None
     calls = _capture_apply(monitor, monkeypatch)
     _cached_info(monkeypatch, cached=True)
 
-    monitor._mdns._on_http_service_state_change(
+    monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"printer.{_HTTP}", ServiceStateChange.Added
     )
 
@@ -159,7 +159,7 @@ def test_http_removed_is_a_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     monitor = _make_monitor(_mqtt_device())
     calls = _capture_apply(monitor, monkeypatch)
 
-    monitor._mdns._on_http_service_state_change(
+    monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"klo.{_HTTP}", ServiceStateChange.Removed
     )
 
@@ -200,7 +200,7 @@ def test_apply_http_txt_reads_identity_trio(monkeypatch: pytest.MonkeyPatch) -> 
 
     # The stray api_encryption key is ignored, not applied (the capture
     # helper fails the test if it ever reaches the monitor).
-    monitor._mdns._apply_http_txt(
+    monitor.mdns._apply_http_txt(
         "klo",
         _http_info(
             {
@@ -224,7 +224,7 @@ def test_apply_http_txt_old_firmware_version_only(monkeypatch: pytest.MonkeyPatc
     monitor = _make_monitor(_mqtt_device())
     applied = _capture_monitor_applies(monitor, monkeypatch)
 
-    monitor._mdns._apply_http_txt("klo", _http_info({"version": "2026.6.4"}))
+    monitor.mdns._apply_http_txt("klo", _http_info({"version": "2026.6.4"}))
 
     assert applied == [("apply_version", "klo", "2026.6.4")]
 
@@ -234,6 +234,6 @@ def test_apply_http_txt_empty_props_is_a_noop(monkeypatch: pytest.MonkeyPatch) -
     monitor = _make_monitor(_mqtt_device())
     applied = _capture_monitor_applies(monitor, monkeypatch)
 
-    monitor._mdns._apply_http_txt("klo", _http_info({}))
+    monitor.mdns._apply_http_txt("klo", _http_info({}))
 
     assert applied == []

--- a/tests/test_mdns_name_match.py
+++ b/tests/test_mdns_name_match.py
@@ -107,7 +107,7 @@ async def _capture_handler(monitor: DeviceStateMonitor, monkeypatch: pytest.Monk
     # real zeroconf.
     monkeypatch.setattr(esphome_zc, "AsyncServiceInfo", _FakeServiceInfo)
 
-    await monitor._mdns.start()
+    await monitor.mdns.start()
     return captured["handler"]
 
 

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -24,11 +24,11 @@ _SERVICE_NAME = "kitchen._esphomelib._tcp.local."
 
 def _prime_sweep(monitor: Any, *, cache_trace: bool = True, live_ptr: bool = False) -> None:
     """Wire the fake zeroconf plus the two cache reads the sweep filter makes."""
-    monitor._mdns._zeroconf = MagicMock()
-    monitor.get_mdns_cache_info = MagicMock(  # type: ignore[method-assign]
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns.get_mdns_cache_info = MagicMock(  # type: ignore[method-assign]
         return_value=MagicMock() if cache_trace else None
     )
-    monitor._mdns.has_live_ptr = MagicMock(return_value=live_ptr)  # type: ignore[method-assign]
+    monitor.mdns.has_live_ptr = MagicMock(return_value=live_ptr)  # type: ignore[method-assign]
 
 
 async def test_sweep_claims_mdns_for_ping_owned_online_device(
@@ -104,11 +104,11 @@ async def test_sweep_skips_ineligible_devices(
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = source
     _prime_sweep(monitor, **prime)
-    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
+    monitor.mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
 
     await shared.resolve_api_mdns_targets(monitor)
 
-    monitor._mdns.resolve_and_claim.assert_not_called()
+    monitor.mdns.resolve_and_claim.assert_not_called()
 
 
 async def test_sweep_resolves_multiple_candidates_concurrently() -> None:
@@ -118,7 +118,7 @@ async def test_sweep_resolves_multiple_candidates_concurrently() -> None:
     monitor.state.state_source["porch"] = ReachabilitySource.PING
     _prime_sweep(monitor)
     resolve = AsyncMock()
-    monitor._mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
+    monitor.mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
 
     await shared.resolve_api_mdns_targets(monitor)
 
@@ -133,7 +133,7 @@ async def test_sweep_surfaces_unexpected_resolve_errors(
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
     _prime_sweep(monitor)
-    monitor._mdns.resolve_and_claim = AsyncMock(  # type: ignore[method-assign]
+    monitor.mdns.resolve_and_claim = AsyncMock(  # type: ignore[method-assign]
         side_effect=AttributeError("boom")
     )
 
@@ -147,12 +147,12 @@ async def test_sweep_without_zeroconf_is_a_noop() -> None:
     device = make_online_api_device()
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.PING
-    monitor._mdns._zeroconf = None
-    monitor._mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
+    monitor.mdns._zeroconf = None
+    monitor.mdns.resolve_and_claim = AsyncMock()  # type: ignore[method-assign]
 
     await shared.resolve_api_mdns_targets(monitor)
 
-    monitor._mdns.resolve_and_claim.assert_not_called()
+    monitor.mdns.resolve_and_claim.assert_not_called()
 
 
 async def test_sweep_rechecks_mdns_owned_device_without_live_ptr() -> None:
@@ -162,7 +162,7 @@ async def test_sweep_rechecks_mdns_owned_device_without_live_ptr() -> None:
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
     _prime_sweep(monitor, live_ptr=False)
     resolve = AsyncMock()
-    monitor._mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
+    monitor.mdns.resolve_and_claim = resolve  # type: ignore[method-assign]
 
     await shared.resolve_api_mdns_targets(monitor)
 
@@ -171,9 +171,9 @@ async def test_sweep_rechecks_mdns_owned_device_without_live_ptr() -> None:
 
 async def test_resolve_and_claim_without_zeroconf_is_a_noop() -> None:
     monitor, callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
-    monitor._mdns._zeroconf = None
+    monitor.mdns._zeroconf = None
 
-    await monitor._mdns.resolve_and_claim("kitchen")
+    await monitor.mdns.resolve_and_claim("kitchen")
 
     assert callbacks.calls == []
 
@@ -184,10 +184,10 @@ def test_should_ping_gates_mdns_ownership_on_live_ptr() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
 
-    monitor._mdns.has_live_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
+    monitor.mdns.has_live_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
     assert shared.should_ping(monitor, device) is True
 
-    monitor._mdns.has_live_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
+    monitor.mdns.has_live_ptr = MagicMock(return_value=True)  # type: ignore[method-assign]
     assert shared.should_ping(monitor, device) is False
 
 
@@ -196,7 +196,7 @@ def test_should_ping_non_api_mdns_ownership_unchanged() -> None:
     device = make_online_api_device(api_enabled=False, loaded_integrations=["mqtt", "wifi"])
     monitor, _callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
-    monitor._mdns.has_live_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
+    monitor.mdns.has_live_ptr = MagicMock(return_value=False)  # type: ignore[method-assign]
 
     assert shared.should_ping(monitor, device) is False
 
@@ -204,23 +204,23 @@ def test_should_ping_non_api_mdns_ownership_unchanged() -> None:
 def test_has_live_ptr_reads_the_browser_cache() -> None:
     monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
     fake_zeroconf = MagicMock()
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
     lookup = fake_zeroconf.zeroconf.cache.current_entry_with_name_and_alias
 
     ptr = MagicMock()
     ptr.is_expired.return_value = False
     lookup.return_value = ptr
-    assert monitor._mdns.has_live_ptr("kitchen") is True
+    assert monitor.mdns.has_live_ptr("kitchen") is True
     lookup.assert_called_with("_esphomelib._tcp.local.", _SERVICE_NAME)
 
     ptr.is_expired.return_value = True
-    assert monitor._mdns.has_live_ptr("kitchen") is False
+    assert monitor.mdns.has_live_ptr("kitchen") is False
 
     lookup.return_value = None
-    assert monitor._mdns.has_live_ptr("kitchen") is False
+    assert monitor.mdns.has_live_ptr("kitchen") is False
 
-    monitor._mdns._zeroconf = None
-    assert monitor._mdns.has_live_ptr("kitchen") is False
+    monitor.mdns._zeroconf = None
+    assert monitor.mdns.has_live_ptr("kitchen") is False
 
 
 def _gated_wire(info: MagicMock, *, result: bool) -> tuple[asyncio.Event, list[int]]:
@@ -248,12 +248,12 @@ async def test_added_during_removed_verify_keeps_device_online(
     gate, _calls = _gated_wire(info, result=True)
 
     verify = asyncio.create_task(
-        monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+        monitor.mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
     )
     await asyncio.sleep(0)
-    assert _SERVICE_NAME in monitor._mdns._inflight_resolves
+    assert _SERVICE_NAME in monitor.mdns._inflight_resolves
 
-    monitor._mdns._on_esphomelib_service_state_change(
+    monitor.mdns._on_esphomelib_service_state_change(
         MagicMock(), "_esphomelib._tcp.local.", _SERVICE_NAME, mdns_module.ServiceStateChange.Added
     )
     assert device.runtime_state.state == DeviceState.ONLINE
@@ -276,11 +276,11 @@ async def test_added_resolve_during_verify_defers_to_the_inflight_verify(
     gate, calls = _gated_wire(info, result=True)
 
     verify = asyncio.create_task(
-        monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+        monitor.mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
     )
     await asyncio.sleep(0)
 
-    monitor._mdns._on_esphomelib_service_state_change(
+    monitor.mdns._on_esphomelib_service_state_change(
         MagicMock(), "_esphomelib._tcp.local.", _SERVICE_NAME, mdns_module.ServiceStateChange.Added
     )
     gate.set()
@@ -304,11 +304,11 @@ async def test_confirmed_wire_miss_outranks_a_stale_cache_added_claim(
     gate, _calls = _gated_wire(info, result=False)
 
     verify = asyncio.create_task(
-        monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+        monitor.mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
     )
     await asyncio.sleep(0)
 
-    monitor._mdns._on_esphomelib_service_state_change(
+    monitor.mdns._on_esphomelib_service_state_change(
         MagicMock(), "_esphomelib._tcp.local.", _SERVICE_NAME, mdns_module.ServiceStateChange.Added
     )
     assert device.runtime_state.state == DeviceState.ONLINE
@@ -330,7 +330,7 @@ async def test_verify_removed_keeps_online_on_a_swallowed_resolve_error(
     info.async_request.side_effect = OSError("socket gone")
 
     with caplog.at_level(logging.WARNING):
-        await monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+        await monitor.mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
 
     assert device.runtime_state.state == DeviceState.ONLINE
     assert callbacks.calls_for("on_state_change") == []
@@ -344,10 +344,10 @@ async def test_verify_removed_bails_when_a_resolve_is_inflight(
     device = make_online_api_device()
     monitor, callbacks = make_state_monitor_with_callbacks([device])
     monitor.state.state_source["kitchen"] = ReachabilitySource.MDNS
-    monitor._mdns._inflight_resolves.add(_SERVICE_NAME)
+    monitor.mdns._inflight_resolves.add(_SERVICE_NAME)
     info = stub_async_service_info(monkeypatch)
 
-    await monitor._mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
+    await monitor.mdns._verify_removed(MagicMock(), _SERVICE_NAME, "kitchen")
 
     info.async_request.assert_not_called()
     assert device.runtime_state.state == DeviceState.ONLINE

--- a/tests/test_non_api_mdns_resolve.py
+++ b/tests/test_non_api_mdns_resolve.py
@@ -71,7 +71,7 @@ def _make_monitor(
         return resolve_map.get(host)
 
     fake_zc.async_resolve_host = AsyncMock(side_effect=_resolve)
-    monitor._mdns._zeroconf = fake_zc
+    monitor.mdns._zeroconf = fake_zc
     return monitor, fake_zc.async_resolve_host
 
 
@@ -179,7 +179,7 @@ async def test_resolve_exception_does_not_propagate() -> None:
             raise OSError("simulated zeroconf failure")
         return ["192.168.1.50"]
 
-    monitor._mdns._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
+    monitor.mdns._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
 
     await shared.resolve_non_api_mdns_targets(monitor)
 
@@ -197,7 +197,7 @@ async def test_no_zeroconf_is_a_noop() -> None:
     """Pre-start (or zeroconf-failed) sweep must not raise."""
     devices = [_device(loaded_integrations=["web_server"])]
     monitor, _ = _make_monitor(devices)
-    monitor._mdns._zeroconf = None  # simulate ``async_setup`` failure
+    monitor.mdns._zeroconf = None  # simulate ``async_setup`` failure
 
     # No exception, no state change.
     await shared.resolve_non_api_mdns_targets(monitor)
@@ -327,7 +327,7 @@ async def test_multiple_devices_resolve_in_parallel(monkeypatch: Any) -> None:
         finally:
             pending -= 1
 
-    monitor._mdns._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
+    monitor.mdns._zeroconf.async_resolve_host = AsyncMock(side_effect=_resolve)
 
     await shared.resolve_non_api_mdns_targets(monitor)
 

--- a/tests/test_ping_loop_pause.py
+++ b/tests/test_ping_loop_pause.py
@@ -40,7 +40,7 @@ def _build_monitor(presence: SubscriberPresence | None) -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
     monitor.state = MonitorState()
     monitor._presence = presence
-    monitor._ping = PingSource(monitor)
+    monitor.ping = PingSource(monitor)
     return monitor
 
 
@@ -68,7 +68,7 @@ def _instrument_loop(
     # per-test instance.
     monkeypatch.setattr(shared_module, "resolve_non_api_mdns_targets", _resolve)
     monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _resolve)
-    monitor._ping._ping_sweep = _sweep  # type: ignore[method-assign]
+    monitor.ping._ping_sweep = _sweep  # type: ignore[method-assign]
 
     # Skip the bootstrap delay; collapse the post-sweep idle wait
     # so the loop ticks fast enough for an asyncio.sleep(0)-driven
@@ -101,7 +101,7 @@ async def test_ping_loop_runs_unconditionally_without_presence(
     monitor = _build_monitor(presence=None)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     try:
         await _drive_until(lambda: counts["sweeps"] >= 2)
     finally:
@@ -125,7 +125,7 @@ async def test_ping_loop_survives_a_raising_resolve_step(
 
     monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _boom)
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     try:
         await _drive_until(lambda: counts["sweeps"] >= 2)
     finally:
@@ -148,9 +148,9 @@ async def test_ping_loop_survives_a_raising_ping_sweep(
         if counts["sweeps"] == 1:
             raise RuntimeError("boom")
 
-    monitor._ping._ping_sweep = _flaky_sweep  # type: ignore[method-assign]
+    monitor.ping._ping_sweep = _flaky_sweep  # type: ignore[method-assign]
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     try:
         await _drive_until(lambda: counts["sweeps"] >= 2)
     finally:
@@ -173,7 +173,7 @@ async def test_ping_loop_does_not_mask_child_cancellation(
 
     monkeypatch.setattr(shared_module, "resolve_api_mdns_targets", _cancelled)
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     with contextlib.suppress(asyncio.CancelledError):
         await asyncio.wait_for(task, timeout=0.5)
 
@@ -195,7 +195,7 @@ async def test_ping_loop_parks_until_first_subscriber(
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     try:
         # Give the loop several scheduling ticks to confirm it
         # actually parks instead of running. Without the gate fix
@@ -229,7 +229,7 @@ async def test_ping_loop_pauses_again_after_last_subscriber_leaves(
     monitor = _build_monitor(presence=presence)
     counts = _instrument_loop(monitor, monkeypatch)
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     try:
         # Cycle one subscriber in, drive at least one sweep, then out.
         with presence.subscriber():
@@ -302,7 +302,7 @@ async def test_subscriber_arrival_mid_idle_bails_within_a_tick(
     counts = _instrument_loop(monitor, monkeypatch)
     monkeypatch.setattr(PingSource, "_interval", 60)
 
-    task = asyncio.create_task(monitor._ping.run())
+    task = asyncio.create_task(monitor.ping.run())
     try:
         with presence.subscriber():
             await _drive_until(lambda: counts["sweeps"] >= 1)

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -34,14 +34,14 @@ def _make_monitor() -> DeviceStateMonitor:
 
     monitor.state = MonitorState()
 
-    monitor._importable = ImportableDiscovery(monitor)
+    monitor.importable = ImportableDiscovery(monitor)
 
-    monitor._mdns = MdnsSource(monitor)
+    monitor.mdns = MdnsSource(monitor)
 
     monitor._presence = None
-    monitor._ping = PingSource(monitor)
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor.ping = PingSource(monitor)
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
     monitor._tasks = set()
     monitor.state.reachability = None
     return monitor
@@ -66,7 +66,7 @@ def _capture_apply(
     def _apply(name: str, info: Any) -> None:
         calls.append((name, info))
 
-    monkeypatch.setattr(monitor._mdns, "_apply_service_info", _apply)
+    monkeypatch.setattr(monitor.mdns, "_apply_service_info", _apply)
     return calls
 
 
@@ -82,7 +82,7 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
         lambda *_args, **_kw: fake_info,
     )
 
-    monitor.probe_device("kitchen")
+    monitor.importable.probe_device("kitchen")
 
     assert apply_calls == [("kitchen", fake_info)]
     assert not monitor._tasks
@@ -113,7 +113,7 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
         _info_ctor,
     )
 
-    monitor.probe_device("my-living-room", service_name="apollo-r-pro-1-eth-5938e0")
+    monitor.importable.probe_device("my-living-room", service_name="apollo-r-pro-1-eth-5938e0")
 
     # Looked up under the OLD broadcast name…
     assert constructor_args == [
@@ -138,9 +138,9 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     async def fake_resolve(*_args, **_kw) -> None:
         return None
 
-    monkeypatch.setattr(monitor._mdns, "_resolve_and_apply", fake_resolve)
+    monkeypatch.setattr(monitor.mdns, "_resolve_and_apply", fake_resolve)
 
-    monitor.probe_device("kitchen")
+    monitor.importable.probe_device("kitchen")
 
     assert apply_calls == []
     # One task was registered for tracking. Wait it out so the
@@ -156,16 +156,16 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
 
     monitor.state = MonitorState()
 
-    monitor._importable = ImportableDiscovery(monitor)
+    monitor.importable = ImportableDiscovery(monitor)
 
-    monitor._mdns = MdnsSource(monitor)
+    monitor.mdns = MdnsSource(monitor)
 
     monitor._presence = None
-    monitor._ping = PingSource(monitor)
-    monitor._mdns._zeroconf = None
+    monitor.ping = PingSource(monitor)
+    monitor.mdns._zeroconf = None
     monitor._tasks = set()
 
-    monitor.probe_device("kitchen")  # no exception, no tasks
+    monitor.importable.probe_device("kitchen")  # no exception, no tasks
     assert not monitor._tasks
 
 
@@ -202,7 +202,7 @@ async def test_apply_service_info_claims_online() -> None:
     fake_info = MagicMock()
     fake_info.parsed_scoped_addresses.return_value = []
     fake_info.decoded_properties = {}
-    monitor._mdns._apply_service_info("kitchen", fake_info)
+    monitor.mdns._apply_service_info("kitchen", fake_info)
 
     # ``_on_state_change`` is the bridge our owner registered for
     # state transitions; the call carries (name, state, source).
@@ -249,7 +249,7 @@ async def test_apply_service_info_routes_mac_txt_to_apply_mac_address() -> None:
     # the canonical form because ``apply_mac_address`` normalizes
     # before invoking the change callback.
     fake_info.decoded_properties = {"mac": "94c9601f8cf1"}
-    monitor._mdns._apply_service_info("kitchen", fake_info)
+    monitor.mdns._apply_service_info("kitchen", fake_info)
 
     assert callbacks.calls_for("on_mac_address_change") == [
         ("on_mac_address_change", "kitchen", "94:C9:60:1F:8C:F1")

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -74,8 +74,8 @@ def _patch_loop_for_wake_tests(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @asynccontextmanager
 async def _running_loop(monitor: DeviceStateMonitor) -> AsyncIterator[None]:
-    """Spawn ``monitor._ping.run()`` and cancel + drain on exit."""
-    task = asyncio.create_task(monitor._ping.run())
+    """Spawn ``monitor.ping.run()`` and cancel + drain on exit."""
+    task = asyncio.create_task(monitor.ping.run())
     try:
         yield
     finally:
@@ -94,11 +94,11 @@ async def _yield_until(predicate: Callable[[], bool], iterations: int = 50) -> N
 def test_probe_device_ping_sets_wake_event() -> None:
     """One probe call flips the loop's wake event without scheduling a task."""
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
-    assert monitor._ping._wake.is_set() is False
+    assert monitor.ping._wake.is_set() is False
 
     monitor.probe_device_ping("garage")
 
-    assert monitor._ping._wake.is_set() is True
+    assert monitor.ping._wake.is_set() is True
     assert monitor._tasks == set()
 
 
@@ -109,7 +109,7 @@ def test_probe_device_ping_skips_online_mdns_claimed_device() -> None:
 
     monitor.probe_device_ping("garage")
 
-    assert monitor._ping._wake.is_set() is False
+    assert monitor.ping._wake.is_set() is False
 
 
 def test_probe_device_ping_wakes_offline_mdns_sourced_device() -> None:
@@ -119,7 +119,7 @@ def test_probe_device_ping_wakes_offline_mdns_sourced_device() -> None:
 
     monitor.probe_device_ping("garage")
 
-    assert monitor._ping._wake.is_set() is True
+    assert monitor.ping._wake.is_set() is True
 
 
 def test_probe_device_ping_unknown_name_fails_open() -> None:
@@ -128,7 +128,7 @@ def test_probe_device_ping_unknown_name_fails_open() -> None:
 
     monitor.probe_device_ping("ghost")
 
-    assert monitor._ping._wake.is_set() is True
+    assert monitor.ping._wake.is_set() is True
 
 
 def test_probe_reachability_fires_both_probes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -136,7 +136,7 @@ def test_probe_reachability_fires_both_probes(monkeypatch: pytest.MonkeyPatch) -
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     probed: list[str] = []
     monkeypatch.setattr(
-        monitor._importable,
+        monitor.importable,
         "probe_device",
         lambda name, service_name=None: probed.append(name),
     )
@@ -144,7 +144,7 @@ def test_probe_reachability_fires_both_probes(monkeypatch: pytest.MonkeyPatch) -
     monitor.probe_reachability("garage")
 
     assert probed == ["garage"]
-    assert monitor._ping._wake.is_set() is True
+    assert monitor.ping._wake.is_set() is True
 
 
 def test_probe_device_ping_herd_collapses_to_single_set() -> None:
@@ -155,7 +155,7 @@ def test_probe_device_ping_herd_collapses_to_single_set() -> None:
     for device in devices:
         monitor.probe_device_ping(device.name)
 
-    assert monitor._ping._wake.is_set() is True
+    assert monitor.ping._wake.is_set() is True
     assert monitor._tasks == set()
 
 

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -75,15 +75,15 @@ def _make_monitor(
 
     monitor.state = MonitorState()
 
-    monitor._importable = ImportableDiscovery(monitor)
+    monitor.importable = ImportableDiscovery(monitor)
 
-    monitor._mdns = MdnsSource(monitor)
+    monitor.mdns = MdnsSource(monitor)
 
     monitor._presence = None  # ping loop runs unconditionally in tests
     monitor._api_dial_budget = asyncio.Semaphore(1)
-    monitor._ping = PingSource(monitor)
-    monitor._api_info = ApiInfoSource(monitor)
-    monitor._api_reviver = ApiReviverSource(monitor)
+    monitor.ping = PingSource(monitor)
+    monitor.api_info = ApiInfoSource(monitor)
+    monitor.api_reviver = ApiReviverSource(monitor)
     monitor._resolve_api_connection = None
     monitor._on_persisted_ip_invalidated = None
     monitor._get_devices = lambda: devices
@@ -91,13 +91,13 @@ def _make_monitor(
     monitor._is_ignored = lambda _name: False
     monitor.state.state_source = {}
     monitor.state.http_urls = {}
-    monitor._mdns._zeroconf = None
-    monitor._mdns._mdns_browser = None
+    monitor.mdns._zeroconf = None
+    monitor.mdns._mdns_browser = None
     monitor._ping_task = None
     monitor._api_info_task = None
     monitor._api_reviver_task = None
     monitor._tasks = set()
-    monitor._importable._import_discovery = None
+    monitor.importable._import_discovery = None
 
     callbacks = RecordingMonitorCallbacks(devices)
     monitor._on_state_change = callbacks.on_state_change
@@ -216,14 +216,14 @@ async def test_stop_cancels_every_async_resource(monkeypatch: pytest.MonkeyPatch
     in_flight = asyncio.create_task(_long_running())
     monitor._tasks.add(in_flight)
     # Replace the zeroconf with one that has an awaitable async_close.
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.async_close = AsyncMock()
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.async_close = AsyncMock()
 
     await _stop_and_drain(monitor)
 
     assert monitor._ping_task is None
-    assert monitor._mdns._mdns_browser is None
-    assert monitor._mdns._zeroconf is None
+    assert monitor.mdns._mdns_browser is None
+    assert monitor.mdns._zeroconf is None
     assert monitor._tasks == set()
     assert in_flight.cancelled() or in_flight.done()
 
@@ -239,14 +239,14 @@ async def test_start_spawns_interface_monitor_and_stop_cancels_it(
     """
     monitor, _callbacks = _make_monitor()
     await _start_with_captured_dispatch(monitor, monkeypatch)
-    task = monitor._mdns._interface_monitor_task
+    task = monitor.mdns._interface_monitor_task
     assert task is not None
     assert not task.done()
-    monitor._mdns._zeroconf.async_close = AsyncMock()
+    monitor.mdns._zeroconf.async_close = AsyncMock()
 
     await _stop_and_drain(monitor)
 
-    assert monitor._mdns._interface_monitor_task is None
+    assert monitor.mdns._interface_monitor_task is None
     assert task.cancelled() or task.done()
 
 
@@ -306,14 +306,14 @@ async def test_close_zeroconf_swallows_crashed_interface_monitor() -> None:
 
     task = asyncio.create_task(_boom())
     await asyncio.sleep(0)  # let it crash before we hand it to close_zeroconf
-    monitor._mdns._interface_monitor_task = task
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.async_close = AsyncMock()
+    monitor.mdns._interface_monitor_task = task
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.async_close = AsyncMock()
 
-    await monitor._mdns.close_zeroconf()  # must not raise
+    await monitor.mdns.close_zeroconf()  # must not raise
 
-    assert monitor._mdns._interface_monitor_task is None
-    assert monitor._mdns._zeroconf is None
+    assert monitor.mdns._interface_monitor_task is None
+    assert monitor.mdns._zeroconf is None
 
 
 async def test_stop_swallows_browser_cancel_exception(
@@ -327,12 +327,12 @@ async def test_stop_swallows_browser_cancel_exception(
     """
     monitor, _callbacks = _make_monitor()
     await _start_with_captured_dispatch(monitor, monkeypatch)
-    monitor._mdns._mdns_browser.async_cancel = AsyncMock(side_effect=RuntimeError("browser broke"))
-    monitor._mdns._zeroconf.async_close = AsyncMock()
+    monitor.mdns._mdns_browser.async_cancel = AsyncMock(side_effect=RuntimeError("browser broke"))
+    monitor.mdns._zeroconf.async_close = AsyncMock()
 
     await _stop_and_drain(monitor)  # must not raise
 
-    assert monitor._mdns._mdns_browser is None
+    assert monitor.mdns._mdns_browser is None
 
 
 async def test_stop_swallows_zeroconf_close_exception(
@@ -341,11 +341,11 @@ async def test_stop_swallows_zeroconf_close_exception(
     """``zeroconf.async_close`` raise also lands at debug, not the caller."""
     monitor, _callbacks = _make_monitor()
     await _start_with_captured_dispatch(monitor, monkeypatch)
-    monitor._mdns._zeroconf.async_close = AsyncMock(side_effect=RuntimeError("zeroconf broke"))
+    monitor.mdns._zeroconf.async_close = AsyncMock(side_effect=RuntimeError("zeroconf broke"))
 
     await _stop_and_drain(monitor)  # must not raise
 
-    assert monitor._mdns._zeroconf is None
+    assert monitor.mdns._zeroconf is None
 
 
 async def test_close_zeroconf_is_bounded_when_async_close_hangs(
@@ -359,13 +359,13 @@ async def test_close_zeroconf_is_bounded_when_async_close_hangs(
     async def _hang() -> None:
         await asyncio.sleep(30)
 
-    monitor._mdns._zeroconf.async_close = _hang
+    monitor.mdns._zeroconf.async_close = _hang
 
     # Returns far under the 30s hang (timeout guard fails fast on a regression).
     async with asyncio.timeout(5):
-        await monitor._mdns.close_zeroconf()
+        await monitor.mdns.close_zeroconf()
 
-    assert monitor._mdns._zeroconf is None
+    assert monitor.mdns._zeroconf is None
     await _stop_and_drain(monitor)
 
 
@@ -415,8 +415,8 @@ async def test_start_falls_back_when_zeroconf_construct_fails(
 
     await monitor.start()
     try:
-        assert monitor._mdns._zeroconf is None
-        assert monitor._mdns._mdns_browser is None
+        assert monitor.mdns._zeroconf is None
+        assert monitor.mdns._mdns_browser is None
         # Ping task is still running — we want OFFLINE detection
         # even without zeroconf.
         assert monitor._ping_task is not None
@@ -456,8 +456,8 @@ async def test_start_continues_when_browser_construct_fails(
 
     await monitor.start()
     try:
-        assert monitor._mdns._zeroconf is fake_zeroconf
-        assert monitor._mdns._mdns_browser is None
+        assert monitor.mdns._zeroconf is fake_zeroconf
+        assert monitor.mdns._mdns_browser is None
     finally:
         await _stop_and_drain(monitor)
 
@@ -484,7 +484,7 @@ async def test_dispatch_removed_event_flips_offline_keeps_last_known_ip(
     stub_async_service_info(monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -509,7 +509,7 @@ async def test_dispatch_removed_event_stays_online_when_verify_resolves(
     stub_async_service_info(monkeypatch, resolved=True, addresses=("10.0.0.1",))
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -545,7 +545,7 @@ async def test_dispatch_removed_event_clears_reachability_tracker(
     stub_async_service_info(monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -590,7 +590,7 @@ async def test_dispatch_added_cache_hit_propagates_full_txt_bundle(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -629,7 +629,7 @@ async def test_dispatch_added_cache_hit_falls_back_to_v6_when_no_v4(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -664,7 +664,7 @@ async def test_dispatch_added_with_explicit_empty_api_encryption_pushes_empty_st
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -705,7 +705,7 @@ async def test_dispatch_added_without_api_encryption_txt_preserves_last_known(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -740,7 +740,7 @@ async def test_dispatch_added_without_api_encryption_txt_keeps_unknown_at_none(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -789,7 +789,7 @@ async def test_dispatch_added_api_encryption_absent_with_other_content_clears_to
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -835,7 +835,7 @@ async def test_dispatch_added_api_encryption_bare_key_pushes_empty_string(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -919,7 +919,7 @@ async def test_dispatch_added_sparse_announce_preserves_last_known(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -956,7 +956,7 @@ async def test_dispatch_added_cache_miss_resolves_and_applies(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -989,7 +989,7 @@ async def test_dispatch_added_cache_miss_skips_apply_when_request_returns_false(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1022,7 +1022,7 @@ async def test_dispatch_added_cache_miss_swallows_resolve_exception(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1058,7 +1058,7 @@ async def test_dispatch_added_phantom_ptr_does_not_revive_ping_offline(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"kitchen.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1084,7 +1084,7 @@ async def test_dispatch_skips_unconfigured_devices(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             ESPHOMELIB_SERVICE_TYPE,
             f"stranger.{ESPHOMELIB_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1154,7 +1154,7 @@ async def test_dispatch_http_service_added_records_url_and_refires_importable(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1186,7 +1186,7 @@ async def test_dispatch_http_service_added_skips_when_no_importable(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"stranger.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1220,7 +1220,7 @@ async def test_dispatch_http_service_removed_clears_url_and_refires(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -1241,7 +1241,7 @@ async def test_dispatch_http_service_removed_for_untracked_is_noop(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"stranger.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Removed,
@@ -1269,7 +1269,7 @@ async def test_dispatch_http_service_added_cache_miss_resolves_and_applies(
     dispatch = await _start_with_captured_dispatch(monitor, monkeypatch, import_discovery=discovery)
     try:
         dispatch(
-            monitor._mdns._zeroconf.zeroconf,
+            monitor.mdns._zeroconf.zeroconf,
             HTTP_SERVICE_TYPE,
             f"factory-firmware.{HTTP_SERVICE_TYPE}",
             ServiceStateChange.Added,
@@ -1294,9 +1294,9 @@ def test_revisit_all_importables_no_op_when_discovery_not_running() -> None:
     before the dashboard's mDNS browser has come up.
     """
     monitor, callbacks = _make_monitor()
-    monitor._importable._import_discovery = None
+    monitor.importable._import_discovery = None
 
-    monitor.revisit_all_importables()  # must not raise
+    monitor.importable.revisit_all_importables()  # must not raise
 
     assert callbacks.calls_for("on_importable_added") == []
 
@@ -1304,14 +1304,14 @@ def test_revisit_all_importables_no_op_when_discovery_not_running() -> None:
 def test_revisit_all_importables_re_emits_every_cached_entry() -> None:
     """``revisit_all_importables`` walks every entry and re-fires the ADD callback."""
     monitor, callbacks = _make_monitor(devices=[])
-    monitor._importable._import_discovery = _make_import_discovery(
+    monitor.importable._import_discovery = _make_import_discovery(
         {
             f"a.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("a"),
             f"b.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("b"),
         }
     )
 
-    monitor.revisit_all_importables()
+    monitor.importable.revisit_all_importables()
 
     emitted = {call[1].name for call in callbacks.calls_for("on_importable_added")}
     assert emitted == {"a", "b"}
@@ -1331,10 +1331,10 @@ def test_revisit_importable_seeds_url_from_cache_when_http_already_resolved(
     ``AdoptableDevice`` carries the link from the first event.
     """
     monitor, callbacks = _make_monitor(devices=[])
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
     discovered = _build_discovered("factory-firmware")
-    monitor._importable._import_discovery = _make_import_discovery(
+    monitor.importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": discovered}
     )
 
@@ -1344,7 +1344,7 @@ def test_revisit_importable_seeds_url_from_cache_when_http_already_resolved(
     fake_info.port = 8080
     monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
-    monitor.revisit_importable("factory-firmware")
+    monitor.importable.revisit_importable("factory-firmware")
 
     emitted = callbacks.calls_for("on_importable_added")
     assert len(emitted) == 1
@@ -1360,13 +1360,13 @@ def test_revisit_importable_skips_seed_when_url_already_set() -> None:
     pre-populated one (no AsyncServiceInfo lookup at all).
     """
     monitor, callbacks = _make_monitor(devices=[])
-    monitor._mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf = MagicMock()
     monitor.state.http_urls["factory-firmware"] = "http://factory-firmware.local"
-    monitor._importable._import_discovery = _make_import_discovery(
+    monitor.importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
 
-    monitor.revisit_importable("factory-firmware")
+    monitor.importable.revisit_importable("factory-firmware")
 
     emitted = callbacks.calls_for("on_importable_added")
     assert emitted[0][1].web_url == "http://factory-firmware.local"
@@ -1375,12 +1375,12 @@ def test_revisit_importable_skips_seed_when_url_already_set() -> None:
 def test_revisit_importable_skips_seed_when_zeroconf_down() -> None:
     """Pre-start monitor (zeroconf=None) silently bails out of the seed."""
     monitor, _callbacks = _make_monitor(devices=[])
-    monitor._mdns._zeroconf = None
-    monitor._importable._import_discovery = _make_import_discovery(
+    monitor.mdns._zeroconf = None
+    monitor.importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
 
-    monitor.revisit_importable("factory-firmware")  # must not raise
+    monitor.importable.revisit_importable("factory-firmware")  # must not raise
 
     assert monitor.state.http_urls == {}
 
@@ -1395,9 +1395,9 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
     we leave it to the regular browser-callback path.
     """
     monitor, _callbacks = _make_monitor(devices=[])
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
-    monitor._importable._import_discovery = _make_import_discovery(
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
+    monitor.importable._import_discovery = _make_import_discovery(
         {f"factory-firmware.{ESPHOMELIB_SERVICE_TYPE}": _build_discovered("factory-firmware")}
     )
 
@@ -1405,7 +1405,7 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
     fake_info.load_from_cache.return_value = False
     monkeypatch.setattr(importable_module, "AsyncServiceInfo", lambda *_a, **_kw: fake_info)
 
-    monitor.revisit_importable("factory-firmware")
+    monitor.importable.revisit_importable("factory-firmware")
 
     assert monitor.state.http_urls == {}
 
@@ -1619,7 +1619,7 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
 
     monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
     monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
-    monitor.get_cached_addresses = MagicMock(return_value=None)
+    monitor.mdns.get_cached_addresses = MagicMock(return_value=None)
     cache_calls = {"n": 0}
 
     def _has_cached_failure(host: str) -> bool:
@@ -1690,15 +1690,15 @@ def test_get_cached_addresses_returns_addresses_on_cache_hit(
 ) -> None:
     """A cache hit returns the parsed addresses; miss returns None."""
     monitor, _callbacks = _make_monitor()
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
 
     info = MagicMock()
     info.load_from_cache.return_value = True
     info.parsed_scoped_addresses.return_value = ["10.0.0.1", "10.0.0.2"]
     monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: info)
 
-    assert monitor.get_cached_addresses("kitchen.local") == ["10.0.0.1", "10.0.0.2"]
+    assert monitor.mdns.get_cached_addresses("kitchen.local") == ["10.0.0.1", "10.0.0.2"]
 
 
 def test_get_cached_addresses_returns_none_on_cache_miss(
@@ -1706,14 +1706,14 @@ def test_get_cached_addresses_returns_none_on_cache_miss(
 ) -> None:
     """``load_from_cache`` False → ``None`` (caller falls back to DNS / mDNS query)."""
     monitor, _callbacks = _make_monitor()
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
 
     info = MagicMock()
     info.load_from_cache.return_value = False
     monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: info)
 
-    assert monitor.get_cached_addresses("kitchen.local") is None
+    assert monitor.mdns.get_cached_addresses("kitchen.local") is None
 
 
 def test_get_cached_addresses_returns_none_when_addresses_empty(
@@ -1727,15 +1727,15 @@ def test_get_cached_addresses_returns_none_when_addresses_empty(
     caller as "no addresses I can use".
     """
     monitor, _callbacks = _make_monitor()
-    monitor._mdns._zeroconf = MagicMock()
-    monitor._mdns._zeroconf.zeroconf = MagicMock()
+    monitor.mdns._zeroconf = MagicMock()
+    monitor.mdns._zeroconf.zeroconf = MagicMock()
 
     info = MagicMock()
     info.load_from_cache.return_value = True
     info.parsed_scoped_addresses.return_value = []
     monkeypatch.setattr(mdns_module, "AddressResolver", lambda _name: info)
 
-    assert monitor.get_cached_addresses("kitchen.local") is None
+    assert monitor.mdns.get_cached_addresses("kitchen.local") is None
 
 
 async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -88,22 +88,22 @@ def _make_monitor(
 
     monitor.state = MonitorState()
 
-    monitor._importable = ImportableDiscovery(monitor)
+    monitor.importable = ImportableDiscovery(monitor)
 
-    monitor._mdns = MdnsSource(monitor)
+    monitor.mdns = MdnsSource(monitor)
 
     monitor._presence = None
-    monitor._ping = PingSource(monitor)
+    monitor.ping = PingSource(monitor)
     monitor._get_devices = lambda: devices
     monitor._get_devices_by_name = lambda name: [d for d in devices if d.name == name]
     monitor._is_ignored = lambda _name: False
     monitor.state.state_source = {}
     monitor.state.http_urls = {}
-    monitor._mdns._zeroconf = None
-    monitor._mdns._mdns_browser = None
+    monitor.mdns._zeroconf = None
+    monitor.mdns._mdns_browser = None
     monitor._ping_task = None
     monitor._tasks = set()
-    monitor._importable._import_discovery = None
+    monitor.importable._import_discovery = None
     monitor.state.reachability = tracker
     monitor._on_state_change = _flip_state(devices)
     monitor._on_ip_change = lambda _n, _i, _l: None
@@ -218,10 +218,10 @@ def test_select_ping_targets_keeps_device_with_known_ip_when_dns_failed() -> Non
     """A cached DNS failure with a known IP pings the IP, not OFFLINE+dns_failed."""
     devices = [_make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])]
     monitor = _make_monitor(devices)
-    monitor.get_cached_addresses = lambda _a: None
+    monitor.mdns.get_cached_addresses = lambda _a: None
     monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=True)
 
-    pingable, dns_failed = monitor._ping._select_ping_targets()
+    pingable, dns_failed = monitor.ping._select_ping_targets()
 
     assert devices[0] in pingable
     assert dns_failed == []
@@ -242,7 +242,7 @@ async def test_resolve_and_ping_falls_back_to_known_ip() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         AsyncMock(return_value=fake_result),
     ) as mock_ping:
-        await monitor._ping._resolve_and_ping(devices[0])
+        await monitor.ping._resolve_and_ping(devices[0])
 
     assert mock_ping.await_args.args[0] == "10.0.0.5"
     assert devices[0].runtime_state.state is DeviceState.ONLINE
@@ -261,7 +261,7 @@ async def test_ping_success_records_rtt_and_observation() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         AsyncMock(return_value=fake_result),
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     snap = tracker.snapshot(
         "kitchen", state=DeviceState.ONLINE, active_source="ping", ip="10.0.0.42"
@@ -283,7 +283,7 @@ async def test_ping_failure_does_not_record_rtt() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         AsyncMock(return_value=fake_result),
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     snap = tracker.snapshot(
         "kitchen", state=DeviceState.OFFLINE, active_source="ping", ip="10.0.0.42"
@@ -305,7 +305,7 @@ async def test_ping_retry_absorbs_transient_miss() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         fake_ping,
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     assert fake_ping.await_count == 2
     # First call is the cheap single-shot.
@@ -332,7 +332,7 @@ async def test_ping_retry_still_offline_when_retry_also_misses() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         fake_ping,
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     assert fake_ping.await_count == 2
     assert devices[0].runtime_state.state == DeviceState.OFFLINE
@@ -353,7 +353,7 @@ async def test_ping_no_retry_when_first_probe_succeeds() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         fake_ping,
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     fake_ping.assert_awaited_once()
 
@@ -369,7 +369,7 @@ async def test_ping_no_retry_when_already_offline() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         fake_ping,
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     fake_ping.assert_awaited_once()
     assert devices[0].runtime_state.state == DeviceState.OFFLINE
@@ -393,7 +393,7 @@ async def test_ping_retry_absorbs_transient_miss_when_unknown() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         fake_ping,
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     assert fake_ping.await_count == 2
     assert fake_ping.await_args_list[1].kwargs.get("count", 1) > 1
@@ -454,7 +454,7 @@ async def test_ping_device_uses_privileged_flag_from_probe() -> None:
     """``_ping_device`` forwards ``self._privileged`` to every ``icmp_ping`` call."""
     devices = [_make_device(state=DeviceState.UNKNOWN)]
     monitor = _make_monitor(devices, ReachabilityTracker())
-    monitor._ping._privileged = False
+    monitor.ping._privileged = False
 
     miss = MagicMock(is_alive=False, min_rtt=0.0)
     hit = MagicMock(is_alive=True, min_rtt=2.0)
@@ -463,7 +463,7 @@ async def test_ping_device_uses_privileged_flag_from_probe() -> None:
         "esphome_device_builder.controllers._device_state_monitor.ping.icmp_ping",
         fake_ping,
     ):
-        await monitor._ping._ping_device(devices[0], "10.0.0.42")
+        await monitor.ping._ping_device(devices[0], "10.0.0.42")
 
     assert fake_ping.await_args_list[0].kwargs.get("privileged") is False
     assert fake_ping.await_args_list[1].kwargs.get("privileged") is False
@@ -554,7 +554,7 @@ async def test_mdns_removed_via_dispatch_clears_tracker() -> None:
 def test_get_mdns_cache_info_no_zeroconf_returns_none() -> None:
     """No zeroconf → no cache to read → ``None``."""
     monitor = _make_monitor([_make_device()], None)
-    assert monitor.get_mdns_cache_info("kitchen") is None
+    assert monitor.mdns.get_mdns_cache_info("kitchen") is None
 
 
 def test_get_mdns_cache_info_no_record_returns_none() -> None:
@@ -563,8 +563,8 @@ def test_get_mdns_cache_info_no_record_returns_none() -> None:
     fake_zeroconf = MagicMock()
     fake_zeroconf.zeroconf.cache.get_all_by_details = MagicMock(return_value=[])
     fake_zeroconf.zeroconf.cache.current_entry_with_name_and_alias = MagicMock(return_value=None)
-    monitor._mdns._zeroconf = fake_zeroconf
-    assert monitor.get_mdns_cache_info("kitchen") is None
+    monitor.mdns._zeroconf = fake_zeroconf
+    assert monitor.mdns.get_mdns_cache_info("kitchen") is None
 
 
 def test_get_mdns_cache_info_against_real_zeroconf_record() -> None:
@@ -600,9 +600,9 @@ def test_get_mdns_cache_info_against_real_zeroconf_record() -> None:
         monitor = _make_monitor([_make_device()], None)
         # The helper reads ``self._zeroconf.zeroconf`` — wrap the real
         # ``Zeroconf`` in a stub object exposing the same attribute.
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
-        info = monitor.get_mdns_cache_info("kitchen")
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
         assert info is not None
         # Age is "now - created" in seconds. Allow a small margin
         # for the milliseconds elapsed between the test's
@@ -646,9 +646,9 @@ def test_get_mdns_a_record_ttl_remaining_picks_min_across_a_aaaa() -> None:
         zc.cache.async_add_records([a_rec, aaaa_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
-        ttl_remaining = monitor.get_mdns_a_record_ttl_remaining("kitchen")
+        ttl_remaining = monitor.mdns.get_mdns_a_record_ttl_remaining("kitchen")
         assert ttl_remaining is not None
         # AAAA's 40s wins (smaller).
         assert ttl_remaining == pytest.approx(40.0, abs=0.5)
@@ -661,9 +661,9 @@ def test_get_mdns_a_record_ttl_remaining_no_records_returns_none() -> None:
     monitor = _make_monitor([_make_device()], None)
     fake_zeroconf = MagicMock()
     fake_zeroconf.zeroconf.cache.get_all_by_details = MagicMock(return_value=[])
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
 
-    assert monitor.get_mdns_a_record_ttl_remaining("kitchen") is None
+    assert monitor.mdns.get_mdns_a_record_ttl_remaining("kitchen") is None
 
 
 def test_get_mdns_cache_info_picks_latest_across_record_types() -> None:
@@ -698,9 +698,9 @@ def test_get_mdns_cache_info_picks_latest_across_record_types() -> None:
         zc.cache.async_add_records([a_rec, ptr_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
-        info = monitor.get_mdns_cache_info("kitchen")
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
         assert info is not None
         # PTR (5s ago) is fresher than A (110s ago) → PTR wins.
         assert info.age_seconds == pytest.approx(5.0, abs=0.5)
@@ -759,9 +759,9 @@ def test_get_mdns_cache_info_decodes_txt_records() -> None:
         zc.cache.async_add_records([a_rec, txt_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
-        info = monitor.get_mdns_cache_info("kitchen")
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
         assert info is not None
         assert info.txt_records == {
             "version": "2025.4.0",
@@ -823,7 +823,7 @@ def test_get_mdns_cache_info_sorts_txt_records_for_wire_stability() -> None:
         )
         zc.cache.async_add_records([a_rec])
         monitor = _make_monitor([_make_device()], None)
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
         snapshots: list[dict[str, str]] = []
         for payload, age_offset in ((ascending, 4_000), (descending, 1_000)):
@@ -836,7 +836,7 @@ def test_get_mdns_cache_info_sorts_txt_records_for_wire_stability() -> None:
                 created=current_time_millis() - age_offset,
             )
             zc.cache.async_add_records([txt_rec])
-            info = monitor.get_mdns_cache_info("kitchen")
+            info = monitor.mdns.get_mdns_cache_info("kitchen")
             assert info is not None
             snapshots.append(dict(info.txt_records))
 
@@ -902,9 +902,9 @@ def test_get_mdns_cache_info_keeps_empty_value_keys_visible() -> None:
         zc.cache.async_add_records([a_rec, txt_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
-        info = monitor.get_mdns_cache_info("kitchen")
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
         assert info is not None
         assert info.txt_records == {
             "version": "2025.4.0",
@@ -1011,9 +1011,9 @@ def test_get_mdns_cache_info_no_txt_records_returns_empty_mapping() -> None:
         zc.cache.async_add_records([a_rec])
 
         monitor = _make_monitor([_make_device()], None)
-        monitor._mdns._zeroconf = MagicMock(zeroconf=zc)
+        monitor.mdns._zeroconf = MagicMock(zeroconf=zc)
 
-        info = monitor.get_mdns_cache_info("kitchen")
+        info = monitor.mdns.get_mdns_cache_info("kitchen")
         assert info is not None
         assert info.txt_records == {}
     finally:
@@ -1043,9 +1043,9 @@ def test_get_mdns_cache_info_picks_latest_record() -> None:
     fake_zeroconf.zeroconf.cache.current_entry_with_name_and_alias = MagicMock(return_value=None)
 
     monitor = _make_monitor([_make_device()], None)
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
 
-    info = monitor.get_mdns_cache_info("kitchen")
+    info = monitor.mdns.get_mdns_cache_info("kitchen")
     assert isinstance(info, MdnsCacheInfo)
     # Newer record wins; allow a small margin for the millisecond
     # difference between the test's ``current_time_millis()`` capture
@@ -1070,7 +1070,7 @@ async def test_refresh_mdns_no_zeroconf_is_a_noop() -> None:
     monitor = _make_monitor(devices, tracker)
     # ``_make_monitor`` already sets ``_zeroconf = None`` — the
     # method returns immediately without trying to resolve.
-    await monitor.refresh_mdns("kitchen")
+    await monitor.mdns.refresh_mdns("kitchen")
     snap = tracker.snapshot("kitchen", state=DeviceState.UNKNOWN, active_source="unknown", ip="")
     assert snap["mdns_last_seen_seconds_ago"] is None
 
@@ -1092,9 +1092,9 @@ async def test_refresh_mdns_calls_resolve_host() -> None:
     monitor = _make_monitor(devices, tracker)
     fake_zeroconf = MagicMock()
     fake_zeroconf.async_resolve_host = AsyncMock(return_value=["10.0.0.42"])
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
 
-    await monitor.refresh_mdns("kitchen")
+    await monitor.mdns.refresh_mdns("kitchen")
 
     fake_zeroconf.async_resolve_host.assert_awaited_once_with("kitchen.local", 3.0)
     assert devices[0].runtime_state.state is DeviceState.ONLINE
@@ -1114,9 +1114,9 @@ async def test_refresh_mdns_swallows_resolve_errors() -> None:
     monitor = _make_monitor(devices, ReachabilityTracker())
     fake_zeroconf = MagicMock()
     fake_zeroconf.async_resolve_host = AsyncMock(side_effect=OSError("network down"))
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
 
-    await monitor.refresh_mdns("kitchen")
+    await monitor.mdns.refresh_mdns("kitchen")
     assert devices[0].runtime_state.state is DeviceState.UNKNOWN
 
 
@@ -1132,7 +1132,7 @@ async def test_refresh_mdns_empty_resolve_no_state_change() -> None:
     monitor = _make_monitor(devices, ReachabilityTracker())
     fake_zeroconf = MagicMock()
     fake_zeroconf.async_resolve_host = AsyncMock(return_value=[])
-    monitor._mdns._zeroconf = fake_zeroconf
+    monitor.mdns._zeroconf = fake_zeroconf
 
-    await monitor.refresh_mdns("kitchen")
+    await monitor.mdns.refresh_mdns("kitchen")
     assert devices[0].runtime_state.state is DeviceState.UNKNOWN


### PR DESCRIPTION
# What does this implement/fix?

`DeviceStateMonitor` carried a grandfathered `# noqa: PLR0904` (26 public defs vs the cap of 20), which froze its public surface — so in-package siblings reached private internals directly: `shared.py` used `monitor._mdns` (`has_live_ptr`, `resolve_and_claim`, `zeroconf`) and the API reviver used `monitor._ping` (`icmp_available`, `icmp_concurrency`, `ping_once`) and the raw `monitor._on_persisted_ip_invalidated` callback.

This PR does the surface refactor and adds the sanctioned seams, with no behaviour change:

- **The five sources become public attributes** — `monitor.mdns`, `monitor.ping`, `monitor.importable`, `monitor.api_info`, `monitor.api_reviver`. Per-source queries and nudges route through them; `shared.py` and `api_reviver.py` no longer touch `_`-prefixed monitor attributes.
- **12 thin one-line delegators are deleted** (`zeroconf` property, `refresh_mdns`, `get_mdns_a_record_ttl_remaining`, `get_mdns_cache_info`, `get_cached_addresses`, `reconcile_from_mdns_cache`, `probe_device`, `revisit_importable`, `revisit_all_importables`, `get_importable_devices`, `request_version_reprobe`, `get_cached_dns_addresses`); callers use the public source attributes (or `monitor.state.dns_cache` for the DNS-cache read).
- **One seam added**: `invalidate_persisted_ip(name, stale_ip)` folds the `_on_persisted_ip_invalidated is not None` guard so the reviver calls it unconditionally. (The issue's other named seams already exist post-#2014: `ping.icmp_available`, `ping.ping_once`, and `shared.apply_ping_result` as the None-guarded `record_ping_rtt` wrapper.)
- **The monitor keeps the genuinely cross-source core** (lifecycle, precedence ledger, the `apply_*` dedupe family, `probe_device_ping`, `probe_reachability`) — 15 public defs, so the **PLR0904 noqa is dropped** with 5 methods of headroom.
- `tests/controllers/devices/conftest.py`'s `RecordingStateMonitor` mirrors the new surface with nested typed sub-fakes sharing the one `calls` list; call-tuple names are unchanged so existing assertions kept their meaning.

Reviewer notes — two reroutes change the *method name*, not just the path (the deleted delegators had renamed their targets):

- `monitor.reconcile_from_mdns_cache(name)` → `monitor.mdns.reconcile_from_cache(name)`
- `monitor.request_version_reprobe(name)` → `monitor.api_info.request_reprobe(name)`

`revisit_importable` and `get_importable_devices` had no production callers on the monitor (the `DevicesController` method of the same name reads `controller.state.import_result`); their behaviour is still covered by tests through `monitor.importable`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2021

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
