### PR TITLE
Bump the esphome floor when the catalog syncs a stable release

### DIFF
--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -151,14 +151,19 @@ jobs:
         run: sed -i "s/^esphome==.*/esphome==$VERSION/" esphome-constraints.txt
 
       - name: Bump esphome floor
+        id: floor
         # The catalog is generated against one esphome version and the sync
         # scripts refuse a mismatched install, so once the catalog moves to a
         # stable release, older esphome versions no longer actually work —
         # raise the pyproject floor in the same PR. The script skips
-        # prereleases and never lowers the floor.
+        # prereleases and never lowers the floor. Its one-line summary goes
+        # into the PR body so the reviewer sees the floor moved.
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: python script/bump_esphome_floor.py "$VERSION"
+        run: |
+          floor=$(python script/bump_esphome_floor.py "$VERSION")
+          echo "floor: $floor"
+          echo "summary=$floor" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test catalog
         # Catches regressions in popular components (missing fields,
@@ -321,6 +326,7 @@ jobs:
             Automated catalog refresh.
 
             Schema source: **${{ steps.version.outputs.source }}** (version `${{ steps.version.outputs.version }}`).
+            Dependency floor: **${{ steps.floor.outputs.summary }}**.
             Triggered by: **${{ github.event_name == 'schedule' && 'nightly schedule' || format('manual dispatch by @{0}', github.actor) }}**.
 
             ${{ steps.diff.outputs.summary }}

--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -150,6 +150,16 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: sed -i "s/^esphome==.*/esphome==$VERSION/" esphome-constraints.txt
 
+      - name: Bump esphome floor
+        # The catalog is generated against one esphome version and the sync
+        # scripts refuse a mismatched install, so once the catalog moves to a
+        # stable release, older esphome versions no longer actually work —
+        # raise the pyproject floor in the same PR. The script skips
+        # prereleases and never lowers the floor.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: python script/bump_esphome_floor.py "$VERSION"
+
       - name: Smoke-test catalog
         # Catches regressions in popular components (missing fields,
         # type flips, id-vs-reference confusion). Runs BEFORE the
@@ -168,6 +178,7 @@ jobs:
               esphome_device_builder/definitions/board_bodies/ \
               esphome_device_builder/definitions/featured_components.index.json \
               esphome-constraints.txt \
