### PR TITLE
Extract a shared resolve-under-root path guard

### DIFF
--- a/esphome_device_builder/controllers/config/settings.py
+++ b/esphome_device_builder/controllers/config/settings.py
@@ -24,6 +24,7 @@ from ...helpers.api import CommandError
 from ...helpers.auth import hash_password
 from ...helpers.credentials import resolve_credentials
 from ...helpers.network_interfaces import resolve_bind_host
+from ...helpers.paths import PathEscapeError, resolve_under_root
 from ...helpers.secrets_state import migrate_placeholder_wifi_secrets
 from ...models import ErrorCode
 
@@ -294,9 +295,9 @@ class DashboardSettings:
         """
         Return a path relative to the config dir, validated against path traversal.
 
-        ``relative_to`` raises ``ValueError`` when ``parts`` resolve outside
-        the config dir; we translate that into a ``CommandError`` so the
-        WS dispatcher surfaces it as ``INVALID_ARGS`` instead of the
+        :class:`PathEscapeError` (when ``parts`` resolve outside the
+        config dir) is translated into a ``CommandError`` so the WS
+        dispatcher surfaces it as ``INVALID_ARGS`` instead of the
         generic ``INTERNAL_ERROR`` that an unclassified ``ValueError``
         would produce. Single chokepoint for every handler that builds
         a configuration path.
@@ -304,8 +305,8 @@ class DashboardSettings:
         joined = self.config_dir.joinpath(*parts)
         assert self.absolute_config_dir is not None  # type narrowing
         try:
-            joined.resolve().relative_to(self.absolute_config_dir)
-        except ValueError as err:
+            resolve_under_root(joined, self.absolute_config_dir)
+        except PathEscapeError as err:
             # ``!r`` quotes + escapes the offending value so embedded
             # CR/LF/control bytes can't break the error string when
             # the frontend echoes it back to the user. ``!r`` *first*,

--- a/esphome_device_builder/controllers/firmware/download.py
+++ b/esphome_device_builder/controllers/firmware/download.py
@@ -24,6 +24,7 @@ from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
 from ...helpers.json import JSONDecodeError
 from ...helpers.json import loads as json_loads
+from ...helpers.paths import resolve_under_root
 from ...helpers.storage_path import resolve_storage_path
 from ...models.boards import normalize_platform
 from .helpers import _find_sibling_cli
@@ -229,7 +230,7 @@ def _resolve_artifact_path(configuration: str, file: str) -> tuple[Path, str]:
     """Resolve a build artifact to ``(path, download_name)``, traversal-safe.
 
     Raises ``FileNotFoundError`` when the device isn't built or *file* is
-    absent, and ``ValueError`` (from ``relative_to``) when *file* escapes the
+    absent, and ``PathEscapeError`` (a ``ValueError``) when *file* escapes the
     build directory. ``download_name`` is restricted to a filename-safe charset
     so it can't inject into a ``Content-Disposition`` header.
     """
@@ -239,10 +240,7 @@ def _resolve_artifact_path(configuration: str, file: str) -> tuple[Path, str]:
         raise FileNotFoundError(msg)
 
     base_dir = storage.firmware_bin_path.parent.resolve()
-    path = (base_dir / file).resolve()
-    # Path traversal protection — resolve() collapses ``..`` / absolute
-    # ``file`` / symlinks, then relative_to raises if it escaped base_dir.
-    path.relative_to(base_dir)
+    path = resolve_under_root(base_dir / file, base_dir)
 
     if not path.is_file():
         msg = f"Binary not found: {file}"

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -63,6 +63,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from ...helpers.async_ import run_in_executor
 from ...helpers.lazy_module import async_import_module
+from ...helpers.paths import PathEscapeError, resolve_under_root
 from ...helpers.peer_link_bundle import (
     BundleAssembler,
     BundleAssemblerError,
@@ -623,7 +624,10 @@ class SubmitJobReceiver:
                 self._config_dir,
                 prepare,
             )
-        except _PathEscapeError as exc:
+        except PathEscapeError as exc:
+            # Wire-shape problem (traversal via ``configuration_filename``
+            # / ``dashboard_id``), not a receiver-side I/O failure — maps
+            # to ``invalid_header``, distinct from ``extract_failed``.
             _LOGGER.warning(
                 "submit_job from %s: target_dir %s escaped remote-builds root; rejecting",
                 session.dashboard_id,
@@ -756,20 +760,6 @@ class _SubmitJobRejectionError(Exception):
         self.reason = reason
 
 
-class _PathEscapeError(Exception):
-    """*target_dir* resolved outside the remote-builds root.
-
-    Surfaced from :func:`_validate_write_extract_bundle` so the
-    caller can map to a typed
-    :class:`SubmitJobAckFrameData.reason` of ``invalid_header``.
-    Distinct from the ``EsphomeError`` / ``OSError`` paths
-    (which surface as ``extract_failed``) because this is a
-    wire-shape problem — the offloader's ``configuration_filename``
-    or its captured ``dashboard_id`` carries a path-traversal
-    shape — not a receiver-side I/O failure.
-    """
-
-
 def _validate_write_extract_bundle(
     bundle_path: Path,
     bundle_bytes: bytes,
@@ -800,24 +790,18 @@ def _validate_write_extract_bundle(
     (#678) still produces an absolute-vs-absolute
     ``relative_to`` pair.
 
-    Raises :class:`_PathEscapeError` on the path-escape branch
+    Raises :class:`PathEscapeError` on the path-escape branch
     so the caller can distinguish "bad input shape" from
     "extract failed". Raises
     :class:`esphome.bundle.EsphomeError` / :class:`OSError`
     untouched for the extract / write paths.
     """
