### PR TITLE
Ship native ESP-IDF bootloader and partition files in remote build artifacts

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -29,7 +29,7 @@ BUILD_FILES: tuple[str, ...] = (
     "build/firmware.elf",
     # Native counterparts of the PIO bootloader/partition trio above —
     # ``esphome upload --bootloader`` / ``--partition-table`` read these
-    # exact paths on an esp-idf-toolchain build (#2113).
+    # exact paths on an esp-idf-toolchain build.
     "build/bootloader/bootloader.bin",
     "build/partition_table/partition-table.bin",
     "build/ota_data_initial.bin",

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -27,4 +27,10 @@ BUILD_FILES: tuple[str, ...] = (
     "build/firmware.factory.bin",
     "build/{name}.bin",
     "build/firmware.elf",
+    # Native counterparts of the PIO bootloader/partition trio above —
+    # ``esphome upload --bootloader`` / ``--partition-table`` read these
+    # exact paths on an esp-idf-toolchain build (#2113).
+    "build/bootloader/bootloader.bin",
+    "build/partition_table/partition-table.bin",
+    "build/ota_data_initial.bin",
 )

--- a/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
+++ b/esphome_device_builder/controllers/remote_build/artifact_platforms/esp32.py
@@ -27,9 +27,10 @@ BUILD_FILES: tuple[str, ...] = (
     "build/firmware.factory.bin",
     "build/{name}.bin",
     "build/firmware.elf",
-    # Native counterparts of the PIO bootloader/partition trio above —
-    # ``esphome upload --bootloader`` / ``--partition-table`` read these
-    # exact paths on an esp-idf-toolchain build.
+    # Native counterparts of the PIO bootloader/partition trio above.
+    # ``esphome upload --bootloader`` / ``--partition-table`` read the
+    # first two on an esp-idf-toolchain build; ``ota_data_initial.bin``
+    # mirrors the PIO entry for factory-image assembly.
     "build/bootloader/bootloader.bin",
     "build/partition_table/partition-table.bin",
     "build/ota_data_initial.bin",

--- a/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
+++ b/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
@@ -69,7 +69,7 @@ async def test_esp_idf_compile_download_round_trip(
     )
 
     # The native bootloader/partition set rides back for OTA
-    # bootloader / partition-table updates (#2113).
+    # bootloader / partition-table updates.
     native_flash_files = [
         build_path / "build" / "bootloader" / "bootloader.bin",
         build_path / "build" / "partition_table" / "partition-table.bin",

--- a/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
+++ b/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
@@ -61,12 +61,24 @@ async def test_esp_idf_compile_download_round_trip(
     paired_instances: PairedInstances,
 ) -> None:
     """A native-IDF compile lands the same downloads offloader-side as a local build (#1102)."""
-    data_dir, _build_path = await run_offload_compile_round_trip(
+    data_dir, build_path = await run_offload_compile_round_trip(
         paired_instances,
         job_id="off-idf-1",
         configuration_filename=_CONFIGURATION_FILENAME,
         yaml_body=_ESP_IDF_YAML,
     )
+
+    # The native bootloader/partition set rides back for OTA
+    # bootloader / partition-table updates (#2113).
+    native_flash_files = [
+        build_path / "build" / "bootloader" / "bootloader.bin",
+        build_path / "build" / "partition_table" / "partition-table.bin",
+        build_path / "build" / "ota_data_initial.bin",
+    ]
+    missing = await asyncio.to_thread(
+        lambda: [str(p) for p in native_flash_files if not p.is_file()]
+    )
+    assert not missing, f"native flash files not materialised: {missing}"
 
     # The set a local build of this device would offer for download. Off the
     # loop: ``collect_download_entries`` stats the build dir (blockbuster).

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -160,7 +160,7 @@ def test_esp32_includes_native_idf_elf() -> None:
 
 
 def test_esp32_includes_native_idf_bootloader_set() -> None:
-    """Native-IDF bootloader / partition-table OTA reads the nested build/ paths (#2113)."""
+    """Native-IDF bootloader / partition-table OTA reads the nested build/ paths."""
     rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
     assert "build/bootloader/bootloader.bin" in rendered
     assert "build/partition_table/partition-table.bin" in rendered

--- a/tests/test_artifact_platforms.py
+++ b/tests/test_artifact_platforms.py
@@ -159,6 +159,14 @@ def test_esp32_includes_native_idf_elf() -> None:
     assert "build/firmware.elf" in rendered
 
 
+def test_esp32_includes_native_idf_bootloader_set() -> None:
+    """Native-IDF bootloader / partition-table OTA reads the nested build/ paths (#2113)."""
+    rendered = [f.format(name="kitchen") for f in esp32.BUILD_FILES]
+    assert "build/bootloader/bootloader.bin" in rendered
+    assert "build/partition_table/partition-table.bin" in rendered
+    assert "build/ota_data_initial.bin" in rendered
+
+
 def test_libretiny_includes_uf2_and_bin() -> None:
     """Libretiny ships both .uf2 (UART/ltchiptool) and .bin (OTA)."""
     rendered = [f.format(name="bw15") for f in build_files_for_platform("bk72xx")]

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -744,6 +744,9 @@ def test_materialise_native_idf_round_trip_without_pio_metadata(
             "build/firmware.factory.bin": b"FACTORY",
             "build/firmware.ota.bin": b"OTA",
             "build/firmware.elf": b"ELF",
+            "build/bootloader/bootloader.bin": b"BOOT",
+            "build/partition_table/partition-table.bin": b"PART",
+            "build/ota_data_initial.bin": b"OTADATA",
         },
     )
     build_path = _materialise_in_tmp(tarball, offloader_root)
@@ -751,6 +754,11 @@ def test_materialise_native_idf_round_trip_without_pio_metadata(
     assert build_path == offloader_root / ".esphome" / "build" / "kitchen"
     assert (build_path / "build" / "kitchen.bin").is_file()
     assert (build_path / "build" / "firmware.factory.bin").is_file()
+    # esphome upload --bootloader / --partition-table read these exact
+    # nested paths on an esp-idf-toolchain build (#2113).
+    assert (build_path / "build" / "bootloader" / "bootloader.bin").is_file()
+    assert (build_path / "build" / "partition_table" / "partition-table.bin").is_file()
+    assert (build_path / "build" / "ota_data_initial.bin").is_file()
     assert not (build_path / "platformio.ini").exists()
     # Native IDF ships no idedata cache, so the offloader stages none.
     sentinel = offloader_root / "___DASHBOARD_SENTINEL___.yaml"

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -754,8 +754,6 @@ def test_materialise_native_idf_round_trip_without_pio_metadata(
     assert build_path == offloader_root / ".esphome" / "build" / "kitchen"
     assert (build_path / "build" / "kitchen.bin").is_file()
     assert (build_path / "build" / "firmware.factory.bin").is_file()
-    # esphome upload --bootloader / --partition-table read these exact
-    # nested paths on an esp-idf-toolchain build (#2113).
     assert (build_path / "build" / "bootloader" / "bootloader.bin").is_file()
     assert (build_path / "build" / "partition_table" / "partition-table.bin").is_file()
     assert (build_path / "build" / "ota_data_initial.bin").is_file()


### PR DESCRIPTION
# What does this implement/fix?

Remote compiles of native ESP-IDF builds materialised locally without their bootloader, so the OTA bootloader update failed with "Cannot read bootloader file". The packer's ESP32 list covers the full PlatformIO layout plus the native firmware images, but not the nested build/ sub-tree esphome reads on an esp-idf toolchain build. Add build/bootloader/bootloader.bin, build/partition_table/partition-table.bin and build/ota_data_initial.bin to BUILD_FILES; missing files are already skipped and the two layouts never coexist on disk, so PlatformIO builds are unchanged. Tests pin the new entries and the pack plus materialise round trip at the nested paths.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2113

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
