### PR TITLE
Unify the mDNS cache-first resolve tails behind one helper

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -346,13 +346,9 @@ class MdnsSource:
         """
         if (zc := self._zeroconf) is None:
             return
-        zeroconf = zc.zeroconf
         broadcast = service_name or device_name
         info = AsyncServiceInfo(_ESPHOME_SERVICE_TYPE, f"{broadcast}.{_ESPHOME_SERVICE_TYPE}")
-        if info.load_from_cache(zeroconf):
-            self._apply_service_info(device_name, info)
-            return
-        self._monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name))
+        self._cache_apply_or_resolve(zc.zeroconf, info, device_name)
 
     async def resolve_then(
         self,
@@ -415,11 +411,25 @@ class MdnsSource:
         # a stale PTR for a long-gone device); claiming here latched
         # it ONLINE forever with no IP, locking out the ICMP sweep.
         info = AsyncServiceInfo(service_type, name)
-        if info.load_from_cache(zeroconf):
-            self._apply_service_info(device_name, info)
-            return
+        self._cache_apply_or_resolve(zeroconf, info, device_name)
 
-        monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name))
+    def _cache_apply_or_resolve(
+        self,
+        zeroconf: Any,
+        info: AsyncServiceInfo,
+        device_name: str,
+        apply: Callable[[str, AsyncServiceInfo], None] | None = None,
+    ) -> None:
+        """
+        Apply *info* off the zeroconf cache, else fire-and-forget a wire resolve.
+
+        The cache-hit apply is synchronous by contract — an adopted
+        card populates immediately, no task spawned.
+        """
+        if info.load_from_cache(zeroconf):
+            (apply or self._apply_service_info)(device_name, info)
+            return
+        self._monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name, apply))
 
     async def _resolve_and_apply(
         self,
@@ -539,12 +549,7 @@ class MdnsSource:
         if not bucket or all(device.api_enabled for device in bucket):
             return
         info = AsyncServiceInfo(service_type, name)
-        if info.load_from_cache(zeroconf):
-            self._apply_http_txt(device_name, info)
-            return
-        monitor._track_task(
-            self._resolve_and_apply(zeroconf, info, device_name, self._apply_http_txt)
-        )
+        self._cache_apply_or_resolve(zeroconf, info, device_name, self._apply_http_txt)
 
     def _apply_http_txt(self, device_name: str, info: AsyncServiceInfo) -> None:
         """

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -420,26 +420,12 @@ class MdnsSource:
         device_name: str,
         apply: Callable[[str, AsyncServiceInfo], None] | None = None,
     ) -> None:
-        """
-        Apply *info* off the zeroconf cache, else fire-and-forget a wire resolve.
-
-        The cache-hit apply is synchronous by contract — an adopted
-        card populates immediately, no task spawned.
-        """
+        """Apply *info* synchronously off the zeroconf cache, else resolve fire-and-forget."""
+        applier = apply or self._apply_service_info
         if info.load_from_cache(zeroconf):
-            (apply or self._apply_service_info)(device_name, info)
+            applier(device_name, info)
             return
-        self._monitor._track_task(self._resolve_and_apply(zeroconf, info, device_name, apply))
-
-    async def _resolve_and_apply(
-        self,
-        zeroconf: Any,
-        info: AsyncServiceInfo,
-        device_name: str,
-        apply: Callable[[str, AsyncServiceInfo], None] | None = None,
-    ) -> None:
-        """Resolve a cache-miss mDNS service and propagate its details (fire-and-forget shape)."""
-        await self.resolve_then(zeroconf, info, device_name, apply or self._apply_service_info)
+        self._monitor._track_task(self.resolve_then(zeroconf, info, device_name, applier))
 
     async def _verify_removed(self, zeroconf: Any, name: str, device_name: str) -> None:
         """Resolve before honouring a ``Removed``; only a confirmed miss applies OFFLINE."""

--- a/tests/test_probe_device.py
+++ b/tests/test_probe_device.py
@@ -135,7 +135,7 @@ async def test_probe_device_cache_miss_spawns_task(monkeypatch) -> None:
     async def fake_resolve(*_args, **_kw) -> None:
         return None
 
-    monkeypatch.setattr(monitor.mdns, "_resolve_and_apply", fake_resolve)
+    monkeypatch.setattr(monitor.mdns, "resolve_then", fake_resolve)
 
     monitor.mdns.probe_device("kitchen")
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2040, which colocated `probe_device` with the other resolvers and left `MdnsSource` holding three line-for-line copies of the same cache-hit-apply-else-fire-and-forget-resolve tail: `probe_device`, the esphomelib browser Added handler, and the `_http._tcp` browser handler (same shape with `_apply_http_txt` as the applier). The semantics are load-bearing (#1748 resolve-before-claim, #1776 latch class), so a fix landing in one copy but not the others was the standing risk.

No behaviour change:

- New private `_cache_apply_or_resolve(zeroconf, info, device_name, apply=None)` — `load_from_cache` hit → synchronous apply (the pinned `probe_device` contract: an adopted card populates immediately, no task spawned); miss → `_track_task(_resolve_and_apply(...))`. The `apply` parameter mirrors `_resolve_and_apply`'s, defaulting to `_apply_service_info`, so the HTTP path passes `_apply_http_txt` through unchanged.
- All three fire-and-forget tails collapse to one call each.
- `resolve_and_claim` deliberately keeps its awaited variant (different timeout, caller awaits the verdict) — per the issue, it shares only the two cache-hit lines and folding it in would perturb semantics.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2041

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
