### PR TITLE
Simplify the ping sweep after the sweep-base and public-seam refactors

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/_sweep_source.py
@@ -34,6 +34,10 @@ class SweepSource:
         if monitor._presence is not None:
             monitor._presence.add_subscriber_callback(self._wake.set)
 
+    def wake(self) -> None:
+        """Bail the idle wait so the next sweep runs without waiting out the interval."""
+        self._wake.set()
+
     async def run(self) -> None:
         await asyncio.sleep(self._bootstrap_delay)
         if not await self._prepare():

--- a/esphome_device_builder/controllers/_device_state_monitor/api_info.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_info.py
@@ -73,7 +73,7 @@ class ApiInfoSource(ApiSweepSource):
     def request_reprobe(self, name: str) -> None:
         """Force one probe of *name* on the next sweep, ignoring the mac+version guard."""
         self._force_reprobe.add(name)
-        self._wake.set()
+        self.wake()
 
     async def _prepare(self) -> bool:
         # The sweep loop still runs without the worker library: the

--- a/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/api_reviver.py
@@ -13,9 +13,9 @@ connects are heavy on the device (scarce connection slots), so revival is
 strictly last-resort and identity-verified:
 
 1. Candidates are devices with **no other reachability signal**: not
-   ONLINE, ``api_enabled``, last-known ``Device.ip``, no resolved
-   addresses, and :func:`shared.address_resolution_exhausted` proving
-   the ping sweep already tried and had no target.
+   ONLINE, ``api_enabled``, last-known ``Device.ip``, and
+   :func:`shared.sweep_has_no_target` proving the ping sweep already
+   tried and had no target.
 2. ICMP the persisted IP as a cheap **negative** filter — silence means
    no dial, the device is off or moved.
 3. Something answered: pay for one short-lived ``device_info`` worker
@@ -103,11 +103,9 @@ class ApiReviverSource(ApiSweepSource):
         if not api_worker_available():
             _LOGGER.debug("aioesphomeapi not installed; API revival disabled")
             return False
-        # The bootstrap sleep outlasts ping's privilege probe, so a
-        # still-undecided outcome means the probe never ran; either way
-        # the negative pre-filter can't be trusted, and availability
-        # can't change within a process.
-        if self._monitor.ping.icmp_available is not True:
+        # False until ping's privilege probe lands (the bootstrap sleep
+        # outlasts it); availability can't change within a process.
+        if not self._monitor.ping.icmp_available:
             _LOGGER.warning(
                 "API revival disabled: ICMP is unavailable, so the persisted-IP "
                 "pre-filter can't run and a verified ONLINE could never demote"
@@ -170,9 +168,8 @@ class ApiReviverSource(ApiSweepSource):
             if device.api_enabled
             and device.ip
             and device.runtime_state.state is not DeviceState.ONLINE
-            and not device.runtime_state.ip_addresses
             and self._cooldown.ready((device.name, device.ip), now)
-            and shared.address_resolution_exhausted(self._monitor, device.address)
+            and shared.sweep_has_no_target(self._monitor, device)
         ]
 
     async def _prefilter(self, device: Device, ip: str) -> float | None:

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from icmplib import async_ping as icmp_ping
 from icmplib.exceptions import ICMPLibError
 
+from ...helpers.async_ import log_gather_failures
 from ...helpers.hostname import is_local_hostname
 from ...models import Device, DeviceState
 from . import shared
@@ -47,7 +48,7 @@ async def _can_use_icmp_lib_with_privilege() -> bool | None:
 
 
 class PingSource(SweepSource):
-    """ICMP ping loop owning the periodic sweep and the wake-on-add early trigger."""
+    """ICMP ping sweep: mDNS pre-resolve, target selection, and the ping pass."""
 
     _sweep_label = "ICMP ping"
     # The mDNS browser's head start so the common case (everything
@@ -71,142 +72,10 @@ class PingSource(SweepSource):
         # Set in ``_prepare`` once the privilege probe lands; the pre-
         # ``run`` default is only seen by tests that mock ``icmp_ping``.
         self._privileged: bool = True
