### PR TITLE
Reconnect the peer link on the receiver's mDNS reannounce

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -408,12 +408,7 @@ class PeerLinkClient:
             return
         wake = asyncio.Event()
         listener = _ReceiverWakeListener(self._wake_record_name, wake)
-        try:
-            zc.async_add_listener(listener, None)
-        except Exception:  # noqa: BLE001 - the wake is an optimisation, never a requirement
-            # A wedged / closing zeroconf falls back to the plain sleep.
-            await asyncio.sleep(backoff)
-            return
+        zc.async_add_listener(listener, None)
         try:
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(wake.wait(), backoff)

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -19,12 +19,15 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ipaddress
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 import aiohttp
 from yarl import URL
+from zeroconf import RecordUpdateListener, Zeroconf
+from zeroconf.const import _TYPE_A, _TYPE_AAAA
 
 from ....helpers import json as _json
 from ....helpers.async_ import drain_tasks
@@ -124,6 +127,36 @@ _LOCAL_CLOSE_RECEIVER_REJECTED = "receiver_rejected"
 _LOCAL_CLOSE_PIN_MISMATCH = "pin_mismatch"
 
 
+def _mdns_record_name(hostname: str) -> str | None:
+    """Return the lowercase trailing-dot record name, or ``None`` for an IP."""
+    with contextlib.suppress(ValueError):
+        ipaddress.ip_address(hostname)
+        return None
+    return f"{hostname.rstrip('.').lower()}."
+
+
+class _ReceiverWakeListener(RecordUpdateListener):
+    """One-shot wake on an A/AAAA record for the receiver's hostname.
+
+    The receiver's startup advertise re-announces its address records,
+    so waking the reconnect wait on one turns a worst-case 30s backoff
+    into an immediate retry (aioesphomeapi's ReconnectLogic pattern).
+    """
+
+    def __init__(self, record_name: str, wake: asyncio.Event) -> None:
+        self._record_name = record_name
+        self._wake = wake
+
+    def async_update_records(self, zc: Zeroconf, now: float, records: list[Any]) -> None:
+        if self._wake.is_set():
+            return
+        for update in records:
+            new = update.new
+            if new.type in (_TYPE_A, _TYPE_AAAA) and new.name.lower() == self._record_name:
+                self._wake.set()
+                return
+
+
 class PeerLinkClient:
     """
     Long-lived offloader-side peer-link Noise WS session.
@@ -155,8 +188,15 @@ class PeerLinkClient:
         receiver_label: str,
         bus: EventBus,
         resolver: AbstractResolver | None = None,
+        get_zeroconf: Callable[[], Zeroconf | None] | None = None,
     ) -> None:
         self._hostname = receiver_hostname
+        # mDNS fast-reconnect inputs: the shared zeroconf (``None``
+        # getter or return skips the optimisation) and the A/AAAA
+        # record name that signals the receiver came back (``None``
+        # for an IP endpoint — nothing to match).
+        self._get_zeroconf = get_zeroconf
+        self._wake_record_name = _mdns_record_name(receiver_hostname)
         self._port = receiver_port
         self._identity_priv = identity_priv
         self._identity_pub = public_bytes_for_priv(identity_priv)
@@ -349,7 +389,7 @@ class PeerLinkClient:
                     backoff = _RECONNECT_INITIAL_BACKOFF_SECONDS
                 else:
                     backoff = min(backoff * 2, _RECONNECT_MAX_BACKOFF_SECONDS)
-                await asyncio.sleep(backoff)
+                await self._wait_reconnect(backoff)
         except asyncio.CancelledError:
             # ``_run_one_session`` already sent the structured
             # ``terminate`` frame in its own CancelledError handler
@@ -359,6 +399,31 @@ class PeerLinkClient:
             # OPENED first.
             self._fire_closed(_LOCAL_CLOSE_CLIENT_STOPPED)
             raise
+
+    async def _wait_reconnect(self, backoff: float) -> None:
+        """Sleep *backoff*, waking early on an mDNS record for the receiver.
+
+        Fail-soft: without a zeroconf instance, or for an IP endpoint,
+        this is a plain sleep.
+        """
+        zc = self._get_zeroconf() if self._get_zeroconf is not None else None
+        if zc is None or self._wake_record_name is None:
+            await asyncio.sleep(backoff)
+            return
+        wake = asyncio.Event()
+        listener = _ReceiverWakeListener(self._wake_record_name, wake)
+        zc.async_add_listener(listener, None)
+        try:
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(wake.wait(), backoff)
+                _LOGGER.debug(
+                    "peer-link client to %s:%d: mDNS record for %s seen; reconnecting now",
+                    self._hostname,
+                    self._port,
+                    self._wake_record_name,
+                )
+        finally:
+            zc.async_remove_listener(listener)
 
     async def _run_one_session(self) -> str:
         """

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -129,19 +129,15 @@ _LOCAL_CLOSE_PIN_MISMATCH = "pin_mismatch"
 
 def _mdns_record_name(hostname: str) -> str | None:
     """Return the lowercase trailing-dot record name, or ``None`` for an IP."""
