### PR TITLE
Call resolve_packages directly now the floor guarantees it

### DIFF
--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -438,8 +438,10 @@ def load_device_yaml(path: Path) -> dict | None:
     if not isinstance(config, dict):
         return None
     # ``packages:`` is a separate pass in the ESPHome pipeline
-    # (``resolve_packages`` in ``esphome.config.validate_config``):
-    # packages need to be loaded and merged so blocks they contribute
+    # (``do_packages_pass`` + ``merge_packages`` in
+    # ``esphome.config.validate_config``, wrapped for external callers
+    # as ``esphome.components.packages.resolve_packages``): packages
+    # need to be loaded and merged so blocks they contribute
     # (api / wifi / target-platform / …) become top-level keys. Without
     # this step a config that puts those blocks behind ``packages:``
     # comes back from ``yaml_util.load_yaml`` with everything still

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from esphome import const, yaml_util
+from esphome.components.packages import resolve_packages
 from esphome.const import CONF_PACKAGES
 from esphome.core import EsphomeError
 from esphome.storage_json import StorageJSON
@@ -33,34 +34,6 @@ from ._parsing import (
     yaml_has_api_encryption,
     yaml_has_top_level_block,
 )
-
-# Prefer the upstream single-call seam when present (the
-# ``resolve_packages`` proposal landing as esphome/esphome#16235).
-# Fall back to the two-step ``do_packages_pass`` + ``merge_packages``
-# that ESPHome's own ``validate_config`` pipeline strings together
-# today. Both imports are guarded by ``try/except ImportError``:
-# a future esphome that ships only ``resolve_packages`` (deprecating
-# or moving the two-step helpers) would otherwise break our module-
-# load. Once the dashboard's dep floor moves past the release that
-# shipped ``resolve_packages``, the entire fallback path can be
-# deleted in one commit.
-try:
-    from esphome.components.packages import (  # type: ignore[attr-defined]
-        resolve_packages as _resolve_packages,
-    )
-except ImportError:
-    _resolve_packages = None
-
-try:
-    from esphome.components.packages import (
-        do_packages_pass as _do_packages_pass,
-    )
-    from esphome.components.packages import (
-        merge_packages as _merge_packages,
-    )
-except ImportError:
-    _do_packages_pass = None  # type: ignore[assignment]
-    _merge_packages = None  # type: ignore[assignment]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -438,13 +411,10 @@ def load_device_yaml(path: Path) -> dict | None:
 
     Resolves ``!secret`` / ``!include`` / etc. like a real compile,
     flattens any ``packages:`` block into the main config via
-    ESPHome's package-resolution internals (the single-call
-    ``resolve_packages`` on newer ESPHome, the two-step
-    ``do_packages_pass`` + ``merge_packages`` fallback on older
-    builds), so callers see what the compiler actually sees —
-    ``api:`` / ``wifi:`` / target-platform blocks contributed by
-    packages register as top-level keys here — and returns
-    ``None`` when the file isn't a mapping or fails to parse.
+    ESPHome's ``resolve_packages``, so callers see what the compiler
+    actually sees — ``api:`` / ``wifi:`` / target-platform blocks
+    contributed by packages register as top-level keys here — and
+    returns ``None`` when the file isn't a mapping or fails to parse.
 
     Package resolution is best-effort: a remote (git) package needs
     network access, an invalid package definition fails ESPHome's
@@ -467,16 +437,15 @@ def load_device_yaml(path: Path) -> dict | None:
         return None
     if not isinstance(config, dict):
         return None
