### PR TITLE
Rehome probe_device on MdnsSource and make resolve_then public

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -519,7 +519,7 @@ class DeviceStateMonitor(TaskControllerBase):
 
     def probe_reachability(self, device_name: str) -> None:
         """Full reachability nudge: eager mDNS resolve + ICMP sweep wake for *device_name*."""
-        self.importable.probe_device(device_name)
+        self.mdns.probe_device(device_name)
         self.probe_device_ping(device_name)
 
     # ------------------------------------------------------------------

--- a/esphome_device_builder/controllers/_device_state_monitor/importable.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/importable.py
@@ -10,7 +10,6 @@ from zeroconf.asyncio import AsyncServiceInfo
 
 from ...models import AdoptableDevice
 from .helpers import (
-    _ESPHOME_SERVICE_TYPE,
     _HTTP_SERVICE_TYPE,
     _http_url_from_service_info,
     device_name_from_service,
@@ -37,33 +36,6 @@ class ImportableDiscovery:
         """Forward esphomelib browser events to the upstream DashboardImportDiscovery."""
         if self._import_discovery is not None:
             self._import_discovery.browser_callback(zeroconf, service_type, name, state_change)
-
-    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
-        """
-        Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
-
-        Short-circuits the post-adoption wait for the next mDNS
-        announce — flips the card from "Unknown" to fully-populated
-        immediately by reading the zeroconf cache (sync hit) or
-        kicking off a fire-and-forget ``async_request``.
-
-        ``service_name`` defaults to ``device_name``; pass it
-        explicitly when the device's mDNS-advertised name (its
-        original factory-firmware hostname) differs from the
-        user-chosen YAML name so the lookup hits the cache while
-        the apply still keys to the configured name.
-        """
-        monitor = self._monitor
-        if (zc := monitor.mdns.zeroconf) is None:
-            return
-        zeroconf = zc.zeroconf
-        broadcast = service_name or device_name
-        full_service = f"{broadcast}.{_ESPHOME_SERVICE_TYPE}"
-        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, full_service)
-        if info.load_from_cache(zeroconf):
-            monitor.mdns._apply_service_info(device_name, info)
-            return
-        monitor._track_task(monitor.mdns._resolve_and_apply(zeroconf, info, device_name))
 
     def revisit_importable(self, device_name: str) -> None:
         """
@@ -150,7 +122,7 @@ class ImportableDiscovery:
         self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
     ) -> None:
         """Resolve a cache-miss HTTP service and store its URL."""
-        await self._monitor.mdns._resolve_then(
+        await self._monitor.mdns.resolve_then(
             zeroconf, info, device_name, self._apply_http_service_info
         )
 

--- a/esphome_device_builder/controllers/_device_state_monitor/importable.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/importable.py
@@ -116,14 +116,8 @@ class ImportableDiscovery:
         if info.load_from_cache(zeroconf):
             self._apply_http_service_info(device_name, info)
             return
-        monitor._track_task(self._resolve_and_apply_http(zeroconf, info, device_name))
-
-    async def _resolve_and_apply_http(
-        self, zeroconf: Any, info: AsyncServiceInfo, device_name: str
-    ) -> None:
-        """Resolve a cache-miss HTTP service and store its URL."""
-        await self._monitor.mdns.resolve_then(
-            zeroconf, info, device_name, self._apply_http_service_info
+        monitor._track_task(
+            monitor.mdns.resolve_then(zeroconf, info, device_name, self._apply_http_service_info)
         )
 
     def _apply_http_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -316,7 +316,7 @@ class MdnsSource:
         if info.load_from_cache(zc.zeroconf):
             self._apply_service_info(device_name, info)
             return
-        await self._resolve_then(
+        await self.resolve_then(
             zc.zeroconf,
             info,
             device_name,
@@ -328,6 +328,66 @@ class MdnsSource:
         """Whether the cache holds an unexpired esphomelib PTR for *device_name*."""
         ptr = self._cached_ptr(f"{device_name}.{_ESPHOME_SERVICE_TYPE}")
         return ptr is not None and not ptr.is_expired(current_time_millis())
+
+    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
+        """
+        Eagerly resolve a device's ``_esphomelib._tcp.local.`` service.
+
+        Short-circuits the post-adoption wait for the next mDNS
+        announce — flips the card from "Unknown" to fully-populated
+        immediately by reading the zeroconf cache (sync hit) or
+        kicking off a fire-and-forget ``async_request``.
+
+        ``service_name`` defaults to ``device_name``; pass it
+        explicitly when the device's mDNS-advertised name (its
+        original factory-firmware hostname) differs from the
+        user-chosen YAML name so the lookup hits the cache while
+        the apply still keys to the configured name.
+        """
+        if (zc := self._zeroconf) is None:
+            return
+        zeroconf = zc.zeroconf
+        broadcast = service_name or device_name
+        info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"{broadcast}.{_ESPHOME_SERVICE_TYPE}")
+        if info.load_from_cache(zeroconf):
+            self._apply_service_info(device_name, info)
+            return
+        self._monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name))
+
+    async def resolve_then(
+        self,
+        zeroconf: Any,
+        info: AsyncServiceInfo,
+        device_name: str,
+        apply: Callable[[str, AsyncServiceInfo], None],
+        *,
+        timeout_ms: float = _MDNS_RESOLVE_TIMEOUT_MS,
+    ) -> bool | None:
+        """
+        Resolve a cache-miss service and hand the result to *apply*.
+
+        Shared fire-and-forget shape between the esphomelib and
+        HTTP browser paths: spawn a task on cache miss,
+        ``async_request`` the record, swallow exceptions to a
+        debug log, dispatch to the per-type applier on success.
+        At most one resolve per service name is in flight. Returns
+        True when the service resolved and *apply* ran, False on a
+        confirmed miss, None when there is no verdict (a swallowed
+        error, or a resolve already in flight).
+        """
+        if info.name in self._inflight_resolves:
+            return None
+        self._inflight_resolves.add(info.name)
+        try:
+            if not await info.async_request(zeroconf, timeout=timeout_ms):
+                return False
+        except Exception:
+            _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
+            return None
+        finally:
+            self._inflight_resolves.discard(info.name)
+        apply(device_name, info)
+        return True
 
     def _on_esphomelib_service_state_change(
         self, zeroconf: Any, service_type: str, name: str, state_change: ServiceStateChange
@@ -370,7 +430,7 @@ class MdnsSource:
         apply: Callable[[str, AsyncServiceInfo], None] | None = None,
     ) -> None:
         """Resolve a cache-miss mDNS service and propagate its details (fire-and-forget shape)."""
-        await self._resolve_then(zeroconf, info, device_name, apply or self._apply_service_info)
+        await self.resolve_then(zeroconf, info, device_name, apply or self._apply_service_info)
 
     async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
         """Resolve before honouring a ``Removed``; only a confirmed miss applies OFFLINE."""
@@ -378,7 +438,7 @@ class MdnsSource:
             # A concurrent resolve decides; the sweep re-checks either way.
             return
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, name)
-        verdict = await self._resolve_then(zeroconf, info, device_name, self._apply_service_info)
+        verdict = await self.resolve_then(zeroconf, info, device_name, self._apply_service_info)
         if verdict is None:
             # Errored, not missed — never demote on uncertainty, and say
             # so above DEBUG since this gates the browser's OFFLINE path.
@@ -394,41 +454,6 @@ class MdnsSource:
         monitor.forget(device_name)
         if monitor.state.reachability is not None:
             monitor.state.reachability.clear(device_name)
-
-    async def _resolve_then(
-        self,
-        zeroconf: Any,
-        info: AsyncServiceInfo,
-        device_name: str,
-        apply: Callable[[str, AsyncServiceInfo], None],
-        *,
-        timeout_ms: float = _MDNS_RESOLVE_TIMEOUT_MS,
-    ) -> bool | None:
-        """
-        Resolve a cache-miss service and hand the result to *apply*.
-
-        Shared fire-and-forget shape between the esphomelib and
-        HTTP browser paths: spawn a task on cache miss,
-        ``async_request`` the record, swallow exceptions to a
-        debug log, dispatch to the per-type applier on success.
-        At most one resolve per service name is in flight. Returns
-        True when the service resolved and *apply* ran, False on a
-        confirmed miss, None when there is no verdict (a swallowed
-        error, or a resolve already in flight).
-        """
-        if info.name in self._inflight_resolves:
-            return None
-        self._inflight_resolves.add(info.name)
-        try:
-            if not await info.async_request(zeroconf, timeout=timeout_ms):
-                return False
-        except Exception:
-            _LOGGER.debug("mDNS resolve failed for %s", device_name, exc_info=True)
-            return None
-        finally:
-            self._inflight_resolves.discard(info.name)
-        apply(device_name, info)
-        return True
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -366,8 +366,7 @@ class MdnsSource:
         """
         Resolve a cache-miss service and hand the result to *apply*.
 