+    bare = hostname.rstrip(".")
     with contextlib.suppress(ValueError):
-        ipaddress.ip_address(hostname)
+        ipaddress.ip_address(bare)
         return None
-    return f"{hostname.rstrip('.').lower()}."
+    return f"{bare.lower()}."
 
 
 class _ReceiverWakeListener(RecordUpdateListener):
-    """One-shot wake on an A/AAAA record for the receiver's hostname.
-
-    The receiver's startup advertise re-announces its address records,
-    so waking the reconnect wait on one turns a worst-case 30s backoff
-    into an immediate retry (aioesphomeapi's ReconnectLogic pattern).
-    """
+    """One-shot wake on an A/AAAA record for the receiver's hostname."""
 
     def __init__(self, record_name: str, wake: asyncio.Event) -> None:
         self._record_name = record_name
@@ -412,7 +408,12 @@ class PeerLinkClient:
             return
         wake = asyncio.Event()
         listener = _ReceiverWakeListener(self._wake_record_name, wake)
-        zc.async_add_listener(listener, None)
+        try:
+            zc.async_add_listener(listener, None)
+        except Exception:  # noqa: BLE001 - the wake is an optimisation, never a requirement
+            # A wedged / closing zeroconf falls back to the plain sleep.
+            await asyncio.sleep(backoff)
+            return
         try:
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(wake.wait(), backoff)

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -19,7 +19,10 @@ lookup) reach into a stable surface.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import TYPE_CHECKING
+
+from zeroconf import Zeroconf
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import drain_tasks
@@ -29,6 +32,17 @@ from .peer_link_client import PeerLinkClient
 
 if TYPE_CHECKING:
     from .offloader import OffloaderController
+
+
+def _zeroconf_getter(controller: OffloaderController) -> Callable[[], Zeroconf | None]:
+    """Return a lazy reader for the shared inner sync ``Zeroconf``."""
+
+    def _get() -> Zeroconf | None:
+        devices = controller._db.devices
+        aiozc = devices.zeroconf if devices is not None else None
+        return aiozc.zeroconf if aiozc is not None else None
+
+    return _get
 
 
 def spawn_peer_link_client(controller: OffloaderController, pairing: StoredPairing) -> None:
@@ -68,10 +82,9 @@ def spawn_peer_link_client(controller: OffloaderController, pairing: StoredPairi
         resolver=controller.state.peer_link_resolver,
         # Same shared zeroconf the resolver rides; read lazily so a
         # zeroconf that comes up (or goes away) after spawn is honoured
-        # on the next reconnect wait.
-        get_zeroconf=lambda: (
-            controller._db.devices.zeroconf if controller._db.devices is not None else None
-        ),
+        # on the next reconnect wait. The listener API lives on the
+        # inner sync ``Zeroconf``, not the ``AsyncZeroconf`` wrapper.
+        get_zeroconf=_zeroconf_getter(controller),
     )
     task = asyncio.create_task(
         client.run(),

--- a/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_lifecycle.py
@@ -66,6 +66,12 @@ def spawn_peer_link_client(controller: OffloaderController, pairing: StoredPairi
         receiver_label=pairing.label,
         bus=controller._db.bus,
         resolver=controller.state.peer_link_resolver,
+        # Same shared zeroconf the resolver rides; read lazily so a
+        # zeroconf that comes up (or goes away) after spawn is honoured
+        # on the next reconnect wait.
+        get_zeroconf=lambda: (
+            controller._db.devices.zeroconf if controller._db.devices is not None else None
+        ),
     )
     task = asyncio.create_task(
         client.run(),

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -6268,6 +6268,18 @@ async def test_wait_reconnect_wakes_on_receiver_address_record() -> None:
     zc.async_remove_listener.assert_called_once()
 
 
+async def test_wait_reconnect_falls_back_to_sleep_when_listener_registration_fails() -> None:
+    """A wedged zeroconf degrades to the plain sleep instead of raising."""
+    client = _make_offloader_client(EventBus(), receiver_hostname="esphome-builder-abc.local")
+    zc = MagicMock(spec=Zeroconf)
+    zc.async_add_listener = MagicMock(side_effect=RuntimeError("closing"))
+    client._get_zeroconf = lambda: zc
+
+    await client._wait_reconnect(0)
+
+    zc.async_remove_listener.assert_not_called()
+
+
 async def test_wait_reconnect_plain_sleep_for_ip_endpoint() -> None:
     """An IP-endpoint pairing has nothing to match; the wait is a plain sleep."""
     client = _make_offloader_client(EventBus(), receiver_hostname="192.168.1.5")

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -76,6 +76,9 @@ from esphome_device_builder.controllers.remote_build.peer_link_client.client imp
     _LOCAL_CLOSE_RECEIVER_REJECTED,
     _mdns_record_name,
 )
+from esphome_device_builder.controllers.remote_build.peer_link_lifecycle import (
+    spawn_peer_link_client,
+)
 from esphome_device_builder.helpers import json as _json
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.event_bus import EventBus
@@ -6253,6 +6256,8 @@ async def test_wait_reconnect_wakes_on_receiver_address_record() -> None:
     assert not waiter.done()
 
     listeners[0].async_update_records(zc, 0.0, [matching])
+    # A second matching batch after the wake is a no-op (one-shot gate).
+    listeners[0].async_update_records(zc, 0.0, [matching])
     await asyncio.wait_for(waiter, timeout=1.0)
     zc.async_remove_listener.assert_called_once()
 
@@ -6266,3 +6271,28 @@ async def test_wait_reconnect_plain_sleep_for_ip_endpoint() -> None:
     await client._wait_reconnect(0)
 
     zc.async_add_listener.assert_not_called()
+
+
+async def test_spawn_peer_link_client_wires_the_zeroconf_getter(
+    offloader_controller_dir: Path,
+) -> None:
+    """The spawned client reads the shared zeroconf lazily through its getter."""
+    offloader = _make_offloader_controller(config_dir=offloader_controller_dir)
+    offloader._db.bus = EventBus()
+    _prime_offloader_identity_for_spawn(offloader)
+    pairing = _stub_pairing(status=PeerStatus.APPROVED)
+
+    spawn_peer_link_client(offloader, pairing)
+    handle = offloader.state.peer_link_clients[pairing.pin_sha256]
+    try:
+        assert handle.client._get_zeroconf is not None
+        # devices.zeroconf is the lazily-read source; follow both shapes.
+        assert handle.client._get_zeroconf() is None
+        sentinel = MagicMock()
+        offloader._db.devices.zeroconf = sentinel
+        assert handle.client._get_zeroconf() is sentinel
+        offloader._db.devices = None
+        assert handle.client._get_zeroconf() is None
+    finally:
+        handle.task.cancel()
+        await asyncio.gather(handle.task, return_exceptions=True)

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -34,6 +34,7 @@ from aiohttp import WSMessage, WSMsgType, web
 from aiohttp.test_utils import TestServer, get_unused_port_socket
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
+from zeroconf.const import _TYPE_A
 
 from esphome_device_builder.api.ws import init_ws_app
 from esphome_device_builder.controllers.remote_build import (
@@ -73,6 +74,7 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
 from esphome_device_builder.controllers.remote_build.peer_link_client.client import (
     _LOCAL_CLOSE_AUTH_REJECTED,
     _LOCAL_CLOSE_RECEIVER_REJECTED,
+    _mdns_record_name,
 )
 from esphome_device_builder.helpers import json as _json
 from esphome_device_builder.helpers.api import CommandError
@@ -6212,3 +6214,55 @@ async def test_run_one_session_logs_connected_peer_after_tcp_connect(
     # reconnect landed on a different host than expected.
     assert "peer=" in msg
     assert "127.0.0.1" in msg.split("peer=", 1)[1]
+
+
+# ---------------------------------------------------------------------------
+# mDNS fast reconnect
+# ---------------------------------------------------------------------------
+
+
+def test_mdns_record_name_shapes() -> None:
+    """Hostnames normalise to a lowercase trailing-dot name; IPs match nothing."""
+    assert _mdns_record_name("Esphome-Builder-ABC.local") == "esphome-builder-abc.local."
+    assert _mdns_record_name("esphome-builder-abc.local.") == "esphome-builder-abc.local."
+    assert _mdns_record_name("192.168.1.5") is None
+    assert _mdns_record_name("fd00::a1") is None
+
+
+async def test_wait_reconnect_wakes_on_receiver_address_record() -> None:
+    """An A record for the receiver's host breaks the backoff wait immediately."""
+    client = _make_offloader_client(EventBus(), receiver_hostname="esphome-builder-abc.local")
+    listeners: list[Any] = []
+    zc = MagicMock()
+    zc.async_add_listener = MagicMock(side_effect=lambda lst, _q: listeners.append(lst))
+    client._get_zeroconf = lambda: zc
+
+    waiter = asyncio.create_task(client._wait_reconnect(30.0))
+    await asyncio.sleep(0)
+    assert len(listeners) == 1
+
+    matching = MagicMock()
+    matching.new.type = _TYPE_A
+    matching.new.name = "Esphome-Builder-ABC.local."
+    # A non-matching record first: must not wake.
+    other = MagicMock()
+    other.new.type = _TYPE_A
+    other.new.name = "someone-else.local."
+    listeners[0].async_update_records(zc, 0.0, [other])
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    listeners[0].async_update_records(zc, 0.0, [matching])
+    await asyncio.wait_for(waiter, timeout=1.0)
+    zc.async_remove_listener.assert_called_once()
+
+
+async def test_wait_reconnect_plain_sleep_for_ip_endpoint() -> None:
+    """An IP-endpoint pairing has nothing to match; the wait is a plain sleep."""
+    client = _make_offloader_client(EventBus(), receiver_hostname="192.168.1.5")
+    zc = MagicMock()
+    client._get_zeroconf = lambda: zc
+
+    await client._wait_reconnect(0)
+
+    zc.async_add_listener.assert_not_called()

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -34,6 +34,8 @@ from aiohttp import WSMessage, WSMsgType, web
 from aiohttp.test_utils import TestServer, get_unused_port_socket
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from noise.exceptions import NoiseInvalidMessage
+from zeroconf import Zeroconf
+from zeroconf.asyncio import AsyncZeroconf
 from zeroconf.const import _TYPE_A
 
 from esphome_device_builder.api.ws import init_ws_app
@@ -6229,6 +6231,7 @@ def test_mdns_record_name_shapes() -> None:
     assert _mdns_record_name("Esphome-Builder-ABC.local") == "esphome-builder-abc.local."
     assert _mdns_record_name("esphome-builder-abc.local.") == "esphome-builder-abc.local."
     assert _mdns_record_name("192.168.1.5") is None
+    assert _mdns_record_name("192.168.1.5.") is None
     assert _mdns_record_name("fd00::a1") is None
 
 
@@ -6236,7 +6239,10 @@ async def test_wait_reconnect_wakes_on_receiver_address_record() -> None:
     """An A record for the receiver's host breaks the backoff wait immediately."""
     client = _make_offloader_client(EventBus(), receiver_hostname="esphome-builder-abc.local")
     listeners: list[Any] = []
-    zc = MagicMock()
+    # spec'd so a call to a method the real sync Zeroconf doesn't have
+    # fails here instead of only in production (the AsyncZeroconf-vs-
+    # Zeroconf wrapper bug shape).
+    zc = MagicMock(spec=Zeroconf)
     zc.async_add_listener = MagicMock(side_effect=lambda lst, _q: listeners.append(lst))
     client._get_zeroconf = lambda: zc
 
@@ -6265,7 +6271,7 @@ async def test_wait_reconnect_wakes_on_receiver_address_record() -> None:
 async def test_wait_reconnect_plain_sleep_for_ip_endpoint() -> None:
     """An IP-endpoint pairing has nothing to match; the wait is a plain sleep."""
     client = _make_offloader_client(EventBus(), receiver_hostname="192.168.1.5")
-    zc = MagicMock()
+    zc = MagicMock(spec=Zeroconf)
     client._get_zeroconf = lambda: zc
 
     await client._wait_reconnect(0)
@@ -6286,11 +6292,18 @@ async def test_spawn_peer_link_client_wires_the_zeroconf_getter(
     handle = offloader.state.peer_link_clients[pairing.pin_sha256]
     try:
         assert handle.client._get_zeroconf is not None
-        # devices.zeroconf is the lazily-read source; follow both shapes.
+        # devices.zeroconf is the lazily-read source; follow every shape.
+        offloader._db.devices.zeroconf = None
         assert handle.client._get_zeroconf() is None
-        sentinel = MagicMock()
-        offloader._db.devices.zeroconf = sentinel
-        assert handle.client._get_zeroconf() is sentinel
+        # The getter must hand back the inner sync Zeroconf (where the
+        # listener API lives), not the AsyncZeroconf wrapper.
+        aiozc = MagicMock(spec=AsyncZeroconf)
+        inner = MagicMock(spec=Zeroconf)
+        aiozc.zeroconf = inner
+        offloader._db.devices.zeroconf = aiozc
+        got = handle.client._get_zeroconf()
+        assert got is inner
+        assert hasattr(got, "async_add_listener")  # the sync Zeroconf API
         offloader._db.devices = None
         assert handle.client._get_zeroconf() is None
     finally:

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -6268,18 +6268,6 @@ async def test_wait_reconnect_wakes_on_receiver_address_record() -> None:
     zc.async_remove_listener.assert_called_once()
 
 
-async def test_wait_reconnect_falls_back_to_sleep_when_listener_registration_fails() -> None:
-    """A wedged zeroconf degrades to the plain sleep instead of raising."""
-    client = _make_offloader_client(EventBus(), receiver_hostname="esphome-builder-abc.local")
-    zc = MagicMock(spec=Zeroconf)
-    zc.async_add_listener = MagicMock(side_effect=RuntimeError("closing"))
-    client._get_zeroconf = lambda: zc
-
-    await client._wait_reconnect(0)
-
-    zc.async_remove_listener.assert_not_called()
-
-
 async def test_wait_reconnect_plain_sleep_for_ip_endpoint() -> None:
     """An IP-endpoint pairing has nothing to match; the wait is a plain sleep."""
     client = _make_offloader_client(EventBus(), receiver_hostname="192.168.1.5")


### PR DESCRIPTION
# What does this implement/fix?

Restarting a receiver while the offloader sits in its reconnect backoff means waiting out up to 30 seconds even though the receiver announced itself on mDNS the moment it came back. The peer-link client's backoff sleep is now an interruptible wait: while disconnected it registers a one-shot zeroconf record listener for the receiver's hostname, and an incoming A/AAAA record for that name breaks the wait and reconnects immediately (the same pattern aioesphomeapi's ReconnectLogic uses for device reconnects).

Fail-soft in every degraded shape: no zeroconf instance, or an IP-endpoint pairing (nothing to match), falls back to the plain sleep. The lifecycle passes the shared zeroconf lazily so an instance that comes up after the client spawns is honoured on the next wait.

**Related issue or feature (if applicable):**

- observed while testing receiver restarts against a paired offloader

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