-        # Privilege-probe outcome for siblings (the API reviver gates on
-        # it): ``None`` until the probe lands, then True iff some ICMP
-        # socket mode works and the sweep is running.
-        self.icmp_available: bool | None = None
-
-    def wake(self) -> None:
-        """Bail the idle wait so the next sweep runs without waiting out the interval."""
-        self._wake.set()
-
-    async def _prepare(self) -> bool:
-        privileged = await _can_use_icmp_lib_with_privilege()
-        self.icmp_available = privileged is not None
-        if privileged is None:
-            _LOGGER.warning(
-                "ICMP ping sweep disabled: opening an ICMP socket was denied in both "
-                "privileged and unprivileged modes (needs CAP_NET_RAW, or "
-                "net.ipv4.ping_group_range covering this process's group); "
-                "device state will only update via mDNS"
-            )
-            return False
-        self._privileged = privileged
-        _LOGGER.debug("Using icmplib in privileged=%s mode for the ICMP ping sweep", privileged)
-        return True
-
-    async def _sweep(self) -> None:
-        # Disjoint candidate sets — resolve both concurrently so a
-        # wire-miss in one doesn't delay the sweep behind the other.
-        # A failing resolve step is logged and must not skip the
-        # sibling resolve or the ping pass for this interval.
-        results = await asyncio.gather(
-            shared.resolve_non_api_mdns_targets(self._monitor),
-            shared.resolve_api_mdns_targets(self._monitor),
-            return_exceptions=True,
-        )
-        for result in results:
-            if isinstance(result, BaseException) and not isinstance(result, Exception):
-                # Never mask a cancellation as a benign step failure.
-                raise result
-            if isinstance(result, Exception):
-                _LOGGER.warning("mDNS resolve step failed; continuing", exc_info=result)
-        await self._ping_sweep()
-
-    async def _ping_sweep(self) -> None:
-        pingable, dns_failed = self._select_ping_targets()
-        if not pingable and not dns_failed:
-            return
-        if _LOGGER.isEnabledFor(logging.DEBUG):
-            # Signature spans both buckets so a device whose 120s
-            # DNS-failure cache TTL flips it between ``pingable`` and
-            # ``dns_failed`` every 60s sweep doesn't re-emit the log
-            # line each cycle. New devices, mDNS claims, and removals
-            # still resurface it.
-            signature = tuple(sorted((d.name, d.address) for d in pingable + dns_failed))
-            if signature != self._last_logged_targets:
-                self._last_logged_targets = signature
-                if dns_failed:
-                    _LOGGER.debug(
-                        "Pinging %d devices: %s; skipping %d (cached DNS failure): %s",
-                        len(pingable),
-                        _format_devices(pingable) or "(none)",
-                        len(dns_failed),
-                        _format_devices(dns_failed),
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Pinging %d devices: %s", len(pingable), _format_devices(pingable)
-                    )
-        # ``self.icmp_concurrency`` semaphore caps in-flight ICMP at
-        # ``ICMP_BATCH_SIZE``; no need to pre-chunk the gather.
-        await asyncio.gather(
-            *(self._resolve_and_ping(device) for device in pingable),
-            return_exceptions=True,
-        )
-
-    def _select_ping_targets(self) -> tuple[list[Device], list[Device]]:
-        """Return ``(pingable, dns_failed)`` and apply per-device side-effects."""
-        pingable: list[Device] = []
-        dns_failed: list[Device] = []
-        monitor = self._monitor
-        for device in monitor._get_devices():
-            if not device.address or not shared.should_ping(monitor, device):
-                continue
-            if shared.address_resolution_exhausted(monitor, device.address) and (
-                not device.runtime_state.ip_addresses
-            ):
-                # The address won't resolve and we have no known IP.
-                # Don't hand the bare hostname to icmplib (it would hammer
-                # the system resolver every sweep). Apply OFFLINE under the
-                # ``ping`` source so a future successful resolve can flip
-                # the device back. Everything else falls through to
-                # ``pingable``: a zeroconf-cached ``.local`` gets *pinged*
-                # rather than claimed ONLINE off cache presence (a stale or
-                # reflected entry for a dead device would latch it ONLINE
-                # forever, #1776), and a device with a known IP (e.g. from
-                # MQTT) is pinged at that IP. One predicate, shared with
-                # the reviver's cohort gate.
-                monitor.apply(device.name, DeviceState.OFFLINE, "ping")
-                dns_failed.append(device)
-                continue
-            pingable.append(device)
-        return pingable, dns_failed
-
-    async def _resolve_and_ping(self, device: Device) -> None:
-        """Resolve *device.address* through the DNS cache and ICMP it."""
-        monitor = self._monitor
-        async with self.icmp_concurrency:
-            addresses = await monitor.state.dns_cache.async_resolve(device.address)
-            if not addresses and is_local_hostname(device.address):
-                # System resolver couldn't resolve the ``.local`` (no nss-mdns
-                # in most container images). Fall back to zeroconf's own mDNS
-                # cache, kept fresh by the ``AsyncServiceBrowser``, rather than
-                # giving up — but ping still decides liveness, so a stale or
-                # reflected entry demotes instead of latching ONLINE (#1776).
-                addresses = monitor.mdns.get_cached_addresses(device.address)
-            if not addresses:
-                # mDNS-less devices: the ``.local`` won't resolve but a
-                # prior MQTT/DNS observation left a usable IP. Ping that so
-                # ping can confirm a device the network won't resolve.
-                addresses = list(device.runtime_state.ip_addresses)
-            if not addresses:
-                monitor.apply(device.name, DeviceState.OFFLINE, "ping")
-                return
-            # Ping the IPv4 primary, not ``addresses[0]`` — a resolve/cache
-            # hit can order a scoped IPv6 first even when an IPv4 is present,
-            # and ICMP across subnets is friendlier on V4. ``_pick_ipv4`` is
-            # the same chooser ``apply_ip_addresses`` uses for ``device.ip``,
-            # so the pinged IP and the drawer's primary stay in lockstep.
-            target = _pick_ipv4(addresses)
-            # ``apply_ip_addresses`` populates ``device.ip`` (V4 primary)
-            # and the full ``runtime_state.ip_addresses`` list for ``.local`` hosts
-            # that don't broadcast ``_esphomelib._tcp`` (non-API ESPHome
-            # devices); without it those devices show an em-dash in the
-            # drawer's IP row even after successful pings, and forwarding the
-            # whole set keeps a cached multi-IP device's secondary addresses.
-            monitor.apply_ip_addresses(device.name, addresses)
-            await self._ping_device(device, target)
+        # Privilege-probe outcome for siblings (the API reviver gates
+        # on it): True once some ICMP socket mode works and the sweep
+        # is running.
+        self.icmp_available: bool = False
 
     async def ping_once(self, target: str, *, retry: bool) -> float | None:
         """
@@ -238,6 +107,128 @@ class PingSource(SweepSource):
             # flooding the logs with stack traces.
             _LOGGER.debug("Ping of %s failed: %s", target, exc)
         return None
+
+    async def _prepare(self) -> bool:
+        privileged = await _can_use_icmp_lib_with_privilege()
+        self.icmp_available = privileged is not None
+        if privileged is None:
+            _LOGGER.warning(
+                "ICMP ping sweep disabled: opening an ICMP socket was denied in both "
+                "privileged and unprivileged modes (needs CAP_NET_RAW, or "
+                "net.ipv4.ping_group_range covering this process's group); "
+                "device state will only update via mDNS"
+            )
+            return False
+        self._privileged = privileged
+        _LOGGER.debug("Using icmplib in privileged=%s mode for the ICMP ping sweep", privileged)
+        return True
+
+    async def _sweep(self) -> None:
+        # Disjoint candidate sets — resolve both concurrently so a
+        # wire-miss in one doesn't delay the sweep behind the other.
+        # A failing resolve step is logged and must not skip the
+        # sibling resolve or the ping pass for this interval.
+        results = await asyncio.gather(
+            shared.resolve_non_api_mdns_targets(self._monitor),
+            shared.resolve_api_mdns_targets(self._monitor),
+            return_exceptions=True,
+        )
+        log_gather_failures(results, "mDNS resolve step failed; continuing")
+        await self._ping_sweep()
+
+    async def _ping_sweep(self) -> None:
+        pingable, dns_failed = self._select_ping_targets()
+        if not pingable and not dns_failed:
+            return
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            # Signature spans both buckets so a device whose 120s
+            # DNS-failure cache TTL flips it between ``pingable`` and
+            # ``dns_failed`` every 60s sweep doesn't re-emit the log
+            # line each cycle. New devices, mDNS claims, and removals
+            # still resurface it.
+            signature = tuple(sorted((d.name, d.address) for d in pingable + dns_failed))
+            if signature != self._last_logged_targets:
+                self._last_logged_targets = signature
+                if dns_failed:
+                    _LOGGER.debug(
+                        "Pinging %d devices: %s; skipping %d (cached DNS failure): %s",
+                        len(pingable),
+                        _format_devices(pingable) or "(none)",
+                        len(dns_failed),
+                        _format_devices(dns_failed),
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Pinging %d devices: %s", len(pingable), _format_devices(pingable)
+                    )
+        # ``self.icmp_concurrency`` semaphore caps in-flight ICMP at
+        # ``ICMP_BATCH_SIZE``; no need to pre-chunk the gather.
+        results = await asyncio.gather(
+            *(self._resolve_and_ping(device) for device in pingable),
+            return_exceptions=True,
+        )
+        log_gather_failures(results, "Ping pass failed for a device; continuing")
+
+    def _select_ping_targets(self) -> tuple[list[Device], list[Device]]:
+        """Return ``(pingable, dns_failed)`` and apply per-device side-effects."""
+        pingable: list[Device] = []
+        dns_failed: list[Device] = []
+        monitor = self._monitor
+        for device in monitor._get_devices():
+            if not device.address or not shared.should_ping(monitor, device):
+                continue
+            if shared.sweep_has_no_target(monitor, device):
+                # The address won't resolve and we have no known IP.
+                # Don't hand the bare hostname to icmplib (it would hammer
+                # the system resolver every sweep). Apply OFFLINE under the
+                # ``ping`` source so a future successful resolve can flip
+                # the device back. Everything else falls through to
+                # ``pingable``: a zeroconf-cached ``.local`` gets *pinged*
+                # rather than claimed ONLINE off cache presence (a stale or
+                # reflected entry for a dead device would latch it ONLINE
+                # forever, #1776), and a device with a known IP (e.g. from
+                # MQTT) is pinged at that IP. One predicate, shared with
+                # the reviver's cohort gate.
+                shared.apply_ping_result(monitor, device.name, None)
+                dns_failed.append(device)
+                continue
+            pingable.append(device)
+        return pingable, dns_failed
+
+    async def _resolve_and_ping(self, device: Device) -> None:
+        """Resolve *device.address* through the DNS cache and ICMP it."""
+        monitor = self._monitor
+        async with self.icmp_concurrency:
+            addresses = await monitor.state.dns_cache.async_resolve(device.address)
+            if not addresses and is_local_hostname(device.address):
+                # System resolver couldn't resolve the ``.local`` (no nss-mdns
+                # in most container images). Fall back to zeroconf's own mDNS
+                # cache, kept fresh by the ``AsyncServiceBrowser``, rather than
+                # giving up — but ping still decides liveness, so a stale or
+                # reflected entry demotes instead of latching ONLINE (#1776).
+                addresses = monitor.mdns.get_cached_addresses(device.address)
+            if not addresses:
+                # mDNS-less devices: the ``.local`` won't resolve but a
+                # prior MQTT/DNS observation left a usable IP. Ping that so
+                # ping can confirm a device the network won't resolve.
+                addresses = list(device.runtime_state.ip_addresses)
+            if not addresses:
+                shared.apply_ping_result(monitor, device.name, None)
+                return
+            # Ping the IPv4 primary, not ``addresses[0]`` — a resolve/cache
+            # hit can order a scoped IPv6 first even when an IPv4 is present,
+            # and ICMP across subnets is friendlier on V4. ``_pick_ipv4`` is
+            # the same chooser ``apply_ip_addresses`` uses for ``device.ip``,
+            # so the pinged IP and the drawer's primary stay in lockstep.
+            target = _pick_ipv4(addresses)
+            # ``apply_ip_addresses`` populates ``device.ip`` (V4 primary)
+            # and the full ``runtime_state.ip_addresses`` list for ``.local`` hosts
+            # that don't broadcast ``_esphomelib._tcp`` (non-API ESPHome
+            # devices); without it those devices show an em-dash in the
+            # drawer's IP row even after successful pings, and forwarding the
+            # whole set keeps a cached multi-IP device's secondary addresses.
+            monitor.apply_ip_addresses(device.name, addresses)
+            await self._ping_device(device, target)
 
     async def _ping_device(self, device: Device, target: str) -> None:
         # Skip the retry only for already-OFFLINE devices: the miss

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -72,20 +72,25 @@ def apply_ping_result(monitor: DeviceStateMonitor, name: str, rtt_ms: float | No
     monitor.apply(name, DeviceState.ONLINE if rtt_ms is not None else DeviceState.OFFLINE, "ping")
 
 
-def address_resolution_exhausted(monitor: DeviceStateMonitor, address: str) -> bool:
+def sweep_has_no_target(monitor: DeviceStateMonitor, device: Device) -> bool:
     """
