### PR TITLE
Bound the ping pass to a worker pool and dedupe duplicate-name probes

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/ping.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/ping.py
@@ -161,23 +161,45 @@ class PingSource(SweepSource):
                     _LOGGER.debug(
                         "Pinging %d devices: %s", len(pingable), _format_devices(pingable)
                     )
-        # ``self.icmp_concurrency`` semaphore caps in-flight ICMP at
-        # ``ICMP_BATCH_SIZE``; no need to pre-chunk the gather.
-        results = await asyncio.gather(
-            *(self._resolve_and_ping(device) for device in pingable),
-            return_exceptions=True,
-        )
-        log_gather_failures(results, "Ping pass failed for a device; continuing")
+        # The worker count caps this sweep's own fan-out (no parked
+        # Task per device); ``self.icmp_concurrency`` stays acquired
+        # per probe because it is the *cross-consumer* budget — the
+        # reviver's pre-filter holds the same semaphore, so a
+        # concurrent sweep + reviver still total ICMP_BATCH_SIZE.
+        # Workers share one iterator; a per-device failure is logged
+        # and the worker moves on.
+        iterator = iter(pingable)
+
+        async def _drain() -> None:
+            for device in iterator:
+                try:
+                    await self._resolve_and_ping(device)
+                except Exception:
+                    _LOGGER.warning(
+                        "Ping pass failed for %s; continuing", device.name, exc_info=True
+                    )
+
+        workers = min(shared.ICMP_BATCH_SIZE, len(pingable))
+        await asyncio.gather(*(_drain() for _ in range(workers)))
 
     def _select_ping_targets(self) -> tuple[list[Device], list[Device]]:
         """Return ``(pingable, dns_failed)`` and apply per-device side-effects."""
         pingable: list[Device] = []
         dns_failed: list[Device] = []
+        seen: set[tuple[str, str]] = set()
         monitor = self._monitor
         live_ptrs = monitor.mdns.live_ptr_service_names()
         for device in monitor._get_devices():
             if not device.address or not shared.should_ping(monitor, device, live_ptrs):
                 continue
+            key = (device.name, device.address)
+            if key in seen:
+                # Duplicate-name YAMLs share one broadcast; the apply
+                # path fans a probe's result out to the whole name
+                # bucket, so a second probe of the same pair is pure
+                # duplicate packets.
+                continue
+            seen.add(key)
             if shared.sweep_has_no_target(monitor, device):
                 # The address won't resolve and we have no known IP.
                 # Don't hand the bare hostname to icmplib (it would hammer

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1785,6 +1785,30 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
         await _stop_and_drain(monitor)
 
 
+async def test_ping_pass_failure_for_one_device_does_not_skip_the_rest(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raising per-device probe is logged; the workers keep draining the queue."""
+    bad = _device(name="bad", address="bad.example.com")
+    good = _device(name="good", address="good.example.com")
+    monitor, _callbacks = _make_monitor([bad, good])
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
+    probed: list[str] = []
+
+    async def _probe(device: Device) -> None:
+        probed.append(device.name)
+        if device.name == "bad":
+            raise RuntimeError("boom")
+
+    monitor.ping._resolve_and_ping = _probe  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING):
+        await monitor.ping._ping_sweep()
+
+    assert sorted(probed) == ["bad", "good"]
+    assert "Ping pass failed for bad; continuing" in caplog.text
+
+
 def test_apply_ip_short_circuits_when_value_unchanged() -> None:
     """``apply_ip`` is a no-op when both primary + list already match.
 

--- a/tests/test_state_monitor_reachability.py
+++ b/tests/test_state_monitor_reachability.py
@@ -214,6 +214,19 @@ def test_lower_priority_offline_does_not_drop_higher_priority_online() -> None:
     assert monitor.state.state_source["kitchen"] == "mdns"
 
 
+def test_select_ping_targets_dedupes_duplicate_name_pairs() -> None:
+    """Duplicate-name YAMLs share one probe; the apply path fans the result out."""
+    first = _make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])
+    twin = _make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])
+    monitor = _make_monitor([first, twin])
+    monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
+
+    pingable, dns_failed = monitor.ping._select_ping_targets()
+
+    assert pingable == [first]
+    assert dns_failed == []
+
+
 def test_select_ping_targets_keeps_device_with_known_ip_when_dns_failed() -> None:
     """A cached DNS failure with a known IP pings the IP, not OFFLINE+dns_failed."""
     devices = [_make_device(state=DeviceState.OFFLINE, ip_addresses=["10.0.0.5"])]


### PR DESCRIPTION
# What does this implement/fix?

Finishes #2047 on top of #2049 (which removed the super-linear PTR term and the cache-trace gate cost). Two remaining fleet-scale costs in the ping pass:

- The ping pass now drains through at most `ICMP_BATCH_SIZE` workers sharing one iterator instead of materializing one parked Task per device behind the semaphore; at 1000 devices that is 24 Tasks instead of ~1000, and a per-device failure is now logged with the device name (the old `return_exceptions` gather logged it anonymously). The `icmp_concurrency` semaphore stays acquired per probe: it is the cross-consumer budget shared with the reviver's pre-filter, so a concurrent sweep + reviver still total `ICMP_BATCH_SIZE` in flight, which the worker cap alone would not bound.
- `_select_ping_targets` dedupes by `(name, address)`: duplicate-name YAMLs share one broadcast and the apply path fans a probe's result out to the whole bucket, so the second probe was pure duplicate packets (the reviver already dedupes by pair for the same reason).

Two issue items deliberately not taken, with rationale: carrying cached addresses from selection into `_resolve_and_ping` would split the `sweep_has_no_target` predicate the reviver shares, for a cost the #2046 cheap-first reorder already reduced to one cache walk per dns-failed `.local` device; and resolving outside the ICMP slot stays as-is since holding one slot across resolve + ping is a documented deliberate bound.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2047

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
