### PR TITLE
Give the monitor a confirmed-offline seam owning the ledger teardown

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -267,12 +267,7 @@ class DeviceStateMonitor(TaskControllerBase):
             self._emit_source_change(name, old, ReachabilitySource.UNKNOWN)
 
     def confirmed_offline(self, name: str, source: str) -> None:
-        """
-        Tear down every per-name ledger after *source* confirms *name* is gone.
-
-        OFFLINE applied under *source*, resolved addresses dropped,
-        precedence ledger forgotten, per-signal freshness cleared.
-        """
+        """Tear down every per-name ledger after *source* confirms *name* is gone."""
         self.apply(name, DeviceState.OFFLINE, source)
         self.clear_resolved_addresses(name)
         self.forget(name)

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -266,6 +266,19 @@ class DeviceStateMonitor(TaskControllerBase):
         if old is not None:
             self._emit_source_change(name, old, ReachabilitySource.UNKNOWN)
 
+    def confirmed_offline(self, name: str, source: str) -> None:
+        """
+        Tear down every per-name ledger after *source* confirms *name* is gone.
+
+        OFFLINE applied under *source*, resolved addresses dropped,
+        precedence ledger forgotten, per-signal freshness cleared.
+        """
+        self.apply(name, DeviceState.OFFLINE, source)
+        self.clear_resolved_addresses(name)
+        self.forget(name)
+        if self.state.reachability is not None:
+            self.state.reachability.clear(name)
+
     def _emit_source_change(self, name: str, old: str, new: str) -> None:
         """Notify the owner when *name*'s authoritative source actually flips."""
         if self._on_source_change is not None and old != new:

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -435,12 +435,7 @@ class MdnsSource:
             return
         if verdict:
             return
-        monitor = self._monitor
-        monitor.apply(device_name, DeviceState.OFFLINE, "mdns")
-        monitor.clear_resolved_addresses(device_name)
-        monitor.forget(device_name)
-        if monitor.state.reachability is not None:
-            monitor.state.reachability.clear(device_name)
+        self._monitor.confirmed_offline(device_name, "mdns")
 
     def _apply_service_info(self, device_name: str, info: AsyncServiceInfo) -> None:
         """

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1830,6 +1830,40 @@ def test_clear_resolved_addresses_without_callback_is_a_noop() -> None:
     assert device.runtime_state.ip_addresses == ["10.0.0.1"]
 
 
+def test_confirmed_offline_tears_down_every_per_name_ledger() -> None:
+    """OFFLINE under the source, addresses cleared, ledger forgotten, freshness cleared."""
+    device = _device(state=DeviceState.ONLINE, ip="10.0.0.1", ip_addresses=["10.0.0.1"])
+    monitor, callbacks = _make_monitor([device])
+    tracker = ReachabilityTracker()
+    monitor.state.reachability = tracker
+    tracker.observe("kitchen", "ping")
+    monitor.state.state_source["kitchen"] = "mdns"
+
+    monitor.confirmed_offline("kitchen", "mdns")
+
+    assert callbacks.calls_for("on_state_change") == [
+        ("on_state_change", "kitchen", DeviceState.OFFLINE, "mdns"),
+    ]
+    assert callbacks.calls_for("on_resolved_addresses_cleared") == [
+        ("on_resolved_addresses_cleared", "kitchen"),
+    ]
+    assert monitor.state.state_source == {}
+    snap = tracker.snapshot("kitchen", state=DeviceState.OFFLINE, active_source="unknown", ip="")
+    assert snap["ping_last_seen_seconds_ago"] is None
+
+
+def test_confirmed_offline_without_tracker_is_guarded() -> None:
+    """No reachability tracker wired → the teardown still runs without raising."""
+    device = _device(state=DeviceState.ONLINE, ip="10.0.0.1", ip_addresses=["10.0.0.1"])
+    monitor, _callbacks = _make_monitor([device])
+    monitor.state.state_source["kitchen"] = "mdns"
+
+    monitor.confirmed_offline("kitchen", "mdns")
+
+    assert device.runtime_state.state is DeviceState.OFFLINE
+    assert monitor.state.state_source == {}
+
+
 @pytest.mark.parametrize(
     "call",
     [


### PR DESCRIPTION
# What does this implement/fix?

`MdnsSource._verify_removed`'s confirmed-miss branch hand-composed the monitor's "confirmed gone" teardown from ledger internals — four mutations in sequence (`apply` OFFLINE, `clear_resolved_addresses`, `forget`, `state.reachability.clear`). Which per-name ledgers exist is monitor knowledge, not mdns knowledge: a new `MonitorState` ledger would require remembering to update the mDNS source's OFFLINE branch, and a future confirmed-gone source (e.g. MQTT LWT) would copy the quartet.

No behaviour change:

- New `DeviceStateMonitor.confirmed_offline(name, source)` owns the composition, in the same order the inline branch ran it (OFFLINE applied under *source* → resolved addresses dropped → precedence ledger forgotten → per-signal freshness cleared, None-guarded).
- `_verify_removed`'s branch collapses to `self._monitor.confirmed_offline(device_name, "mdns")`.
- The verify-before-demote asymmetry (#1748/#1776/#1993) stays exactly where it was — only the mutation bundle moved down a layer.
- Two direct unit tests pin the composition and the no-tracker guard; the existing end-to-end browser-Removed test keeps pinning the dispatch path.

Monitor public surface goes 15 → 16 defs, still well under the PLR0904 cap.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2044

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
