### PR TITLE
Spawn job subprocesses with stdin closed

### DIFF
--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -362,6 +362,12 @@ async def tracked_subprocess(
     call the helper after to short-circuit if the cancel landed
     between this subprocess and the next one.
     """
+    # No job subprocess legitimately reads stdin, and nothing can
+    # answer one that tries: an inherited tty parks an interactive
+    # CLI prompt (esphome's device chooser) forever, hanging the
+    # lane. DEVNULL turns the prompt into an immediate EOFError
+    # traceback in the streamed job output instead.
+    kwargs.setdefault("stdin", asyncio.subprocess.DEVNULL)
     proc = await create_subprocess_exec(*args, **kwargs)
     prev = lane.current_process
     lane.current_process = proc

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -64,6 +64,7 @@ import sys
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -785,6 +786,38 @@ async def test_tracked_subprocess_gets_devnull_stdin(
 
     assert output.strip() == b"''"
     assert exit_code == 0
+
+
+async def test_tracked_subprocess_defaults_stdin_to_devnull(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """The spawn kwarg defaults to DEVNULL stdin."""
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    with patch(
+        "esphome_device_builder.controllers.firmware.runner.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as spawn:
+        async with controller._tracked_subprocess(controller.state.compile_lane, "/bin/true"):
+            pass
+    assert spawn.await_args is not None
+    assert spawn.await_args.kwargs["stdin"] is asyncio.subprocess.DEVNULL
+
+
+async def test_tracked_subprocess_stdin_override_wins(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """An explicit stdin kwarg survives the DEVNULL default."""
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    with patch(
+        "esphome_device_builder.controllers.firmware.runner.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as spawn:
+        async with controller._tracked_subprocess(
+            controller.state.compile_lane, "/bin/true", stdin=asyncio.subprocess.PIPE
+        ):
+            pass
+    assert spawn.await_args is not None
+    assert spawn.await_args.kwargs["stdin"] is asyncio.subprocess.PIPE
 
 
 async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -765,6 +765,33 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
     assert controller.state.compile_lane.current_process is None
 
 
+async def test_tracked_subprocess_gets_devnull_stdin(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    """A spawn that reads stdin sees immediate EOF, never a blocking prompt.
+
+    An inherited tty would park an interactive CLI prompt (esphome's
+    device chooser) forever, hanging the lane. The ``wait_for`` bound
+    turns a regression into a test failure instead of a suite hang.
+    """
+    controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+
+    async with controller._tracked_subprocess(
+        controller.state.compile_lane,
+        sys.executable,
+        "-c",
+        "import sys\nprint(repr(sys.stdin.read()))\n",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    ) as proc:
+        assert proc.stdout is not None
+        output = await asyncio.wait_for(proc.stdout.read(), timeout=10)
+        exit_code = await proc.wait()
+
+    assert output.strip() == b"''"
+    assert exit_code == 0
+
+
 async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     firmware_controller_factory: FirmwareControllerFactory,
     tmp_path: Path,

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -768,12 +768,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
 async def test_tracked_subprocess_gets_devnull_stdin(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """A spawn that reads stdin sees immediate EOF, never a blocking prompt.
-
-    An inherited tty would park an interactive CLI prompt (esphome's
-    device chooser) forever, hanging the lane. The ``wait_for`` bound
-    turns a regression into a test failure instead of a suite hang.
-    """
+    """A spawn that reads stdin sees immediate EOF, never a blocking prompt."""
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
 
     async with controller._tracked_subprocess(


### PR DESCRIPTION
# What does this implement/fix?

Job subprocesses inherited the dashboard's stdin, so an esphome CLI path that prompts interactively (the upload device chooser in #2107) parks on `input()` forever; nothing can answer it and the lane hangs until the job is cancelled. `tracked_subprocess` now defaults the spawn to `stdin=DEVNULL` (callers can still override), turning any future prompt into an immediate `EOFError` traceback in the streamed job output; the job fails visibly with the cause in the log instead of hanging silently.

Hardening follow-up to #2115, which removed the one known prompt path.

**Related issue or feature (if applicable):**

- related to #2107

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