-    # Resolve-and-stay-under-root. ``Path.resolve()`` normalises
-    # ``..`` / symlinks; ``relative_to`` raises ``ValueError``
-    # when the result climbs outside the remote-builds root.
     # The upstream filename validator catches separator / ``..``
     # in ``configuration_filename`` upfront, but ``dashboard_id``
     # flows through unvalidated from the Noise handshake /
     # receiver-side registration; this gate catches anything an
     # exotic ``dashboard_id`` shape would slip past.
-    try:
-        target_dir.resolve().relative_to(remote_builds_root.resolve())
-    except ValueError as exc:
-        raise _PathEscapeError(str(target_dir)) from exc
+    resolve_under_root(target_dir, remote_builds_root)
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     bundle_path.write_bytes(bundle_bytes)
     extracted: Path = prepare_bundle_for_compile(bundle_path, target_dir)

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -773,8 +773,4 @@ class GitRepo:
 
 def _encloses_own_source(toplevel: Path) -> bool:
     """Whether *toplevel* is the Device Builder's own source checkout."""
-    try:
-        _OWN_SOURCE_ROOT.relative_to(toplevel.resolve())
-    except ValueError:
-        return False
-    return True
+    return _OWN_SOURCE_ROOT.is_relative_to(toplevel.resolve())

--- a/esphome_device_builder/helpers/paths.py
+++ b/esphome_device_builder/helpers/paths.py
@@ -19,10 +19,15 @@ def resolve_under_root(target: Path, root: Path) -> Path:
     escape. Blocking (``resolve`` walks the filesystem) — call from
     executor threads.
     """
+    # Explicit NUL gate: POSIX ``resolve()`` raises ``ValueError`` on an
+    # embedded NUL but Windows swallows it, so the check can't ride the
+    # except below on every platform.
+    if "\x00" in str(target):
+        raise PathEscapeError(f"{str(target)!r} contains a NUL byte")
     try:
         resolved = target.resolve()
     except ValueError as err:
-        raise PathEscapeError(f"{target!r} is unresolvable: {err}") from err
+        raise PathEscapeError(f"{str(target)!r} is unresolvable: {err}") from err
     if not resolved.is_relative_to(root.resolve()):
         raise PathEscapeError(f"{target} resolves outside {root}")
     return resolved

--- a/esphome_device_builder/helpers/paths.py
+++ b/esphome_device_builder/helpers/paths.py
@@ -1,0 +1,28 @@
+"""Shared path-containment guard for write / delete / serve targets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class PathEscapeError(ValueError):
+    """*target* resolved outside the trusted *root*."""
+
+
+def resolve_under_root(target: Path, root: Path) -> Path:
+    """
+    Resolve *target* and require it stays under resolved *root*.
+
+    Collapses ``..`` / symlinks via ``Path.resolve()`` before the
+    containment check; returns the resolved target. A target that
+    can't be resolved at all (embedded NUL) fails closed as an
+    escape. Blocking (``resolve`` walks the filesystem) — call from
+    executor threads.
+    """
+    try:
+        resolved = target.resolve()
+    except ValueError as err:
+        raise PathEscapeError(f"{target!r} is unresolvable: {err}") from err
+    if not resolved.is_relative_to(root.resolve()):
+        raise PathEscapeError(f"{target} resolves outside {root}")
+    return resolved

--- a/esphome_device_builder/helpers/paths.py
+++ b/esphome_device_builder/helpers/paths.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 class PathEscapeError(ValueError):
-    """*target* resolved outside the trusted *root*."""
+    """*target* resolved outside the trusted *root*, or couldn't be resolved at all."""
 
 
 def resolve_under_root(target: Path, root: Path) -> Path:
@@ -29,5 +29,7 @@ def resolve_under_root(target: Path, root: Path) -> Path:
     except ValueError as err:
         raise PathEscapeError(f"{str(target)!r} is unresolvable: {err}") from err
     if not resolved.is_relative_to(root.resolve()):
-        raise PathEscapeError(f"{target} resolves outside {root}")
+        # ``!r`` so control characters in a user-controlled filename
+        # can't inject into logs / error strings built from this message.
+        raise PathEscapeError(f"{str(target)!r} resolves outside {str(root)!r}")
     return resolved

--- a/tests/helpers/test_paths.py
+++ b/tests/helpers/test_paths.py
@@ -61,6 +61,17 @@ def test_unresolvable_target_fails_closed(tmp_path: Path) -> None:
         resolve_under_root(tmp_path / "bad\x00name.yaml", tmp_path)
 
 