+              pyproject.toml \
             && [ -z "$(git ls-files --others --exclude-standard esphome_device_builder/definitions/components/ esphome_device_builder/definitions/board_bodies/)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -827,7 +827,10 @@ When changing the sync script or catalog handling, watch for these:
 - **Don't add `Co-Authored-By: Claude` to commits** in this repo.
 - **Don't bump the `esphome` dependency casually.** Dependabot ignores it
   for a reason — bumping needs a coordinated catalog re-sync against the
-  matching schema version. Do it deliberately at release time.
+  matching schema version. The catalog-sync workflow owns the bump: its
+  PR carries the regenerated catalog, the `esphome-constraints.txt` CI
+  pin, and (on stable releases) the pyproject floor via
+  `script/bump_esphome_floor.py`.
 - **Don't reorder existing public methods** without a reason. The
   controllers' API surface is the de-facto public interface for the
   frontend.

--- a/script/bump_esphome_floor.py
+++ b/script/bump_esphome_floor.py
@@ -16,26 +16,24 @@ def bump_floor(version: str, pyproject: Path = _PYPROJECT) -> str | None:
     Rewrite the ``esphome>=`` floor in *pyproject* to *version*.
 
     A prerelease or a version at or below the current floor is skipped
-    (returns ``None``); a rewrite returns the old floor. The catalog is
-    generated against one esphome version and the sync scripts refuse a
-    mismatched install, so a stable catalog bump makes that release the
-    oldest one that actually works.
+    (returns ``None``); a rewrite returns the old floor. Prints one
+    summary line either way; fails loud unless exactly one floor exists.
     """
     new = _parse_stable(version)
     if new is None:
-        print(f"floor: skipping {version} (not a stable release)")
+        print(f"unchanged ({version} is not a stable release)")
         return None
     text = pyproject.read_text(encoding="utf-8")
     floors = _FLOOR_RE.finditer(text)
     match = next(floors, None)
     if match is None or next(floors, None) is not None:
-        raise SystemExit(f"floor: expected exactly one esphome>= floor in {pyproject}")
+        raise SystemExit(f"expected exactly one esphome>= floor in {pyproject}")
     old = ".".join(match.groups())
     if new <= tuple(int(part) for part in match.groups()):
-        print(f"floor: skipping {version} (floor already at esphome>={old})")
+        print(f"unchanged (already at esphome>={old})")
         return None
     pyproject.write_text(text.replace(match[0], f'"esphome>={version}"'), encoding="utf-8")
-    print(f"floor: esphome>={old} -> esphome>={version}")
+    print(f"esphome>={old} raised to esphome>={version}")
     return old
 
 

--- a/script/bump_esphome_floor.py
+++ b/script/bump_esphome_floor.py
@@ -1,0 +1,56 @@
+"""Raise the pyproject ``esphome`` floor to a newly-synced stable release."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+_STABLE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+_FLOOR_RE = re.compile(r'"esphome>=(\d+)\.(\d+)\.(\d+)"')
+
+
+def bump_floor(version: str, pyproject: Path = _PYPROJECT) -> str | None:
+    """
+    Rewrite the ``esphome>=`` floor in *pyproject* to *version*.
+
+    A prerelease or a version at or below the current floor is skipped
+    (returns ``None``); a rewrite returns the old floor. The catalog is
+    generated against one esphome version and the sync scripts refuse a
+    mismatched install, so a stable catalog bump makes that release the
+    oldest one that actually works.
+    """
+    new = _parse_stable(version)
+    if new is None:
+        print(f"floor: skipping {version} (not a stable release)")
+        return None
+    text = pyproject.read_text(encoding="utf-8")
+    floors = _FLOOR_RE.finditer(text)
+    match = next(floors, None)
+    if match is None or next(floors, None) is not None:
+        raise SystemExit(f"floor: expected exactly one esphome>= floor in {pyproject}")
+    old = ".".join(match.groups())
+    if new <= tuple(int(part) for part in match.groups()):
+        print(f"floor: skipping {version} (floor already at esphome>={old})")
+        return None
+    pyproject.write_text(text.replace(match[0], f'"esphome>={version}"'), encoding="utf-8")
+    print(f"floor: esphome>={old} -> esphome>={version}")
+    return old
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: bump_esphome_floor.py <esphome-version>", file=sys.stderr)
+        return 2
+    bump_floor(argv[0])
+    return 0
+
+
+def _parse_stable(version: str) -> tuple[int, int, int] | None:
+    match = _STABLE_RE.match(version)
+    return (int(match[1]), int(match[2]), int(match[3])) if match else None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_bump_esphome_floor.py
+++ b/tests/test_bump_esphome_floor.py
@@ -69,3 +69,12 @@ def test_duplicate_floor_fails_loud(tmp_path: Path) -> None:
     path.write_text(_PYPROJECT + _PYPROJECT)
     with pytest.raises(SystemExit, match="exactly one"):
         bump_floor("2026.7.0", path)
+
+
+@pytest.mark.parametrize("version", ["2026.7.0", "2026.8.0b1", "2026.6.0"])
+def test_summary_is_one_line(
+    pyproject: Path, capsys: pytest.CaptureFixture[str], version: str
+) -> None:
+    """The workflow captures stdout as a single-line GITHUB_OUTPUT value; every path prints one."""
+    bump_floor(version, pyproject)
+    assert len(capsys.readouterr().out.strip().splitlines()) == 1

--- a/tests/test_bump_esphome_floor.py
+++ b/tests/test_bump_esphome_floor.py
@@ -1,0 +1,71 @@
+"""Coverage for script/bump_esphome_floor.py: stable-only, forward-only floor bumps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from script.bump_esphome_floor import bump_floor
+
+_PYPROJECT = """\
+[project.optional-dependencies]
+esphome = [
+  "esphome>=2026.6.0",
+]
+test = [
+  "codespell==2.4.3",
+]
+"""
+
+
+@pytest.fixture
+def pyproject(tmp_path: Path) -> Path:
+    path = tmp_path / "pyproject.toml"
+    path.write_text(_PYPROJECT)
+    return path
+
+
+def test_newer_stable_bumps(pyproject: Path) -> None:
+    assert bump_floor("2026.7.0", pyproject) == "2026.6.0"
+    assert '"esphome>=2026.7.0"' in pyproject.read_text(encoding="utf-8")
+    assert "2026.6.0" not in pyproject.read_text(encoding="utf-8")
+
+
+def test_bump_touches_only_the_floor_line(pyproject: Path) -> None:
+    bump_floor("2026.7.1", pyproject)
+    assert pyproject.read_text(encoding="utf-8") == _PYPROJECT.replace("2026.6.0", "2026.7.1")
+
+
+def test_prerelease_skipped(pyproject: Path) -> None:
+    assert bump_floor("2026.8.0b1", pyproject) is None
+    assert pyproject.read_text(encoding="utf-8") == _PYPROJECT
+
+
+def test_equal_version_skipped(pyproject: Path) -> None:
+    assert bump_floor("2026.6.0", pyproject) is None
+    assert pyproject.read_text(encoding="utf-8") == _PYPROJECT
+
+
+def test_older_version_never_lowers(pyproject: Path) -> None:
+    assert bump_floor("2026.5.9", pyproject) is None
+    assert pyproject.read_text(encoding="utf-8") == _PYPROJECT
+
+
+def test_numeric_compare_not_lexicographic(pyproject: Path) -> None:
+    assert bump_floor("2026.10.0", pyproject) == "2026.6.0"
+    assert '"esphome>=2026.10.0"' in pyproject.read_text(encoding="utf-8")
+
+
+def test_missing_floor_fails_loud(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+    path.write_text('[project]\nname = "x"\n')
+    with pytest.raises(SystemExit, match="exactly one"):
+        bump_floor("2026.7.0", path)
+
+
+def test_duplicate_floor_fails_loud(tmp_path: Path) -> None:
+    path = tmp_path / "pyproject.toml"
+    path.write_text(_PYPROJECT + _PYPROJECT)
+    with pytest.raises(SystemExit, match="exactly one"):
+        bump_floor("2026.7.0", path)


### PR DESCRIPTION
# What does this implement/fix?

Makes the catalog-sync workflow bump the pyproject `esphome` floor when it syncs against a stable release, so the floor stops drifting behind the catalog. The catalog is generated against one esphome version and the sync scripts refuse a mismatched install; once the catalog moves to a stable release, older esphome versions no longer actually work, and a floor that still admits them is a floor we would not support. #2131 and #2132 did this bump by hand; this automates it.

New `script/bump_esphome_floor.py` does the rewrite: it skips prereleases (the floor never points at a beta) and never lowers the floor (a manual dispatch of an older version can't regress it), and fails loud if the floor line is missing or ambiguous. The sync workflow calls it right after the existing `esphome-constraints.txt` pin bump, so one sync PR ships the catalog, the CI pin, and the floor in lockstep; pyproject.toml joins the change-detection pathspec so a floor-only delta still opens a PR.

**Related issue or feature (if applicable):**

- follows #2131, #2132

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

## Verification

`tests/test_bump_esphome_floor.py` covers the bump, both skip paths, numeric (not lexicographic) comparison, and the loud failures. Ran the script against the repo's real pyproject: `2026.8.0b1` and `2026.6.0` skip, `2026.7.0` rewrites exactly the floor line.
