### PR TITLE
Announce slow venv provisions; expose auto-provision on the wire

### DIFF
--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -651,7 +651,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
                     f"no provisioner available to build esphome {version} "
                     "(receiver stopping?); refusing to compile with the installed version"
                 )
-            return await provisioner.provision(version)
+            return await provisioner.provision(
+                version,
+                on_build=lambda line: _ingest_output_line(job, self._db.bus, line),
+            )
         if job.job_type is JobType.CLEAN:
             if provisioner is not None and (cached := await provisioner.cached_cmd(version)):
                 return cached

--- a/esphome_device_builder/controllers/remote_build/_summaries.py
+++ b/esphome_device_builder/controllers/remote_build/_summaries.py
@@ -114,6 +114,7 @@ def pairing_summary(
         last_connect_error=last_connect_error,
         esphome_version=pairing.esphome_version,
         enabled=pairing.enabled,
+        auto_provision_supported=pairing.auto_provision_supported,
     )
 
 

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -76,7 +76,8 @@ class EnvProvisioner:
     async def provision(
         self, version: str, *, on_build: Callable[[str], None] | None = None
     ) -> list[str]:
-        """Return the esphome command for *version*, building its venv on first use.
+        """
+        Return the esphome command for *version*, building its venv on first use.
 
         ``on_build`` fires once with a status line when a cache miss means
         a venv build (a multi-minute ``pip install``) is about to run; a
@@ -96,11 +97,16 @@ class EnvProvisioner:
             if not await self._warm(venv, version):
                 if not await self._is_healthy(venv, version):
                     if on_build is not None:
-                        on_build(
-                            f"Provisioning esphome {version} into an isolated "
-                            "environment; the first build for a version installs "
-                            "it from PyPI and can take a few minutes...\n"
-                        )
+                        # Best-effort observer: a raising hook must not
+                        # fail a provision the build could survive.
+                        try:
+                            on_build(
+                                f"Provisioning esphome {version} into an isolated "
+                                "environment; the first build for a version installs "
+                                "it from PyPI and can take a few minutes...\n"
+                            )
+                        except Exception:
+                            _LOGGER.exception("provision on_build hook failed")
                     await self._build(version, venv)
                     if not await self._is_healthy(venv, version):
                         await run_in_executor(_rmtree, venv)

--- a/esphome_device_builder/controllers/remote_build/env_provisioner.py
+++ b/esphome_device_builder/controllers/remote_build/env_provisioner.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from esphome.core import CORE
@@ -72,8 +73,14 @@ class EnvProvisioner:
         base = self._data_dir if self._data_dir is not None else Path(CORE.data_dir)
         return remote_build_layout.venvs_dir(base)
 
