### PR TITLE
Give the mDNS clear op its own seam instead of the empty-ip sentinel

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -76,9 +76,17 @@ SourceChangeCallback = Callable[[str, ReachabilitySource], None]
 # mDNS IP resolution callback. ``primary`` is the IPv4 we lock onto
 # for ICMP / OTA cache args (or the first scoped IPv6 when no V4 is
 # present); ``addresses`` is the announced set in zeroconf's
-# ``parsed_scoped_addresses`` order. Empty primary + empty list clears
-# only the resolved set; ``device.ip`` keeps the last-known primary.
+# ``parsed_scoped_addresses`` order. Both are always non-empty — a
+# confirmed loss of resolution flows through
+# ``ResolvedAddressesClearedCallback`` instead.
 IPChangeCallback = Callable[[str, str, list[str]], None]
+
+# Confirmed loss of mDNS resolution for *name*: drop the resolved
+# ``ip_addresses`` set. ``device.ip`` keeps the last-known primary
+# (RAM mirrors the metadata sidecar) so the api_reviver can repair a
+# mid-process mDNS death; only its identity-verified invalidation
+# clears that value.
+ResolvedAddressesClearedCallback = Callable[[str], None]
 
 # mDNS ``version`` TXT change.
 VersionChangeCallback = Callable[[str, str], None]
@@ -146,6 +154,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         resolve_api_connection: ApiConnectionResolver | None = None,
         on_source_change: SourceChangeCallback | None = None,
         on_persisted_ip_invalidated: PersistedIpInvalidatedCallback | None = None,
+        on_resolved_addresses_cleared: ResolvedAddressesClearedCallback | None = None,
     ) -> None:
         super().__init__()
         self._get_devices = get_devices
@@ -170,6 +179,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         self._is_ignored = is_ignored or (lambda _name: False)
         self._resolve_api_connection = resolve_api_connection
         self._on_persisted_ip_invalidated = on_persisted_ip_invalidated
+        self._on_resolved_addresses_cleared = on_resolved_addresses_cleared
         self.state = MonitorState(reachability=reachability)
         self._ping_task: asyncio.Task | None = None
         self._api_info_task: asyncio.Task | None = None
@@ -349,17 +359,19 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
 
     def apply_ip(self, name: str, ip: str) -> bool:
         """
-        Record a single-IP observation. Empty string clears the resolved set.
+        Record a single-IP observation; *ip* must be truthy.
 
         Used by sources that only know one address per device
         (MQTT, DNS fallback). When *ip* is already in the device's
         ``ip_addresses`` list, only the primary slot is touched —
         a narrower MQTT / DNS observation must not shrink a multi-
         IP view mDNS already populated. Callers with the full
-        announced set should reach for :meth:`apply_ip_addresses`.
+        announced set should reach for :meth:`apply_ip_addresses`;
+        a confirmed loss of resolution goes through
+        :meth:`clear_resolved_addresses`.
         """
         if not ip:
-            return self._dispatch_ip(name, "", [])
+            raise ValueError("empty ip; use clear_resolved_addresses")
         devices = self._get_devices_by_name(name)
         if not devices:
             return False
@@ -372,16 +384,32 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
 
     def apply_ip_addresses(self, name: str, addresses: list[str]) -> bool:
         """
-        Record the full set of announced IPs for *name*.
+        Record the full set of announced IPs; *addresses* must be non-empty.
 
         Picks an IPv4 primary via :func:`_pick_ipv4` (falling back
         to the first scoped IPv6) so ``device.ip`` stays the single
         target for ICMP / OTA, and forwards the complete list to
-        ``runtime_state.ip_addresses``. Empty list clears only the
-        resolved set.
+        ``runtime_state.ip_addresses``.
         """
