### PR TITLE
Advertise the HA add-on identity on mDNS

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -441,12 +441,12 @@ The receiver advertises the listener's port over mDNS as a TXT property:
 |---|---|---|
 | `server_version` | `"1.2.3"` | always |
 | `esphome_version` | `"2026.5.0"` | always |
-| `friendly_name` | human machine label (e.g. `"MacBook-Pro"`; the HA add-on advertises `"Home Assistant"`) | when a friendly name is set (always in practice) |
+| `friendly_name` | human machine label (e.g. `"MacBook-Pro"`; the HA add-on's is its Supervisor container hostname, e.g. `"5c53de3b-esphome"`) | when a friendly name is set (always in practice) |
 | `pin_sha256` | lowercase-hex SHA-256 of the X25519 peer-link pubkey | when the peer-link listener is bound |
 | `remote_build_port` | stringified int (e.g. `"6055"`) — the port actually bound, which may differ from `--remote-build-port` when a taken port fell forward to the next free one | when the peer-link listener is bound (same condition as `pin_sha256`) |
-| `ha_addon` | `"1"` | only when the dashboard is the HA add-on, so peers can label it `"Home Assistant"` |
+| `ha_addon` | `"1"` | only when the dashboard is the HA add-on, so peers can label it `"Home Assistant App"` (the frontend derives the same from the container hostname when the flag is absent) |
 
-The service-instance name and SRV target are stable per-install identifiers (`esphome-builder-<dashboard_id[:8]>.local`) derived from the persisted `dashboard_id`, not the OS hostname, so they don't change across reboots; `friendly_name` carries the human machine label for display (the HA add-on's container hostname is opaque, so it advertises the literal `"Home Assistant"`).
+The service-instance name and SRV target are stable per-install identifiers (`esphome-builder-<dashboard_id[:8]>.local`) derived from the persisted `dashboard_id`, not the OS hostname, so they don't change across reboots; `friendly_name` carries the human machine label for display. The HA add-on's `friendly_name` is its Supervisor-assigned container hostname (`<repo-hash>-esphome`, with `-beta` / `-dev` channel suffixes), which the frontend maps to `"Home Assistant App"`; the `ha_addon` TXT flag is an additive confirmation.
 
 Same-subnet peers read `remote_build_port` from TXT so a `--remote-build-port` override is auto-discovered. Cross-subnet peers type the port into the pair dialog (it's an arg on `request_pair`).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -441,11 +441,12 @@ The receiver advertises the listener's port over mDNS as a TXT property:
 |---|---|---|
 | `server_version` | `"1.2.3"` | always |
 | `esphome_version` | `"2026.5.0"` | always |
-| `friendly_name` | human machine label (e.g. `"MacBook-Pro"`) | when a friendly name is set (always in practice) |
+| `friendly_name` | human machine label (e.g. `"MacBook-Pro"`; the HA add-on advertises `"Home Assistant"`) | when a friendly name is set (always in practice) |
 | `pin_sha256` | lowercase-hex SHA-256 of the X25519 peer-link pubkey | when the peer-link listener is bound |
 | `remote_build_port` | stringified int (e.g. `"6055"`) — the port actually bound, which may differ from `--remote-build-port` when a taken port fell forward to the next free one | when the peer-link listener is bound (same condition as `pin_sha256`) |
+| `ha_addon` | `"1"` | only when the dashboard is the HA add-on, so peers can label it `"Home Assistant"` |
 
-The service-instance name and SRV target are stable per-install identifiers (`esphome-builder-<dashboard_id[:8]>.local`) derived from the persisted `dashboard_id`, not the OS hostname, so they don't change across reboots; `friendly_name` carries the human machine label for display.
+The service-instance name and SRV target are stable per-install identifiers (`esphome-builder-<dashboard_id[:8]>.local`) derived from the persisted `dashboard_id`, not the OS hostname, so they don't change across reboots; `friendly_name` carries the human machine label for display (the HA add-on's container hostname is opaque, so it advertises the literal `"Home Assistant"`).
 
 Same-subnet peers read `remote_build_port` from TXT so a `--remote-build-port` override is auto-discovered. Cross-subnet peers type the port into the pair dialog (it's an arg on `request_pair`).
 

--- a/esphome_device_builder/controllers/remote_build/_mdns.py
+++ b/esphome_device_builder/controllers/remote_build/_mdns.py
@@ -106,7 +106,8 @@ def peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer
     remote_build_port = decode_txt_port(properties.get(b"remote_build_port"))
     # Human machine label; ``""`` for older receivers that don't send it.
     friendly_name = decode_txt_value(properties.get(b"friendly_name"))
-    # Present only on the HA add-on, so peers can label it "Home Assistant".
+    # Present only on the HA add-on; an additive hint for the "Home Assistant
+    # App" label the UI otherwise derives from the container hostname.
     ha_addon = decode_txt_value(properties.get(b"ha_addon")) == "1"
     # ``info.name`` comes back as ``<instance>.<service_type>``;
     # we only want the leftmost label (the stable instance label).

--- a/esphome_device_builder/controllers/remote_build/_mdns.py
+++ b/esphome_device_builder/controllers/remote_build/_mdns.py
@@ -106,8 +106,7 @@ def peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer
     remote_build_port = decode_txt_port(properties.get(b"remote_build_port"))
     # Human machine label; ``""`` for older receivers that don't send it.
     friendly_name = decode_txt_value(properties.get(b"friendly_name"))
-    # Present only on the HA add-on; an additive hint for the "Home Assistant
-    # App" label the UI otherwise derives from the container hostname.
+    # ``ha_addon`` TXT key: ``"1"`` only when the peer is the HA add-on.
     ha_addon = decode_txt_value(properties.get(b"ha_addon")) == "1"
     # ``info.name`` comes back as ``<instance>.<service_type>``;
     # we only want the leftmost label (the stable instance label).

--- a/esphome_device_builder/controllers/remote_build/_mdns.py
+++ b/esphome_device_builder/controllers/remote_build/_mdns.py
@@ -106,6 +106,8 @@ def peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer
     remote_build_port = decode_txt_port(properties.get(b"remote_build_port"))
     # Human machine label; ``""`` for older receivers that don't send it.
     friendly_name = decode_txt_value(properties.get(b"friendly_name"))
+    # Present only on the HA add-on, so peers can label it "Home Assistant".
+    ha_addon = decode_txt_value(properties.get(b"ha_addon")) == "1"
     # ``info.name`` comes back as ``<instance>.<service_type>``;
     # we only want the leftmost label (the stable instance label).
     instance = (info.name or name).split(".", 1)[0]
@@ -121,4 +123,5 @@ def peer_from_service_info(name: str, info: AsyncServiceInfo) -> RemoteBuildPeer
         friendly_name=friendly_name,
         pin_sha256=pin_sha256,
         remote_build_port=remote_build_port,
+        ha_addon=ha_addon,
     )

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -405,10 +405,9 @@ class DeviceBuilder:
                 server_version=server_version,
                 esphome_version=esphome_version,
                 dashboard_id=dashboard_identity.dashboard_id,
