### PR TITLE
Ignore ninja sub-build counters when deriving compile progress

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -107,16 +107,14 @@ _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 # ESP-IDF / ninja per-target counter: ``[907/1424] Building C object …``.
 # Kept out of ``_PROGRESS_PATTERNS`` because it carries no percentage —
-# ``_ingest_output_line`` derives one from the two capture groups.
-# Anchored to the line start and to ninja's literal space after the
-# ``]`` so mid-line ``[N/M]`` text and bare bracketed fragments never
-# trip it; the start anchor tolerates ANSI CSI prefixes (``\x1b[2K``
-# etc.) — same production concern as the ``Writing at`` pattern above.
-# Counters with totals under ``_NINJA_MIN_TOTAL`` are ignored, so
-# ``[1/2] Re-running CMake...`` sub-steps can't spike the gauge. The
-# floor alone no longer filters the bootloader ExternalProject
-# sub-build (123 steps on IDF 5.x, up from ~97) — the largest-total
-# gate in ``_ingest_output_line`` handles sub-builds of any size.
+# ``_ninja_progress`` derives one from the two capture groups. Anchored
+# to the line start and to ninja's literal space after the ``]`` so
+# mid-line ``[N/M]`` text and bare bracketed fragments never trip it;
+# the start anchor tolerates ANSI CSI prefixes (``\x1b[2K`` etc.) —
+# same production concern as the ``Writing at`` pattern above. The
+# ``_NINJA_MIN_TOTAL`` floor drops tiny sub-steps (``[1/2] Re-running
+# CMake...``); ExternalProject sub-builds of any size are kept off the
+# gauge by ``_ninja_progress``'s largest-total gate.
 _NINJA_MIN_TOTAL = 100
 _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -107,15 +107,16 @@ _PROGRESS_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 # ESP-IDF / ninja per-target counter: ``[907/1424] Building C object …``.
 # Kept out of ``_PROGRESS_PATTERNS`` because it carries no percentage —
-# ``_parse_progress`` derives one from the two capture groups. Anchored
-# to the line start and to ninja's literal space after the ``]`` so
-# mid-line ``[N/M]`` text and bare bracketed fragments never trip it;
-# the start anchor tolerates ANSI CSI prefixes (``\x1b[2K`` etc.) —
-# same production concern as the ``Writing at`` pattern above. Counters
-# with totals under ``_NINJA_MIN_TOTAL`` are ignored: ``[1/2]
-# Re-running CMake...`` sub-steps and the ~97-step bootloader
-# ExternalProject sub-build would otherwise spike the gauge to ~100
-# before the app build starts.
+# ``_ingest_output_line`` derives one from the two capture groups.
+# Anchored to the line start and to ninja's literal space after the
+# ``]`` so mid-line ``[N/M]`` text and bare bracketed fragments never
+# trip it; the start anchor tolerates ANSI CSI prefixes (``\x1b[2K``
+# etc.) — same production concern as the ``Writing at`` pattern above.
+# Counters with totals under ``_NINJA_MIN_TOTAL`` are ignored, so
+# ``[1/2] Re-running CMake...`` sub-steps can't spike the gauge. The
+# floor alone no longer filters the bootloader ExternalProject
+# sub-build (123 steps on IDF 5.x, up from ~97) — the largest-total
+# gate in ``_ingest_output_line`` handles sub-builds of any size.
 _NINJA_MIN_TOTAL = 100
 _NINJA_PROGRESS_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:\x1b\[[0-9;]*[A-Za-z])*\s*\[\s*(\d+)\s*/\s*(\d+)\s*\] "

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -189,10 +189,11 @@ def _parse_progress(line: str) -> int | None:
     """Extract a 0-100 progress percentage from a build/flash output line.
 
     Returns ``None`` when the line doesn't match one of the known
-    percent shapes (see ``_PROGRESS_PATTERNS``) or a ninja ``[N/M]``
-    counter with at least ``_NINJA_MIN_TOTAL`` steps. Stray ``%``
-    signs elsewhere in the build output (Unpacking bars, memory-usage
-    reports) are intentionally ignored.
+    percent shapes (see ``_PROGRESS_PATTERNS``). Stray ``%`` signs
+    elsewhere in the build output (Unpacking bars, memory-usage
+    reports) are intentionally ignored. Ninja ``[N/M]`` counters are
+    handled separately (:func:`_parse_ninja_counter`) — deriving a
+    percentage from one needs per-job state.
     """
     for pattern in _PROGRESS_PATTERNS:
         match = pattern.search(line)
@@ -201,10 +202,15 @@ def _parse_progress(line: str) -> int | None:
         value = int(match.group(1))
         if 0 <= value <= 100:
             return value
+    return None
+
+
+def _parse_ninja_counter(line: str) -> tuple[int, int] | None:
+    """Extract ``(done, total)`` from a ninja ``[N/M]`` counter line, else ``None``."""
     if match := _NINJA_PROGRESS_PATTERN.match(line):
         done, total = int(match.group(1)), int(match.group(2))
-        if total >= _NINJA_MIN_TOTAL and done <= total:
-            return done * 100 // total
+        if done <= total:
+            return done, total
     return None
 
 
@@ -368,6 +374,17 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     bus.fire(EventType.JOB_OUTPUT, out_payload)
     _stamp_compile_phase(job, line)
     progress = _parse_progress(line)