-    # ``packages:`` is a separate pass in the ESPHome pipeline (see
-    # ``do_packages_pass`` + ``merge_packages`` in
-    # ``esphome.config.validate_config``): packages need to be loaded
-    # and merged so blocks they contribute (api / wifi / target-platform
-    # / …) become top-level keys. Without this step a config that
-    # puts those blocks behind ``packages:`` comes back from
-    # ``yaml_util.load_yaml`` with everything still nested under
-    # ``packages:``, and the dashboard's flag detection silently
-    # misses them. We delegate to ESPHome internals — the loader
-    # and merge algorithm live upstream.
+    # ``packages:`` is a separate pass in the ESPHome pipeline
+    # (``resolve_packages`` in ``esphome.config.validate_config``):
+    # packages need to be loaded and merged so blocks they contribute
+    # (api / wifi / target-platform / …) become top-level keys. Without
+    # this step a config that puts those blocks behind ``packages:``
+    # comes back from ``yaml_util.load_yaml`` with everything still
+    # nested under ``packages:``, and the dashboard's flag detection
+    # silently misses them. We delegate to ESPHome internals — the
+    # loader and merge algorithm live upstream.
     #
     # This resolves offline: the dashboard sets ``CORE.skip_external_update`` at
     # startup (``DashboardSettings.parse_args``), so esphome's git layer treats
@@ -486,11 +455,7 @@ def load_device_yaml(path: Path) -> dict | None:
     # real builds refresh via the esphome CLI's own resolve.
     if isinstance(config.get(CONF_PACKAGES), (dict, list)):
         try:
-            if _resolve_packages is not None:
-                config = _resolve_packages(config)
-            elif _do_packages_pass is not None and _merge_packages is not None:
-                config = _do_packages_pass(config)
-                config = _merge_packages(config)
+            config = resolve_packages(config)
         except Exception:
             # Best-effort: a bad / unreachable package shouldn't
             # blank the device's metadata. Keep the unmerged shape
@@ -502,8 +467,8 @@ def load_device_yaml(path: Path) -> dict | None:
                 exc_info=True,
             )
     # ``config`` came from ``yaml_util.load_yaml`` (esphome,
-    # untyped) and was further passed through the package-merge
-    # helpers (also untyped), so it stays ``Any`` despite the
+    # untyped) and was further passed through ``resolve_packages``
+    # (also untyped), so it stays ``Any`` despite the
     # ``isinstance(config, dict)`` narrowing earlier. Cast at the
     # return so the public ``dict | None`` signature is honest
     # without forcing every caller to re-narrow on receive.

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -199,7 +199,8 @@ def test_load_device_yaml_merges_packages(tmp_path: Path) -> None:
     ``loaded_integrations=[]`` because the unmerged config still
     had those keys nested under ``packages:`` instead of at the
     top level. We delegate to ESPHome's own ``resolve_packages``