-    async def provision(self, version: str) -> list[str]:
+    async def provision(
+        self, version: str, *, on_build: Callable[[str], None] | None = None
+    ) -> list[str]:
         """Return the esphome command for *version*, building its venv on first use.
+
+        ``on_build`` fires once with a status line when a cache miss means
+        a venv build (a multi-minute ``pip install``) is about to run; a
+        warm or healthy cached venv fires nothing.
 
         Raises :class:`EnvProvisionError` for an unpinnable version, or a venv
         that won't build or fails its health check; a bad venv is removed so a
@@ -88,6 +95,12 @@ class EnvProvisioner:
         async with self._lock_for(version):
             if not await self._warm(venv, version):
                 if not await self._is_healthy(venv, version):
+                    if on_build is not None:
+                        on_build(
+                            f"Provisioning esphome {version} into an isolated "
+                            "environment; the first build for a version installs "
+                            "it from PyPI and can take a few minutes...\n"
+                        )
                     await self._build(version, venv)
                     if not await self._is_healthy(venv, version):
                         await run_in_executor(_rmtree, venv)

--- a/esphome_device_builder/controllers/remote_build/pair_status.py
+++ b/esphome_device_builder/controllers/remote_build/pair_status.py
@@ -256,6 +256,7 @@ def fire_offloader_pairing_added(
         "last_connect_error": summary.last_connect_error,
         "esphome_version": summary.esphome_version,
         "enabled": summary.enabled,
+        "auto_provision_supported": summary.auto_provision_supported,
     }
     controller._db.bus.fire(EventType.OFFLOADER_PAIRING_ADDED, payload)
 

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -187,6 +187,10 @@ class PairingSummary(DashboardModel):
     # Per-pairing enable toggle the Settings UI renders the
     # switch from; ``False`` skips the row in pick_build_path.
     enabled: bool = True
+    # Receiver capability from the session handshake: a mismatched
+    # version is built in a provisioned venv, so the UI can say
+    # "builds run with your version" instead of warning on skew.
+    auto_provision_supported: bool = False
 
 
 @dataclass

--- a/esphome_device_builder/models/remote_build/offloader.py
+++ b/esphome_device_builder/models/remote_build/offloader.py
@@ -188,8 +188,8 @@ class PairingSummary(DashboardModel):
     # switch from; ``False`` skips the row in pick_build_path.
     enabled: bool = True
     # Receiver capability from the session handshake: a mismatched
-    # version is built in a provisioned venv, so the UI can say
-    # "builds run with your version" instead of warning on skew.
+    # target version is built in a venv provisioned with the
+    # offloader's own esphome.
     auto_provision_supported: bool = False
 
 

--- a/esphome_device_builder/models/remote_build/offloader_events.py
+++ b/esphome_device_builder/models/remote_build/offloader_events.py
@@ -52,6 +52,7 @@ class OffloaderPairingAddedData(TypedDict):
     last_connect_error: str
     esphome_version: str
     enabled: bool
+    auto_provision_supported: bool
 
 
 class OffloaderPairEndpointReboundData(TypedDict):

--- a/tests/controllers/firmware/test_per_job_esphome_cmd.py
+++ b/tests/controllers/firmware/test_per_job_esphome_cmd.py
@@ -69,7 +69,10 @@ async def test_resolve_esphome_cmd_provisions_for_mismatched_target(
     cmd = await controller._resolve_esphome_cmd(_remote_job("2026.5.0"))
 
     assert cmd == ["venv/bin/python", "-m", "esphome"]
-    provisioner.provision.assert_awaited_once_with("2026.5.0")
+    provisioner.provision.assert_awaited_once()
+    assert provisioner.provision.await_args.args == ("2026.5.0",)
+    # The provision-progress hook streams into the job output.
+    assert callable(provisioner.provision.await_args.kwargs["on_build"])
 
 
 def _clean_job(target_esphome_version: str) -> FirmwareJob:

--- a/tests/test_remote_build_controller.py
+++ b/tests/test_remote_build_controller.py
@@ -4895,6 +4895,16 @@ async def test_get_offloader_settings_returns_master_plus_pairings(tmp_path: Pat
     assert view.pairings[0].enabled is True  # Default for the seeded row.
 
 
+def test_pairing_summary_surfaces_auto_provision_supported() -> None:
+    """``PairingSummary.auto_provision_supported`` mirrors the storage-shape field."""
+    pairing = _valid_stored_pairing()
+    pairing.auto_provision_supported = True
+    summary = pairing_summary(pairing, connected=False)
+    assert summary.auto_provision_supported is True
+    pairing.auto_provision_supported = False
+    assert pairing_summary(pairing, connected=False).auto_provision_supported is False
+
+
 def test_pairing_summary_surfaces_enabled_field(tmp_path: Path) -> None:
     """``PairingSummary.enabled`` mirrors the storage-shape field.
 

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -199,6 +199,23 @@ async def test_provision_on_build_fires_only_on_cache_miss(
     assert len(lines) == 1  # warm hit announces nothing
 
 
+async def test_provision_survives_a_raising_on_build_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raising observer logs and the provision proceeds (best-effort hook)."""
+    runner = _FakeRunner()
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+
+    def _boom(_line: str) -> None:
+        raise RuntimeError("observer broke")
+
+    cmd = await provisioner.provision("2026.6.4", on_build=_boom)
+
+    assert "esphome-2026.6.4" in str(cmd[0])
+    assert runner.count("venv") == 1  # the build still ran
+
+
 async def test_cached_cmd_refuses_unpinnable(tmp_path: Path) -> None:
     """A dev / local version is never cached-servable."""
     provisioner = EnvProvisioner(data_dir=tmp_path)

--- a/tests/test_remote_build_env_provisioner.py
+++ b/tests/test_remote_build_env_provisioner.py
@@ -182,6 +182,23 @@ async def test_cached_cmd_returns_none_when_not_provisioned(tmp_path: Path) -> N
     assert await provisioner.cached_cmd("2026.6.4") is None
 
 
+async def test_provision_on_build_fires_only_on_cache_miss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``on_build`` announces the slow first build; a warm re-provision is silent."""
+    runner = _FakeRunner()
+    _patch_runner(monkeypatch, runner)
+    provisioner = EnvProvisioner(data_dir=tmp_path)
+    lines: list[str] = []
+
+    await provisioner.provision("2026.6.4", on_build=lines.append)
+    assert len(lines) == 1
+    assert "2026.6.4" in lines[0]
+
+    await provisioner.provision("2026.6.4", on_build=lines.append)
+    assert len(lines) == 1  # warm hit announces nothing
+
+
 async def test_cached_cmd_refuses_unpinnable(tmp_path: Path) -> None:
     """A dev / local version is never cached-servable."""
     provisioner = EnvProvisioner(data_dir=tmp_path)


### PR DESCRIPTION
# What does this implement/fix?

Two field observations from the first real beta remote build:

1. The job log sat silent for almost two minutes while the receiver pip-installed the offloader's esphome into a fresh venv. `EnvProvisioner.provision` now takes an `on_build` hook that fires once on a cache miss, and the firmware controller streams it into the job output ("Provisioning esphome (version) into an isolated environment; the first build for a version installs it from PyPI and can take a few minutes...") so the operator sees why nothing is compiling yet. Warm and cached provisions announce nothing.

2. The offloader's Send-builds row could only show the receiver's installed version, with no way to know a mismatch still builds the offloader's own version in a provisioned venv. `PairingSummary` now carries `auto_provision_supported` (already on `StoredPairing` from the handshake, already keyed on by the scheduler) so the frontend can render honest copy instead of a skew warning.

**Related issue or feature (if applicable):**

- follow-up to #2082, companion frontend PR: esphome/device-builder-frontend#1248

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1248

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.