+                # Peers read the add-on's Supervisor container hostname
+                # (``friendly_name``) plus this flag to label it "Home Assistant".
                 on_ha_addon=self.settings.on_ha_addon,
-                # The add-on's container hostname is opaque; give peers a
-                # human label to show instead.
-                name="Home Assistant" if self.settings.on_ha_addon else None,
             )
 
         await self.remote_build_receiver.start()

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -405,6 +405,10 @@ class DeviceBuilder:
                 server_version=server_version,
                 esphome_version=esphome_version,
                 dashboard_id=dashboard_identity.dashboard_id,
+                on_ha_addon=self.settings.on_ha_addon,
+                # The add-on's container hostname is opaque; give peers a
+                # human label to show instead.
+                name="Home Assistant" if self.settings.on_ha_addon else None,
             )
 
         await self.remote_build_receiver.start()

--- a/esphome_device_builder/device_builder.py
+++ b/esphome_device_builder/device_builder.py
@@ -405,8 +405,6 @@ class DeviceBuilder:
                 server_version=server_version,
                 esphome_version=esphome_version,
                 dashboard_id=dashboard_identity.dashboard_id,
-                # Peers read the add-on's Supervisor container hostname
-                # (``friendly_name``) plus this flag to label it "Home Assistant".
                 on_ha_addon=self.settings.on_ha_addon,
             )
 

--- a/esphome_device_builder/helpers/dashboard_advertise.py
+++ b/esphome_device_builder/helpers/dashboard_advertise.py
@@ -308,6 +308,7 @@ class DashboardAdvertiser:
         name: str | None = None,
         hostname: str | None = None,
         dashboard_id: str | None = None,