-        primary = _pick_ipv4(addresses) if addresses else ""
-        return self._dispatch_ip(name, primary, addresses)
+        if not addresses:
+            raise ValueError("empty addresses; use clear_resolved_addresses")
+        return self._dispatch_ip(name, _pick_ipv4(addresses), addresses)
+
+    def clear_resolved_addresses(self, name: str) -> bool:
+        """
+        Drop the resolved-address set after a confirmed loss of mDNS.
+
+        ``device.ip`` keeps the last-known primary (RAM mirrors the
+        metadata sidecar); only the api_reviver's identity-verified
+        invalidation clears that value.
+        """
+        if self._on_resolved_addresses_cleared is None:
+            return False
+        devices = self._get_devices_by_name(name)
+        if not devices or all(not d.runtime_state.ip_addresses for d in devices):
+            return False
+        self._on_resolved_addresses_cleared(name)
+        return True
 
     def _dispatch_ip(self, name: str, primary: str, addresses: list[str]) -> bool:
         """
@@ -397,12 +425,7 @@ class DeviceStateMonitor(TaskControllerBase):  # noqa: PLR0904 (grandfathered; n
         devices = self._get_devices_by_name(name)
         if not devices:
             return False
-        # The clear op (``primary == ""``) dedupes on the resolved set
-        # alone — ``device.ip`` keeps the last-known primary.
-        if all(
-            d.runtime_state.ip_addresses == addresses and (not primary or d.ip == primary)
-            for d in devices
-        ):
+        if all(d.ip == primary and d.runtime_state.ip_addresses == addresses for d in devices):
             return False
         self._on_ip_change(name, primary, addresses)
         return True

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -391,7 +391,7 @@ class MdnsSource:
             return
         monitor = self._monitor
         monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
-        monitor.apply_ip(device_name, "")
+        monitor.clear_resolved_addresses(device_name)
         monitor.forget(device_name)
         if monitor.state.reachability is not None:
             monitor.state.reachability.clear(device_name)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -213,6 +213,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             presence=self._db.subscriber_presence,
             resolve_api_connection=self._resolve_device_api_connection,
             on_persisted_ip_invalidated=self._on_persisted_ip_invalidated,
+            on_resolved_addresses_cleared=self._on_resolved_addresses_cleared,
         )
         # Per-signal freshness tracker (mDNS / ping / MQTT last-seen,
         # ping RTT) feeding the device drawer's Reachability section.
@@ -1124,6 +1125,9 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     def _on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
         state_callbacks.on_ip_change(self, name, ip, addresses)
+
+    def _on_resolved_addresses_cleared(self, name: str) -> None:
+        state_callbacks.on_resolved_addresses_cleared(self, name)
 
     def _on_persisted_ip_invalidated(self, name: str, stale_ip: str) -> None:
         state_callbacks.on_persisted_ip_invalidated(self, name, stale_ip)

--- a/esphome_device_builder/controllers/devices/state_callbacks.py
+++ b/esphome_device_builder/controllers/devices/state_callbacks.py
@@ -89,18 +89,12 @@ def on_source_change(controller: DevicesController, name: str, source: Reachabil
 
 
 def on_ip_change(controller: DevicesController, name: str, ip: str, addresses: list[str]) -> None:
-    """Forward IP updates onto the event bus and persist the primary value.
-
-    ``ip=""`` (empty *addresses*) clears only the resolved set;
-    ``device.ip`` keeps the last-known primary in RAM and on disk so
-    the OTA address cache and the api_reviver's cohort gate survive
-    offline windows.
-    """
+    """Forward IP updates onto the event bus and persist the primary value."""
     new_addresses = list(addresses)
     for device in controller._devices_by_name(name):
-        if device.runtime_state.ip_addresses == new_addresses and (not ip or device.ip == ip):
+        if device.ip == ip and device.runtime_state.ip_addresses == new_addresses:
             continue
-        if ip and device.ip != ip:
+        if device.ip != ip:
             device.ip = ip
             controller._metadata_store.update(device.configuration, ip=ip)
         device.runtime_state.ip_addresses = list(new_addresses)
@@ -108,8 +102,24 @@ def on_ip_change(controller: DevicesController, name: str, ip: str, addresses: l
             "Device %s (%s) IPs: %s",
             name,
             device.configuration,
-            ", ".join(new_addresses) or "(cleared)",
+            ", ".join(new_addresses),
         )
+        controller._fire_device_updated(device)
+
+
+def on_resolved_addresses_cleared(controller: DevicesController, name: str) -> None:
+    """
+    Clear the resolved set after a confirmed loss of mDNS resolution.
+
+    ``device.ip`` keeps the last-known primary in RAM and on disk so
+    the OTA address cache and the api_reviver's cohort gate survive
+    offline windows.
+    """
+    for device in controller._devices_by_name(name):
+        if not device.runtime_state.ip_addresses:
+            continue
+        device.runtime_state.ip_addresses = []
+        _LOGGER.debug("Device %s (%s) IPs: (cleared)", name, device.configuration)
         controller._fire_device_updated(device)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -922,9 +922,12 @@ class RecordingMonitorCallbacks:
 
     def on_ip_change(self, name: str, ip: str, addresses: list[str]) -> None:
         self.calls.append(("on_ip_change", name, ip, list(addresses)))
-        if ip:
-            self._flip(name, "ip", ip)
+        self._flip(name, "ip", ip)
         self._flip(name, "ip_addresses", list(addresses))
+
+    def on_resolved_addresses_cleared(self, name: str) -> None:
+        self.calls.append(("on_resolved_addresses_cleared", name))
+        self._flip(name, "ip_addresses", [])
 
     def on_version_change(self, name: str, version: str) -> None:
         self.calls.append(("on_version_change", name, version))
@@ -978,6 +981,7 @@ def make_state_monitor_with_callbacks(
         on_api_encryption_change=callbacks.on_api_encryption_change,
         on_mac_address_change=callbacks.on_mac_address_change,
         on_persisted_ip_invalidated=callbacks.on_persisted_ip_invalidated,
+        on_resolved_addresses_cleared=callbacks.on_resolved_addresses_cleared,
     )
     return monitor, callbacks
 

--- a/tests/controllers/devices/test_branches_coverage.py
+++ b/tests/controllers/devices/test_branches_coverage.py
@@ -851,7 +851,7 @@ def test_on_ip_change_skips_when_ip_unchanged(
     assert spawned == []
 
 
-def test_on_ip_change_empty_keeps_last_known_ip_and_skips_cleared_sibling(
+def test_on_resolved_addresses_cleared_keeps_ip_and_skips_cleared_sibling(
     tmp_path: Path,
     make_controller: MakeControllerFactory,
     capture_devices_events: CaptureDevicesEventsFactory,
@@ -864,13 +864,13 @@ def test_on_ip_change_empty_keeps_last_known_ip_and_skips_cleared_sibling(
     controller._scanner._devices_by_name = {"kitchen": [device, sibling]}  # type: ignore[attr-defined]
     captured = capture_devices_events(controller, EventType.DEVICE_UPDATED)
 
-    controller._on_ip_change("kitchen", "", [])
+    controller._on_resolved_addresses_cleared("kitchen")
 
     assert device.ip == "192.168.1.42"
     assert device.runtime_state.ip_addresses == []
     assert len(captured) == 1
 
-    controller._on_ip_change("kitchen", "", [])
+    controller._on_resolved_addresses_cleared("kitchen")
     assert len(captured) == 1
 
 

--- a/tests/test_api_reviver.py
+++ b/tests/test_api_reviver.py
@@ -220,7 +220,7 @@ async def test_mid_process_mdns_death_enters_the_cohort_and_revives() -> None:
 
     # The confirmed-Removed branch in ``mdns._verify_removed``.
     monitor.apply("kitchen", DeviceState.OFFLINE, "mdns")
-    monitor.apply_ip("kitchen", "")
+    monitor.clear_resolved_addresses("kitchen")
     monitor.forget("kitchen")
     assert device.ip == "192.168.1.50"
     assert device.runtime_state.ip_addresses == []

--- a/tests/test_dns_cache.py
+++ b/tests/test_dns_cache.py
@@ -726,8 +726,8 @@ async def test_on_ip_change_persists_non_empty_value() -> None:
     assert controller._metadata_store.get("kitchen.yaml") == {"ip": "10.0.0.1"}
 
 
-def test_on_ip_change_empty_clears_only_the_resolved_set() -> None:
-    """Empty IP (device left mDNS) keeps the last-known ``ip`` and schedules no write."""
+def test_on_resolved_addresses_cleared_keeps_last_known_ip() -> None:
+    """The clear keeps the last-known ``ip`` and schedules no write."""
     device = Device(
         name="kitchen",
         friendly_name="Kitchen",
@@ -740,7 +740,7 @@ def test_on_ip_change_empty_clears_only_the_resolved_set() -> None:
         [device], create_background_task=record_scheduled_coros(scheduled)
     )
 
-    controller._on_ip_change("kitchen", "", [])
+    controller._on_resolved_addresses_cleared("kitchen")
 
     assert device.ip == "10.0.0.1"
     assert device.runtime_state.ip_addresses == []

--- a/tests/test_state_fanout_duplicate_names.py
+++ b/tests/test_state_fanout_duplicate_names.py
@@ -81,7 +81,7 @@ async def test_ip_clear_fans_out_only_to_siblings_still_holding_addresses() -> N
         create_background_task=close_scheduled_coro,
     )
 
-    controller._on_ip_change("kitchen", "", [])
+    controller._on_resolved_addresses_cleared("kitchen")
 
     assert a.ip == "10.0.0.5"
     assert a.runtime_state.ip_addresses == []

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -109,6 +110,7 @@ def _make_monitor(
     monitor._on_mac_address_change = callbacks.on_mac_address_change
     monitor._on_importable_added = callbacks.on_importable_added
     monitor._on_importable_removed = callbacks.on_importable_removed
+    monitor._on_resolved_addresses_cleared = callbacks.on_resolved_addresses_cleared
     monitor.state.reachability = None
     monitor.state.dns_cache = MagicMock()
     return monitor, callbacks
@@ -1748,7 +1750,7 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
     ``.local``, so the zeroconf cache supplies a scoped V6 address;
     the ping targets it and the device goes ONLINE under ``ping``
     with the V6 address in ``Device.ip``. Without the fallback the
-    device would get ``apply_ip("")`` and the dashboard wouldn't
+    device would have no ping target and the dashboard wouldn't
     have an IP to OTA against.
     """
     device = _device(address="kitchen.local", state=DeviceState.UNKNOWN)