-    (the same the compiler's ``validate_config`` runs) so the
+    (the wrapper over the ``do_packages_pass`` + ``merge_packages``
+    the compiler's ``validate_config`` chains itself) so the
     dashboard sees what the compiler sees.
     """
     (tmp_path / "common.yaml").write_text(

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -8,14 +8,10 @@ indicator.
 
 from __future__ import annotations
 
-import importlib
-import sys
-import types
 from pathlib import Path
 from unittest import mock
 
 import pytest
-from esphome.components import packages as _real_esphome_packages
 
 from esphome_device_builder.helpers import device_yaml
 from esphome_device_builder.helpers.device_yaml import (
@@ -202,10 +198,9 @@ def test_load_device_yaml_merges_packages(tmp_path: Path) -> None:
     dashboard report ``api_encrypted=False``, ``target_platform=""``,
     ``loaded_integrations=[]`` because the unmerged config still
     had those keys nested under ``packages:`` instead of at the
-    top level. We delegate to ESPHome's own ``do_packages_pass`` +
-    ``merge_packages`` (the same two-step the compiler's
-    ``validate_config`` runs) so the dashboard sees what the
-    compiler sees.
+    top level. We delegate to ESPHome's own ``resolve_packages``
+    (the same the compiler's ``validate_config`` runs) so the
+    dashboard sees what the compiler sees.
     """
     (tmp_path / "common.yaml").write_text(
         "esp32:\n"
@@ -265,161 +260,27 @@ def test_detect_platform_from_yaml_returns_empty_when_resolved_config_has_no_pla
     assert detect_platform_from_yaml(yaml_content, resolved) == ""
 
 
-def test_load_device_yaml_uses_two_step_when_resolve_packages_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Two-step fallback runs when the upstream ``resolve_packages`` is missing.
-
-    Pins the fallback path independently of which esphome release
-    happens to be installed in the test runner. CI runs against
-    whatever esphome ships today (no ``resolve_packages``); local
-    development can hit either side. The forced-None monkeypatch
-    makes coverage of the two-step branch deterministic regardless.
-    """
-    monkeypatch.setattr(device_yaml._loading, "_resolve_packages", None)
-    (tmp_path / "common.yaml").write_text(
-        "esp32:\n  board: esp32dev\nwifi:\n  ssid: x\n  password: y\n"
-    )
-    yaml_file = tmp_path / "ble.yaml"
-    yaml_file.write_text("esphome:\n  name: ble\npackages:\n  common: !include common.yaml\n")
-    config = load_device_yaml(yaml_file)
-    assert config is not None
-    # Two-step path fired → packages merged → top-level keys
-    # surface.
-    assert "packages" not in config
-    assert "esp32" in config
-    assert "wifi" in config
-
-
-def test_load_device_yaml_uses_upstream_resolve_packages_when_available(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """When the upstream ``resolve_packages`` import is available it wins.
-
-    The two-step ``do_packages_pass`` + ``merge_packages`` path is
-    the fallback for older esphome releases — once the upstream PR
-    (esphome/esphome#16235) lands and the dashboard's dep floor
-    moves past it, the single-call seam takes over. Stubs the
-    upstream symbol with a spy and confirms the wrapper goes
-    through it (and the two-step is NOT called).
-    """
-    yaml_file = tmp_path / "with_pkg.yaml"
-    yaml_file.write_text("esphome:\n  name: x\npackages:\n  shared:\n    wifi:\n      ssid: y\n")
-    spy = mock.MagicMock(side_effect=lambda c: c)
-    monkeypatch.setattr(device_yaml._loading, "_resolve_packages", spy)
-    with mock.patch.object(device_yaml._loading, "_do_packages_pass") as two_step_spy:
-        config = load_device_yaml(yaml_file)
-    assert config is not None
-    spy.assert_called_once()
-    two_step_spy.assert_not_called()
-
-
 def test_load_device_yaml_recovers_when_merge_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A bad / unreachable package can't blank the device's metadata.
 
     Pinning the catch-all error handler on the merge call: if
-    ``do_packages_pass`` (or ``resolve_packages``) raises — the
-    typical case is a remote package whose git ref vanished, but
-    also a malformed local package YAML, a missing file, etc. —
-    the function returns the unmerged config so the raw-YAML
-    fallback paths at the call sites still surface what they
-    can. Pre-fix degradation, not a hard failure.
+    ``resolve_packages`` raises — the typical case is a remote
+    package whose git ref vanished, but also a malformed local
+    package YAML, a missing file, etc. — the function returns the
+    unmerged config so the raw-YAML fallback paths at the call
+    sites still surface what they can. Pre-fix degradation, not a
+    hard failure.
     """
     yaml_file = tmp_path / "broken_pkg.yaml"
     yaml_file.write_text("esphome:\n  name: x\npackages:\n  shared:\n    wifi:\n      ssid: y\n")
     boom = mock.MagicMock(side_effect=RuntimeError("simulated package failure"))
-    monkeypatch.setattr(device_yaml._loading, "_resolve_packages", boom)
+    monkeypatch.setattr(device_yaml._loading, "resolve_packages", boom)
     config = load_device_yaml(yaml_file)
     assert config is not None
     # Merge raised → caller keeps the unmerged shape rather than
     # crashing or returning ``None``.
-    assert "packages" in config
-
-
-def test_module_import_handles_missing_resolve_packages(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Module load survives an esphome that lacks ``resolve_packages``.
-
-    Pins the ``except ImportError: _resolve_packages = None`` branch
-    at module load. Reloads ``device_yaml`` against a stubbed
-    ``esphome.components.packages`` that has only the two-step
-    helpers — the typical shape of ESPHome releases that ship
-    BEFORE esphome/esphome#16235 lands. Without the import guard
-    the module would fail to import on those releases.
-    """
-    real_packages = _real_esphome_packages
-    stub = types.SimpleNamespace(
-        do_packages_pass=real_packages.do_packages_pass,
-        merge_packages=real_packages.merge_packages,
-        # Intentionally NO ``resolve_packages`` attribute — that's
-        # the upstream-not-yet-shipped state.
-    )
-    monkeypatch.setitem(sys.modules, "esphome.components.packages", stub)
-    reloaded = importlib.reload(device_yaml._loading)
-    try:
-        assert reloaded._resolve_packages is None
-        assert reloaded._do_packages_pass is real_packages.do_packages_pass
-        assert reloaded._merge_packages is real_packages.merge_packages
-    finally:
-        # Restore so subsequent tests see the real module.
-        monkeypatch.setitem(sys.modules, "esphome.components.packages", real_packages)
-        importlib.reload(device_yaml._loading)
-
-
-def test_module_import_handles_missing_two_step(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Module load survives an esphome that drops the two-step helpers.
-
-    Pins the ``except ImportError`` branch on the
-    ``do_packages_pass`` / ``merge_packages`` import. Belt-and-
-    suspenders for the day esphome ships only ``resolve_packages``
-    and removes / renames the two-step. Without the guard the
-    module would fail to import once the dep floor moves.
-    """
-    real_packages = _real_esphome_packages
-    stub = types.SimpleNamespace(
-        # Only ``resolve_packages`` exposed — no two-step helpers.
-        resolve_packages=getattr(real_packages, "resolve_packages", lambda c: c),
-    )
-    monkeypatch.setitem(sys.modules, "esphome.components.packages", stub)
-    reloaded = importlib.reload(device_yaml._loading)
-    try:
-        assert reloaded._do_packages_pass is None
-        assert reloaded._merge_packages is None
-        assert reloaded._resolve_packages is stub.resolve_packages
-    finally:
-        monkeypatch.setitem(sys.modules, "esphome.components.packages", real_packages)
-        importlib.reload(device_yaml._loading)
-
-
-def test_load_device_yaml_falls_back_when_both_imports_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """No-op gracefully when neither upstream import shape is available.
-
-    A future esphome that deprecates ``do_packages_pass`` /
-    ``merge_packages`` AND moves ``resolve_packages`` (rename,
-    refactor, …) would otherwise leave us with no merge path. The
-    module's ``try/except ImportError`` guards both imports - the
-    function then degrades to the unmerged shape, the same fallback
-    we use when a package merge fails at runtime. Pre-fix
-    behaviour stays available even if the upstream API surface
-    drifts.
-    """
-    monkeypatch.setattr(device_yaml._loading, "_resolve_packages", None)
-    monkeypatch.setattr(device_yaml._loading, "_do_packages_pass", None)
-    monkeypatch.setattr(device_yaml._loading, "_merge_packages", None)
-    yaml_file = tmp_path / "with_pkg.yaml"
-    yaml_file.write_text("esphome:\n  name: x\npackages:\n  shared:\n    wifi:\n      ssid: y\n")
-    config = load_device_yaml(yaml_file)
-    assert config is not None
-    # Without a merge path the ``packages:`` block stays — caller
-    # then falls back to the raw-scan / StorageJSON surfaces the
-    # rest of the metadata pipeline already handles.
     assert "packages" in config
 
 


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #2124. The floor is `esphome>=2026.5.1`, which ships `esphome.components.packages.resolve_packages`, so the two module-load `try/except` guards and the `do_packages_pass` + `merge_packages` fallback branch in `load_device_yaml` can never run. This imports `resolve_packages` directly and calls it; the runtime best-effort `try/except` around the call stays, since a bad or unreachable package is a runtime condition, not a version shim. The tests that only pinned the removed import/branch machinery are dropped, the merge-raises test is retargeted at the direct symbol, and the now-unused test imports are trimmed.

Deletions only, no behaviour change at any supported esphome.

**Related issue or feature (if applicable):**

- part of https://github.com/esphome/device-builder/issues/2122 (the packages shim; #2124 closes the issue)

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
