### PR TITLE
Provision beta esphome versions on the receiver

### DIFF
--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -26,7 +26,7 @@ from esphome.helpers import rmtree as _esphome_rmtree
 from ...helpers import remote_build_layout
 from ...helpers.async_ import run_in_executor
 from ...helpers.subprocess import run_subprocess_capture
-from ...helpers.version_compat import is_pinnable_version
+from ...helpers.version_compat import is_pinnable_version, pinnable_version_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,9 +125,9 @@ class EnvProvisioner:
         """
         if not is_pinnable_version(installed_version):
             return
-        installed_key = _release_key(installed_version)
+        installed_key = pinnable_version_key(installed_version)
         for venv, version in await run_in_executor(self._list_venvs):
-            if _release_key(version) < installed_key:
+            if pinnable_version_key(version) < installed_key:
                 _LOGGER.info(
                     "Removing stale esphome venv %s (older than installed %s)",
                     version,
@@ -243,18 +243,6 @@ def _venv_esphome_cmd(venv: Path) -> list[str]:
 def _version_in_output(version: str, output: str) -> bool:
     """Whether *version* appears in *output* as a whole token, not inside a longer number."""
     return re.search(rf"(?<![\w.]){re.escape(version)}(?![\w.])", output) is not None
-
-
-def _release_key(version: str) -> tuple[int, ...]:
-    """Sort key for a plain-release version, trailing ``.0`` normalised out.
-
-    So ``2026.6`` and ``2026.6.0`` order equal rather than the shorter one
-    counting as older, which would sweep an effectively-installed venv.
-    """
-    parts = [int(part) for part in version.split(".")]
-    while len(parts) > 1 and parts[-1] == 0:
-        parts.pop()
-    return tuple(parts)
 
 
 def _prepare_venv_dir(venv: Path) -> None:

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -1,9 +1,9 @@
-"""Provision + cache one esphome venv per release version (receiver-side).
+"""Provision + cache one esphome venv per pinnable version (receiver-side).
 
 A receiver whose installed esphome differs from the offloader's builds the
 offloader's version into an isolated venv and compiles from it, instead of
 handing back firmware built with the wrong version. Venvs are cached per
-release under ``<data_dir>/.remote_builds/venvs/esphome-<version>/`` and reused
+version under ``<data_dir>/.remote_builds/venvs/esphome-<version>/`` and reused
 across every device/build; a per-version lock serialises concurrent first
 builds of the same version while different versions build concurrently.
 
@@ -47,7 +47,7 @@ class EnvProvisionError(Exception):
 
 class EnvProvisioner:
     """
-    Create + cache one esphome venv per release version, keyed by version.
+    Create + cache one esphome venv per pinnable version, keyed by version.
 
     Callers serialize on the compile lane (``provision`` in COMPILE,
     ``clean_all`` in RESET_BUILD_ENV, ``sweep_stale`` at start), so a wipe

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -7,8 +7,9 @@ release under ``<data_dir>/.remote_builds/venvs/esphome-<version>/`` and reused
 across every device/build; a per-version lock serialises concurrent first
 builds of the same version while different versions build concurrently.
 
-RELEASE versions only: a dev / prerelease target can't be pinned to a
-reproducible ``pip install esphome==<version>`` and is refused.
+Pinnable versions only (final releases and a/b/rc pre-releases, which PyPI
+publishes): a dev / local target can't be pinned to a reproducible
+``pip install esphome==<version>`` and is refused.
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ from esphome.helpers import rmtree as _esphome_rmtree
 from ...helpers import remote_build_layout
 from ...helpers.async_ import run_in_executor
 from ...helpers.subprocess import run_subprocess_capture
