### PR TITLE
Stamp compile_ended_at on native esp-idf builds

### DIFF
--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -156,8 +156,13 @@ _COMPILE_BRACKET_PERCENT: re.Pattern[str] = re.compile(r"^\s*\[\s*\d{1,3}\s*%\s*
 
 # PlatformIO closes each environment with ``===== [SUCCESS] Took N seconds =====``
 # (or ``[FAILED]``); marks ``compile_ended_at`` so an install's flash phase,
-# which streams after, isn't counted.
-_COMPILE_END_PATTERN: re.Pattern[str] = re.compile(r"\[(?:SUCCESS|FAILED)\] Took ")
+# which streams after, isn't counted. esp-idf's native (non-pio) build prints
+# no banner — there esphome's own ``Successfully compiled program`` INFO line
+# (emitted right after ninja returns) closes the span, and ninja's
+# ``ninja: build stopped: subcommand failed.`` closes a failed build.
+_COMPILE_END_PATTERN: re.Pattern[str] = re.compile(
+    r"\[(?:SUCCESS|FAILED)\] Took |Successfully compiled program|ninja: build stopped"
+)
 
 # History retention.
 #   - "Primary" = COMPILE / UPLOAD / INSTALL: dedup'd to the most

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -394,9 +394,10 @@ def _stamp_compile_phase(job: FirmwareJob, line: str) -> None:
     """
     Stamp the compile-phase wall-clocks off *line*.
 
-    Start on the first build line and end on the summary banner (pio) or
-    esphome's ``Successfully compiled program`` line (native esp-idf), so the
-    span excludes the download and, for an install, the flash. ANSI is
+    Start on the first build line and end on the summary banner (pio) or, for
+    native esp-idf, esphome's ``Successfully compiled program`` line — ninja's
+    ``build stopped`` closer on failure — so the span excludes the download
+    and, for an install, the flash. ANSI is
     stripped first — the ``[SUCCESS] Took`` banner colours *inside* the
     brackets. Runs per streamed line, so it short-circuits once both stamps
     are latched (an install flashes long after the compile ends) and

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -394,12 +394,14 @@ def _stamp_compile_phase(job: FirmwareJob, line: str) -> None:
     """
     Stamp the compile-phase wall-clocks off *line*.
 
-    Start on the first build line and end on the summary banner, so the span
-    excludes the download and, for an install, the flash. ANSI is stripped
-    first — the ``[SUCCESS] Took`` banner colours *inside* the brackets. Runs
-    per streamed line, so it short-circuits once both stamps are latched (an
-    install flashes long after the compile ends) and pre-filters the end scan
-    on a plain-text substring before paying for the ANSI strip + regex.
+    Start on the first build line and end on the summary banner (pio) or
+    esphome's ``Successfully compiled program`` line (native esp-idf), so the
+    span excludes the download and, for an install, the flash. ANSI is
+    stripped first — the ``[SUCCESS] Took`` banner colours *inside* the
+    brackets. Runs per streamed line, so it short-circuits once both stamps
+    are latched (an install flashes long after the compile ends) and
+    pre-filters the end scan on plain-text substrings before paying for the
+    ANSI strip + regex.
     """
     if job.compile_ended_at is not None:
         return
@@ -407,9 +409,12 @@ def _stamp_compile_phase(job: FirmwareJob, line: str) -> None:
         if _is_compile_start_line(_ANSI_ESCAPE.sub("", line)):
             job.compile_started_at = _now_iso()
         return
-    # ``Took `` is plain text in the banner (only the [SUCCESS]/[FAILED] token
-    # carries inline ANSI), so this skips the strip + regex on every other line.
-    if "Took " in line and _COMPILE_END_PATTERN.search(_ANSI_ESCAPE.sub("", line)):
+    # Every end marker carries a plain-text token (the banner colours only the
+    # [SUCCESS]/[FAILED] word; the INFO line is wrapped, not interleaved), so
+    # this skips the strip + regex on every other line.
+    if (
+        "Took " in line or "Successfully compiled" in line or "build stopped" in line
+    ) and _COMPILE_END_PATTERN.search(_ANSI_ESCAPE.sub("", line)):
         job.compile_ended_at = _now_iso()
 
 

--- a/tests/controllers/firmware/test_compile_phase.py
+++ b/tests/controllers/firmware/test_compile_phase.py
@@ -158,6 +158,12 @@ class TestCompileEnd:
             # Real ANSI banner: colours sit *inside* the brackets.
             "\x1b[0m===== [\x1b[32m\x1b[1mSUCCESS\x1b[0m] Took 14.73 seconds =====\x1b[0m",
             "[\x1b[31m\x1b[1mFAILED\x1b[0m] Took 4.10 seconds",
+            # Native esp-idf prints no banner; esphome's own INFO line closes it.
+            "\x1b[32mINFO Successfully compiled program to path "
+            "'/data/build/x/.pioenvs/x/program'\x1b[0m\n",
+            "INFO Successfully compiled program.",
+            # A failed ninja build ends with its build-stopped closer instead.
+            "ninja: build stopped: subcommand failed.",
         ],
     )
     def test_banner_ends_after_start(self, line: str) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Native esp-idf builds never get a `compile_ended_at` stamp. The end scanner only knows PlatformIO's `[SUCCESS] Took` banner, and the cmake/ninja path doesn't print one, so every esp-idf compile persists a half-open span; the frontend's compile time readout then leans on fallbacks (esphome/device-builder-frontend#1258 covers the display side).

Two new end markers close the span at the source: esphome's own `Successfully compiled program` INFO line, emitted right after ninja returns, and ninja's `ninja: build stopped: subcommand failed.` closer for failed builds. Both are platform independent and stream through the remote build relay too, so remote compiles stamp before the artifact transfer instead of not at all.

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1258

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
