### PR TITLE
Raise wire-receive test deadlines to a CI-safe 10s

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -154,7 +154,7 @@ class PairedInstances:
         """The receiver-role dashboard's receiver-side sibling."""
         return self.receiver_handles.receiver
 
-    async def wait_until_session_opened(self, *, timeout: float = 2.0) -> None:
+    async def wait_until_session_opened(self, *, timeout: float = 10.0) -> None:
         """Block until both sides have observed the peer-link session opening.
 
         Two awaits because the two sides reach "opened" on slightly
@@ -177,7 +177,7 @@ class PairedInstances:
         await asyncio.wait_for(self.offloader_opened.received.wait(), timeout=timeout)
         await asyncio.wait_for(self.receiver_opened.received.wait(), timeout=timeout)
 
-    async def wait_until_session_closed(self, *, timeout: float = 2.0) -> None:
+    async def wait_until_session_closed(self, *, timeout: float = 10.0) -> None:
         """Block until both sides have observed the peer-link session closing.
 
         Mirror of :meth:`wait_until_session_opened` for the
@@ -307,7 +307,7 @@ async def _paired_instances_ctx(
     #    flips the local row to APPROVED, fires
     #    OFFLOADER_PAIR_STATUS_CHANGED, and spawns the long-lived
     #    peer-link client.
-    await asyncio.wait_for(pair_status_changed.received.wait(), timeout=2.0)
+    await asyncio.wait_for(pair_status_changed.received.wait(), timeout=10.0)
     assert pair_status_changed[-1]["status"] == "approved"
 
     instances = PairedInstances(

--- a/tests/e2e/test_bootstrap_pairing_key.py
+++ b/tests/e2e/test_bootstrap_pairing_key.py
@@ -137,7 +137,7 @@ async def test_bootstrap_pairing_key_round_trip(tmp_path: Path) -> None:
         )
         assert summary.status is PeerStatus.APPROVED
         assert summary.pin_sha256 == pin_sha256
-        assert await asyncio.wait_for(bootstrap, timeout=2.0) is True
+        assert await asyncio.wait_for(bootstrap, timeout=10.0) is True
 
         # Receiver landed the approved row, closed the window, cleared the key.
         [peer] = receiver.state.approved_peers.values()
@@ -147,8 +147,8 @@ async def test_bootstrap_pairing_key_round_trip(tmp_path: Path) -> None:
         assert receiver.state.bootstrap_pairing_key is None
 
         # The pairing carries through to a live peer-link session on both sides.
-        await asyncio.wait_for(inst.offloader_opened.received.wait(), timeout=2.0)
-        await asyncio.wait_for(inst.receiver_opened.received.wait(), timeout=2.0)
+        await asyncio.wait_for(inst.offloader_opened.received.wait(), timeout=10.0)
+        await asyncio.wait_for(inst.receiver_opened.received.wait(), timeout=10.0)
         assert peer.dashboard_id in receiver.state.peer_link_sessions
 
 

--- a/tests/e2e/test_cancel_job.py
+++ b/tests/e2e/test_cancel_job.py
@@ -130,7 +130,7 @@ async def test_offloader_cancel_job_routes_to_receiver_firmware_cancel(
     )
 
     assert result == {"sent": True}
-    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=2.0)
+    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=10.0)
     receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=job.job_id)
 
 
@@ -168,7 +168,7 @@ async def test_offloader_cancel_job_full_round_trip_to_state_changed(
         job_id=job.remote_job_id,
     )
 
-    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=2.0)
+    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=10.0)
     receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=job.job_id)
 
     # Simulate the firmware queue's JOB_CANCELLED that the
@@ -237,7 +237,7 @@ async def test_offloader_cancel_job_unknown_correlation_drops_silently(
     # earlier unknown cancel — so the assertion below catches a
     # late incorrect cancel deterministically rather than racing
     # an arbitrary timeout.
-    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=2.0)
+    await asyncio.wait_for(receiver_firmware_cancel.called.wait(), timeout=10.0)
     receiver_firmware_cancel.mock.assert_awaited_once_with(job_id=known_job.job_id)
 
 

--- a/tests/e2e/test_identity_rotation.py
+++ b/tests/e2e/test_identity_rotation.py
@@ -34,7 +34,7 @@ async def _repair(instances: PairedInstances) -> None:
         instances.offloader_bus, EventType.OFFLOADER_PAIR_STATUS_CHANGED
     )
     await instances.receiver.approve_peer(dashboard_id=instances.offloader_dashboard_id)