+    if progress is None and (counter := _parse_ninja_counter(line)) is not None:
+        done, total = counter
+        # Only the largest total seen drives the gauge: an ExternalProject
+        # sub-build (the esp-idf bootloader, 123 steps on IDF 5.x) streams
+        # its own counter through the same output, and its ``[N/N]`` final
+        # step would otherwise latch 100% mid-build. The floor still drops
+        # tiny sub-steps (``[1/2] Re-running CMake...``) before any real
+        # counter has registered a total.
+        if total >= _NINJA_MIN_TOTAL and total >= job.ninja_total:
+            job.ninja_total = total
+            progress = done * 100 // total
     if progress is None or progress <= (job.progress or 0):
         return
     _fire_job_progress(job, bus, progress)

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -192,7 +192,7 @@ def _parse_progress(line: str) -> int | None:
     percent shapes (see ``_PROGRESS_PATTERNS``). Stray ``%`` signs
     elsewhere in the build output (Unpacking bars, memory-usage
     reports) are intentionally ignored. Ninja ``[N/M]`` counters are
-    handled separately (:func:`_parse_ninja_counter`) — deriving a
+    handled separately (:func:`_ninja_progress`) — deriving a
     percentage from one needs per-job state.
     """
     for pattern in _PROGRESS_PATTERNS:
@@ -212,6 +212,26 @@ def _parse_ninja_counter(line: str) -> tuple[int, int] | None:
         if done <= total:
             return done, total
     return None
+
+
+def _ninja_progress(job: FirmwareJob, line: str) -> int | None:
+    """
+    Derive a 0-100 percentage from a ninja ``[N/M]`` counter line.
+
+    Only the largest total seen this run drives the gauge: an
+    ExternalProject sub-build (the esp-idf bootloader, 123 steps on
+    IDF 5.x) streams its own counter through the same output, and its
+    ``[N/N]`` final step would otherwise latch 100% mid-build. The
+    ``_NINJA_MIN_TOTAL`` floor drops tiny sub-steps (``[1/2]
+    Re-running CMake...``) that arrive before any real total registers.
+    """
+    if (counter := _parse_ninja_counter(line)) is None:
+        return None
+    done, total = counter
+    if total < _NINJA_MIN_TOTAL or total < job.ninja_total:
+        return None
+    job.ninja_total = total
+    return done * 100 // total
 
 
 def _validate_upload_target(port: str, *, bootloader: bool) -> None:
@@ -374,17 +394,8 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     bus.fire(EventType.JOB_OUTPUT, out_payload)
     _stamp_compile_phase(job, line)
     progress = _parse_progress(line)
-    if progress is None and (counter := _parse_ninja_counter(line)) is not None:
-        done, total = counter
-        # Only the largest total seen drives the gauge: an ExternalProject
-        # sub-build (the esp-idf bootloader, 123 steps on IDF 5.x) streams
-        # its own counter through the same output, and its ``[N/N]`` final
-        # step would otherwise latch 100% mid-build. The floor still drops
-        # tiny sub-steps (``[1/2] Re-running CMake...``) before any real
-        # counter has registered a total.
-        if total >= _NINJA_MIN_TOTAL and total >= job.ninja_total:
-            job.ninja_total = total
-            progress = done * 100 // total
+    if progress is None:
+        progress = _ninja_progress(job, line)
     if progress is None or progress <= (job.progress or 0):
         return
     _fire_job_progress(job, bus, progress)

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -213,11 +213,9 @@ class FirmwareJob(DashboardModel):
     # yet -- most compile output is opaque, but the heavy phases (PIO
     # build, esptool flash) do emit percentages we can latch onto.
     progress: int | None = None
-    # Largest ninja ``[N/M]`` total seen this run. Counters with smaller
-    # totals (ExternalProject sub-builds like the esp-idf bootloader)
-    # don't drive the gauge — their ``[N/N]`` final step would latch
-    # 100% mid-build. Parser bookkeeping only: kept off the wire and
-    # off disk.
+    # Largest ninja ``[N/M]`` total seen this run — backs the sub-build
+    # gate in ``_ninja_progress``. Parser bookkeeping only: kept off
+    # the wire and off disk.
     ninja_total: int = field(default=0, metadata={"serialize": "omit"})
     # Offloader's ``dashboard_id`` when this job came in via the
     # peer-link ``submit_job`` flow (issue #106). Empty for

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -213,6 +213,12 @@ class FirmwareJob(DashboardModel):
     # yet -- most compile output is opaque, but the heavy phases (PIO
     # build, esptool flash) do emit percentages we can latch onto.
     progress: int | None = None
+    # Largest ninja ``[N/M]`` total seen this run. Counters with smaller
+    # totals (ExternalProject sub-builds like the esp-idf bootloader)
+    # don't drive the gauge — their ``[N/N]`` final step would latch
+    # 100% mid-build. Parser bookkeeping only: kept off the wire and
+    # off disk.
+    ninja_total: int = field(default=0, metadata={"serialize": "omit"})
     # Offloader's ``dashboard_id`` when this job came in via the
     # peer-link ``submit_job`` flow (issue #106). Empty for
     # locally-submitted jobs. Surfaced in the firmware-tasks UI

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -438,9 +438,9 @@ class FirmwareJob(DashboardModel):
           another build server uses :meth:`clear_run_state`
           instead, so it doesn't claim a restart that didn't
           happen.)
-        - **Clears per-run state** — ``progress`` / ``error`` /
-          ``started_at`` / ``completed_at`` / ``exit_code``
-          back to their defaults.
+        - **Clears per-run state** — ``progress`` / ``ninja_total`` /
+          ``error`` / ``started_at`` / ``completed_at`` /
+          ``exit_code`` back to their defaults.
         - **Doesn't change ``status``** — the caller decides
           the transition (load path flips ``RUNNING`` →
           ``QUEUED``; future callers might want a different
@@ -502,13 +502,14 @@ class FirmwareJob(DashboardModel):
             self.apply_build_source(REMOTE_PENDING_JOB_BUILD_SOURCE)
 
     def clear_run_state(self) -> None:
-        """Clear per-run fields (progress / error / timing / exit code); keeps output and identity.
+        """Clear per-run fields (progress / gauge / error / timing); keeps output and identity.
 
         ``reset`` is this plus a restart marker; a mid-build re-route to
         another server calls this directly so the log isn't stamped with a
         restart notice that never happened.
         """
         self.progress = None