-from ...helpers.version_compat import is_release_version
+from ...helpers.version_compat import is_pinnable_version
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,13 +75,15 @@ class EnvProvisioner:
     async def provision(self, version: str) -> list[str]:
         """Return the esphome command for *version*, building its venv on first use.
 
-        Raises :class:`EnvProvisionError` for a non-release version, or a venv
+        Raises :class:`EnvProvisionError` for an unpinnable version, or a venv
         that won't build or fails its health check; a bad venv is removed so a
         retry starts clean. A warm-cached venv deleted out-of-band re-provisions
         rather than handing back a cmd for a missing interpreter.
         """
-        if not is_release_version(version):
-            raise EnvProvisionError(f"cannot provision non-release esphome version {version!r}")
+        if not is_pinnable_version(version):
+            raise EnvProvisionError(
+                f"cannot provision esphome version {version!r} (not a PyPI release or pre-release)"
+            )
         venv = self.venvs_dir / f"{_VENV_PREFIX}{version}"
         async with self._lock_for(version):
             if not await self._warm(venv, version):
@@ -103,7 +106,7 @@ class EnvProvisioner:
         ``pio_components``, PIO cache) — but only when the venv is already
         cached from the build; a clean is never worth a ``pip install``.
         """
-        if not is_release_version(version):
+        if not is_pinnable_version(version):
             return None
         venv = self.venvs_dir / f"{_VENV_PREFIX}{version}"
         async with self._lock_for(version):
@@ -116,11 +119,11 @@ class EnvProvisioner:
     async def sweep_stale(self, installed_version: str) -> None:
         """Remove cached venvs older than *installed_version* (a startup sweep).
 
-        No-op when *installed_version* isn't a plain release (a dev receiver),
+        No-op when *installed_version* isn't pinnable (a dev receiver),
         since older / newer can't be ordered against it. Runs at receiver start
         before any build, so it never races a provision.
         """
-        if not is_release_version(installed_version):
+        if not is_pinnable_version(installed_version):
             return
         installed_key = _release_key(installed_version)
         for venv, version in await run_in_executor(self._list_venvs):
@@ -153,7 +156,7 @@ class EnvProvisioner:
         return lock
 
     def _list_venvs(self) -> list[tuple[Path, str]]:
-        """``(dir, version)`` for each ``esphome-<release>`` venv on disk."""
+        """``(dir, version)`` for each ``esphome-<version>`` venv on disk."""
         venvs_dir = self.venvs_dir
         if not venvs_dir.is_dir():
             return []
@@ -162,7 +165,7 @@ class EnvProvisioner:
             if not child.is_dir() or not child.name.startswith(_VENV_PREFIX):
                 continue
             version = child.name[len(_VENV_PREFIX) :]
-            if is_release_version(version):
+            if is_pinnable_version(version):
                 found.append((child, version))
         return found
 

--- a/esphome_device_builder/helpers/build_scheduler.py
+++ b/esphome_device_builder/helpers/build_scheduler.py
@@ -25,7 +25,7 @@ from ..models.remote_build import (
     StoredPairing,
 )
 from .api import CommandError
-from .version_compat import VersionMatchPolicy, is_release_version, version_satisfies_policy
+from .version_compat import VersionMatchPolicy, is_pinnable_version, version_satisfies_policy
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -268,14 +268,16 @@ def _no_compatible_peer_message(result: _FilterResult, inputs: BuildSchedulerInp
 
 
 def _provisionable_mismatch(inputs: BuildSchedulerInputs, pairing: StoredPairing) -> bool:
-    """Whether *pairing* can auto-provision this offloader's (release) esphome.
+    """Whether *pairing* can auto-provision this offloader's esphome.
 
     A version-mismatched receiver that advertises ``auto_provision_supported``
     stays eligible because it builds our version into a venv — but only when
-    our own version is a plain release it can pin (a dev offloader can't be
-    provisioned, so don't route a mismatch to it).
+    our own version is pinnable on PyPI (release or a/b/rc pre-release; a dev
+    offloader can't be provisioned, so don't route a mismatch to it).
     """