-    await asyncio.wait_for(pair_status_changed.received.wait(), timeout=2.0)
+    await asyncio.wait_for(pair_status_changed.received.wait(), timeout=10.0)
 
 
 async def test_offloader_identity_rotation_recovers_session(
@@ -70,7 +70,7 @@ async def test_offloader_identity_rotation_recovers_session(
     await _repair(paired_instances)
 
     # Session recovers, now pinned to the rotated key on both sides.
-    await asyncio.wait_for(reopened.received.wait(), timeout=2.0)
+    await asyncio.wait_for(reopened.received.wait(), timeout=10.0)
     assert dashboard_id in paired_instances.receiver.state.peer_link_sessions
     assert paired_instances.receiver.state.approved_peers[dashboard_id].pin_sha256 == v1.pin_sha256
     live = paired_instances.offloader.state.peer_link_clients[receiver_pin]

--- a/tests/e2e/test_initial_state_seed.py
+++ b/tests/e2e/test_initial_state_seed.py
@@ -93,7 +93,7 @@ async def test_initial_state_seeds_receiver_settings_and_jobs(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async with client.ws_connect("/ws") as ws:
-        await ws.receive(timeout=2.0)  # server_version handshake
+        await ws.receive(timeout=10.0)  # server_version handshake
 
         initial = await _subscribe_and_get_initial(ws, "sub-1")
         assert initial["remote_build_settings"] == {
@@ -115,7 +115,7 @@ async def test_initial_state_seeds_receiver_settings_and_jobs(
 
     # A second tab connecting later sees everything in the snapshot.
     async with client.ws_connect("/ws") as ws:
-        await ws.receive(timeout=2.0)
+        await ws.receive(timeout=10.0)
 
         initial = await _subscribe_and_get_initial(ws, "sub-2")
         assert initial["remote_build_settings"] == {

--- a/tests/e2e/test_install_round_trip.py
+++ b/tests/e2e/test_install_round_trip.py
@@ -722,7 +722,7 @@ async def _wait_for_offloader_idle(
     paired_instances: PairedInstances,
     queue_status_events: Any,
     *,
-    timeout: float = 2.0,
+    timeout: float = 10.0,
 ) -> None:
     """
     Block until the offloader's ``_peer_queue_status`` reports idle for this pin.

--- a/tests/e2e/test_local_compile.py
+++ b/tests/e2e/test_local_compile.py
@@ -86,7 +86,7 @@ async def test_local_compile_round_trip_over_ws(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async with client.ws_connect("/ws") as ws:
-        info = (await ws.receive(timeout=2.0)).json()
+        info = (await ws.receive(timeout=10.0)).json()
         assert info["requires_auth"] is False
 
         await _send_command(ws, "subscribe_events", "sub-1")

--- a/tests/e2e/test_offloader_include_local.py
+++ b/tests/e2e/test_offloader_include_local.py
@@ -97,7 +97,7 @@ async def test_include_local_toggle_round_trip_over_ws(
     assert db.remote_build_offloader is not None
 
     async with client.ws_connect("/ws") as ws:
-        await ws.receive(timeout=2.0)  # server_version / requires_auth handshake
+        await ws.receive(timeout=10.0)  # server_version / requires_auth handshake
 
         initial = await _subscribe_and_get_initial(ws, "sub-1")
         assert initial["include_local_in_pool"] is False
@@ -127,7 +127,7 @@ async def test_include_local_toggle_round_trip_over_ws(
     # In-RAM state flipped, so a fresh subscriber paints the new value immediately.
     assert db.remote_build_offloader.state.include_local_in_pool is True
     async with client.ws_connect("/ws") as ws2:
-        await ws2.receive(timeout=2.0)
+        await ws2.receive(timeout=10.0)
         initial2 = await _subscribe_and_get_initial(ws2, "sub-2")
         assert initial2["include_local_in_pool"] is True
 
@@ -180,7 +180,7 @@ async def test_include_local_runs_overflow_compile_on_local_lane(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async with client.ws_connect("/ws") as ws:
-        await ws.receive(timeout=2.0)  # server_version / requires_auth handshake
+        await ws.receive(timeout=10.0)  # server_version / requires_auth handshake
         await _subscribe_and_get_initial(ws, "sub-1")
         await _send_command(
             ws, "remote_build/set_offloader_settings", "set-1", include_local_in_pool=True
@@ -217,7 +217,7 @@ async def test_include_local_off_overflow_compile_waits_for_server(
     (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
 
     async with client.ws_connect("/ws") as ws:
-        await ws.receive(timeout=2.0)
+        await ws.receive(timeout=10.0)
         initial = await _subscribe_and_get_initial(ws, "sub-1")
         assert initial["include_local_in_pool"] is False  # default off
 

--- a/tests/e2e/test_submit_job_fanout.py
+++ b/tests/e2e/test_submit_job_fanout.py
@@ -155,7 +155,7 @@ async def test_remote_peer_job_output_fans_out_to_offloader_bus(
         JobOutputData(job_id=job.job_id, line="Compiling kitchen.cpp...\n"),
     )
 
-    await asyncio.wait_for(outputs.received.wait(), timeout=2.0)
+    await asyncio.wait_for(outputs.received.wait(), timeout=10.0)
     payload = outputs[-1]
     assert payload["job_id"] == "off-job-1"  # offloader's tag, not the receiver's
     assert payload["line"] == "Compiling kitchen.cpp...\n"

--- a/tests/test_remote_build_peer_link.py
+++ b/tests/test_remote_build_peer_link.py
@@ -121,7 +121,7 @@ def _seed_peer(controller: RemoteBuildController, peer: StoredPeer) -> None:
     controller.receiver.state.approved_peers[peer.dashboard_id] = peer
 
 
-async def _wait_until(condition: Callable[[], bool], *, timeout: float = 2.0) -> None:
+async def _wait_until(condition: Callable[[], bool], *, timeout: float = 10.0) -> None:
     """Yield to the loop until *condition()* returns truthy or *timeout* elapses.
 
     Raises :exc:`TimeoutError` (via :func:`asyncio.wait_for`) when
@@ -1294,7 +1294,7 @@ async def test_e2e_peer_link_session_responds_to_offloader_ping(
     try:
         ping = session.encrypt(_json.dumps({"type": "ping", "nonce": 42}))
         await ws.send_bytes(ping)
-        pong_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+        pong_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=10.0)
     finally:
         await ws.close()
 
@@ -1335,14 +1335,14 @@ async def test_e2e_peer_link_session_kicks_old_on_duplicate_connect(
     try:
         # The old session should receive a ``terminate`` frame
         # carrying ``reason: superseded`` before the WS closes.
-        terminate_encrypted = await asyncio.wait_for(old_ws.receive_bytes(), timeout=2.0)
+        terminate_encrypted = await asyncio.wait_for(old_ws.receive_bytes(), timeout=10.0)
         terminate = _decode_app_frame(old_session, terminate_encrypted)
         assert terminate["type"] == "terminate"
         assert terminate["reason"] == TerminateReason.SUPERSEDED.value
         # Receive one more frame to drive the WS through the
         # CLOSE transition; aiohttp's client side only flips
         # ``closed`` on the next ``receive()``-style call.
-        close_msg = await asyncio.wait_for(old_ws.receive(), timeout=2.0)
+        close_msg = await asyncio.wait_for(old_ws.receive(), timeout=10.0)
         assert close_msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING)
         # The registry now holds the NEW session; the old one is gone.
         assert "alpha" in controller.receiver.state.peer_link_sessions
@@ -1403,7 +1403,7 @@ async def test_e2e_peer_link_session_drained_on_controller_stop(
         # frame the offloader sees.
         stop_task = asyncio.create_task(controller.stop())
 
-        terminate_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+        terminate_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=10.0)
         terminate = _decode_app_frame(session, terminate_encrypted)
         assert terminate["type"] == "terminate"
         assert terminate["reason"] == TerminateReason.SERVER_SHUTTING_DOWN.value
@@ -1440,7 +1440,7 @@ async def test_e2e_peer_link_session_oversize_frame_terminates(
         # 16-byte auth tag; the encrypted size is plaintext + 16.
         oversize = session.encrypt(b"x" * (APP_FRAME_MAX_BYTES + 1))
         await ws.send_bytes(oversize)
-        terminate_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+        terminate_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=10.0)
         terminate = _decode_app_frame(session, terminate_encrypted)
         assert terminate["type"] == "terminate"
         assert terminate["reason"] == TerminateReason.MALFORMED_FRAME.value
@@ -1555,7 +1555,7 @@ async def test_e2e_submit_job_dispatches_to_receiver(
         await ws.send_bytes(session.encrypt(_json.dumps(header)))
         for chunk in chunks:
             await ws.send_bytes(session.encrypt(_json.dumps(chunk)))
-        ack_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=2.0)
+        ack_encrypted = await asyncio.wait_for(ws.receive_bytes(), timeout=10.0)
     finally:
         await ws.close()
 
@@ -2313,7 +2313,7 @@ async def test_run_peer_link_session_heartbeat_closures_route_to_session(
     # Wait for ``_run_peer_link_session`` to register and kick off
     # the heartbeat task — the helper sets ``heartbeat_started``
     # the moment its callbacks land in ``captured``.
-    await asyncio.wait_for(heartbeat_started.wait(), timeout=2.0)
+    await asyncio.wait_for(heartbeat_started.wait(), timeout=10.0)
     # ``register_peer_link_session`` now schedules a one-shot
     # ``queue_status`` push on session open (cold-connect signal
     # for the install scheduler). Wait for that frame to


### PR DESCRIPTION
# What does this implement/fix?

`test_e2e_submit_job_dispatches_to_receiver` timed out on the Windows CI runner waiting for the submit ack: the test drives a full Noise session over a real aiohttp WS plus executor hops, and its 2s receive deadline is too tight for a loaded runner under xdist (observed on PR #2100's run, Python 3.14 / windows-latest, unrelated to that PR's change).

This raises every `timeout=2.0` wire-receive wait in the real-wire suites (`tests/test_remote_build_peer_link.py` and `tests/e2e/`) to 10s. A test timeout only bounds how long a failure takes to report; passing tests return the moment the frame lands, so green runs are unaffected. Deliberately untouched: the 0.5s wait in `test_offloader_include_local.py` that asserts a TimeoutError (a negative "nothing must arrive" check), and the 2s waits across the rest of the suite, which are in-process bus/state waits with no wire or crypto in the path and no flake history.

Test-only change.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
