### PR TITLE
Refresh stale docs caches in sync_components and cover them in --clean

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -45,6 +45,7 @@ import re
 import shutil
 import sys
 import textwrap
+import time
 import unicodedata
 import urllib.request
 import zipfile
@@ -95,6 +96,10 @@ _DOCS_INDEX_URL = (
 _DOCS_REPO_URL = "https://github.com/esphome/esphome.io.git"
 _DOCS_REPO_BRANCH = "current"
 _DOCS_CLONE_DIR = "esphome.io"
+_DOCS_INDEX_CACHE_NAME = "esphome.io-index.mdx"
+# The docs index is a moving target (new components land weekly), unlike
+# the version-keyed schema bundles which cache immutably.
+_DOCS_INDEX_MAX_AGE = 24 * 3600.0
 _IMAGE_BASE_URL = "https://esphome.io/images/"
 
 # CDN at schema.esphome.io rejects requests without a recognisable
@@ -946,7 +951,7 @@ def main() -> int:
     parser.add_argument(
         "--clean",
         action="store_true",
-        help="Wipe cached schemas before fetching.",
+        help="Wipe cached schemas and docs-derived caches before fetching.",
     )
     parser.add_argument(
         "--limit-component",
@@ -958,9 +963,8 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if args.clean and _CACHE_ROOT.exists():
-        for d in _CACHE_ROOT.glob("esphome-schema-*"):
-            shutil.rmtree(d)
+    if args.clean:
+        _clean_caches()
 
     version = args.version or resolve_latest_release(
         include_prereleases=args.include_prereleases,
@@ -1082,6 +1086,18 @@ def ensure_schema(version: str) -> Path:
         msg = f"Schema bundle layout unexpected — missing {schema_dir}"
         raise RuntimeError(msg)
     return schema_dir
+
+
+def _clean_caches() -> None:
+    """Wipe the cached schema bundles and the docs-derived caches."""
+    if not _CACHE_ROOT.exists():
+        return
+    for d in _CACHE_ROOT.glob("esphome-schema-*"):
+        shutil.rmtree(d)
+    (_CACHE_ROOT / _DOCS_INDEX_CACHE_NAME).unlink(missing_ok=True)
+    docs_clone = _CACHE_ROOT / _DOCS_CLONE_DIR
+    if docs_clone.exists():
+        shutil.rmtree(docs_clone)
 
 
 def _http_get(url: str, *, timeout: int = 30) -> bytes:
@@ -2281,19 +2297,29 @@ def load_image_map() -> dict[str, str]:
     where ``component_id`` matches our catalog ids (qualified with
     ``<domain>.<id>`` for platform-providing components).
 
-    No ImagesMap if the docs file can't be fetched — image_url stays
+    Cached under ``.cache/`` for ``_DOCS_INDEX_MAX_AGE`` — the index gains
+    rows between releases, so a bare exists() cache silently dropped
+    ``image_url`` for newer components (#2053). No ImagesMap if the docs
+    file can't be fetched and no cached copy exists — image_url stays
     empty for every component.
     """
-    cache_file = _CACHE_ROOT / "esphome.io-index.mdx"
+    cache_file = _CACHE_ROOT / _DOCS_INDEX_CACHE_NAME
     cache_file.parent.mkdir(parents=True, exist_ok=True)
-    if not cache_file.exists():
+    stale = (
+        not cache_file.exists() or time.time() - cache_file.stat().st_mtime > _DOCS_INDEX_MAX_AGE
+    )
+    if stale:
         try:
             cache_file.write_bytes(_http_get(_DOCS_INDEX_URL))
         except Exception:
+            if not cache_file.exists():
+                _LOGGER.warning(
+                    "Could not fetch docs index page — image URLs will be empty",
+                )
+                return {}
             _LOGGER.warning(
-                "Could not fetch docs index page — image URLs will be empty",
+                "Could not refresh docs index page — using the stale cached copy",
             )
-            return {}
 
     text = cache_file.read_text(errors="ignore")
     pattern = re.compile(

--- a/tests/test_sync_components_image_map_cache.py
+++ b/tests/test_sync_components_image_map_cache.py
@@ -1,0 +1,96 @@
+"""Docs-cache invalidation in ``script/sync_components.py`` (#2053)."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from script import sync_components  # type: ignore[import-not-found]
+
+_INDEX_ROW = b'["DHT", "/components/sensor/dht/", "dht.svg"]'
+_FRESH_ROW = b'["IMU", "/components/sensor/imu/", "imu.svg"]'
+
+
+@pytest.fixture
+def cache_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(sync_components, "_CACHE_ROOT", tmp_path)
+    return tmp_path
+
+
+def _write_index(cache_root: Path, payload: bytes, *, age: float = 0.0) -> Path:
+    cache_file = cache_root / sync_components._DOCS_INDEX_CACHE_NAME
+    cache_file.write_bytes(payload)
+    if age:
+        stamp = time.time() - age
+        os.utime(cache_file, (stamp, stamp))
+    return cache_file
+
+
+def test_fresh_cache_skips_the_fetch(cache_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_index(cache_root, _INDEX_ROW)
+
+    def _boom(url: str, **kwargs: object) -> bytes:
+        raise AssertionError("fresh cache must not refetch")
+
+    monkeypatch.setattr(sync_components, "_http_get", _boom)
+    image_map = sync_components.load_image_map()
+    assert image_map["sensor.dht"].endswith("dht.svg")
+
+
+def test_stale_cache_is_refetched(cache_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache_file = _write_index(cache_root, _INDEX_ROW, age=sync_components._DOCS_INDEX_MAX_AGE + 60)
+    monkeypatch.setattr(sync_components, "_http_get", lambda url, **kw: _FRESH_ROW)
+    image_map = sync_components.load_image_map()
+    assert cache_file.read_bytes() == _FRESH_ROW
+    assert "sensor.imu" in image_map
+    assert "sensor.dht" not in image_map
+
+
+def test_stale_cache_survives_a_failed_refresh(
+    cache_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_index(cache_root, _INDEX_ROW, age=sync_components._DOCS_INDEX_MAX_AGE + 60)
+
+    def _boom(url: str, **kwargs: object) -> bytes:
+        raise OSError("offline")
+
+    monkeypatch.setattr(sync_components, "_http_get", _boom)
+    image_map = sync_components.load_image_map()
+    assert image_map["sensor.dht"].endswith("dht.svg")
+
+
+def test_missing_cache_and_failed_fetch_returns_empty(
+    cache_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(url: str, **kwargs: object) -> bytes:
+        raise OSError("offline")
+
+    monkeypatch.setattr(sync_components, "_http_get", _boom)
+    assert sync_components.load_image_map() == {}
+
+
+def test_clean_caches_removes_schemas_and_docs_caches(cache_root: Path) -> None:
+    schema_dir = cache_root / "esphome-schema-2026.6.0"
+    schema_dir.mkdir(parents=True)
+    (schema_dir / "schema.json").write_text("{}")
+    docs_clone = cache_root / sync_components._DOCS_CLONE_DIR
+    docs_clone.mkdir()
+    (docs_clone / "index.mdx").write_text("x")
+    index_cache = _write_index(cache_root, _INDEX_ROW)
+    unrelated = cache_root / "esphome-devices"
+    unrelated.mkdir()
+
+    sync_components._clean_caches()
+
+    assert not schema_dir.exists()
+    assert not docs_clone.exists()
+    assert not index_cache.exists()
+    assert unrelated.exists()
+
+
+def test_clean_caches_tolerates_a_missing_cache_root(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(sync_components, "_CACHE_ROOT", tmp_path / "absent")
+    sync_components._clean_caches()


### PR DESCRIPTION
# What does this implement/fix?

The docs `components/index.mdx` cache under `.cache/` was guarded by a bare exists() check, so a local checkout never refreshed it; a stale copy silently dropped `image_url` for components added to the docs index since the cache was written, while CI (no cache) kept them.

The cache now refreshes once it is older than 24 hours; if the refresh fetch fails the stale copy is still used, and the empty map (which trips the sentinel abort) only happens when there is no cached copy at all. `--clean` now also wipes the docs-derived caches (the index file and the esphome.io clone), not just the schema bundles. The version-keyed schema bundles keep their immutable caching.

**Related issue or feature (if applicable):**

- fixes #2053

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
