### PR TITLE
Deflake the ping-loop state assertions

### DIFF
--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -1610,7 +1610,7 @@ async def test_repeat_sweep_with_unchanged_targets_logs_once(
     monitor.state.dns_cache.async_resolve = AsyncMock(return_value=["192.0.2.5"])
     monitor.state.dns_cache.has_cached_failure = MagicMock(return_value=False)
     # The shrunk interval gives the loop plenty of room to run
-    # several sweeps inside ``_let_ping_loop_run_briefly``'s window — a
+    # several sweeps inside ``_wait_for_ping_sweep``'s window — a
     # regression that re-logs every cycle would emit multiple
     # "Pinging" lines instead of one.
     _shrink_ping_intervals(monkeypatch)

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -169,23 +169,25 @@ async def _start_with_captured_dispatch(
     return captured["dispatch"]
 
 
-async def _let_ping_loop_run_briefly(
+async def _wait_for_ping_sweep(
     monitor: DeviceStateMonitor, *, until: Callable[[], bool] | None = None
 ) -> None:
-    """Yield long enough for the ping loop (paired with ``_shrink_ping_intervals``) to sweep.
+    """
+    Poll *until* (deadline-bounded, raising on timeout), or one fixed yield without it.
 
-    Positive assertions pass *until* — a loaded CI worker can stretch a
-    sweep past any fixed sleep, so the wait polls for the condition up
-    to a generous deadline. Negative assertions keep the bare fixed
-    yield (there is nothing to wait for).
+    The bare-yield form is for negative assertions — nothing to wait for.
     """
     if monitor._ping_task is None:
         return
     if until is None:
         await asyncio.sleep(0.05)
         return
-    deadline = asyncio.get_running_loop().time() + 5.0
-    while not until() and asyncio.get_running_loop().time() < deadline:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 5.0
+    while not until():
+        if loop.time() >= deadline:
+            msg = "ping loop did not reach the expected state within 5s"
+            raise AssertionError(msg)
         await asyncio.sleep(0.01)
 
 
@@ -1431,7 +1433,7 @@ def test_revisit_importable_seeds_nothing_on_cache_miss(
 
 
 def _shrink_ping_intervals(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Collapse the bootstrap delay + interval so ``_let_ping_loop_run_briefly`` sees sweeps."""
+    """Collapse the bootstrap delay + interval so ``_wait_for_ping_sweep`` sees sweeps."""
     monkeypatch.setattr(ping_module.PingSource, "_bootstrap_delay", 0)
     monkeypatch.setattr(ping_module.PingSource, "_interval", 0.001)
 
@@ -1459,7 +1461,7 @@ async def test_start_drives_ping_pipeline_to_online_state(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(
+        await _wait_for_ping_sweep(
             monitor, until=lambda: device.runtime_state.state == DeviceState.ONLINE
         )
         assert device.runtime_state.state == DeviceState.ONLINE
@@ -1519,7 +1521,7 @@ async def test_start_marks_offline_on_icmp_exception(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(
+        await _wait_for_ping_sweep(
             monitor, until=lambda: device.runtime_state.state == DeviceState.OFFLINE
         )
         assert device.runtime_state.state == DeviceState.OFFLINE
@@ -1552,7 +1554,7 @@ async def test_start_skips_ping_for_cached_dns_failures(
     with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
-            await _let_ping_loop_run_briefly(monitor)
+            await _wait_for_ping_sweep(monitor)
         finally:
             await _stop_and_drain(monitor)
 
@@ -1580,7 +1582,7 @@ async def test_start_logs_ping_count_at_debug(
     with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
-            await _let_ping_loop_run_briefly(monitor)
+            await _wait_for_ping_sweep(monitor)
         finally:
             await _stop_and_drain(monitor)
 
@@ -1616,7 +1618,7 @@ async def test_repeat_sweep_with_unchanged_targets_logs_once(
     with caplog.at_level(logging.DEBUG, logger=ping_module.__name__):
         await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
         try:
-            await _let_ping_loop_run_briefly(monitor)
+            await _wait_for_ping_sweep(monitor)
         finally:
             await _stop_and_drain(monitor)
 
@@ -1698,7 +1700,7 @@ async def test_start_skips_devices_without_address(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(monitor)
+        await _wait_for_ping_sweep(monitor)
         monitor.state.dns_cache.async_resolve.assert_not_called()
     finally:
         await _stop_and_drain(monitor)
@@ -1795,7 +1797,7 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(
+        await _wait_for_ping_sweep(
             monitor, until=lambda: device.runtime_state.state == DeviceState.ONLINE
         )
         assert device.runtime_state.state == DeviceState.ONLINE

--- a/tests/test_state_monitor_lifecycle.py
+++ b/tests/test_state_monitor_lifecycle.py
@@ -169,11 +169,24 @@ async def _start_with_captured_dispatch(
     return captured["dispatch"]
 
 
-async def _let_ping_loop_run_briefly(monitor: DeviceStateMonitor) -> None:
-    """Yield long enough for the ping loop (paired with ``_shrink_ping_intervals``) to sweep."""
+async def _let_ping_loop_run_briefly(
+    monitor: DeviceStateMonitor, *, until: Callable[[], bool] | None = None
+) -> None:
+    """Yield long enough for the ping loop (paired with ``_shrink_ping_intervals``) to sweep.
+
+    Positive assertions pass *until* — a loaded CI worker can stretch a
+    sweep past any fixed sleep, so the wait polls for the condition up
+    to a generous deadline. Negative assertions keep the bare fixed
+    yield (there is nothing to wait for).
+    """
     if monitor._ping_task is None:
         return
-    await asyncio.sleep(0.05)
+    if until is None:
+        await asyncio.sleep(0.05)
+        return
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while not until() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
 
 
 async def _stop_and_drain(monitor: DeviceStateMonitor) -> None:
@@ -1446,7 +1459,9 @@ async def test_start_drives_ping_pipeline_to_online_state(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(monitor)
+        await _let_ping_loop_run_briefly(
+            monitor, until=lambda: device.runtime_state.state == DeviceState.ONLINE
+        )
         assert device.runtime_state.state == DeviceState.ONLINE
     finally:
         await _stop_and_drain(monitor)
@@ -1504,7 +1519,9 @@ async def test_start_marks_offline_on_icmp_exception(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(monitor)
+        await _let_ping_loop_run_briefly(
+            monitor, until=lambda: device.runtime_state.state == DeviceState.OFFLINE
+        )
         assert device.runtime_state.state == DeviceState.OFFLINE
     finally:
         await _stop_and_drain(monitor)
@@ -1778,7 +1795,9 @@ async def test_start_uses_v6_fallback_when_only_v6_in_mdns_cache(
 
     await _start_with_captured_dispatch(monitor, monkeypatch, park_ping_loop=False)
     try:
-        await _let_ping_loop_run_briefly(monitor)
+        await _let_ping_loop_run_briefly(
+            monitor, until=lambda: device.runtime_state.state == DeviceState.ONLINE
+        )
         assert device.runtime_state.state == DeviceState.ONLINE
         assert device.ip == "fe80::1%en0"
     finally:


### PR DESCRIPTION
# What does this implement/fix?

`test_start_uses_v6_fallback_when_only_v6_in_mdns_cache` flaked on the release run: `_let_ping_loop_run_briefly` is a fixed 50ms yield, and a loaded xdist worker stretched the first ping sweep past it, so the device was still UNKNOWN at assert time. The helper now takes an optional `until` condition and polls it up to a generous deadline; the three positive-assertion call sites (two ONLINE, one OFFLINE) pass their expected state, so they wait exactly as long as the sweep needs and no longer. The one negative-assertion site keeps the bare fixed yield since there is nothing to wait for.

**Related issue or feature (if applicable):**

- flaked on https://github.com/esphome/device-builder/actions/runs/29398950914/job/87298874613

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