+        self.ninja_total = 0
         self.error = None
         self.failure_reason = JobFailureReason.NONE
         self.started_at = None

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -607,9 +607,11 @@ async def test_ninja_compile_progress_lines_fire_job_progress(
 ) -> None:
     """Ninja ``[N/M]`` counters drive ``JOB_PROGRESS`` for ESP-IDF builds.
 
-    ESP-IDF builds emit no percentage at all; the per-target
-    counter is the only progress signal, and sub-100 totals
-    (CMake re-runs) must not move the gauge.
+    ESP-IDF builds emit no percentage at all; the per-target counter
+    is the only progress signal. Sub-100 totals (CMake re-runs) must
+    not move the gauge, and the bootloader ExternalProject sub-build's
+    own counter — over 100 steps on IDF 5.x — must not latch 100%
+    before the app build finishes.
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
@@ -619,6 +621,9 @@ async def test_ninja_compile_progress_lines_fire_job_progress(
         "print('[1/2] Re-running CMake...')\n"
         "print('[100/1424] Building C object esp-idf/a.c.obj')\n"
         "print('[907/1424] Building C object esp-idf/b.c.obj')\n"
+        "print('[10/123] Building C object esp-idf/log/log.c.obj')\n"
+        "print('[123/123] Linking CXX executable bootloader.elf')\n"
+        "print(\"[1409/1424] Completed 'bootloader'\")\n"
         "print('[1424/1424] Linking firmware.elf')\n"
         "sys.exit(0)\n",
     )
@@ -628,8 +633,11 @@ async def test_ninja_compile_progress_lines_fire_job_progress(
     captured = await _run_until_terminal(controller)
 
     progress_values = [d["progress"] for d in captured["job_progress"]]
-    # The [1/2] CMake sub-step is below the total floor and fires nothing.
-    assert progress_values == [7, 63, 100]
+    # The [1/2] CMake sub-step is below the total floor and the
+    # bootloader sub-build's counters carry a smaller total than the
+    # app build's — neither fires; 100 lands only on the app's final
+    # target.
+    assert progress_values == [7, 63, 98, 100]
     assert job.progress == 100
     assert job.status == JobStatus.COMPLETED
 

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -32,239 +32,224 @@ from esphome_device_builder.controllers.firmware.helpers import (
 from esphome_device_builder.models.firmware import FirmwareJob, JobType
 
 
-class TestRealProgressLines:
-    """Lines that should resolve to a percentage."""
-
-    @pytest.mark.parametrize(
-        ("line", "expected"),
-        [
-            ("[  1%] Compiling .pio/foo.cpp.o", 1),
-            ("[ 17%] Compiling .pio/bar.cpp.o", 17),
-            ("[100%] Linking .pioenvs/firmware.elf", 100),
-            # leading whitespace is fine, ESPHome's --dashboard mode
-            # sometimes prefixes lines with indent.
-            ("    [ 42%] Compiling baz.cpp.o", 42),
-        ],
-    )
-    def test_pio_arduino_compile_marker(self, line: str, expected: int) -> None:
-        assert _parse_progress(line) == expected
-
-    @pytest.mark.parametrize(
-        ("line", "expected"),
-        [
-            ("Writing at 0x00010000... (5 %)", 5),
-            ("Writing at 0x00050000... (45 %)", 45),
-            ("Writing at 0x00100000... (100 %)", 100),
-            # esptool sometimes drops the space before %.
-            ("Writing at 0x00050000... (45%)", 45),
-        ],
-    )
-    def test_esptool_writing_marker_legacy(self, line: str, expected: int) -> None:
-        assert _parse_progress(line) == expected
-
-    @pytest.mark.parametrize(
-        ("line", "expected"),
-        [
-            # Issue #140: newer esptool dropped the parens around the
-            # percent and added an ASCII progress bar + bytes counter.
-            # The percentage is now decimal — we capture the integer
-            # part since the dashboard's progress bar is a coarse 0-100.
-            (
-                "Writing at 0x000cf943 [========================>     ]  84.8% "
-                "491520/579918 bytes...",
-                84,
-            ),
-            ("Writing at 0x00010000 [                              ]  0.0% 0/579918 bytes...", 0),
-            (
-                "Writing at 0x000a1234 [==============================] 100.0% "
-                "579918/579918 bytes...",
-                100,
-            ),
-            # Carriage-return-terminated chunk: ``iter_lines_with_progress``
-            # splits on ``\r`` so esptool's in-place line refreshes survive
-            # the pipe. The trailing ``\r`` is part of the chunk handed to
-            # ``_parse_progress``; it must not break the match.
-            (
-                "Writing at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...\r",
-                42,
-            ),
-            # ANSI-prefixed line — the runner sets ``FORCE_COLOR=1`` /
-            # ``CLICOLOR_FORCE=1`` so esptool emits ``\x1b[2K`` clear-line
-            # escapes before each refresh. An anchored ``^\s*`` regex
-            # would silently fail in production (the escapes aren't
-            # whitespace) while passing in plain-text tests. Pinning
-            # this case prevents a future "tighten the regex" refactor
-            # from re-introducing the anchor and breaking serial install
-            # progress capture again — that's exactly the regression
-            # this PR fixes (issue #140).
-            (
-                "\x1b[2KWriting at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...",
-                42,
-            ),
-        ],
-    )
-    def test_esptool_writing_marker_new(self, line: str, expected: int) -> None:
-        assert _parse_progress(line) == expected
-
-    @pytest.mark.parametrize(
-        ("line", "expected"),
-        [
-            ("Uploading: [====================] 100% Done...", 100),
-            ("Uploading: [====      ] 35% ...", 35),
-            ("    Uploading: [===========] 50%", 50),
-        ],
-    )
-    def test_esphome_ota_marker(self, line: str, expected: int) -> None:
-        assert _parse_progress(line) == expected
-
-
-class TestNoisyLinesIgnored:
-    """Lines that look percent-y but aren't real progress signals."""
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # The original bug report: PIO platform-package extract bar
-            # pinned the dashboard to 100% before the compile had
-            # actually started any meaningful work.
-            "Unpacking [####################################] 100%",
-            "Unpacking  [##                                  ] 5%",
-        ],
-    )
-    def test_unpacking_bar_ignored(self, line: str) -> None:
-        assert _parse_progress(line) is None
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # PIO emits a memory-usage report at the end of the link
-            # step. The percentages there describe how full each
-            # memory region is, not build progress.
-            "RAM:   [==        ]  19.3% (used 63276 bytes from 327680 bytes)",
-            "Flash: [========  ]  80.0% (used 1467116 bytes from 1835008 bytes)",
-        ],
-    )
-    def test_memory_usage_report_ignored(self, line: str) -> None:
-        assert _parse_progress(line) is None
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # Narrative log text that happens to mention a percentage
-            # — should never be treated as progress.
-            "Saved 75% of build artifacts to cache.",
-            "Coverage report: lines 87% / branches 65%",
-            "INFO Flash erased — 100% complete in 0.5s",
-        ],
-    )
-    def test_stray_percentages_ignored(self, line: str) -> None:
-        assert _parse_progress(line) is None
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # No percentage at all.
-            "INFO Successfully compiled program.",
-            "Compiling .pio/foo.cpp.o",
-            "",
-        ],
-    )
-    def test_lines_without_percent_ignored(self, line: str) -> None:
-        assert _parse_progress(line) is None
-
-
-class TestOutOfRange:
-    """Sanity-check the bounds.
-
-    A percentage > 100 is data corruption, not progress; we drop it
-    to keep ``job.progress`` clean.
-    """
-
-    def test_over_one_hundred_is_dropped(self) -> None:
-        # Hypothetical malformed esptool output. ``101`` would fall
-        # outside our 0..100 contract and pollute the UI.
-        assert _parse_progress("Writing at 0x00010000... (101 %)") is None
-
-    def test_three_digit_within_range(self) -> None:
-        # 100 is allowed; the regex accepts up to three digits to
-        # cover this exact value.
-        assert _parse_progress("[100%] Linking firmware.elf") == 100
-
-
-class TestNinjaCounterLines:
-    """Ninja ``[N/M]`` counters parse to ``(done, total)``; noise doesn't."""
-
-    @pytest.mark.parametrize(
-        ("line", "expected"),
-        [
-            (
-                "[907/1424] Building C object esp-idf/bt/CMakeFiles/__idf_bt.dir/"
-                "host/bluedroid/bta/av/bta_av_cfg.c.obj",
-                (907, 1424),
-            ),
-            ("[1424/1424] Linking .pioenvs/firmware.elf", (1424, 1424)),
-            ("[1/1424] Generating memory view", (1, 1424)),
-            ("[1/2] Re-running CMake...", (1, 2)),
-            ("    [907/1424] Building C object foo.c.obj", (907, 1424)),
-            # CR-terminated in-place refresh chunk.
-            ("[907/1424] Building C object foo.c.obj\r", (907, 1424)),
-            # ANSI clear-line prefix — a bare ``^\s*`` anchor would
-            # silently fail in production while passing plain-text tests
-            # (same trap as the esptool ``Writing at`` pattern).
-            ("\x1b[2K[907/1424] Building C object foo.c.obj", (907, 1424)),
-        ],
-    )
-    def test_counter_lines_parse(self, line: str, expected: tuple[int, int]) -> None:
-        assert _parse_ninja_counter(line) == expected
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # Malformed: done past total.
-            "[150/100] Building C object foo.c.obj",
-            # Mid-line counters are narrative text, not progress.
-            "note: see [110/200] above",
-            # Ninja always puts a space after the ``]`` — a bare or
-            # glued counter isn't its output shape.
-            "[907/1424]",
-            "[907/1424]Building C object foo.c.obj",
-            # Build noise that brackets digits without being a counter.
-            "otadata,data,ota,0x9000,8K,",
-            "*" * 79,
-        ],
-    )
-    def test_non_counter_lines_ignored(self, line: str) -> None:
-        assert _parse_ninja_counter(line) is None
-
-    def test_parse_progress_leaves_counters_alone(self) -> None:
-        assert _parse_progress("[907/1424] Building C object foo.c.obj") is None
-
-
 def _job() -> FirmwareJob:
     return FirmwareJob(job_id="j1", configuration="kitchen.yaml", job_type=JobType.COMPILE)
 
 