@@ -1794,17 +1796,34 @@ def test_apply_ip_short_circuits_when_value_unchanged() -> None:
     assert callbacks.calls_for("on_ip_change") == []
 
 
-def test_apply_ip_empty_clears_only_the_resolved_set() -> None:
-    """The clear op drops ``ip_addresses``, keeps the last-known ``ip``, and dedupes on repeat."""
+def test_clear_resolved_addresses_keeps_last_known_ip_and_dedupes() -> None:
+    """The clear drops ``ip_addresses``, keeps the last-known ``ip``, and no-ops on repeat."""
     device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1"])
     monitor, callbacks = _make_monitor([device])
 
-    assert monitor.apply_ip("kitchen", "") is True
+    assert monitor.clear_resolved_addresses("kitchen") is True
     assert device.ip == "10.0.0.1"
     assert device.runtime_state.ip_addresses == []
 
-    assert monitor.apply_ip("kitchen", "") is False
-    assert callbacks.calls_for("on_ip_change") == [("on_ip_change", "kitchen", "", [])]
+    assert monitor.clear_resolved_addresses("kitchen") is False
+    assert callbacks.calls_for("on_resolved_addresses_cleared") == [
+        ("on_resolved_addresses_cleared", "kitchen"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda m: m.apply_ip("kitchen", ""), id="apply_ip_empty"),
+        pytest.param(lambda m: m.apply_ip_addresses("kitchen", []), id="apply_ip_addresses_empty"),
+    ],
+)
+def test_empty_ip_observations_are_rejected(call: Callable[[DeviceStateMonitor], bool]) -> None:
+    """Observations must carry an address; the clear op has its own seam."""
+    monitor, _callbacks = _make_monitor([_device(ip="10.0.0.1", ip_addresses=["10.0.0.1"])])
+
+    with pytest.raises(ValueError, match="clear_resolved_addresses"):
+        call(monitor)
 
 
 def test_apply_ip_addresses_fires_when_list_changes_but_primary_does_not() -> None:

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1811,6 +1811,25 @@ def test_clear_resolved_addresses_keeps_last_known_ip_and_dedupes() -> None:
     ]
 
 
