### PR TITLE
Fold the remaining toolchain literal into the shared constants

### DIFF
--- a/esphome_device_builder/constants.py
+++ b/esphome_device_builder/constants.py
@@ -128,9 +128,11 @@ FEATURED_EXCLUDED_CATEGORIES: frozenset[str] = frozenset({"core", "ota", "update
 # stores. Matched as strings rather than through ``esphome.const.Toolchain``
 # to keep this module a stdlib-only leaf; the wire values don't change.
 # Shared because the dashboard's spawn gate (``controllers/devices/
-# backtrace.py``) and the helper child's idedata decision (``helper_cli.py``)
-# encode one contract and must agree; stdlib-only home, so the child pays
-# nothing to import it.
+# backtrace.py``), the helper child's idedata decision (``helper_cli.py``) and
+# the offload pack / unpack pair (``controllers/remote_build/
+# artifacts_tarball.py``, ``helpers/remote_artifacts_materialise.py``) encode
+# one contract and must agree; stdlib-only home, so the child pays nothing to
+# import it.
 TOOLCHAIN_ESP_IDF = "esp-idf"
 TOOLCHAIN_SDK_NRF = "sdk-nrf"
 

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -60,6 +60,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from esphome.storage_json import StorageJSON
 
+from ...constants import TOOLCHAIN_ESP_IDF
 from ...helpers.build_artifacts import _firmware_offset_for_platform
 from ...helpers.cross_os_path import cross_os_basename
 from ...helpers.json import loads as json_loads
@@ -206,7 +207,7 @@ def _collect_pack_members(  # noqa: C901
     # absence on a PIO build is a real failure that must surface here rather
     # than ship a silently-incomplete tarball. Detect native-IDF positively
     # off the build toolchain, never off file absence.
-    if getattr(storage, "toolchain", None) != "esp-idf":
+    if storage.toolchain != TOOLCHAIN_ESP_IDF:
         if not platformio_ini.is_file():
             msg = f"platformio.ini missing for {configuration}: {platformio_ini}"
             raise FileNotFoundError(msg)

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -30,6 +30,7 @@ from esphome.helpers import rmtree
 from esphome.storage_json import StorageJSON
 from esphome.writer import storage_should_clean
 
+from ..constants import TOOLCHAIN_ESP_IDF
 from ..controllers.remote_build.artifacts_tarball import (
     IDEDATA_MEMBER_NAME,
     PLATFORMIO_INI_MEMBER_NAME,
@@ -179,7 +180,7 @@ def _open_and_extract_build_tree(tarball: bytes, configuration: str) -> _Extract
     # their absence there is wire drift. Detect native-IDF positively off
     # the toolchain, never off file absence, so a corrupt PIO tarball that
     # lost its metadata still raises rather than passing as native-IDF.
-    if receiver_storage.get("toolchain") != "esp-idf":
+    if receiver_storage.get("toolchain") != TOOLCHAIN_ESP_IDF:
         if not (build_path / PLATFORMIO_INI_MEMBER_NAME).is_file():
             raise MaterialiseError(
                 f"tarball missing required {PLATFORMIO_INI_MEMBER_NAME!r} member"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ regressions, not async hygiene.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import re
 import sys
@@ -31,7 +30,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from blockbuster import blockbuster_ctx
 from esphome.core import CORE
-from esphome.storage_json import StorageJSON
 
 from esphome_device_builder.controllers._device_mqtt_coordinator import (
     DeviceMqttCoordinator,
@@ -68,15 +66,6 @@ from esphome_device_builder.models import (
 
 if TYPE_CHECKING:
     from blockbuster import BlockBuster
-
-# True when the installed esphome's StorageJSON carries a ``toolchain``
-# field (>= 2026.5.0). That field is the exact dependency the offload path
-# keys native-IDF detection on (``toolchain == "esp-idf"``); older esphome
-# drops it on load, so tests that synthesize a native-IDF build skip there.
-# Probed off the StorageJSON signature directly rather than a correlated
-# const so the gate tracks the real runtime dependency. Mirrors the
-# native-IDF compile e2e gate.
-HAS_NATIVE_IDF_TOOLCHAIN = "toolchain" in inspect.signature(StorageJSON.__init__).parameters
 
 # Call sites known to do bounded blocking I/O during one-time server
 # startup, where the cost is paid once and not on the request path.

--- a/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
+++ b/tests/e2e/slow/esp32/test_esp_idf_compile_download.py
@@ -3,9 +3,9 @@ A real native ESP-IDF compile round-trips through the offload session (#1102).
 
 The native-IDF toolchain (``esp32: toolchain: esp-idf``) builds into
 ``build/`` not ``.pioenvs/<name>/``, so it stresses the offloader's
-artifact enumeration differently than the LibreTiny e2e. Skipped on
-esphome without the toolchain (< 2026.5.0); runs for real on the e2e
-CI job's ``dev`` channel. ``timeout(900)`` covers a cold IDF install.
+artifact enumeration differently than the LibreTiny e2e. Runs for real
+on the e2e CI job's ``dev`` channel. ``timeout(900)`` covers a cold IDF
+install.
 """
 
 from __future__ import annotations
@@ -22,12 +22,7 @@ from esphome_device_builder.controllers.firmware.download import (
     get_binaries,
 )
 
-from ....conftest import HAS_NATIVE_IDF_TOOLCHAIN
 from ...conftest import PairedInstances, run_offload_compile_round_trip
-
-pytestmark = pytest.mark.skipif(
-    not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
-)
 
 _DEVICE = "esp-idf-e2e"
 _CONFIGURATION_FILENAME = f"{_DEVICE}.yaml"

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -48,7 +48,6 @@ from esphome_device_builder.helpers.storage_path import (
     resolve_idedata_path,
     resolve_storage_path,
 )
-from tests.conftest import HAS_NATIVE_IDF_TOOLCHAIN
 from tests.test_remote_build_artifacts_download import _write_receiver_state
 
 _SENTINEL = object()
@@ -729,9 +728,6 @@ def test_materialise_remaps_posix_receiver_on_separator_mangling_offloader(
     assert (build_path / ".pioenvs" / "kitchen" / "firmware.bin").is_file()
 
 
-@pytest.mark.skipif(
-    not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
-)
 def test_materialise_native_idf_round_trip_without_pio_metadata(
     paired_roots: tuple[Path, Path],
 ) -> None:

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -58,7 +58,6 @@ from esphome_device_builder.models import (
     JobStatus,
 )
 
-from .conftest import HAS_NATIVE_IDF_TOOLCHAIN
 from .conftest import make_peer_link_session as _make_session
 
 # ---------------------------------------------------------------------------
@@ -631,9 +630,6 @@ def test_pack_build_artifacts_raises_when_pio_platformio_ini_missing(tmp_path: P
         pack_build_artifacts("kitchen.yaml")
 
 
-@pytest.mark.skipif(
-    not HAS_NATIVE_IDF_TOOLCHAIN, reason="esphome lacks the native ESP-IDF toolchain (< 2026.5.0)"
-)
 def test_pack_build_artifacts_native_idf_omits_pio_metadata(tmp_path: Path) -> None:
     """Native ESP-IDF (no platformio.ini / idedata) packs storage + build/ files, no PIO members."""
     _write_receiver_state(


### PR DESCRIPTION
# What does this implement/fix?

`artifacts_tarball.py` compared the build toolchain against a bare `"esp-idf"` literal; that is the same native-IDF decision the backtrace decoder already reads from `TOOLCHAIN_ESP_IDF`, so it now reads the constant too. The unpack side in `remote_artifacts_materialise.py` carried the identical literal, so it gets the same treatment, and a future toolchain is one edit rather than several.

The `getattr(storage, "toolchain", None)` default goes away on the pack side. `StorageJSON.toolchain` landed in esphome 2026.5.1, under the declared 2026.6.0 floor, so the attribute is always present and the default was unreachable. The unpack side keeps its `.get` default on purpose; it reads a wire dict shipped by the receiver, where the key can legitimately be absent.

That floor also made `HAS_NATIVE_IDF_TOOLCHAIN` in `tests/conftest.py` always true, so it is gone and the three native-IDF tests it guarded now always run.

No behaviour change either way; `Toolchain.ESP_IDF.value` is exactly `"esp-idf"`, so the constant compares equal to what a sidecar records.

#2105 introduced the constants and has since landed, so this is rebased onto main and stands alone.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2123

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
