### PR TITLE
Cut the per-sweep O(N^2) terms in the mDNS hot paths

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -15,11 +15,12 @@ import logging
 from collections.abc import Callable, Mapping
 from functools import partial
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from esphome.zeroconf import AsyncEsphomeZeroconf
 from zeroconf import (
     AddressResolver,
+    DNSPointer,
     DNSRecord,
     IPVersion,
     ServiceStateChange,
@@ -27,7 +28,7 @@ from zeroconf import (
     millis_to_seconds,
 )
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
-from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_SRV, _TYPE_TXT
+from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR, _TYPE_SRV, _TYPE_TXT
 
 from ...helpers.async_ import drain_tasks, log_task_exit
 from ...helpers.hostname import normalize_hostname
@@ -308,6 +309,47 @@ class MdnsSource:
     def has_live_ptr(self, device_name: str) -> bool:
         """Whether the cache holds an unexpired esphomelib PTR for *device_name*."""
         return self._cached_ptr(f"{device_name}.{_ESPHOME_SERVICE_TYPE}") is not None
+
+    def live_ptr_service_names(self) -> set[str]:
+        """
+        Snapshot the unexpired esphomelib PTR aliases in the cache.
+
+        One O(cache) pass for sweep-scale callers — zeroconf's
+        per-alias lookup scans every PTR under the type-domain, so
+        N per-device :meth:`has_live_ptr` calls are O(N·cache).
+        Membership key is ``f"{name}.{_ESPHOME_SERVICE_TYPE}"``,
+        the same comparison the per-alias lookup makes.
+        """
+        if self._zeroconf is None:
+            return set()
+        now_ms = current_time_millis()
+        return {
+            cast(DNSPointer, record).alias
+            for record in self._zeroconf.zeroconf.cache.get_all_by_details(
+                _ESPHOME_SERVICE_TYPE, _TYPE_PTR, _CLASS_IN
+            )
+            if not record.is_expired(now_ms)
+        }
+
+    def has_cached_trace(self, name: str) -> bool:
+        """
+        Whether the cache holds any record for *name*, expired included.
+
+        The existence check :meth:`get_mdns_cache_info` callers pay
+        full snapshot construction for — same record gathering, no
+        decode or allocation. Keep the two in lockstep.
+        """
+        if self._zeroconf is None:
+            return False
+        if self._get_address_records(name):
+            return True
+        cache = self._zeroconf.zeroconf.cache
+        service_name = f"{name}.{_ESPHOME_SERVICE_TYPE}"
+        return bool(
+            cache.get_all_by_details(service_name, _TYPE_SRV, _CLASS_IN)
+            or cache.get_all_by_details(service_name, _TYPE_TXT, _CLASS_IN)
+            or self._cached_ptr(service_name) is not None
+        )
 
     def probe_device(self, device_name: str, service_name: str | None = None) -> None:
         """

--- a/esphome_device_builder/controllers/_device_state_monitor/mdns.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/mdns.py
@@ -314,11 +314,7 @@ class MdnsSource:
         """
         Snapshot the unexpired esphomelib PTR aliases in the cache.
 
-        One O(cache) pass for sweep-scale callers — zeroconf's
-        per-alias lookup scans every PTR under the type-domain, so
-        N per-device :meth:`has_live_ptr` calls are O(N·cache).
-        Membership key is ``f"{name}.{_ESPHOME_SERVICE_TYPE}"``,
-        the same comparison the per-alias lookup makes.
+        Membership key is ``f"{name}.{_ESPHOME_SERVICE_TYPE}"``.
         """
         if self._zeroconf is None:
             return set()
@@ -335,9 +331,8 @@ class MdnsSource:
         """
         Whether the cache holds any record for *name*, expired included.
 
-        The existence check :meth:`get_mdns_cache_info` callers pay
-        full snapshot construction for — same record gathering, no
-        decode or allocation. Keep the two in lockstep.
+        Same record buckets as :meth:`get_mdns_cache_info`; keep the
+        two in lockstep.
         """
         if self._zeroconf is None:
             return False

--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -174,8 +174,9 @@ class PingSource(SweepSource):
         pingable: list[Device] = []
         dns_failed: list[Device] = []
         monitor = self._monitor
+        live_ptrs = monitor.mdns.live_ptr_service_names()
         for device in monitor._get_devices():
-            if not device.address or not shared.should_ping(monitor, device):
+            if not device.address or not shared.should_ping(monitor, device, live_ptrs):
                 continue
             if shared.sweep_has_no_target(monitor, device):
                 # The address won't resolve and we have no known IP.

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -60,8 +60,7 @@ def should_ping(
     have a path to come online via DNS + ping.
 
     Sweep-scale callers pass one
-    :meth:`MdnsSource.live_ptr_service_names` snapshot as
-    *live_ptrs* so N devices don't pay N O(cache) PTR scans.
+    :meth:`MdnsSource.live_ptr_service_names` snapshot as *live_ptrs*.
     """
     if device.runtime_state.state != DeviceState.ONLINE:
         return True
@@ -162,6 +161,7 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     zeroconf = monitor.mdns.zeroconf
     if zeroconf is None:
         return
+    live_ptrs = monitor.mdns.live_ptr_service_names()
     candidates = [
         d
         for d in monitor._get_devices()
@@ -169,7 +169,7 @@ async def resolve_non_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
         and is_local_hostname(d.address)
         and d.loaded_integrations
         and "api" not in d.loaded_integrations
-        and should_ping(monitor, d)
+        and should_ping(monitor, d, live_ptrs)
     ]
     if not candidates:
         return

--- a/esphome_device_builder/controllers/_device_state_monitor/shared.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/shared.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Set as AbstractSet
 from typing import TYPE_CHECKING
 
 from ...helpers.hostname import is_local_hostname
 from ...models import Device, DeviceState, ReachabilitySource
+from .helpers import _ESPHOME_SERVICE_TYPE
 
 if TYPE_CHECKING:
     from .controller import DeviceStateMonitor
@@ -42,7 +44,11 @@ _MDNS_HOSTNAME_RESOLVE_TIMEOUT = 3.0
 ICMP_BATCH_SIZE = 24
 
 
-def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
+def should_ping(
+    monitor: DeviceStateMonitor,
+    device: Device,
+    live_ptrs: AbstractSet[str] | None = None,
+) -> bool:
     """
     Decide whether *device* needs an ICMP probe this sweep.
 
@@ -52,17 +58,21 @@ def should_ping(monitor: DeviceStateMonitor, device: Device) -> bool:
     fire for it), which stays sweep-eligible. OFFLINE / UNKNOWN
     devices always get pinged so off-network hosts mDNS can't reach
     have a path to come online via DNS + ping.
+
+    Sweep-scale callers pass one
+    :meth:`MdnsSource.live_ptr_service_names` snapshot as
+    *live_ptrs* so N devices don't pay N O(cache) PTR scans.
     """
     if device.runtime_state.state != DeviceState.ONLINE:
         return True
     source = monitor.state.state_source.get(device.name, ReachabilitySource.UNKNOWN)
     if _SOURCE_PRIORITY.get(source, 0) <= _SOURCE_PRIORITY[ReachabilitySource.PING]:
         return True
-    return (
-        source == ReachabilitySource.MDNS
-        and device.api_enabled
-        and not monitor.mdns.has_live_ptr(device.name)
-    )
+    if source != ReachabilitySource.MDNS or not device.api_enabled:
+        return False
+    if live_ptrs is not None:
+        return f"{device.name}.{_ESPHOME_SERVICE_TYPE}" not in live_ptrs
+    return not monitor.mdns.has_live_ptr(device.name)
 
 
 def apply_ping_result(monitor: DeviceStateMonitor, name: str, rtt_ms: float | None) -> None:
@@ -121,13 +131,14 @@ async def resolve_api_mdns_targets(monitor: DeviceStateMonitor) -> None:
     """
     if monitor.mdns.zeroconf is None:
         return
+    live_ptrs = monitor.mdns.live_ptr_service_names()
     claims = [
         _resolve_and_claim_logged(monitor, d)
         for d in monitor._get_devices()
         if d.api_enabled
         and d.runtime_state.state is DeviceState.ONLINE
-        and should_ping(monitor, d)
-        and monitor.mdns.get_mdns_cache_info(d.name) is not None
+        and should_ping(monitor, d, live_ptrs)
+        and monitor.mdns.has_cached_trace(d.name)
     ]
     # The common case is a single stuck device — don't pay for a gather.
     if len(claims) == 1:

--- a/esphome_device_builder/controllers/devices/reachability.py
+++ b/esphome_device_builder/controllers/devices/reachability.py
@@ -148,10 +148,9 @@ def on_observation(controller: DevicesController, name: str) -> None:
     pushes the snapshot. Not forwarded by the broadcast
     ``subscribe_events`` channel since a per-device freshness
     ping to every connected client would bloat the bus for no
-    UI gain. Skipped entirely with no drawer subscribed — every
-    positive observation (each announce, each ping hit) lands
-    here, and the snapshot walks the zeroconf cache; a subscriber
-    arriving later gets a fresh snapshot from ``send_initial``.
+    UI gain. Skipped entirely with no drawer subscribed; a
+    subscriber arriving later gets a fresh snapshot from
+    ``send_initial``.
     """
     bus = controller._db.bus
     if not bus.has_listeners(EventType.DEVICE_REACHABILITY):

--- a/esphome_device_builder/controllers/devices/reachability.py
+++ b/esphome_device_builder/controllers/devices/reachability.py
@@ -148,12 +148,18 @@ def on_observation(controller: DevicesController, name: str) -> None:
     pushes the snapshot. Not forwarded by the broadcast
     ``subscribe_events`` channel since a per-device freshness
     ping to every connected client would bloat the bus for no
-    UI gain.
+    UI gain. Skipped entirely with no drawer subscribed — every
+    positive observation (each announce, each ping hit) lands
+    here, and the snapshot walks the zeroconf cache; a subscriber
+    arriving later gets a fresh snapshot from ``send_initial``.
     """
+    bus = controller._db.bus
+    if not bus.has_listeners(EventType.DEVICE_REACHABILITY):
+        return
     snapshot = controller._build_reachability_snapshot(name)
     if snapshot is None:
         return
-    controller._db.bus.fire(EventType.DEVICE_REACHABILITY, snapshot)
+    bus.fire(EventType.DEVICE_REACHABILITY, snapshot)
 
 
 async def refresh_device_mdns(controller: DevicesController, name: str) -> None:

--- a/esphome_device_builder/helpers/event_bus.py
+++ b/esphome_device_builder/helpers/event_bus.py
@@ -69,6 +69,10 @@ class EventBus:
         self._listeners.setdefault(event_type, set()).add(listener)
         return partial(self._remove_listener, event_type, listener)
 
+    def has_listeners(self, event_type: EventType) -> bool:
+        """Whether any listener is currently subscribed to *event_type*."""
+        return bool(self._listeners.get(event_type))
+
     def _remove_listener(self, event_type: EventType, listener: _ListenerCallback) -> None:
         self._listeners.get(event_type, set()).discard(listener)
 

--- a/tests/controllers/devices/test_subscribe_reachability.py
+++ b/tests/controllers/devices/test_subscribe_reachability.py
@@ -417,6 +417,21 @@ def test_observation_fires_bus_event_for_known_device(
     assert fired[0].data["ping_last_seen_seconds_ago"] is not None
 
 
+def test_observation_with_no_subscriber_skips_snapshot_build(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """With no drawer listening, the observation short-circuits before the cache walk."""
+    controller = make_controller(tmp_path)
+    bus = EventBus()
+    _seed_device(controller)
+    tracker = _wire_reachability(controller, ReachabilityTracker(), bus, wire_callback=True)
+    controller._build_reachability_snapshot = MagicMock()  # type: ignore[method-assign]
+
+    tracker.observe("kitchen", "ping")
+
+    controller._build_reachability_snapshot.assert_not_called()
+
+
 def test_observation_for_deleted_device_is_dropped(
     tmp_path: Path, make_controller: MakeControllerFactory
 ) -> None:

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -56,3 +56,15 @@ def test_fire_logs_and_continues_when_listener_raises(
         and rec.exc_info is not None
         for rec in caplog.records
     ), [rec.message for rec in caplog.records]
+
+
+def test_has_listeners_tracks_subscribe_and_unsubscribe() -> None:
+    """The accessor flips with the listener set so hot paths can gate event construction."""
+    bus = EventBus()
+    assert bus.has_listeners(EventType.DEVICE_REACHABILITY) is False
+
+    unsubscribe = bus.add_listener(EventType.DEVICE_REACHABILITY, lambda _event: None)
+    assert bus.has_listeners(EventType.DEVICE_REACHABILITY) is True
+
+    unsubscribe()
+    assert bus.has_listeners(EventType.DEVICE_REACHABILITY) is False

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -25,10 +25,12 @@ _SERVICE_NAME = "kitchen._esphomelib._tcp.local."
 def _prime_sweep(monitor: Any, *, cache_trace: bool = True, live_ptr: bool = False) -> None:
     """Wire the fake zeroconf plus the two cache reads the sweep filter makes."""
     monitor.mdns._zeroconf = MagicMock()
-    monitor.mdns.get_mdns_cache_info = MagicMock(  # type: ignore[method-assign]
-        return_value=MagicMock() if cache_trace else None
+    monitor.mdns.has_cached_trace = MagicMock(  # type: ignore[method-assign]
+        return_value=cache_trace
     )
-    monitor.mdns.has_live_ptr = MagicMock(return_value=live_ptr)  # type: ignore[method-assign]
+    monitor.mdns.live_ptr_service_names = MagicMock(  # type: ignore[method-assign]
+        return_value={_SERVICE_NAME} if live_ptr else set()
+    )
 
 
 async def test_sweep_claims_mdns_for_ping_owned_online_device(
@@ -217,6 +219,45 @@ def test_has_live_ptr_reads_the_browser_cache() -> None:
 
     monitor.mdns._zeroconf = None
     assert monitor.mdns.has_live_ptr("kitchen") is False
+
+
+def test_live_ptr_service_names_snapshots_unexpired_aliases() -> None:
+    """One cache pass yields the live aliases; expired entries drop out."""
+    monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
+    fake_zeroconf = MagicMock()
+    monitor.mdns._zeroconf = fake_zeroconf
+    live = MagicMock(alias=_SERVICE_NAME)
+    live.is_expired.return_value = False
+    expired = MagicMock(alias="porch._esphomelib._tcp.local.")
+    expired.is_expired.return_value = True
+    fake_zeroconf.zeroconf.cache.get_all_by_details.return_value = [live, expired]
+
+    assert monitor.mdns.live_ptr_service_names() == {_SERVICE_NAME}
+    fake_zeroconf.zeroconf.cache.get_all_by_details.assert_called_once()
+
+    monitor.mdns._zeroconf = None
+    assert monitor.mdns.live_ptr_service_names() == set()
+
+
+def test_has_cached_trace_checks_each_record_bucket() -> None:
+    """Any cached record — address, SRV/TXT, or live PTR — counts as a trace."""
+    monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
+    fake_zeroconf = MagicMock()
+    monitor.mdns._zeroconf = fake_zeroconf
+    cache = fake_zeroconf.zeroconf.cache
+    cache.get_all_by_details.return_value = []
+    cache.current_entry_with_name_and_alias.return_value = None
+    assert monitor.mdns.has_cached_trace("kitchen") is False
+
+    cache.current_entry_with_name_and_alias.return_value = MagicMock()
+    assert monitor.mdns.has_cached_trace("kitchen") is True
+
+    cache.current_entry_with_name_and_alias.return_value = None
+    cache.get_all_by_details.return_value = [MagicMock()]
+    assert monitor.mdns.has_cached_trace("kitchen") is True
+
+    monitor.mdns._zeroconf = None
+    assert monitor.mdns.has_cached_trace("kitchen") is False
 
 
 def _gated_wire(info: MagicMock, *, result: bool) -> tuple[asyncio.Event, list[int]]:

--- a/tests/test_mdns_resolve_first.py
+++ b/tests/test_mdns_resolve_first.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from zeroconf.const import _CLASS_IN, _TYPE_A, _TYPE_AAAA, _TYPE_PTR, _TYPE_SRV, _TYPE_TXT
 
 from esphome_device_builder.controllers._device_state_monitor import mdns as mdns_module
 from esphome_device_builder.controllers._device_state_monitor import shared
@@ -233,27 +234,36 @@ def test_live_ptr_service_names_snapshots_unexpired_aliases() -> None:
     fake_zeroconf.zeroconf.cache.get_all_by_details.return_value = [live, expired]
 
     assert monitor.mdns.live_ptr_service_names() == {_SERVICE_NAME}
-    fake_zeroconf.zeroconf.cache.get_all_by_details.assert_called_once()
+    fake_zeroconf.zeroconf.cache.get_all_by_details.assert_called_once_with(
+        "_esphomelib._tcp.local.", _TYPE_PTR, _CLASS_IN
+    )
 
     monitor.mdns._zeroconf = None
     assert monitor.mdns.live_ptr_service_names() == set()
 
 
 def test_has_cached_trace_checks_each_record_bucket() -> None:
-    """Any cached record — address, SRV/TXT, or live PTR — counts as a trace."""
+    """Address, SRV, TXT, and live-PTR buckets each independently count as a trace."""
     monitor, _callbacks = make_state_monitor_with_callbacks([make_online_api_device()])
     fake_zeroconf = MagicMock()
     monitor.mdns._zeroconf = fake_zeroconf
     cache = fake_zeroconf.zeroconf.cache
-    cache.get_all_by_details.return_value = []
+    buckets: dict[tuple[str, int], list[Any]] = {}
+    cache.get_all_by_details.side_effect = lambda name, type_, _cls: buckets.get((name, type_), [])
     cache.current_entry_with_name_and_alias.return_value = None
     assert monitor.mdns.has_cached_trace("kitchen") is False
 
-    cache.current_entry_with_name_and_alias.return_value = MagicMock()
-    assert monitor.mdns.has_cached_trace("kitchen") is True
+    for bucket_key in [
+        ("kitchen.local.", _TYPE_A),
+        ("kitchen.local.", _TYPE_AAAA),
+        (_SERVICE_NAME, _TYPE_SRV),
+        (_SERVICE_NAME, _TYPE_TXT),
+    ]:
+        buckets[bucket_key] = [MagicMock()]
+        assert monitor.mdns.has_cached_trace("kitchen") is True, bucket_key
+        buckets.clear()
 
-    cache.current_entry_with_name_and_alias.return_value = None
-    cache.get_all_by_details.return_value = [MagicMock()]
+    cache.current_entry_with_name_and_alias.return_value = MagicMock()
     assert monitor.mdns.has_cached_trace("kitchen") is True
 
     monitor.mdns._zeroconf = None


### PR DESCRIPTION
# What does this implement/fix?

The mdns.py /simplify efficiency review found two O(N²)-per-sweep terms plus a hot-path tidy-up, all measurable at ~1000-device fleet scale. This applies them, behaviour-preserving:

- **One live-PTR snapshot per sweep instead of N O(cache) scans.** zeroconf's per-alias PTR lookup (`current_entry_with_name_and_alias`) materialises and scans every esphomelib PTR on the LAN; `should_ping`'s live-PTR branch runs it per device per sweep — 1M record touches per sweep at 1000 devices. New `MdnsSource.live_ptr_service_names()` does one `get_all_by_details` pass building the unexpired-alias set; `should_ping` takes it as an optional `live_ptrs` argument (membership key is the same full-service-name comparison the per-alias lookup makes, so semantics are unchanged — including exact case sensitivity). The ping sweep's `_select_ping_targets` and `resolve_api_mdns_targets` each snapshot once per pass; single-device callers (`probe_device_ping`) keep the per-name `has_live_ptr`.
- **Reachability snapshots are gated on an actual subscriber.** Every positive observation (each announce, each ping hit) built the full `MdnsCacheInfo` snapshot — five cache walks including the PTR scan above — and fired it into a listener set that is empty whenever no drawer is open, the common state. New `EventBus.has_listeners(event_type)` accessor; `on_observation` short-circuits before the cache walk. Nothing is lost: the drawer subscription attaches its listener before `_send_initial`, which re-sends a fresh snapshot on subscribe.
- **`resolve_api_mdns_targets`'s trace gate stops paying for a full snapshot.** It used `get_mdns_cache_info(...) is not None` as an existence check — full record walk, TXT decode, dataclass build, all discarded except truthiness. New `MdnsSource.has_cached_trace(name)` mirrors the same record gathering (expired A/AAAA/SRV/TXT included, PTR live-only) with no decode or allocation.

The review's fourth item — reusing `AddressResolver` instances in `get_cached_addresses` — is deliberately **not** applied: a reused `ServiceInfo` retains address records from earlier loads (zeroconf doesn't remove cache-evicted entries from the info object), so reuse could return stale addresses — the #1776 latch class. Noted here so it isn't re-proposed.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2043

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