-    Report whether the ping sweep provably has no way to target *address*.
+    Report whether the ping sweep provably has no way to target *device*.
 
-    Mirrors ``_select_ping_targets``'s resolution order: a ``.local``
-    with zeroconf-cached addresses is ping's to handle, and only a
-    *cached* DNS failure (written by ping's pre-resolve) proves the
-    sweep already tried. Keep this and ping's selection in lockstep.
+    Mirrors ``_resolve_and_ping``'s resolution chain: known RAM
+    addresses are pinged directly, a ``.local`` with zeroconf-cached
+    addresses is ping's to handle, and only a *cached* DNS failure
+    (written by ping's pre-resolve) proves the sweep already tried.
+    Keep this and that chain in lockstep. Checks run cheapest-first;
+    the zeroconf cache walk only pays off after a proven DNS failure.
     """
+    if device.runtime_state.ip_addresses:
+        return False
+    address = device.address
     if not address:
         return True
-    if is_local_hostname(address) and monitor.mdns.get_cached_addresses(address):
+    if not monitor.state.dns_cache.has_cached_failure(address):
         return False
-    return monitor.state.dns_cache.has_cached_failure(address)
+    return not (is_local_hostname(address) and monitor.mdns.get_cached_addresses(address))
 
 
 def apply_resolved_addresses(

--- a/esphome_device_builder/helpers/async_.py
+++ b/esphome_device_builder/helpers/async_.py
@@ -18,6 +18,21 @@ def log_task_exit(label: str, task: Task[Any]) -> None:
         _LOGGER.error("%s loop crashed: %s", label, exc, exc_info=exc)
 
 
+def log_gather_failures(results: Iterable[Any], message: str) -> None:
+    """
+    Triage a ``gather(..., return_exceptions=True)`` result list.
+
+    Logs each failure at WARNING so one item's failure doesn't skip
+    its siblings; re-raises a cancellation rather than masking it as
+    a benign miss.
+    """
+    for result in results:
+        if isinstance(result, Exception):
+            _LOGGER.warning(message, exc_info=result)
+        elif isinstance(result, BaseException):
+            raise result
+
+
 async def drain_tasks(tasks: Iterable[Task[Any]], *, log_exceptions: bool = False) -> None:
     """
     Cancel and await every task in *tasks*, swallowing exceptions.

--- a/esphome_device_builder/helpers/async_.py
+++ b/esphome_device_builder/helpers/async_.py
@@ -28,7 +28,7 @@ def log_gather_failures(results: Iterable[Any], message: str) -> None:
     """
     for result in results:
         if isinstance(result, Exception):
-            _LOGGER.warning(message, exc_info=result)
+            _LOGGER.warning("%s", message, exc_info=result)
         elif isinstance(result, BaseException):
             raise result
 

--- a/tests/test_api_reviver.py
+++ b/tests/test_api_reviver.py
@@ -145,22 +145,14 @@ async def test_icmp_silence_skips_the_dial_and_cools_down() -> None:
     assert 0 < _cooldown_delta(src, device) <= _ICMP_SILENT_COOLDOWN
 
 
-@pytest.mark.parametrize(
-    "icmp_available",
-    [
-        pytest.param(False, id="probe_said_unavailable"),
-        pytest.param(None, id="probe_never_landed"),
-    ],
-)
 async def test_run_exits_when_icmp_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    icmp_available: bool | None,
 ) -> None:
     """Without a trustworthy negative pre-filter the reviver refuses to run at all."""
     device = make_stuck_offline_device()
     monitor, _callbacks, src = _reviver([device])
-    monitor.ping.icmp_available = icmp_available
+    monitor.ping.icmp_available = False
     monkeypatch.setattr(ApiReviverSource, "_bootstrap_delay", 0)
 
     with caplog.at_level(logging.WARNING):

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1620,7 +1620,12 @@ async def test_dns_failure_flicker_does_not_re_emit_log(
         return MagicMock(is_alive=True, min_rtt=1.0)
 
     monkeypatch.setattr(ping_module, "icmp_ping", _icmp)
-    monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
+    # ``zom.local`` never yields an address, so its RAM ``ip_addresses``
+    # stay empty and the DNS-failure flicker below genuinely moves it
+    # between the pingable and dns_failed buckets each sweep.
+    monitor.state.dns_cache.async_resolve = AsyncMock(
+        side_effect=lambda host: [] if host == "zom.local" else ["192.0.2.5"]
+    )
     monitor.mdns.get_cached_addresses = MagicMock(return_value=None)
     cache_calls = {"n": 0}
 


### PR DESCRIPTION
# What does this implement/fix?

Cleanup pass over the ping sweep following the sweep-base adoption (#2035) and the public-seam rename (#2037). Behavior-free apart from log lines:

- `wake()` moves onto `SweepSource`; it was base machinery stranded on `PingSource` after #2035, and `ApiInfoSource.request_reprobe` was re-spelling `self._wake.set()` inline.
- The two direct `monitor.apply(name, OFFLINE, "ping")` calls (no-target selection, resolve-empty) now route through `shared.apply_ping_result(monitor, name, None)` like the probe path and the reviver, so the ping-sourced transition has one spelling.
- New `helpers.async_.log_gather_failures` owns the gather triage (log failures, re-raise cancellations). `_sweep`'s hand-rolled isinstance loop uses it, and the `_ping_sweep` gather, which previously discarded exceptions silently, now logs them. `mdns.close_zeroconf`'s hand-rolled single-task drain becomes `drain_tasks(log_exceptions=True)`.
- `shared.address_resolution_exhausted` becomes `shared.sweep_has_no_target(monitor, device)`, folding in the `not runtime_state.ip_addresses` conjunct both call sites (ping selection, reviver cohort gate) were adding by hand; the "keep in lockstep" contract now lives in one predicate. Checks run cheapest-first, so the zeroconf cache walk only pays off after a proven DNS failure.
- `icmp_available` de-tri-states to a plain bool; its only consumer (the reviver's `_prepare`) never distinguished `None` from `False`.
- Stale class docstring fixed (the loop lives on the base now) and `ping_once` moved into the public section beside the other cross-source seams.

The flicker log test needed its driver fixed: the cheap-first predicate no longer consults the DNS-failure cache once RAM addresses exist, so the test's flaky device now genuinely never resolves, making the bucket flicker real instead of an artifact of call counting.

Out-of-scope efficiency findings from the same review (the per-device `has_live_ptr` full-bucket scan, per-sweep fleet snapshot reuse, bounded ping workers) are tracked in a separate issue.

**Related issue or feature (if applicable):**

- follow-up cleanup after #2035 and #2037

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