+def test_resolve_value_error_fails_closed(tmp_path: Path) -> None:
+    """A non-NUL ``ValueError`` out of ``resolve()`` also surfaces as an escape."""
+
+    class _UnresolvablePath(type(tmp_path)):  # type: ignore[misc]
+        def resolve(self, strict: bool = False) -> Path:
+            raise ValueError("boom")
+
+    with pytest.raises(PathEscapeError, match="unresolvable"):
+        resolve_under_root(_UnresolvablePath(tmp_path, "x"), tmp_path)
+
+
 def test_escape_error_is_a_value_error(tmp_path: Path) -> None:
     """Callers with an existing ``except ValueError`` contract keep working."""
     root = tmp_path / "root"

--- a/tests/helpers/test_paths.py
+++ b/tests/helpers/test_paths.py
@@ -1,0 +1,69 @@
+"""Coverage for ``helpers.paths.resolve_under_root``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from esphome_device_builder.helpers.paths import PathEscapeError, resolve_under_root
+
+_symlinks = pytest.mark.skipif(sys.platform == "win32", reason="symlinks need privileges")
+
+
+def test_returns_resolved_target_inside_root(tmp_path: Path) -> None:
+    (tmp_path / "sub").mkdir()
+    target = tmp_path / "sub" / ".." / "sub" / "file.yaml"
+    assert resolve_under_root(target, tmp_path) == (tmp_path / "sub" / "file.yaml").resolve()
+
+
+def test_root_itself_passes(tmp_path: Path) -> None:
+    assert resolve_under_root(tmp_path, tmp_path) == tmp_path.resolve()
+
+
+def test_dotdot_traversal_raises(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(PathEscapeError):
+        resolve_under_root(root / ".." / "outside.yaml", root)
+
+
+def test_absolute_target_outside_root_raises(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(PathEscapeError):
+        resolve_under_root(tmp_path / "elsewhere.yaml", root)
+
+
+@_symlinks
+def test_symlink_pointing_outside_root_raises(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "link").symlink_to(outside)
+    with pytest.raises(PathEscapeError):
+        resolve_under_root(root / "link" / "file.yaml", root)
+
+
+@_symlinks
+def test_symlinked_dir_inside_root_resolves(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "real").mkdir(parents=True)
+    (root / "alias").symlink_to(root / "real")
+    assert resolve_under_root(root / "alias" / "f.bin", root) == root.resolve() / "real" / "f.bin"
+
+
+def test_unresolvable_target_fails_closed(tmp_path: Path) -> None:
+    """An embedded NUL makes ``resolve()`` raise; that must surface as an escape."""
+    with pytest.raises(PathEscapeError):
+        resolve_under_root(tmp_path / "bad\x00name.yaml", tmp_path)
+
+
+def test_escape_error_is_a_value_error(tmp_path: Path) -> None:
+    """Callers with an existing ``except ValueError`` contract keep working."""
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(ValueError, match="resolves outside"):
+        resolve_under_root(root / ".." / "x", root)


### PR DESCRIPTION
# What does this implement/fix?

Extracts the shared path-containment guard both issues ask for: `helpers/paths.py` with `resolve_under_root(target, root) -> Path`, which resolves the target (collapsing `..` and symlinks), requires it stays under the resolved root, and raises a typed `PathEscapeError` on escape. A target that can't be resolved at all (embedded NUL) fails closed as an escape; the existing `rel_path` control-byte tests pin that branch. `PathEscapeError` subclasses `ValueError` on purpose so `_resolve_artifact_path`'s documented raises-ValueError contract and its two `except (FileNotFoundError, ValueError)` callers stay untouched.

Converted sites, each dropping its bespoke `try/except ValueError` around `resolve().relative_to(...)`:

- `controllers/config/settings.py` `rel_path`; same `CommandError(INVALID_ARGS)` rewrap
- `controllers/firmware/download.py` `_resolve_artifact_path`; the guard now also returns the resolved path it previously computed separately
- `controllers/remote_build/submit_job.py` `_validate_write_extract_bundle`; the module-private `_PathEscapeError` class is deleted, the caller catches the shared error, and its wire-mapping rationale moved to the catch site

Also collapses `git_repo.py`'s `_encloses_own_source` try/except to a one-line `is_relative_to`, the same idiom family.

Deliberately left, since converting them would add code or cost rather than remove duplication: `editor.py` and `device_builder.py`'s frontend-asset check (already minimal bool `is_relative_to` one-liners on pre-resolved paths); `remote_artifacts_materialise.py`'s per-tar-member loop (the root resolve is hoisted once outside the loop on purpose; a helper re-resolving per member would regress large archives); `git_repo.py` `_rel_to_toplevel` and `artifacts_tarball.py` `_relative_or_raise` (both want the relative path, a different shape). The `reset_env.py` site both issues list no longer exists; #2094 rewrote that handler with no filesystem work.

Behaviour free; no user-visible change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2091
- fixes https://github.com/esphome/device-builder/issues/2093

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