-    return pairing.auto_provision_supported and is_release_version(inputs.offloader_esphome_version)
+    return pairing.auto_provision_supported and is_pinnable_version(
+        inputs.offloader_esphome_version
+    )
 
 
 def _eligible_pairings(inputs: BuildSchedulerInputs) -> _FilterResult:

--- a/esphome_device_builder/helpers/version_compat.py
+++ b/esphome_device_builder/helpers/version_compat.py
@@ -52,13 +52,21 @@ _RELEASE_RE = re.compile(r"\d+(?:\.\d+)*")
 
 
 def is_release_version(version: str) -> bool:
-    """Return whether *version* is a final release, not a pre / dev / local build.
-
-    Stricter than :func:`is_pep440_version`: only a plain release pins to a
-    reproducible ``pip install esphome==<version>``, so the provisioner
-    refuses anything else (a ``-dev`` build can't be pinned to an exact commit).
-    """
+    """Return whether *version* is a final release, not a pre / dev / local build."""
     return _RELEASE_RE.fullmatch(version) is not None
+
+
+_PINNABLE_RE = re.compile(r"\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?")
+
+
+def is_pinnable_version(version: str) -> bool:
+    """Return whether *version* pins to a reproducible ``pip install esphome==<v>``.
+
+    Final releases and a/b/rc pre-releases are both published to PyPI;
+    a ``-dev`` / local build can't be pinned to an exact commit, so the
+    provisioner refuses it.
+    """
+    return _PINNABLE_RE.fullmatch(version) is not None
 
 
 class VersionMatchPolicy(StrEnum):

--- a/esphome_device_builder/helpers/version_compat.py
+++ b/esphome_device_builder/helpers/version_compat.py
@@ -69,6 +69,31 @@ def is_pinnable_version(version: str) -> bool:
     return _PINNABLE_RE.fullmatch(version) is not None
 
 
+_PINNABLE_KEY_RE = re.compile(r"(\d+(?:\.\d+)*)(?:(a|b|rc)(\d+))?")
+_PRE_ORDER = {"a": 0, "b": 1, "rc": 2}
+
+
+def pinnable_version_key(version: str) -> tuple[tuple[int, ...], int, int, int]:
+    """
+    Sort key for a pinnable version.
+
+    Trailing ``.0`` release parts are normalised out (``2026.6`` orders
+    equal to ``2026.6.0``) and a pre-release orders before its final
+    (``2026.7.0b3 < 2026.7.0``). Raises ``ValueError`` for a version
+    :func:`is_pinnable_version` rejects.
+    """
+    match = _PINNABLE_KEY_RE.fullmatch(version)
+    if match is None:
+        msg = f"not a pinnable version: {version!r}"
+        raise ValueError(msg)
+    parts = [int(part) for part in match.group(1).split(".")]
+    while len(parts) > 1 and parts[-1] == 0:
+        parts.pop()
+    if match.group(2) is None:
+        return (tuple(parts), 1, 0, 0)
+    return (tuple(parts), 0, _PRE_ORDER[match.group(2)], int(match.group(3)))
+
+
 class VersionMatchPolicy(StrEnum):
     """How strictly the offloader filters peers by ESPHome version.
 

--- a/esphome_device_builder/helpers/version_compat.py
+++ b/esphome_device_builder/helpers/version_compat.py
@@ -60,11 +60,11 @@ _PINNABLE_RE = re.compile(r"\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?")
 
 
 def is_pinnable_version(version: str) -> bool:
-    """Return whether *version* pins to a reproducible ``pip install esphome==<v>``.
+    """Return whether *version* is a plain release or an a/b/rc pre-release.
 
-    Final releases and a/b/rc pre-releases are both published to PyPI;
-    a ``-dev`` / local build can't be pinned to an exact commit, so the
-    provisioner refuses it.
+    Exactly the shapes PyPI publishes for esphome, so they pin to a
+    reproducible ``pip install esphome==<v>``; dev / post / local /
+    epoch forms are refused.
     """
     return _PINNABLE_RE.fullmatch(version) is not None
 