-        Shared fire-and-forget shape between the esphomelib and
-        HTTP browser paths: spawn a task on cache miss,
+        Shared by the esphomelib and HTTP browser paths:
         ``async_request`` the record, swallow exceptions to a
         debug log, dispatch to the per-type applier on success.
         At most one resolve per service name is in flight. Returns

--- a/esphome_device_builder/controllers/_task_controller_base.py
+++ b/esphome_device_builder/controllers/_task_controller_base.py
@@ -26,12 +26,12 @@ class TaskControllerBase:
     """
 
     def __init__(self) -> None:
-        self._tasks: set[asyncio.Task[None]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
 
-    def _track_task(
-        self, coro: Coroutine[Any, Any, None], *, name: str | None = None
-    ) -> asyncio.Task[None]:
-        """Schedule *coro* and hold a strong ref in :attr:`_tasks` until it settles."""
+    def _track_task[T](
+        self, coro: Coroutine[Any, Any, T], *, name: str | None = None
+    ) -> asyncio.Task[T]:
+        """Schedule *coro*, discarding its result, and hold a strong ref until it settles."""
         task = asyncio.create_task(coro, name=name)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)

--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -141,7 +141,7 @@ async def import_device(
     # chosen ``name``. The scan-change handler probes too but
     # only knows the YAML name, which has no broadcast yet for
     # the rename-during-adopt case.
-    controller._state_monitor.importable.probe_device(name, service_name=mdns_name)
+    controller._state_monitor.mdns.probe_device(name, service_name=mdns_name)
     return {"configuration": configuration}
 
 

--- a/tests/controllers/devices/conftest.py
+++ b/tests/controllers/devices/conftest.py
@@ -61,15 +61,19 @@ class _RecordingAddressCache:
         return self._cached.get(normalize_hostname(host_name))
 
 
+class _RecordingMdnsSource(_RecordingAddressCache):
+    """Typed fake for the monitor's public ``mdns`` source attribute."""
+
+    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
+        self._calls.append(("probe_device", device_name, service_name))
+
+
 class _RecordingImportableSource:
     """Typed fake for the monitor's public ``importable`` source attribute."""
 
     def __init__(self, calls: list[tuple[Any, ...]], importable: list[AdoptableDevice]) -> None:
         self._calls = calls
         self._importable = importable