+def test_apply_ip_for_unknown_name_reports_nothing_applied() -> None:
+    device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1"])
+    monitor, callbacks = _make_monitor([device])
+
+    assert monitor.apply_ip("pantry", "10.0.0.9") is False
+
+    assert callbacks.calls_for("on_ip_change") == []
+
+
+def test_clear_resolved_addresses_without_callback_is_a_noop() -> None:
+    """A monitor built without the callback has nowhere to route the clear."""
+    device = _device(ip="10.0.0.1", ip_addresses=["10.0.0.1"])
+    monitor, _callbacks = _make_monitor([device])
+    monitor._on_resolved_addresses_cleared = None
+
+    assert monitor.clear_resolved_addresses("kitchen") is False
+    assert device.runtime_state.ip_addresses == ["10.0.0.1"]
+
+
 @pytest.mark.parametrize(
     "call",
     [


### PR DESCRIPTION
# What does this implement/fix?

Since #2034 the empty-string form of `apply_ip` multiplexed two different operations over one wire: a real single-IP observation, and "the device left mDNS, clear the resolved set but keep the last-known `Device.ip`". That sentinel had to be decoded in three places (the monitor's dedupe, the controller callback, and the conftest recorder, which needed its own `if ip:` guard to stay faithful).

This gives the clear op its own seam, following the precedent `on_persisted_ip_invalidated` set:

- `monitor.clear_resolved_addresses(name)` owns the set-only dedupe and fires a dedicated `on_resolved_addresses_cleared` callback; `mdns._verify_removed` calls it directly and reads as what it does.
- `on_ip_change` is back to a single unconditional loop with no sentinel arm; `state_callbacks.on_resolved_addresses_cleared` handles the clear (skip already-clear siblings, keep `device.ip` and disk, fire DEVICE_UPDATED).
- `apply_ip("")` and `apply_ip_addresses([])` now raise `ValueError` pointing at the new seam instead of silently misbehaving; no production caller passes either (MQTT gates on truthiness, every `apply_ip_addresses` caller guards non-empty).
- The conftest recorder drops its production-mirroring conditional and records the clear as its own tuple.

Behavior-free for every production path; the only observable change is that programmer misuse of the empty forms fails loud.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2036

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