-class TestNinjaGaugeGating:
-    """``_ninja_progress`` derives a percentage from the dominant counter only."""
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("[  1%] Compiling .pio/foo.cpp.o", 1),
+        ("[ 17%] Compiling .pio/bar.cpp.o", 17),
+        ("[100%] Linking .pioenvs/firmware.elf", 100),
+        # leading whitespace is fine, ESPHome's --dashboard mode
+        # sometimes prefixes lines with indent.
+        ("    [ 42%] Compiling baz.cpp.o", 42),
+    ],
+)
+def test_pio_arduino_compile_marker(line: str, expected: int) -> None:
+    assert _parse_progress(line) == expected
 
-    def test_subbuild_final_counter_does_not_latch_100(self) -> None:
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("Writing at 0x00010000... (5 %)", 5),
+        ("Writing at 0x00050000... (45 %)", 45),
+        ("Writing at 0x00100000... (100 %)", 100),
+        # esptool sometimes drops the space before %.
+        ("Writing at 0x00050000... (45%)", 45),
+    ],
+)
+def test_esptool_writing_marker_legacy(line: str, expected: int) -> None:
+    assert _parse_progress(line) == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        # Issue #140: newer esptool dropped the parens around the
+        # percent and added an ASCII progress bar + bytes counter.
+        # The percentage is now decimal — we capture the integer
+        # part since the dashboard's progress bar is a coarse 0-100.
+        pytest.param(
+            "Writing at 0x000cf943 [========================>     ]  84.8% 491520/579918 bytes...",
+            84,
+            id="decimal_mid",
+        ),
+        pytest.param(
+            "Writing at 0x00010000 [                              ]  0.0% 0/579918 bytes...",
+            0,
+            id="decimal_zero",
+        ),
+        pytest.param(
+            "Writing at 0x000a1234 [==============================] 100.0% 579918/579918 bytes...",
+            100,
+            id="decimal_full",
+        ),
+        # Carriage-return-terminated chunk: ``iter_lines_with_progress``
+        # splits on ``\r`` so esptool's in-place line refreshes survive
+        # the pipe. The trailing ``\r`` is part of the chunk handed to
+        # ``_parse_progress``; it must not break the match.
+        pytest.param(
+            "Writing at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...\r",
+            42,
+            id="cr_terminated",
+        ),
+        # ANSI-prefixed line — the runner sets ``FORCE_COLOR=1`` /
+        # ``CLICOLOR_FORCE=1`` so esptool emits ``\x1b[2K`` clear-line
+        # escapes before each refresh. An anchored ``^\s*`` regex
+        # would silently fail in production (the escapes aren't
+        # whitespace) while passing in plain-text tests. Pinning
+        # this case prevents a future "tighten the regex" refactor
+        # from re-introducing the anchor and breaking serial install
+        # progress capture again — that's exactly the regression
+        # this PR fixes (issue #140).
+        pytest.param(
+            "\x1b[2KWriting at 0x000cf943 [=>     ]  42.5% 200000/579918 bytes...",
+            42,
+            id="ansi_prefixed",
+        ),
+    ],
+)
+def test_esptool_writing_marker_new(line: str, expected: int) -> None:
+    assert _parse_progress(line) == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("Uploading: [====================] 100% Done...", 100),
+        ("Uploading: [====      ] 35% ...", 35),
+        ("    Uploading: [===========] 50%", 50),
+    ],
+)
+def test_esphome_ota_marker(line: str, expected: int) -> None:
+    assert _parse_progress(line) == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # The original bug report: PIO platform-package extract bar
+        # pinned the dashboard to 100% before the compile had
+        # actually started any meaningful work.
+        "Unpacking [####################################] 100%",
+        "Unpacking  [##                                  ] 5%",
+        # PIO emits a memory-usage report at the end of the link
+        # step. The percentages there describe how full each
+        # memory region is, not build progress.
+        "RAM:   [==        ]  19.3% (used 63276 bytes from 327680 bytes)",
+        "Flash: [========  ]  80.0% (used 1467116 bytes from 1835008 bytes)",
+        # Narrative log text that happens to mention a percentage
+        # — should never be treated as progress.
+        "Saved 75% of build artifacts to cache.",
+        "Coverage report: lines 87% / branches 65%",
+        "INFO Flash erased — 100% complete in 0.5s",
+        # No percentage at all.
+        "INFO Successfully compiled program.",
+        "Compiling .pio/foo.cpp.o",
+        "",
+    ],
+)
+def test_noisy_lines_ignored(line: str) -> None:
+    assert _parse_progress(line) is None
+
+
+def test_over_one_hundred_is_dropped() -> None:
+    # Hypothetical malformed esptool output. ``101`` would fall
+    # outside our 0..100 contract and pollute the UI.
+    assert _parse_progress("Writing at 0x00010000... (101 %)") is None
+
+
+def test_three_digit_within_range() -> None:
+    # 100 is allowed; the regex accepts up to three digits to
+    # cover this exact value.
+    assert _parse_progress("[100%] Linking firmware.elf") == 100
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            "[907/1424] Building C object esp-idf/bt/CMakeFiles/__idf_bt.dir/"
+            "host/bluedroid/bta/av/bta_av_cfg.c.obj",
+            (907, 1424),
+        ),
+        ("[1424/1424] Linking .pioenvs/firmware.elf", (1424, 1424)),
+        ("[1/1424] Generating memory view", (1, 1424)),
+        ("[1/2] Re-running CMake...", (1, 2)),
+        ("    [907/1424] Building C object foo.c.obj", (907, 1424)),
+        # CR-terminated in-place refresh chunk.
+        ("[907/1424] Building C object foo.c.obj\r", (907, 1424)),
+        # ANSI clear-line prefix — a bare ``^\s*`` anchor would
+        # silently fail in production while passing plain-text tests
+        # (same trap as the esptool ``Writing at`` pattern).
+        ("\x1b[2K[907/1424] Building C object foo.c.obj", (907, 1424)),
+    ],
+)
+def test_ninja_counter_lines_parse(line: str, expected: tuple[int, int]) -> None:
+    assert _parse_ninja_counter(line) == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Malformed: done past total.
+        "[150/100] Building C object foo.c.obj",
+        # Mid-line counters are narrative text, not progress.
+        "note: see [110/200] above",
+        # Ninja always puts a space after the ``]`` — a bare or
+        # glued counter isn't its output shape.
+        "[907/1424]",
+        "[907/1424]Building C object foo.c.obj",
+        # Build noise that brackets digits without being a counter.
+        "otadata,data,ota,0x9000,8K,",
+        "*" * 79,
+    ],
+)
+def test_non_counter_lines_ignored(line: str) -> None:
+    assert _parse_ninja_counter(line) is None
+
+
+def test_parse_progress_leaves_counters_alone() -> None:
+    assert _parse_progress("[907/1424] Building C object foo.c.obj") is None
+
+
+@pytest.mark.parametrize(
+    "steps",
+    [
         # The bootloader ExternalProject sub-build (123 steps on IDF 5.x)
         # streams its own counter mid-run; its [N/N] final step must not
         # pin the gauge to 100 while the app build is at 99.
-        job = _job()
-        assert _ninja_progress(job, "[10/1133] Building C object a.c.obj") == 0
-        assert _ninja_progress(job, "[123/123] Linking CXX executable bootloader.elf") is None
-        assert _ninja_progress(job, "[1123/1133] Completed 'bootloader'") == 99
-        assert _ninja_progress(job, "[1133/1133] Linking .pioenvs/firmware.elf") == 100
-
-    def test_totals_under_floor_never_start_the_gauge(self) -> None:
-        job = _job()
-        assert _ninja_progress(job, "[1/2] Re-running CMake...") is None
-        assert _ninja_progress(job, "[97/97] Linking bootloader.elf") is None
-
-    def test_growing_total_keeps_advancing(self) -> None:
+        pytest.param(
+            [
+                ("[10/1133] Building C object a.c.obj", 0),
+                ("[123/123] Linking CXX executable bootloader.elf", None),
+                ("[1123/1133] Completed 'bootloader'", 99),
+                ("[1133/1133] Linking .pioenvs/firmware.elf", 100),
+            ],
+            id="subbuild_final_counter_does_not_latch_100",
+        ),
+        pytest.param(
+            [
+                ("[1/2] Re-running CMake...", None),
+                ("[97/97] Linking bootloader.elf", None),
+            ],
+            id="totals_under_floor_never_start_the_gauge",
+        ),
         # Ninja recomputes its total as edges are discovered; an equal or
         # larger total stays authoritative.
-        job = _job()
-        assert _ninja_progress(job, "[10/100] Building C object a.c.obj") == 10
-        assert _ninja_progress(job, "[60/120] Building C object b.c.obj") == 50
+        pytest.param(
+            [
+                ("[10/100] Building C object a.c.obj", 10),
+                ("[60/120] Building C object b.c.obj", 50),
+            ],
+            id="growing_total_keeps_advancing",
+        ),
+    ],
+)
+def test_ninja_gauge_gating(steps: list[tuple[str, int | None]]) -> None:
+    job = _job()
+    for line, expected in steps:
+        assert _ninja_progress(job, line) == expected

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -8,7 +8,7 @@ real ones (PlatformIO ``[ NN%]`` per-file markers, esptool
 else (PIO platform-extract bars, memory-usage reports, stray
 percentages in narrative log text). ESP-IDF builds emit no percent
 at all — their ninja ``[N/M]`` counter is parsed separately
-(``_parse_ninja_counter``) and ``_ingest_output_line`` derives the
+(``_parse_ninja_counter``) and ``_ninja_progress`` derives the
 percentage, gated on the largest total seen so ``[1/2] Re-running
 CMake...`` sub-steps and the bootloader ExternalProject sub-build
 never drive the gauge.
@@ -25,11 +25,10 @@ from __future__ import annotations
 import pytest
 
 from esphome_device_builder.controllers.firmware.helpers import (
-    _ingest_output_line,
+    _ninja_progress,
     _parse_ninja_counter,
     _parse_progress,
 )
-from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.models.firmware import FirmwareJob, JobType
 
 
@@ -245,37 +244,27 @@ def _job() -> FirmwareJob:
     return FirmwareJob(job_id="j1", configuration="kitchen.yaml", job_type=JobType.COMPILE)
 
 
-def _feed(job: FirmwareJob, *lines: str) -> None:
-    bus = EventBus()
-    for line in lines:
-        _ingest_output_line(job, bus, line + "\n")
-
-
 class TestNinjaGaugeGating:
-    """``_ingest_output_line`` derives ninja progress from the dominant counter only."""
+    """``_ninja_progress`` derives a percentage from the dominant counter only."""
 
     def test_subbuild_final_counter_does_not_latch_100(self) -> None:
         # The bootloader ExternalProject sub-build (123 steps on IDF 5.x)
         # streams its own counter mid-run; its [N/N] final step must not
         # pin the gauge to 100 while the app build is at 99.
         job = _job()
-        _feed(job, "[10/1133] Building C object a.c.obj")
-        _feed(job, "[123/123] Linking CXX executable bootloader.elf")
-        _feed(job, "[1123/1133] Completed 'bootloader'")
-        assert job.progress == 99
-        _feed(job, "[1133/1133] Linking .pioenvs/firmware.elf")
-        assert job.progress == 100
+        assert _ninja_progress(job, "[10/1133] Building C object a.c.obj") == 0
+        assert _ninja_progress(job, "[123/123] Linking CXX executable bootloader.elf") is None
+        assert _ninja_progress(job, "[1123/1133] Completed 'bootloader'") == 99
+        assert _ninja_progress(job, "[1133/1133] Linking .pioenvs/firmware.elf") == 100
 
     def test_totals_under_floor_never_start_the_gauge(self) -> None:
         job = _job()
-        _feed(job, "[1/2] Re-running CMake...", "[97/97] Linking bootloader.elf")
-        assert job.progress is None
+        assert _ninja_progress(job, "[1/2] Re-running CMake...") is None
+        assert _ninja_progress(job, "[97/97] Linking bootloader.elf") is None
 
     def test_growing_total_keeps_advancing(self) -> None:
         # Ninja recomputes its total as edges are discovered; an equal or
         # larger total stays authoritative.
         job = _job()
-        _feed(job, "[10/100] Building C object a.c.obj")
-        assert job.progress == 10
-        _feed(job, "[60/120] Building C object b.c.obj")
-        assert job.progress == 50
+        assert _ninja_progress(job, "[10/100] Building C object a.c.obj") == 10
+        assert _ninja_progress(job, "[60/120] Building C object b.c.obj") == 50

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -7,9 +7,11 @@ real ones (PlatformIO ``[ NN%]`` per-file markers, esptool
 ``(NN %)``, ESPHome OTA ``Uploading: 100%``) and skip everything
 else (PIO platform-extract bars, memory-usage reports, stray
 percentages in narrative log text). ESP-IDF builds emit no percent
-at all — their ninja ``[N/M]`` counter derives one, with a total
-floor so ``[1/2] Re-running CMake...`` sub-steps and the bootloader
-sub-build never drive the gauge.
+at all — their ninja ``[N/M]`` counter is parsed separately
+(``_parse_ninja_counter``) and ``_ingest_output_line`` derives the
+percentage, gated on the largest total seen so ``[1/2] Re-running
+CMake...`` sub-steps and the bootloader ExternalProject sub-build
+never drive the gauge.
 
 The regression these tests guard against: a wide-open
 ``\d{1,3}%`` regex pinned ``job.progress`` to 100 the moment
@@ -22,7 +24,13 @@ from __future__ import annotations
 
 import pytest
 
-from esphome_device_builder.controllers.firmware.helpers import _parse_progress
+from esphome_device_builder.controllers.firmware.helpers import (
+    _ingest_output_line,
+    _parse_ninja_counter,
+    _parse_progress,
+)
+from esphome_device_builder.helpers.event_bus import EventBus
+from esphome_device_builder.models.firmware import FirmwareJob, JobType
 
 
 class TestRealProgressLines:
@@ -185,7 +193,7 @@ class TestOutOfRange:
 
 
 class TestNinjaCounterLines:
-    """Ninja ``[N/M]`` counters resolve to a percentage above the total floor."""
+    """Ninja ``[N/M]`` counters parse to ``(done, total)``; noise doesn't."""
 
     @pytest.mark.parametrize(
         ("line", "expected"),
@@ -193,38 +201,26 @@ class TestNinjaCounterLines:
             (
                 "[907/1424] Building C object esp-idf/bt/CMakeFiles/__idf_bt.dir/"
                 "host/bluedroid/bta/av/bta_av_cfg.c.obj",
-                63,
+                (907, 1424),
             ),
-            (
-                "[707/1473] Building C object esp-idf/mbedtls/mbedtls/library/"
-                "CMakeFiles/mbedtls.dir/mbedtls_debug.c.obj",
-                47,
-            ),
-            ("[1424/1424] Linking .pioenvs/firmware.elf", 100),
-            ("[1/1424] Generating memory view", 0),
-            # Total exactly at the floor still counts.
-            ("[50/100] Building C object foo.c.obj", 50),
-            ("    [907/1424] Building C object foo.c.obj", 63),
+            ("[1424/1424] Linking .pioenvs/firmware.elf", (1424, 1424)),
+            ("[1/1424] Generating memory view", (1, 1424)),
+            ("[1/2] Re-running CMake...", (1, 2)),
+            ("    [907/1424] Building C object foo.c.obj", (907, 1424)),
             # CR-terminated in-place refresh chunk.
-            ("[907/1424] Building C object foo.c.obj\r", 63),
+            ("[907/1424] Building C object foo.c.obj\r", (907, 1424)),
             # ANSI clear-line prefix — a bare ``^\s*`` anchor would
             # silently fail in production while passing plain-text tests
             # (same trap as the esptool ``Writing at`` pattern).
-            ("\x1b[2K[907/1424] Building C object foo.c.obj", 63),
+            ("\x1b[2K[907/1424] Building C object foo.c.obj", (907, 1424)),
         ],
     )
