### PR TITLE
Raise the esphome floor to 2026.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ version = "0.0.0" # Set by GH action on release
 
 [project.optional-dependencies]
 esphome = [
-  "esphome>=2026.5.1",
+  "esphome>=2026.6.0",
 ]
 test = [
   "blockbuster>=1.5.5,<1.6",


### PR DESCRIPTION
# What does this implement/fix?

Raises the `esphome` floor from 2026.5.1 to 2026.6.0.

#2120 moved the floor off 2024.1.0 and settled on 2026.5.1 because that is where `StorageJSON.toolchain` lands, which was the oldest version the dashboard could actually read. That answered "what is the earliest version that works" rather than "what do we support", and the two are not the same question for a project that has not shipped and does not publish old versions.

The concrete thing that prompted this: on `esphome == 2026.5.1` exactly, esp32's `_decode_pc` calls `toolchain.get_idedata(config)` unconditionally, with no branch for the native ESP-IDF toolchain. 2026.5.2 added the `CORE.using_toolchain_esp_idf` branch that resolves addr2line off the IDF toolchain instead. Verified against both sources rather than inferred:

- 2026.5.1 — `_decode_pc` calls `get_idedata` whatever the toolchain.
- 2026.5.2 — branches on `using_toolchain_esp_idf` first, never touching idedata.

So the backtrace decoding in #2105 cannot work on a native-ESP-IDF build at the current floor: it degrades to `decode_failed` after spawning a helper child that was never going to succeed. Supporting one superseded patch release would mean either wearing a futile subprocess or carrying a version-conditional gate, and a shim for a single old patch is the kind of thing #2122 exists to delete.

2026.6.0 rather than 2026.5.2 because there is no reason to hold the floor at the oldest version that technically works. The catalog is already generated against the 2026.7.0 schema bundle, so this narrows the gap between the floor and what the catalog describes.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited.
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

## Verification

Full suite on this branch: 6695 passed, 11 skipped. The one failure, `test_libretiny_bk7231n_compile_download_round_trip`, reproduces on a clean `main` without this change and is unrelated.

Nothing else in the tree pins 2026.5.1; the remaining hits are unrelated version fixtures in `tests/test_version_compat.py` and the sync-emit tests.