-
-    def probe_device(self, device_name: str, service_name: str | None = None) -> None:
-        self._calls.append(("probe_device", device_name, service_name))
 
     def revisit_importable(self, device_name: str) -> None:
         self._calls.append(("revisit_importable", device_name))
@@ -144,7 +148,7 @@ class RecordingStateMonitor:
     ) -> None:
         self.calls: list[tuple[Any, ...]] = []
         self._priority = priority_map or {}
-        self.mdns = _RecordingAddressCache(
+        self.mdns = _RecordingMdnsSource(
             self.calls,
             {normalize_hostname(k): v for k, v in (cached_addresses or {}).items()},
             record_as="get_cached_addresses",
@@ -189,7 +193,7 @@ class RecordingStateMonitor:
     def probe_reachability(self, device_name: str) -> None:
         # Delegates like production so callers' per-probe call tuples
         # keep matching regardless of which entry point they used.
-        self.importable.probe_device(device_name)
+        self.mdns.probe_device(device_name)
         self.probe_device_ping(device_name)
 
     def priority_for(self, name: str) -> str:

--- a/tests/test_mdns_cache_reconcile.py
+++ b/tests/test_mdns_cache_reconcile.py
@@ -242,7 +242,7 @@ async def test_resolve_then_dedupes_inflight_service_names() -> None:
     info.async_request = AsyncMock()
     apply = MagicMock()
 
-    await source._resolve_then(MagicMock(), info, "kitchen", apply)
+    await source.resolve_then(MagicMock(), info, "kitchen", apply)
 
     info.async_request.assert_not_called()
     apply.assert_not_called()
@@ -259,7 +259,7 @@ async def test_resolve_then_clears_inflight_after_completion() -> None:
     info.async_request = AsyncMock(return_value=True)
     apply = MagicMock()
 
-    await source._resolve_then(MagicMock(), info, "kitchen", apply)
+    await source.resolve_then(MagicMock(), info, "kitchen", apply)
 
     apply.assert_called_once_with("kitchen", info)
     assert _SERVICE_NAME not in source._inflight_resolves

--- a/tests/test_mdns_http_txt.py
+++ b/tests/test_mdns_http_txt.py
@@ -101,7 +101,7 @@ async def test_http_cache_miss_spawns_resolve_task(monkeypatch: pytest.MonkeyPat
     async def fake_resolve(*_args, **_kw) -> None:
         return None
 
-    monkeypatch.setattr(monitor.mdns, "_resolve_then", fake_resolve)
+    monkeypatch.setattr(monitor.mdns, "resolve_then", fake_resolve)
 
     monitor.mdns._on_http_service_state_change(
         MagicMock(), _HTTP, f"klo.{_HTTP}", ServiceStateChange.Added

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -21,7 +21,6 @@ from esphome_device_builder.controllers._device_state_monitor import (
     DeviceStateMonitor,
 )
 from esphome_device_builder.controllers._device_state_monitor._state import MonitorState
-from esphome_device_builder.controllers._device_state_monitor.importable import ImportableDiscovery
 from esphome_device_builder.controllers._device_state_monitor.mdns import MdnsSource
 from esphome_device_builder.controllers._device_state_monitor.ping import PingSource
 from esphome_device_builder.models import Device, DeviceRuntimeState, DeviceState
@@ -33,8 +32,6 @@ def _make_monitor() -> DeviceStateMonitor:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
-
-    monitor.importable = ImportableDiscovery(monitor)
 
     monitor.mdns = MdnsSource(monitor)
 
@@ -155,8 +152,6 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
     monitor = DeviceStateMonitor.__new__(DeviceStateMonitor)
 
     monitor.state = MonitorState()
-
-    monitor.importable = ImportableDiscovery(monitor)
 
     monitor.mdns = MdnsSource(monitor)
 

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -1,5 +1,5 @@
 """
-Tests for ``DeviceStateMonitor.probe_device``.
+Tests for ``MdnsSource.probe_device``.
 
 Adoption / wizard / on-disk YAML drops all need an eager mDNS
 probe so the new device card lands fully populated (IP, version,
@@ -78,11 +78,11 @@ async def test_probe_device_cache_hit_applies_synchronously(monkeypatch) -> None
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = True
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.importable.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.mdns.AsyncServiceInfo",
         lambda *_args, **_kw: fake_info,
     )
 
-    monitor.importable.probe_device("kitchen")
+    monitor.mdns.probe_device("kitchen")
 
     assert apply_calls == [("kitchen", fake_info)]
     assert not monitor._tasks
@@ -109,11 +109,11 @@ async def test_probe_device_uses_service_name_when_provided(monkeypatch) -> None
         return fake_info
 
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.importable.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.mdns.AsyncServiceInfo",
         _info_ctor,
     )
 
-    monitor.importable.probe_device("my-living-room", service_name="apollo-r-pro-1-eth-5938e0")
+    monitor.mdns.probe_device("my-living-room", service_name="apollo-r-pro-1-eth-5938e0")
 
     # Looked up under the OLD broadcast name…
     assert constructor_args == [
@@ -131,7 +131,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     fake_info = MagicMock()
     fake_info.load_from_cache.return_value = False
     monkeypatch.setattr(
-        "esphome_device_builder.controllers._device_state_monitor.importable.AsyncServiceInfo",
+        "esphome_device_builder.controllers._device_state_monitor.mdns.AsyncServiceInfo",
         lambda *_args, **_kw: fake_info,
     )
 
@@ -140,7 +140,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
 
     monkeypatch.setattr(monitor.mdns, "_resolve_and_apply", fake_resolve)
 
-    monitor.importable.probe_device("kitchen")
+    monitor.mdns.probe_device("kitchen")
 
     assert apply_calls == []
     # One task was registered for tracking. Wait it out so the
@@ -165,7 +165,7 @@ def test_probe_device_no_zeroconf_is_a_noop() -> None:
     monitor.mdns._zeroconf = None
     monitor._tasks = set()
 
-    monitor.importable.probe_device("kitchen")  # no exception, no tasks
+    monitor.mdns.probe_device("kitchen")  # no exception, no tasks
     assert not monitor._tasks
 
 

--- a/tests/test_probe_device_ping.py
+++ b/tests/test_probe_device_ping.py
@@ -136,7 +136,7 @@ def test_probe_reachability_fires_both_probes(monkeypatch: pytest.MonkeyPatch) -
     monitor, _ = make_state_monitor_with_callbacks([_ping_only_device()])
     probed: list[str] = []
     monkeypatch.setattr(
-        monitor.importable,
+        monitor.mdns,
         "probe_device",
         lambda name, service_name=None: probed.append(name),
     )

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -942,8 +942,8 @@ async def test_dispatch_added_cache_miss_resolves_and_applies(
     Drives the cache-miss path end-to-end: dispatch fires, the task
     spawns, ``async_request`` returns True, ``_apply_service_info``
     runs, and the device picks up the version. Awaiting the spawned
-    task is what exercises the real ``_resolve_then`` path (no
-    direct call to ``_resolve_then`` in the test).
+    task is what exercises the real ``resolve_then`` path (no
+    direct call to ``resolve_then`` in the test).
     """
     device = _device()
     monitor, _callbacks = _make_monitor([device])
@@ -977,7 +977,7 @@ async def test_dispatch_added_cache_miss_skips_apply_when_request_returns_false(
     """``async_request`` False (no record arrived in time) → no apply, no ONLINE claim.
 
     Pins the ``if not await info.async_request: return`` branch in
-    ``_resolve_then``: a PTR that never resolves leaves the device
+    ``resolve_then``: a PTR that never resolves leaves the device
     UNKNOWN and unclaimed by mDNS, so the ICMP sweep still owns it.
     """
     device = _device()

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -3,7 +3,7 @@
 This file fills in the branches the per-feature suites
 (``test_mdns_*``, ``test_probe_device``, ``test_non_api_mdns_resolve``)
 don't reach. Tests drive through the public API
-(``start`` / ``stop`` / ``probe_device`` / ``revisit_*`` / the
+(``start`` / ``stop`` / ``revisit_*`` / the
 ``apply_*`` family) plus the dispatch closure that
 ``AsyncServiceBrowser`` would invoke in production. The closure is
 captured by patching ``AsyncServiceBrowser`` so the test owns the


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2037, which made the monitor's sources public seams and surfaced that `probe_device` was canonized on the wrong one: its body is pure mDNS mechanics (reads the zeroconf responder, builds an `_esphomelib._tcp.local.` `AsyncServiceInfo`, hands off to the mDNS apply/resolve pipeline) and never touches importable state — yet it lived on `ImportableDiscovery`, forcing `monitor.mdns._apply_service_info` / `._resolve_and_apply` private reaches through the public `mdns` seam.

No behaviour change:

- **`probe_device(device_name, service_name=None)` moves to `MdnsSource`** verbatim; the two call sites (`DeviceStateMonitor.probe_reachability`, `controllers/devices/importable.py`'s post-import probe) now use `monitor.mdns.probe_device(...)`. That dissolves the `_apply_service_info` / `_resolve_and_apply` reaches from `importable.py` entirely — the moved body calls them as ordinary `self._*` methods.
- **`_resolve_then` is promoted to public `MdnsSource.resolve_then`** (moved into the public block, body unchanged). It was already genuinely cross-source infrastructure — the importable source's HTTP identity path (`_resolve_and_apply_http`) resolves through it — so the remaining `monitor.mdns._private` reach becomes a sanctioned public call.
- Test fake: `probe_device` moves from the `importable` sub-fake to a new `_RecordingMdnsSource` (subclassing the address-cache fake); the recorded `("probe_device", name, service)` tuples are unchanged, so devices-suite assertions kept their meaning.
- `MdnsSource` goes to 13 public defs, `ImportableDiscovery` to 6 — both well under the PLR0904 cap.

After this, no sibling or test reaches a private member through a public source seam on the probe path; the only remaining in-package private reaches are the documented monitor↔source plumbing (`_get_devices`, `_presence`, …).

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2039

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
