### PR TITLE
Add in_docker to the ServerInfo handshake

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -12,7 +12,7 @@ The primary API. A single multiplexed WebSocket handles all 46 commands.
 
 On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/models/api.py):
 ```json
-{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false, "desktop_version": "", "desktop_update_capable": false}
+{"server_version": "0.0.0", "esphome_version": "2026.3.1", "port": 6052, "ha_addon": false, "ha_ingress": false, "requires_auth": false, "desktop_version": "", "desktop_update_capable": false, "in_docker": false}
 ```
 
 `ha_ingress` is `true` only when the connection is proxied through the HA Supervisor ingress (the `X-Ingress-Path` header is present); the frontend slims its header in that case so HA's own panel bar isn't doubled up. An add-on reached directly on its exposed port reports `ha_addon: true` but `ha_ingress: false`.
@@ -20,6 +20,8 @@ On connect, the server sends a [`ServerInfoMessage`](../esphome_device_builder/m
 `desktop_version` carries the ESPHome Desktop wrapper version (from the `ESPHOME_DESKTOP_VERSION` env var) when the dashboard runs inside the desktop app, and is `""` otherwise; the value is sanitized server-side (blank, non-printable, or over-length is treated as unset). The frontend renders it as a footer line only when non-empty.
 
 `desktop_update_capable` is `true` only when the dashboard runs inside an ESPHome Desktop app that exposes its update `api` (0.14.0+, which sets `ESPHOME_DESKTOP_BIN`). Older desktop apps set `desktop_version` but not this, so the frontend gates the "Check for updates" menu item on `desktop_update_capable`, not on `desktop_version`.
+
+`in_docker` is `true` when the process runs inside a container (`/.dockerenv` present, probed once at import so the handshake never stats in the event loop). Together with `ha_addon` and `desktop_version` it lets the frontend's crash-report flow name the ESPHome bug-report form's installation kind (Home Assistant Add-on / Docker / pip).
 
 ### Desktop update commands
 

--- a/esphome_device_builder/api/ws.py
+++ b/esphome_device_builder/api/ws.py
@@ -9,6 +9,7 @@ import asyncio
 import contextlib
 import logging
 import weakref
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import WSCloseCode, WSMsgType, web
@@ -35,6 +36,10 @@ if TYPE_CHECKING:
     from ..device_builder import DeviceBuilder
 
 _LOGGER = logging.getLogger(__name__)
+
+# Container marker, probed once at import (before the event loop runs) so
+# the per-connection handshake never stats in the loop.
+_IN_DOCKER = Path("/.dockerenv").exists()
 
 # Commands a client may send before the authenticated flag is set.
 _PRE_AUTH_COMMANDS = frozenset({"auth", "auth/login"})
@@ -338,6 +343,7 @@ async def websocket_handler(request: web.Request) -> web.StreamResponse:
         requires_auth=(not pre_authenticated),
         desktop_version=settings.desktop_version,
         desktop_update_capable=settings.desktop_update_capable,
+        in_docker=_IN_DOCKER,
     )
     await client.send(info.to_dict())
 

--- a/esphome_device_builder/models/api.py
+++ b/esphome_device_builder/models/api.py
@@ -117,3 +117,7 @@ class ServerInfoMessage(DashboardModel):
     # True when the desktop app (0.14.0+) exposes its update `api` via
     # ESPHOME_DESKTOP_BIN; gates the frontend's "Check for updates" menu item.
     desktop_update_capable: bool = False
+    # True when the process runs inside a container (/.dockerenv probe).
+    # With ha_addon / desktop_version it lets the frontend's crash-report
+    # flow prefill the bug form's installation dropdown (add-on/Docker/pip).
+    in_docker: bool = False

--- a/tests/test_ws_server_info.py
+++ b/tests/test_ws_server_info.py
@@ -1,0 +1,35 @@
+"""Wire contract of the per-connection ServerInfoMessage handshake."""
+
+from __future__ import annotations
+
+from aiohttp import web
+from pytest_aiohttp.plugin import AiohttpClient
+
+from esphome_device_builder.api import ws as ws_module
+from esphome_device_builder.api.ws import create_ws_routes, init_ws_app
+from esphome_device_builder.helpers.json import loads
+
+from .conftest import make_ws_device_builder
+
+
+def _bare_app() -> web.Application:
+    device_builder = make_ws_device_builder()
+    app = web.Application()
+    app["device_builder"] = device_builder
+    app["trusted_site"] = True
+    init_ws_app(app)
+    app.router.add_routes(create_ws_routes())
+    return app
+
+
+async def test_server_info_carries_deployment_signals(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """First frame carries the installation signals the frontend maps."""
+    client = await aiohttp_client(_bare_app())
+    async with client.ws_connect("/ws") as ws:
+        info = loads((await ws.receive(timeout=2.0)).data)
+    assert info["ha_addon"] is False
+    assert info["in_docker"] is ws_module._IN_DOCKER
+    assert isinstance(info["in_docker"], bool)
+    assert "desktop_version" in info

--- a/tests/test_ws_server_info.py
+++ b/tests/test_ws_server_info.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from aiohttp import web
 from pytest_aiohttp.plugin import AiohttpClient
 
@@ -22,14 +23,21 @@ def _bare_app() -> web.Application:
     return app
 
 
-async def test_server_info_carries_deployment_signals(
+@pytest.mark.parametrize("in_docker", [True, False])
+async def test_server_info_forwards_in_docker(
     aiohttp_client: AiohttpClient,
+    monkeypatch: pytest.MonkeyPatch,
+    in_docker: bool,
 ) -> None:
-    """First frame carries the installation signals the frontend maps."""
+    """The handshake forwards the probed container flag verbatim.
+
+    Patching ``_IN_DOCKER`` pins the wiring — comparing against the live
+    constant would pass even on a hardcoded ``False`` in a non-container CI.
+    """
+    monkeypatch.setattr(ws_module, "_IN_DOCKER", in_docker)
     client = await aiohttp_client(_bare_app())
     async with client.ws_connect("/ws") as ws:
         info = loads((await ws.receive(timeout=2.0)).data)
     assert info["ha_addon"] is False
-    assert info["in_docker"] is ws_module._IN_DOCKER
-    assert isinstance(info["in_docker"], bool)
+    assert info["in_docker"] is in_docker
     assert "desktop_version" in info


### PR DESCRIPTION
# What does this implement/fix?

Adds `in_docker` to the `ServerInfoMessage` handshake. `/.dockerenv` is probed once at import (never in the event loop) and shipped in the per-connection server info, so the frontend can distinguish the three installation kinds the ESPHome bug-report form offers — Home Assistant Add-on / Docker / pip — alongside the existing `ha_addon` and `desktop_version` signals.

The companion frontend crash-report flow uses it to fill in the installation fact when it pre-fills a GitHub issue.

**Related issue or feature (if applicable):**

- Companion frontend PR: esphome/device-builder-frontend#1250

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1250

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