-    def test_counter_lines_parse(self, line: str, expected: int) -> None:
-        assert _parse_progress(line) == expected
+    def test_counter_lines_parse(self, line: str, expected: tuple[int, int]) -> None:
+        assert _parse_ninja_counter(line) == expected
 
     @pytest.mark.parametrize(
         "line",
         [
-            # Totals under the floor: CMake sub-steps, bootloader
-            # sub-build, tiny incremental rebuilds.
-            "[1/2] Re-running CMake...",
-            "[97/97] Linking bootloader.elf",
-            "[3/7] Building C object foo.c.obj",
-            "[0/0] nothing",
             # Malformed: done past total.
             "[150/100] Building C object foo.c.obj",
             # Mid-line counters are narrative text, not progress.
@@ -239,4 +235,47 @@ class TestNinjaCounterLines:
         ],
     )
     def test_non_counter_lines_ignored(self, line: str) -> None:
-        assert _parse_progress(line) is None
+        assert _parse_ninja_counter(line) is None
+
+    def test_parse_progress_leaves_counters_alone(self) -> None:
+        assert _parse_progress("[907/1424] Building C object foo.c.obj") is None
+
+
+def _job() -> FirmwareJob:
+    return FirmwareJob(job_id="j1", configuration="kitchen.yaml", job_type=JobType.COMPILE)
+
+
+def _feed(job: FirmwareJob, *lines: str) -> None:
+    bus = EventBus()
+    for line in lines:
+        _ingest_output_line(job, bus, line + "\n")
+
+
+class TestNinjaGaugeGating:
+    """``_ingest_output_line`` derives ninja progress from the dominant counter only."""
+
+    def test_subbuild_final_counter_does_not_latch_100(self) -> None:
+        # The bootloader ExternalProject sub-build (123 steps on IDF 5.x)
+        # streams its own counter mid-run; its [N/N] final step must not
+        # pin the gauge to 100 while the app build is at 99.
+        job = _job()
+        _feed(job, "[10/1133] Building C object a.c.obj")
+        _feed(job, "[123/123] Linking CXX executable bootloader.elf")
+        _feed(job, "[1123/1133] Completed 'bootloader'")
+        assert job.progress == 99
+        _feed(job, "[1133/1133] Linking .pioenvs/firmware.elf")
+        assert job.progress == 100
+
+    def test_totals_under_floor_never_start_the_gauge(self) -> None:
+        job = _job()
+        _feed(job, "[1/2] Re-running CMake...", "[97/97] Linking bootloader.elf")
+        assert job.progress is None
+
+    def test_growing_total_keeps_advancing(self) -> None:
+        # Ninja recomputes its total as edges are discovered; an equal or
+        # larger total stays authoritative.
+        job = _job()
+        _feed(job, "[10/100] Building C object a.c.obj")
+        assert job.progress == 10
+        _feed(job, "[60/120] Building C object b.c.obj")
+        assert job.progress == 50