+        on_ha_addon: bool = False,
     ) -> None:
         """
         Capture the static fields used in the published ``ServiceInfo``.
@@ -340,6 +341,10 @@ class DashboardAdvertiser:
         main HTTP port (``port`` arg) so the existing browse path
         for general dashboard discovery isn't broken. ``None`` when
         the listener isn't bound (default-off shape).
+
+        ``on_ha_addon`` tags the broadcast as the HA add-on so peers
+        can label it (e.g. "Home Assistant") instead of the opaque
+        container hostname.
         """
         friendly = (name or "").strip() or _default_friendly_name()
         explicit_host = (hostname or "").strip()
@@ -354,6 +359,7 @@ class DashboardAdvertiser:
         self._esphome_version = esphome_version
         self._pin_sha256 = pin_sha256
         self._remote_build_port = remote_build_port
+        self._ha_addon = on_ha_addon
         self._info: ServiceInfo | None = None
         self._zeroconf: AsyncEsphomeZeroconf | None = None
         # Background tick that calls :meth:`refresh` on
@@ -479,6 +485,8 @@ class DashboardAdvertiser:
             properties["pin_sha256"] = self._pin_sha256
         if self._remote_build_port is not None:
             properties["remote_build_port"] = str(self._remote_build_port)
+        if self._ha_addon:
+            properties["ha_addon"] = "1"
         # ``server`` is the SRV record's target. Zeroconf appends
         # ``.local.`` if missing; pass it through as-is.
         server = self._hostname if self._hostname.endswith(".") else f"{self._hostname}."

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -271,3 +271,6 @@ class RemoteBuildPeer(DashboardModel):
     # (default-off mode).
     pin_sha256: str = ""
     remote_build_port: int = 0
+    # True when the broadcast is the HA add-on (``ha_addon`` TXT key), so
+    # the UI can label it "Home Assistant" instead of the container hostname.
+    ha_addon: bool = False

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -271,6 +271,7 @@ class RemoteBuildPeer(DashboardModel):
     # (default-off mode).
     pin_sha256: str = ""
     remote_build_port: int = 0
-    # True when the broadcast is the HA add-on (``ha_addon`` TXT key), so
-    # the UI can label it "Home Assistant" instead of the container hostname.
+    # True when the broadcast is the HA add-on (``ha_addon`` TXT key). Additive
+    # confirmation: the UI derives "Home Assistant App" from the Supervisor
+    # container hostname (``friendly_name``) and uses this flag to corroborate.
     ha_addon: bool = False

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -271,7 +271,5 @@ class RemoteBuildPeer(DashboardModel):
     # (default-off mode).
     pin_sha256: str = ""
     remote_build_port: int = 0
-    # True when the broadcast is the HA add-on (``ha_addon`` TXT key). Additive
-    # confirmation: the UI derives "Home Assistant App" from the Supervisor
-    # container hostname (``friendly_name``) and uses this flag to corroborate.
+    # Peer advertised the ``ha_addon`` TXT key (it is the HA add-on).
     ha_addon: bool = False

--- a/esphome_device_builder/models/remote_build/offloader_events.py
+++ b/esphome_device_builder/models/remote_build/offloader_events.py
@@ -186,9 +186,9 @@ class RemoteBuildHostAddedData(TypedDict):
     semantics — frontend keys on ``name`` (mDNS service-instance
     name) and replaces an existing row with the same key.
 
