### PR TITLE
DRY the peer-link-client request registration and session-loss drain

### DIFF
--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ....helpers.peer_link_bundle import (
@@ -60,7 +61,12 @@ async def submit_job(
     already.
     """
     channel = _require_open_channel(client, label="submit_job")
-    ack_fut = _register_ack_future(client._submit_job_acks, job_id, label="submit_job")
+    ack_fut = _register_pending(
+        client._submit_job_acks,
+        job_id,
+        asyncio.get_running_loop().create_future,
+        label="submit_job",
+    )
     try:
         await _send_submit_job_frames(
             client,
@@ -86,7 +92,12 @@ async def reset_build_env(client: PeerLinkClient, *, job_id: str) -> ResetBuildE
     on the ack and every fan-out frame of its reset job.
     """
     channel = _require_open_channel(client, label="reset_build_env")
-    ack_fut = _register_ack_future(client._reset_env_acks, job_id, label="reset_build_env")
+    ack_fut = _register_pending(
+        client._reset_env_acks,
+        job_id,
+        asyncio.get_running_loop().create_future,
+        label="reset_build_env",
+    )
     frame: ResetBuildEnvFrameData = {"type": "reset_build_env", "job_id": job_id}
     try:
         if not await channel.send_frame(cast(dict[str, Any], frame)):
@@ -125,14 +136,12 @@ async def download_artifacts(client: PeerLinkClient, *, job_id: str) -> Download
     session loss mid-download as :class:`SubmitJobSessionLostError`.
     """
     channel = _require_open_channel(client, label="download_artifacts")
-    if job_id in client._artifacts_downloads:
-        msg = (
-            f"download_artifacts: future already registered for job_id={job_id!r} "
-            f"(duplicate download on the same session)"
-        )
-        raise PeerLinkNoSessionError(msg)
-    result: asyncio.Future[DownloadArtifactsResult] = asyncio.get_running_loop().create_future()
-    client._artifacts_downloads[job_id] = _DownloadArtifactsState(future=result)
+    state = _register_pending(
+        client._artifacts_downloads,
+        job_id,
+        lambda: _DownloadArtifactsState(future=asyncio.get_running_loop().create_future()),
+        label="download_artifacts",
+    )
     try:
         frame: DownloadArtifactsFrameData = {
             "type": "download_artifacts",
@@ -143,7 +152,7 @@ async def download_artifacts(client: PeerLinkClient, *, job_id: str) -> Download
                 f"download_artifacts: request send failed mid-flow to "
                 f"{client._hostname}:{client._port}"
             )
-        return await result
+        return await state.future
     finally:
         client._artifacts_downloads.pop(job_id, None)
 
@@ -157,21 +166,20 @@ def _require_open_channel(client: PeerLinkClient, *, label: str) -> PeerLinkChan
     return channel
 
 
-def _register_ack_future[AckT](
-    acks: dict[str, asyncio.Future[AckT]], job_id: str, *, label: str
-) -> asyncio.Future[AckT]:
-    """Allocate + register the per-``job_id`` ack future in *acks*, refusing duplicates."""
-    if job_id in acks:
+def _register_pending[EntryT](
+    pending: dict[str, EntryT], job_id: str, make_entry: Callable[[], EntryT], *, label: str
+) -> EntryT:
+    """Build + register the per-``job_id`` in-flight entry in *pending*, refusing duplicates."""
+    if job_id in pending:
         msg = (
-            f"{label}: ack future already registered for job_id={job_id!r} "
+            f"{label}: request already registered for job_id={job_id!r} "
             f"(duplicate {label} on the same session)"
         )
         raise PeerLinkNoSessionError(msg)
-    # Register BEFORE the request goes out so a same-tick ack from the
+    # Register BEFORE the request goes out so a same-tick reply from the
     # receive loop can't beat the registration into the map.
-    ack_fut: asyncio.Future[AckT] = asyncio.get_running_loop().create_future()
-    acks[job_id] = ack_fut
-    return ack_fut
+    entry = pending[job_id] = make_entry()
+    return entry
 
 
 async def _send_submit_job_frames(

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/client.py
@@ -21,7 +21,7 @@ import asyncio
 import contextlib
 import ipaddress
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Literal
 
 import aiohttp
@@ -249,23 +249,22 @@ class PeerLinkClient:
         # (controller's WS submit handler), same event loop — no
         # lock needed.
         self._active_channel: PeerLinkChannel | None = None
-        # Per-job ack futures populated by :meth:`submit_job`
-        # before the header goes out, drained by the receive
-        # loop's submit_job_ack dispatch, force-completed with
-        # :class:`SubmitJobSessionLostError` in
-        # :meth:`_run_session_loops`'s ``finally`` on session
-        # loss so callers don't hang on the ack timeout.
+        # Per-job ack futures populated by :meth:`submit_job` before
+        # the header goes out, drained by the receive loop's
+        # submit_job_ack dispatch, force-completed by
+        # :meth:`_drain_pending` on session loss so callers don't
+        # hang on the ack timeout.
         self._submit_job_acks: dict[str, asyncio.Future[SubmitJobAckFrameData]] = {}
-        # Per-mirror-job reset_build_env ack futures — same drain shape
-        # as ``_submit_job_acks`` (force-completed on session loss).
+        # Per-mirror-job reset_build_env ack futures — same
+        # register / dispatch / drain lifecycle as ``_submit_job_acks``.
         self._reset_env_acks: dict[str, asyncio.Future[ResetBuildEnvAckFrameData]] = {}
         # Operator-facing "Last connection error" line. Populated
         # by :meth:`_run_one_session`'s exception paths, cleared
         # on every successful session-open so a stale message
         # doesn't survive a reconnect.
         self._last_connect_error: str = ""
-        # Per-job in-flight download state — same drain shape as
-        # ``_submit_job_acks`` (force-completed on session loss).
+        # Per-job in-flight download state — same register / drain
+        # lifecycle as ``_submit_job_acks``, plus assembler state.
         self._artifacts_downloads: dict[str, _DownloadArtifactsState] = {}
 
     @property
@@ -578,7 +577,7 @@ class PeerLinkClient:
             self._last_connect_error = f"{type(exc).__name__}: {exc}"
             return _LOCAL_CLOSE_TRANSPORT_ERROR
 
-    async def _run_session_loops(self, channel: PeerLinkChannel) -> str:  # noqa: C901
+    async def _run_session_loops(self, channel: PeerLinkChannel) -> str:
         """
         Run the receive loop with a heartbeat task in parallel.
 
@@ -669,32 +668,33 @@ class PeerLinkClient:
             # Drain in-flight requesters so they raise
             # :class:`SubmitJobSessionLostError` immediately
             # instead of waiting on the per-flow timeout.
-            self._drain_pending_acks(self._submit_job_acks, label="submit_job")
-            self._drain_pending_acks(self._reset_env_acks, label="reset_build_env")
-            # Same drain shape for in-flight artifact downloads.
-            for pending_job_id, dl_state in list(self._artifacts_downloads.items()):
-                if not dl_state.future.done():
-                    dl_state.future.set_exception(
-                        SubmitJobSessionLostError(
-                            f"download_artifacts: peer-link session to "
-                            f"{self._hostname}:{self._port} ended before "
-                            f"artifacts_end for job_id={pending_job_id!r}"
-                        )
-                    )
+            self._drain_pending(self._submit_job_acks.items(), label="submit_job")
+            self._drain_pending(self._reset_env_acks.items(), label="reset_build_env")
+            self._drain_pending(
+                ((job_id, dl.future) for job_id, dl in self._artifacts_downloads.items()),
+                label="download_artifacts",
+                awaiting="artifacts_end",
+            )
             await drain_tasks((heartbeat_task,))
 
-    def _drain_pending_acks(self, acks: dict[str, asyncio.Future[Any]], *, label: str) -> None:
-        """Fail every undone ack future in *acks* with a session-lost error.
+    def _drain_pending(
+        self,
+        pending: Iterable[tuple[str, asyncio.Future[Any]]],
+        *,
+        label: str,
+        awaiting: str = "ack",
+    ) -> None:
+        """Fail every undone future in *pending* with a session-lost error.
 
         Snapshot before iterating — each requester's ``finally`` pops its
         entry as soon as the future fires.
         """
-        for pending_job_id, pending_fut in list(acks.items()):
+        for pending_job_id, pending_fut in list(pending):
             if not pending_fut.done():
                 pending_fut.set_exception(
                     SubmitJobSessionLostError(
                         f"{label}: peer-link session to "
-                        f"{self._hostname}:{self._port} ended before ack "
+                        f"{self._hostname}:{self._port} ended before {awaiting} "
                         f"for job_id={pending_job_id!r}"
                     )
                 )


### PR DESCRIPTION
# What does this implement/fix?

Finishes DRYing the peer-link-client request/ack future machinery. #2094's simplify pass already consolidated the two ack verbs (`submit_job`, `reset_build_env`) onto shared register/await/drain helpers; this folds the third flow, `download_artifacts`, into the same shape.

`_register_ack_future` becomes `_register_pending[EntryT]` taking an entry factory, so it also serves the download map whose entries carry assembler state alongside the future. `_drain_pending_acks` becomes `_drain_pending` taking `(job_id, future)` pairs, so the hand-rolled download drain block in `_run_session_loops`'s `finally` collapses into the same call as the two ack drains. Session-lost drain messages are byte identical for all three verbs; the duplicate-registration message is now one template ("request already registered"). Dropping the download drain block also took `_run_session_loops` back under the complexity threshold, so its `noqa: C901` is gone.

Deliberately unchanged: `download_artifacts` still has no ack timeout (streaming a large tarball can legitimately exceed the 60s ack window; the heartbeat plus session-loss drain bound it), so `_await_ack` stays with its two callers. The three maps stay per-verb and precisely typed rather than merging into one registry class, which would trade away the `Future[SubmitJobAckFrameData]` / `Future[ResetBuildEnvAckFrameData]` / `_DownloadArtifactsState` typing for casts.

Behaviour free; no wire or API change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2092

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
