### PR TITLE
Raise DuplicateRequestError for duplicate peer-link request registration

### DIFF
--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -54,6 +54,7 @@ from ...models import (
 )
 from ..remote_build.peer_link_client import (
     DownloadArtifactsError,
+    DuplicateRequestError,
     PeerLinkNoSessionError,
     SubmitJobSessionLostError,
     SubmitJobTimeoutError,
@@ -384,7 +385,12 @@ async def _submit_job_to_receiver(
             # what this offloader would have built locally.
             target_esphome_version=_offloader_esphome_version,
         )
-    except (PeerLinkNoSessionError, SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
+    except (
+        PeerLinkNoSessionError,
+        DuplicateRequestError,
+        SubmitJobTimeoutError,
+        SubmitJobSessionLostError,
+    ) as exc:
         _fail_locally(controller, job, reason=f"dispatch failed: {exc}")
         return False
     if not ack["accepted"]:
@@ -403,7 +409,12 @@ async def _send_reset_to_receiver(
     """Send ``reset_build_env`` and return ``True`` on accepted ack, ``False`` otherwise."""
     try:
         ack = await client.reset_build_env(job_id=job.job_id)
-    except (PeerLinkNoSessionError, SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
+    except (
+        PeerLinkNoSessionError,
+        DuplicateRequestError,
+        SubmitJobTimeoutError,
+        SubmitJobSessionLostError,
+    ) as exc:
         _fail_locally(controller, job, reason=f"dispatch failed: {exc}")
         return False
     if not ack["accepted"]:
@@ -614,6 +625,7 @@ async def _fetch_and_materialise(
         packed = await client.download_artifacts(job_id=job.job_id)
     except (
         PeerLinkNoSessionError,
+        DuplicateRequestError,
         SubmitJobSessionLostError,
         DownloadArtifactsError,
     ) as exc:

--- a/esphome_device_builder/controllers/remote_build/_client_models.py
+++ b/esphome_device_builder/controllers/remote_build/_client_models.py
@@ -12,6 +12,7 @@ Public surface (every type without a leading underscore):
 
 * :class:`PeerLinkClientError`,
   :class:`PeerLinkNoSessionError`,
+  :class:`DuplicateRequestError`,
   :class:`SubmitJobTimeoutError`,
   :class:`SubmitJobSessionLostError`,
   :class:`DownloadArtifactsError` — the typed exceptions the
@@ -168,21 +169,24 @@ class PairStatusResult:
 class PeerLinkNoSessionError(RuntimeError):
     """Raised when a peer-link application send needs a live session and there isn't one.
 
-    Used by every :class:`PeerLinkClient` sender that requires
-    the post-handshake dispatch loop to be parked:
-    :meth:`PeerLinkClient.submit_job` and
-    :meth:`PeerLinkClient.cancel_job`. The check funnels through
-    :meth:`PeerLinkClient._require_open_channel`,
-    so a future application-message sender that calls
-    ``_require_open_channel`` inherits the same exception
-    automatically.
+    Every sender that requires the post-handshake dispatch loop
+    to be parked funnels its check through
+    :meth:`PeerLinkClient._require_open_channel`, so a future
+    application-message sender inherits this automatically.
 
-    The WS command on the controller side maps this to a typed
-    ``CommandError(PRECONDITION_FAILED)`` so the frontend can
-    branch on "peer is paired but currently disconnected" vs.
-    "send rejected by the receiver." Same error code at every
-    call site — the user's recovery (wait for reconnect, retry)
-    doesn't depend on which sender raised.
+    The WS command maps it to ``CommandError(PRECONDITION_FAILED)``
+    so the frontend can branch on "peer is paired but currently
+    disconnected" vs. "send rejected by the receiver."
+    """
+
+
+class DuplicateRequestError(RuntimeError):
+    """Raised when a same-``job_id`` request is already in flight on this session.
+
+    A live session exists — the recovery is a fresh ``job_id``,
+    not waiting for reconnect. Maps to the same
+    ``CommandError(PRECONDITION_FAILED)`` as
+    :class:`PeerLinkNoSessionError`.
     """
 
 

--- a/esphome_device_builder/controllers/remote_build/_client_models.py
+++ b/esphome_device_builder/controllers/remote_build/_client_models.py
@@ -167,24 +167,25 @@ class PairStatusResult:
 
 
 class PeerLinkNoSessionError(RuntimeError):
-    """Raised when a peer-link application send needs a live session and there isn't one.
+    """
+    Raised when a peer-link application send needs a live session and there isn't one.
 
-    Every sender that requires the post-handshake dispatch loop
-    to be parked funnels its check through
+    Every sender that requires the post-handshake dispatch loop to be
+    parked funnels its check through
     :meth:`PeerLinkClient._require_open_channel`, so a future
-    application-message sender inherits this automatically.
-
-    The WS command maps it to ``CommandError(PRECONDITION_FAILED)``
-    so the frontend can branch on "peer is paired but currently
-    disconnected" vs. "send rejected by the receiver."
+    application-message sender inherits this automatically. The WS
+    command maps it to ``CommandError(PRECONDITION_FAILED)`` so the
+    frontend can branch on "peer is paired but currently disconnected"
+    vs. "send rejected by the receiver."
     """
 
 
 class DuplicateRequestError(RuntimeError):
-    """Raised when a same-``job_id`` request is already in flight on this session.
+    """
+    Raised when a same-``job_id`` request is already in flight on this session.
 
-    A live session exists — the recovery is a fresh ``job_id``,
-    not waiting for reconnect. Maps to the same
+    A live session exists, so the recovery is a fresh ``job_id`` rather
+    than waiting for reconnect; maps to the same
     ``CommandError(PRECONDITION_FAILED)`` as
     :class:`PeerLinkNoSessionError`.
     """

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/__init__.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .._client_models import (
     DownloadArtifactsError,
     DownloadArtifactsResult,
+    DuplicateRequestError,
     InitiatorRoundTrip,
     PairStatusResult,
     PeerLinkClientError,
@@ -35,6 +36,7 @@ from .one_shot import (
 __all__ = (
     "DownloadArtifactsError",
     "DownloadArtifactsResult",
+    "DuplicateRequestError",
     "InitiatorRoundTrip",
     "PairStatusResult",
     "PeerLinkClient",

--- a/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
+++ b/esphome_device_builder/controllers/remote_build/peer_link_client/_submit.py
@@ -23,6 +23,7 @@ from ....models import (
 )
 from .._client_models import (
     DownloadArtifactsResult,
+    DuplicateRequestError,
     PeerLinkNoSessionError,
     SubmitJobSessionLostError,
     SubmitJobTimeoutError,
@@ -55,7 +56,7 @@ async def submit_job(
     """
     Send a ``submit_job`` header + chunked bundle and await the receiver's ack.
 
-    Same-``job_id`` reentry mid-flow raises :class:`PeerLinkNoSessionError`;
+    Same-``job_id`` reentry mid-flow raises :class:`DuplicateRequestError`;
     the WS layer should generate a fresh id per submit. Callers must not
     retry on timeout / session-loss: the receiver may have queued the job
     already.
@@ -131,7 +132,7 @@ async def download_artifacts(client: PeerLinkClient, *, job_id: str) -> Download
     carries the bootloader / partition / ota_data offsets via
     ``idedata.json``).
 
-    Same-``job_id`` reentry raises :class:`PeerLinkNoSessionError`.
+    Same-``job_id`` reentry raises :class:`DuplicateRequestError`.
     Receiver-reported failures surface as :class:`DownloadArtifactsError`;
     session loss mid-download as :class:`SubmitJobSessionLostError`.
     """
@@ -175,7 +176,7 @@ def _register_pending[EntryT](
             f"{label}: request already registered for job_id={job_id!r} "
             f"(duplicate {label} on the same session)"
         )
-        raise PeerLinkNoSessionError(msg)
+        raise DuplicateRequestError(msg)
     # Register BEFORE the request goes out so a same-tick reply from the
     # receive loop can't beat the registration into the map.
     entry = pending[job_id] = make_entry()

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -30,6 +30,7 @@ from ._validators import (
 from .artifacts_tarball import UnpackArtifactsError, unpack_artifacts_response
 from .peer_link_client import (
     DownloadArtifactsError,
+    DuplicateRequestError,
     PeerLinkNoSessionError,
     SubmitJobSessionLostError,
     SubmitJobTimeoutError,
@@ -118,7 +119,7 @@ async def submit_job(
             target=clean_target,
             bundle_bytes=bundle_bytes,
         )
-    except PeerLinkNoSessionError as exc:
+    except (PeerLinkNoSessionError, DuplicateRequestError) as exc:
         raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
     except (SubmitJobTimeoutError, SubmitJobSessionLostError) as exc:
         raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc
@@ -156,7 +157,7 @@ async def download_artifacts(
     client = controller._lookup_open_peer_link_client(clean_pin, label="download_artifacts")
     try:
         packed = await client.download_artifacts(job_id=job_id)
-    except PeerLinkNoSessionError as exc:
+    except (PeerLinkNoSessionError, DuplicateRequestError) as exc:
         raise CommandError(ErrorCode.PRECONDITION_FAILED, str(exc)) from exc
     except SubmitJobSessionLostError as exc:
         raise CommandError(ErrorCode.UNAVAILABLE, str(exc)) from exc

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -35,6 +35,7 @@ from esphome_device_builder.controllers.firmware._state import Lane
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsError,
     DownloadArtifactsResult,
+    DuplicateRequestError,
     PeerLinkNoSessionError,
 )
 from esphome_device_builder.helpers.api import CommandError
@@ -2022,6 +2023,25 @@ async def test_remote_reset_busy_reject_fails_with_retry_message(
     assert job.error is not None
     assert "busy" in job.error
     assert "retry when its queue is empty" in job.error
+    assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+async def test_remote_reset_duplicate_request_fires_job_failed(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """``reset_build_env`` refusing a duplicate ``job_id`` surfaces in ``job.error``."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    client = _make_client(
+        submit_error=DuplicateRequestError("reset_build_env: request already registered")
+    )
+    _wire_remote_build(controller, client=client)
+    job = _make_reset_job()
+
+    await asyncio.wait_for(remote_runner.run_remote_job(controller, job), timeout=2.0)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "already registered" in job.error
     assert len(captured[EventType.JOB_FAILED]) == 1
 
 

--- a/tests/test_remote_build_peer_link_client.py
+++ b/tests/test_remote_build_peer_link_client.py
@@ -56,6 +56,7 @@ from esphome_device_builder.controllers.remote_build.peer_link import (
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsError,
     DownloadArtifactsResult,
+    DuplicateRequestError,
     PairStatusResult,
     PeerLinkClient,
     PeerLinkClientError,
@@ -4791,7 +4792,7 @@ async def test_reset_build_env_duplicate_job_id_refused() -> None:
     client._active_channel = MagicMock()
     client._reset_env_acks["j-1"] = asyncio.get_running_loop().create_future()
 
-    with pytest.raises(PeerLinkNoSessionError, match="already registered"):
+    with pytest.raises(DuplicateRequestError, match="already registered"):
         await client.reset_build_env(job_id="j-1")
 
 
@@ -4929,7 +4930,7 @@ async def test_submit_job_rejects_duplicate_job_id() -> None:
     )
     # Pre-register a future under the id we'll re-submit against.
     client._submit_job_acks["j-dup"] = asyncio.get_running_loop().create_future()
-    with pytest.raises(PeerLinkNoSessionError):
+    with pytest.raises(DuplicateRequestError, match="already registered"):
         await client.submit_job(
             job_id="j-dup",
             configuration_filename="kitchen.yaml",
@@ -5788,13 +5789,13 @@ async def test_download_artifacts_raises_no_session_error_when_session_closed() 
 
 
 async def test_download_artifacts_rejects_duplicate_job_id_on_same_session() -> None:
-    """A second concurrent download on the same job_id raises :class:`PeerLinkNoSessionError`."""
+    """A second concurrent download on the same job_id raises :class:`DuplicateRequestError`."""
     client = _make_offloader_client(EventBus())
     parked: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
     client._artifacts_downloads["already-running"] = _DownloadArtifactsState(future=parked)
     # Spoof an open channel so the no-session check passes.
     client._active_channel = MagicMock()
-    with pytest.raises(PeerLinkNoSessionError, match="duplicate download"):
+    with pytest.raises(DuplicateRequestError, match="duplicate download_artifacts"):
         await client.download_artifacts(job_id="already-running")
 
 


### PR DESCRIPTION
# What does this implement/fix?

The duplicate-registration guard in `_register_pending` raised `PeerLinkNoSessionError`, which says the opposite of what happened; a duplicate means a session exists and already has an in-flight request for that `job_id`. This adds a `DuplicateRequestError` sibling in `_client_models.py` and raises that instead.

No behaviour change; the guard still maps to `precondition_failed` at the WS layer and still folds into `_fail_locally` in the remote runner, so the catch sites in `submit_job_commands.py` and `remote_runner.py` just widen to include the new type. `_require_open_channel` keeps `PeerLinkNoSessionError`, which is now the only thing it means. The `cancel_job` paths are untouched, they are fire-and-forget with no registration.

The issue was written before #2097, which folded the three separate guards into one helper, so there was a single raise site to retype rather than three.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2096

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