-    ``friendly_name``, ``pin_sha256`` and ``remote_build_port``
-    come from the ``_esphomebuilder._tcp.local.`` TXT record;
-    empty / 0 for receivers that don't broadcast them.
+    ``friendly_name``, ``pin_sha256``, ``remote_build_port`` and
+    ``ha_addon`` come from the ``_esphomebuilder._tcp.local.`` TXT
+    record; empty / 0 / False for receivers that don't broadcast them.
     """
 
     name: str
@@ -201,6 +201,7 @@ class RemoteBuildHostAddedData(TypedDict):
     friendly_name: str
     pin_sha256: str
     remote_build_port: int
+    ha_addon: bool
 
 
 class RemoteBuildHostRemovedData(TypedDict):

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -412,12 +412,12 @@ def test_build_service_info_omits_remote_build_port_when_unset() -> None:
 
 
 def test_build_service_info_carries_ha_addon_when_on_addon() -> None:
-    """The HA add-on tags its broadcast and advertises a human friendly_name."""
-    advertiser = _make_advertiser(name="Home Assistant", hostname="green.local", on_ha_addon=True)
+    """The add-on tags its broadcast; peers label it from the container hostname."""
+    advertiser = _make_advertiser(name="5c53de3b-esphome", hostname="green.local", on_ha_addon=True)
     info = advertiser.build_service_info()
     decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
     assert decoded["ha_addon"] == "1"
-    assert decoded["friendly_name"] == "Home Assistant"
+    assert decoded["friendly_name"] == "5c53de3b-esphome"
 
 
 def test_build_service_info_omits_ha_addon_off_addon() -> None:

--- a/tests/test_dashboard_advertise.py
+++ b/tests/test_dashboard_advertise.py
@@ -42,6 +42,7 @@ def _make_advertiser(
     hostname: str | None = None,
     port: int = 6052,
     pin_sha256: str | None = None,
+    on_ha_addon: bool = False,
 ) -> DashboardAdvertiser:
     return DashboardAdvertiser(
         port=port,
@@ -50,6 +51,7 @@ def _make_advertiser(
         pin_sha256=pin_sha256,
         name=name,
         hostname=hostname,
+        on_ha_addon=on_ha_addon,
     )
 
 
@@ -407,6 +409,23 @@ def test_build_service_info_omits_remote_build_port_when_unset() -> None:
     info = advertiser.build_service_info()
     decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
     assert "remote_build_port" not in decoded
+
+
+def test_build_service_info_carries_ha_addon_when_on_addon() -> None:
+    """The HA add-on tags its broadcast and advertises a human friendly_name."""
+    advertiser = _make_advertiser(name="Home Assistant", hostname="green.local", on_ha_addon=True)
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert decoded["ha_addon"] == "1"
+    assert decoded["friendly_name"] == "Home Assistant"
+
+
+def test_build_service_info_omits_ha_addon_off_addon() -> None:
+    """``ha_addon`` is absent for a normal (non-add-on) dashboard."""
+    advertiser = _make_advertiser(name="green", hostname="green.local")
+    info = advertiser.build_service_info()
+    decoded = {k.decode(): v.decode() for k, v in info.properties.items()}
+    assert "ha_addon" not in decoded
 
 
 def test_set_remote_build_port_updates_subsequent_advertise() -> None:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -106,6 +106,7 @@ def _fake_service_info(
     server_version: str = "1.2.3",
     esphome_version: str = "2026.5.0",
     friendly_name: str = "",
+    ha_addon: bool = False,
 ) -> MagicMock:
     """Build a stand-in for ``AsyncServiceInfo`` carrying the fields we read."""
     info = MagicMock()
@@ -119,6 +120,8 @@ def _fake_service_info(
     }
     if friendly_name:
         info.properties[b"friendly_name"] = friendly_name.encode("utf-8")
+    if ha_addon:
+        info.properties[b"ha_addon"] = b"1"
     return info
 
 
@@ -235,6 +238,7 @@ def test_peer_from_service_info_handles_missing_txt_keys() -> None:
     assert peer.server_version == ""
     assert peer.esphome_version == ""
     assert peer.friendly_name == ""
+    assert peer.ha_addon is False
 
 
 def test_peer_from_service_info_reads_friendly_name_from_txt() -> None:
@@ -243,6 +247,14 @@ def test_peer_from_service_info_reads_friendly_name_from_txt() -> None:
     peer = peer_from_service_info(f"esphome-builder-jwywnve.{SERVICE_TYPE}", info)
     assert peer.name == "esphome-builder-jwywnve"
     assert peer.friendly_name == "MacBook-Pro"
+
+
+def test_peer_from_service_info_reads_ha_addon_from_txt() -> None:
+    """The ``ha_addon`` TXT flag surfaces so peers can label the add-on."""
+    info = _fake_service_info(friendly_name="Home Assistant", ha_addon=True)
+    peer = peer_from_service_info(f"desktop.{SERVICE_TYPE}", info)
+    assert peer.ha_addon is True
+    assert peer.friendly_name == "Home Assistant"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

Add an additive `ha_addon` marker to the dashboard's `_esphomebuilder._tcp` mDNS broadcast so peers can identify the Home Assistant add-on.

- When running as the HA add-on (`settings.on_ha_addon`), advertise an `ha_addon` TXT key (`"1"`).
- Parse it through `peer_from_service_info` into a new `RemoteBuildPeer.ha_addon` field and the `REMOTE_BUILD_HOST_ADDED` payload.

The add-on's `friendly_name` is left as its Supervisor-assigned container hostname (`<repo-hash>-esphome`, with `-beta` / `-dev` channel suffixes). The companion frontend derives the display label ("Home Assistant App", plus the channel) from that hostname and uses this flag as additive confirmation — so we don't overwrite `friendly_name` with a flat "Home Assistant" (an earlier revision did that; it dropped the channel). Non-add-on dashboards are unchanged (no `ha_addon` key).

**Related issue or feature (if applicable):**

- From an onboarding design discussion (no public issue).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1235

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