--- a/tests/controllers/firmware/test_progress.py
+++ b/tests/controllers/firmware/test_progress.py
@@ -253,3 +253,21 @@ def test_ninja_gauge_gating(steps: list[tuple[str, int | None]]) -> None:
     job = _job()
     for line, expected in steps:
         assert _ninja_progress(job, line) == expected
+
+
+def test_ninja_total_stays_off_the_wire() -> None:
+    job = _job()
+    assert _ninja_progress(job, "[500/1133] Building C object a.c.obj") == 44
+    assert job.ninja_total == 1133
+    assert "ninja_total" not in job.to_dict()
+    assert FirmwareJob.from_dict(job.to_dict()).ninja_total == 0
+
+
+def test_clear_run_state_resets_ninja_total() -> None:
+    # A mid-build re-route reuses the same job instance; a stale total
+    # from the aborted run must not gate the fresh run's counters.
+    job = _job()
+    _ninja_progress(job, "[500/1133] Building C object a.c.obj")
+    job.clear_run_state()
+    assert job.ninja_total == 0
+    assert _ninja_progress(job, "[60/120] Building C object b.c.obj") == 50


### PR DESCRIPTION
# What does this implement/fix?

The build gauge showed 100% while ninja was still at `[1123/1133] Completed 'bootloader'`. The percent math already rounds down; the real culprit is the bootloader ExternalProject sub-build, whose own ninja counter streams through the same output. On IDF 5.x it has 123 steps, past the old 100-step floor, so its `[123/123]` final line parsed as 100% and the monotonic latch held it there for the rest of the build.

Ninja counters now only drive the gauge when their total is the largest seen for the job, so sub-build counters of any size are ignored; 100% fires only on the app build's final target. The bookkeeping field is kept off the wire and off disk, so no frontend or persistence shape changes.

**Related issue or feature (if applicable):**

- none, reported directly from live build output

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