--- a/tests/test_build_scheduler.py
+++ b/tests/test_build_scheduler.py
@@ -744,6 +744,24 @@ def test_auto_provision_ignored_when_offloader_is_dev() -> None:
     assert pick_build_path(inputs).path is BuildPath.LOCAL
 
 
+def test_auto_provision_allows_prerelease_offloader() -> None:
+    """A PyPI pre-release offloader can be pinned, so the mismatch routes REMOTE."""
+    pin = "a" * 64
+    pairing = _stub_pairing(
+        pin_sha256=pin, esphome_version="2026.5.0", auto_provision_supported=True
+    )
+    inputs = _inputs(
+        pairings={pin: pairing},
+        open_peer_links={pin},
+        peer_queue_status={pin: _stub_queue_status(pin_sha256=pin)},
+        offloader_esphome_version="2026.7.0b2",
+        version_match_policy=VersionMatchPolicy.RELEASE,
+    )
+    decision = pick_build_path(inputs)
+    assert decision.path is BuildPath.REMOTE
+    assert decision.pin_sha256 == pin
+
+
 def test_version_mismatch_without_auto_provision_falls_back_local() -> None:
     """A mismatched receiver that can't auto-provision still filters to LOCAL."""
     pin = "a" * 64

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -182,8 +182,8 @@ async def test_cached_cmd_returns_none_when_not_provisioned(tmp_path: Path) -> N
     assert await provisioner.cached_cmd("2026.6.4") is None
 
 
-async def test_cached_cmd_refuses_non_release(tmp_path: Path) -> None:
-    """A dev / prerelease version is never cached-servable."""
+async def test_cached_cmd_refuses_unpinnable(tmp_path: Path) -> None:
+    """A dev / local version is never cached-servable."""
     provisioner = EnvProvisioner(data_dir=tmp_path)
     assert await provisioner.cached_cmd("2026.7.0-dev") is None
 
