### PR TITLE
Cover settings_snapshot

### DIFF
--- a/tests/e2e/test_initial_state_seed.py
+++ b/tests/e2e/test_initial_state_seed.py
@@ -1,0 +1,129 @@
+"""WS-client-driven check that ``initial_state`` seeds a late tab's first paint."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiohttp import web
+from pytest_aiohttp.plugin import AiohttpClient
+
+from esphome_device_builder.api import ws as ws_module
+from esphome_device_builder.device_builder import DeviceBuilder
+from esphome_device_builder.models import DEFAULT_CLEANUP_TTL_SECONDS, JobStatus
+
+from ..conftest import MakeSettingsFactory
+
+_FAKE_ESPHOME_OK = (
+    "import sys\n"
+    "print('INFO Reading configuration kitchen.yaml...')\n"
+    "print('INFO Compile finished.')\n"
+    "sys.exit(0)\n"
+)
+
+
+async def _send_command(ws: Any, command: str, message_id: str, **args: Any) -> None:
+    """Send a ``CommandMessage``-shaped frame over *ws*."""
+    await ws.send_json({"command": command, "message_id": message_id, "args": args})
+
+
+async def _recv_until(ws: Any, *, predicate: Any, timeout: float = 10.0) -> dict[str, Any]:
+    """Drain WS frames until *predicate(frame)* is truthy; return that frame."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            msg = "timed out waiting for predicate to match"
+            raise TimeoutError(msg)
+        frame = (await ws.receive(timeout=remaining)).json()
+        if predicate(frame):
+            return frame
+
+
+async def _subscribe_and_get_initial(ws: Any, message_id: str) -> dict[str, Any]:
+    """Subscribe and return the ``initial_state`` snapshot payload."""
+    await _send_command(ws, "subscribe_events", message_id)
+    initial = await _recv_until(ws, predicate=lambda f: f.get("event") == "initial_state")
+    return initial["data"]
+
+
+@pytest.fixture
+async def local_dashboard(
+    make_settings: MakeSettingsFactory,
+    _hermetic_lifecycle: None,
+    aiohttp_client: AiohttpClient,
+    tmp_path: Path,
+) -> Any:
+    """Real ``DeviceBuilder`` wired into an aiohttp WS test client."""
+    settings = make_settings(with_core_path=True)
+    settings.using_password = False
+    db = DeviceBuilder(settings)
+    await db.start()
+
+    app = web.Application()
+    app["device_builder"] = db
+    app["trusted_site"] = True
+    ws_module.init_ws_app(app)
+    app.router.add_routes(ws_module.create_ws_routes())
+
+    client = await aiohttp_client(app)
+    try:
+        yield db, client
+    finally:
+        await db.stop()
+
+
+async def test_initial_state_seeds_receiver_settings_and_jobs(
+    local_dashboard: tuple[DeviceBuilder, Any],
+    tmp_path: Path,
+) -> None:
+    """A late tab paints the Build server panel from the snapshot alone.
+
+    First connection: defaults in the snapshot, then a settings write
+    and a full local compile. Second connection: the snapshot already
+    carries the written settings and the finished job (without its
+    ``output`` buffer) before any follow_jobs subscription exists.
+    """
+    db, client = local_dashboard
+    assert db.firmware is not None
+    db.firmware.state.esphome_cmd = [sys.executable, "-c", _FAKE_ESPHOME_OK]
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+    async with client.ws_connect("/ws") as ws:
+        await ws.receive(timeout=2.0)  # server_version handshake
+
+        initial = await _subscribe_and_get_initial(ws, "sub-1")
+        assert initial["remote_build_settings"] == {
+            "enabled": True,
+            "cleanup_ttl_seconds": DEFAULT_CLEANUP_TTL_SECONDS,
+        }
+        assert initial["firmware_jobs"] == []
+
+        await _send_command(
+            ws, "remote_build/set_settings", "set-1", enabled=True, cleanup_ttl_seconds=7200
+        )
+        await _recv_until(ws, predicate=lambda f: f.get("message_id") == "set-1" and "result" in f)
+
+        await _send_command(ws, "firmware/compile", "comp-1", configuration="kitchen.yaml")
+        completed = await _recv_until(
+            ws, predicate=lambda f: f.get("event") == "job_completed", timeout=15.0
+        )
+        job_id = completed["data"]["job"]["job_id"]
+
+    # A second tab connecting later sees everything in the snapshot.
+    async with client.ws_connect("/ws") as ws:
+        await ws.receive(timeout=2.0)
+
+        initial = await _subscribe_and_get_initial(ws, "sub-2")
+        assert initial["remote_build_settings"] == {
+            "enabled": True,
+            "cleanup_ttl_seconds": 7200,
+        }
+        jobs = {job["job_id"]: job for job in initial["firmware_jobs"]}
+        assert jobs[job_id]["status"] == JobStatus.COMPLETED.value
+        assert jobs[job_id]["configuration"] == "kitchen.yaml"
+        # Same projection follow_jobs replays: no live output buffer.
+        assert "output" not in jobs[job_id]

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -72,6 +72,7 @@ from esphome_device_builder.helpers.peer_link_identity import PeerLinkIdentitySt
 from esphome_device_builder.helpers.remote_build_layout import RemoteBuildPath
 from esphome_device_builder.helpers.version_compat import VersionMatchPolicy
 from esphome_device_builder.models import (
+    DEFAULT_CLEANUP_TTL_SECONDS,
     ErrorCode,
     EventType,
     IdentityView,
@@ -1402,6 +1403,20 @@ async def test_set_settings_round_trips(tmp_path: Path) -> None:
     assert written == RemoteBuildSettingsView(enabled=True)
     read = await controller.receiver.get_settings()
     assert read == RemoteBuildSettingsView(enabled=True)
+
+
+async def test_settings_snapshot_tracks_ram_canonical_settings(tmp_path: Path) -> None:
+    """``settings_snapshot`` reads the RAM-canonical scalars, following writes."""
+    controller = _make_controller(config_dir=tmp_path)
+    assert controller.receiver.settings_snapshot() == {
+        "enabled": True,
+        "cleanup_ttl_seconds": DEFAULT_CLEANUP_TTL_SECONDS,
+    }
+    await controller.receiver.set_settings(enabled=False, cleanup_ttl_seconds=7200)
+    assert controller.receiver.settings_snapshot() == {
+        "enabled": False,
+        "cleanup_ttl_seconds": 7200,
+    }
 
 
 async def test_set_settings_rejects_non_bool(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds the coverage codecov flagged on #2078: `ReceiverController.settings_snapshot()` had no direct test. The new case pins the RAM-canonical contract — the snapshot serves the model defaults after a bare start and follows a `set_settings` write for both scalars.

**Related issue or feature (if applicable):**

- follow-up coverage for #2078

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