@@ -203,10 +203,10 @@ async def test_cached_cmd_returns_cmd_after_provision(
     assert runner.count("venv") == 1  # no extra build
 
 
-async def test_provision_refuses_non_release(
+async def test_provision_refuses_unpinnable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A dev / prerelease target is refused before any subprocess runs."""
+    """A dev / local target is refused before any subprocess runs."""
     runner = _FakeRunner()
     _patch_runner(monkeypatch, runner)
     provisioner = EnvProvisioner(data_dir=tmp_path)
@@ -215,6 +215,20 @@ async def test_provision_refuses_non_release(
         await provisioner.provision("2026.7.0-dev")
 
     assert runner.calls == []
+
+
+async def test_provision_accepts_prerelease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A PyPI pre-release (beta) provisions and cache-serves like a release."""
+    runner = _FakeRunner()
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    built = await provisioner.provision("2026.7.0b2")
+
+    assert "esphome-2026.7.0b2" in str(built[0])
+    assert await provisioner.cached_cmd("2026.7.0b2") == built
 
 
 @pytest.mark.parametrize("fail_at", ["venv", "install", "version"])

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -299,6 +299,20 @@ async def test_sweep_stale_removes_older_keeps_installed_and_newer(tmp_path: Pat
     assert newer.exists()
 
 
+async def test_sweep_stale_orders_beta_installs(tmp_path: Path) -> None:
+    """A beta-installed receiver sweeps older releases and keeps the final it precedes."""
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    older = await _seed_venv(provisioner, "2026.6.4")
+    earlier_beta = await _seed_venv(provisioner, "2026.7.0b1")
+    final = await _seed_venv(provisioner, "2026.7.0")
+
+    await provisioner.sweep_stale("2026.7.0b3")
+
+    assert not older.exists()
+    assert not earlier_beta.exists()
+    assert final.exists()  # the beta precedes its final; never sweep it
+
+
 async def test_sweep_stale_tolerates_missing_dir_and_skips_non_venv_entries(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_version_compat.py
+++ b/tests/test_version_compat.py
@@ -7,6 +7,7 @@ import pytest
 from esphome_device_builder.helpers.version_compat import (
     VersionMatchPolicy,
     is_pep440_version,
+    is_pinnable_version,
     is_release_version,
     major_versions_match,
     version_satisfies_policy,
@@ -34,6 +35,26 @@ from esphome_device_builder.helpers.version_compat import (
 def test_is_release_version(version: str, expected: bool) -> None:
     """Only plain dotted-numeric releases pass; pre / dev / post / local do not."""
     assert is_release_version(version) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        pytest.param("2026.6.4", True, id="release"),
+        pytest.param("2026.7.0a1", True, id="alpha"),
+        pytest.param("2026.7.0b2", True, id="beta"),
+        pytest.param("2026.7.0rc1", True, id="rc"),
+        pytest.param("2026.7.0-dev", False, id="dev"),
+        pytest.param("1.0.0.post1", False, id="post"),
+        pytest.param("1.0.0+local", False, id="local"),
+        pytest.param("1!2.0.0", False, id="epoch"),
+        pytest.param("", False, id="empty"),
+        pytest.param("not-a-version", False, id="garbage"),
+    ],
+)
+def test_is_pinnable_version(version: str, expected: bool) -> None:
+    """PyPI-published shapes (release plus a/b/rc pre-releases) pass; dev / post / local do not."""
+    assert is_pinnable_version(version) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_version_compat.py
+++ b/tests/test_version_compat.py
@@ -10,6 +10,7 @@ from esphome_device_builder.helpers.version_compat import (
     is_pinnable_version,
     is_release_version,
     major_versions_match,
+    pinnable_version_key,
     version_satisfies_policy,
     versions_match_exactly,
 )
@@ -55,6 +56,20 @@ def test_is_release_version(version: str, expected: bool) -> None:
 def test_is_pinnable_version(version: str, expected: bool) -> None:
     """PyPI-published shapes (release plus a/b/rc pre-releases) pass; dev / post / local do not."""
     assert is_pinnable_version(version) is expected
+
+
+def test_pinnable_version_key_ordering() -> None:
+    """Trailing ``.0`` normalises equal; pre-releases order a < b < rc < final."""
+    key = pinnable_version_key
+    assert key("2026.6") == key("2026.6.0")
+    assert key("2026.6.4") < key("2026.7.0")
+    assert key("2026.7.0a1") < key("2026.7.0b2")
+    assert key("2026.7.0b2") < key("2026.7.0b3")
+    assert key("2026.7.0b3") < key("2026.7.0rc1")
+    assert key("2026.7.0rc1") < key("2026.7.0")
+    assert key("2026.6.4") < key("2026.7.0b1")
+    with pytest.raises(ValueError, match="not a pinnable version"):
+        key("2026.7.0-dev")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

A receiver refused to provision a beta offloader ("cannot provision non-release esphome version '2026.7.0b2'") and fell back to a local build — but betas are published to PyPI and `pip install esphome==2026.7.0b2` is exactly as reproducible as a final release. The provisioner and the dispatch eligibility gate now key on a new `is_pinnable_version` (final releases plus a/b/rc pre-releases); dev and local builds stay refused since they can't be pinned to a commit. `is_release_version` and the version-match policies are unchanged.

Covers both sides: the receiver provisions and cache-serves a beta venv, and the offloader-side scheduler keeps an auto-provision peer eligible for a beta offloader instead of silently routing LOCAL.

**Related issue or feature (if applicable):**

- seen in the field: `*** receiver couldn't provision esphome (cannot provision non-release esphome version '2026.7.0b2'); building locally instead ***`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
