### PR TITLE
Restore the Windows build-path fix for the native ESP-IDF toolchain

### DIFF
--- a/.github/workflows/windows-real-compile.yml
+++ b/.github/workflows/windows-real-compile.yml
@@ -1,11 +1,11 @@
 name: Windows real-compile (MAX_PATH)
 
-# tests/e2e/slow/windows: a real ESP-IDF compile on a windows-latest runner that proves the
-# Windows build-data relocation (short, space-free root) builds and keeps building — covering
-# both MAX_PATH and spaced profile dirs. A cold ESP-IDF toolchain download makes this a
-# ~20-40 min job, so it is gated to changes that touch the mechanism plus a weekly drift check
-# rather than running on every PR. The default test matrix ignores tests/e2e, so this workflow
-# is the only place this e2e runs.
+# tests/e2e/slow/windows: real compiles on windows-latest runners that prove the Windows
+# build-data relocation (short, space-free root) builds and keeps building — covering both
+# MAX_PATH and spaced profile dirs. Each suite is a cold multi-minute toolchain download plus a
+# full compile, so they fan out one-per-runner (this is the longest CI job) and are gated to
+# changes that touch the mechanism plus a weekly drift check rather than running on every PR.
+# The default test matrix ignores tests/e2e, so this workflow is the only place these e2e run.
 #
 # YAML anchors (``&trigger-paths`` / ``*trigger-paths``) keep the push and pull_request path
 # filters in lockstep.
@@ -34,10 +34,23 @@ on:
 
 jobs:
   windows-maxpath:
-    name: Real ESP-IDF compile (Windows MAX_PATH)
+    name: Windows real compile (${{ matrix.suite }})
     runs-on: windows-latest
-    # Cold ESP-IDF toolchain download + a full mbedtls compile, then clean / clean-all, runs
-    # minutes; the pytest --timeout=3000 below caps the run, this caps the whole job.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ``native_idf`` / ``platformio`` select one toolchain parametrization of the MAX_PATH
+          # e2e (its compile fixture is module-scoped per toolchain); ``migration`` is the
+          # original-layout-survives-relocation esp8266 case.
+          - suite: native_idf
+            tests: tests/e2e/slow/windows/test_windows_short_paths.py -k native_idf
+          - suite: platformio
+            tests: tests/e2e/slow/windows/test_windows_short_paths.py -k platformio
+          - suite: migration
+            tests: tests/e2e/slow/windows/test_windows_migration.py
+    # Cold toolchain download + a full compile, then clean / clean-all, runs minutes; the
+    # pytest --timeout=3000 below caps the run, this caps the whole job.
     timeout-minutes: 60
     steps:
       - name: Check out code from GitHub
@@ -56,5 +69,5 @@ jobs:
       - name: Show installed esphome version
         run: uv pip show esphome
 
-      - name: Run Windows MAX_PATH e2e
-        run: uv run pytest -q tests/e2e/slow/windows --durations=10 --timeout=3000 --no-cov
+      - name: Run Windows MAX_PATH e2e (${{ matrix.suite }})
+        run: uv run pytest -q ${{ matrix.tests }} --durations=10 --timeout=3000 --no-cov

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -14,7 +14,10 @@ compile subprocess resolve there, whichever toolchain the config selects). Per-d
 roots nest under one ``C:\esphb`` parent rather than scattering ``C:\esphb-*`` across the drive
 root. Existing data is moved in once (best-effort) so warm caches survive: from the legacy flat
 ``C:\esphb-<id8>`` of the first relocation release, else from ``<config>/.esphome``,
-``~/.platformio`` and esphome's machine-global IDF cache. Real dirs (no junction), so CMake's
+``~/.platformio`` and esphome's machine-global IDF cache. Sweeping the IDF cache in trades
+upstream's all-projects sharing for the space-free guarantee: the multi-GB install becomes
+per-dashboard, and a cache later repopulated by CLI use is not re-merged (the completion marker
+short-circuits). Real dirs (no junction), so CMake's
 REALPATH can't reintroduce the spaced/long
 path. The tree is left on uninstall (a reinstall keeps the warm toolchain); delete ``C:\esphb`` by
 hand to reclaim space. No-op off Windows (including a Linux Docker container on Windows -- the
@@ -91,7 +94,10 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     override_pio = not user_set_pio and _relocate_into(pio, _platformio_dir())
     if override_pio:
         os.environ["PLATFORMIO_CORE_DIR"] = str(pio)
-    user_set_idf = "ESPHOME_ESP_IDF_PREFIX" in os.environ
+    # Unlike ESPHOME_DATA_DIR (bare presence wins in CORE.data_dir), esphome treats an
+    # empty/whitespace ESPHOME_ESP_IDF_PREFIX as unset — mirror that or an empty var would
+    # silently fall back to the long + spaced machine-global cache this exists to avoid.
+    user_set_idf = bool(os.environ.get("ESPHOME_ESP_IDF_PREFIX", "").strip())
     idf_cache = _default_idf_cache()
     idf_sources = (idf_cache,) if idf_cache is not None else ()
     override_idf = not user_set_idf and _relocate_into(idf, *idf_sources)
@@ -107,7 +113,8 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
         yield
     finally:
         # All three vars were unset on entry (ESPHOME_DATA_DIR guarded above; the toolchain vars
-        # only overridden when absent), so popping is the right restore.
+        # only overridden when absent — or, for the IDF prefix, empty, which esphome also treats
+        # as unset), so popping is the right restore.
         os.environ.pop("ESPHOME_DATA_DIR", None)
         if override_pio:
             os.environ.pop("PLATFORMIO_CORE_DIR", None)

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -102,10 +102,19 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     # empty/whitespace ESPHOME_ESP_IDF_PREFIX as unset — mirror that or an empty var would
     # silently fall back to the long + spaced machine-global cache this exists to avoid.
     prev_idf = os.environ.get("ESPHOME_ESP_IDF_PREFIX")
-    override_idf = not (prev_idf and prev_idf.strip()) and _relocate_into(idf, _default_idf_cache())
+    user_set_idf = bool(prev_idf and prev_idf.strip())
+    override_idf = not user_set_idf and _relocate_into(idf, _default_idf_cache())
     if override_idf:
         saved["ESPHOME_ESP_IDF_PREFIX"] = prev_idf  # may be present-but-empty; kept verbatim
         os.environ["ESPHOME_ESP_IDF_PREFIX"] = str(idf)
+    elif not user_set_idf:
+        # Unrelocated, esphome falls back to its machine-global cache — the long + spaced path
+        # this exists to avoid — so name it before the compile fails cryptically.
+        _LOGGER.warning(
+            "ESP-IDF toolchain not relocated; native builds will use %s, where deep or spaced "
+            "paths may fail",
+            _default_idf_cache(),
+        )
     _LOGGER.info(
         "Windows build data at %s (pio %s, idf %s)",
         root,
@@ -154,6 +163,9 @@ def _default_idf_cache() -> Path | None:
     try:
         import platformdirs  # noqa: PLC0415
     except ImportError:
+        # Distinguishes migration-skipped-because-unavailable from a genuinely absent cache;
+        # the relocation marker written this run means a later install won't re-migrate.
+        _LOGGER.debug("platformdirs unavailable; no machine-global IDF cache to migrate")
         return None
     return Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
 

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -103,7 +103,8 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     # silently fall back to the long + spaced machine-global cache this exists to avoid.
     prev_idf = os.environ.get("ESPHOME_ESP_IDF_PREFIX")
     user_set_idf = bool(prev_idf and prev_idf.strip())
-    override_idf = not user_set_idf and _relocate_into(idf, _default_idf_cache())
+    idf_cache = _default_idf_cache()
+    override_idf = not user_set_idf and _relocate_into(idf, idf_cache)
     if override_idf:
         saved["ESPHOME_ESP_IDF_PREFIX"] = prev_idf  # may be present-but-empty; kept verbatim
         os.environ["ESPHOME_ESP_IDF_PREFIX"] = str(idf)
@@ -113,7 +114,7 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
         _LOGGER.warning(
             "ESP-IDF toolchain not relocated; native builds will use %s, where deep or spaced "
             "paths may fail",
-            _default_idf_cache(),
+            idf_cache or "esphome's default cache location",
         )
     _LOGGER.info(
         "Windows build data at %s (pio %s, idf %s)",

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -2,16 +2,20 @@ r"""
 Relocate Windows build data to one short, space-free root (dodges MAX_PATH + spaces).
 
 Native Windows ESP-IDF builds fail two ways from a normal config path: the 260-char ``MAX_PATH``
-limit on the deep build tree, and a pioarduino whitespace guard / gcc ``-fdebug-prefix-map``
-truncation when the path contains a space (common: ``C:\Users\First Last\...``).
+limit on the deep build tree and toolchain install (the native ESP-IDF toolchain nests ~209 chars
+below its install dir), and spaces in the path (common: ``C:\Users\First Last\...``) — ESP-IDF
+refuses spaced install paths, and pioarduino has its own whitespace guard / gcc
+``-fdebug-prefix-map`` truncation.
 
 :func:`windows_short_build_paths` points the build tree at ``C:\esphb\<id8>`` for the ``with``
-block by setting ``ESPHOME_DATA_DIR`` = that root and ``PLATFORMIO_CORE_DIR`` = ``<root>\pio`` in
-the process env (so ``CORE.data_dir`` and every compile subprocess resolve there). Per-dashboard
+block by setting ``ESPHOME_DATA_DIR`` = that root, ``PLATFORMIO_CORE_DIR`` = ``<root>\pio`` and
+``ESPHOME_ESP_IDF_PREFIX`` = ``<root>\idf`` in the process env (so ``CORE.data_dir`` and every
+compile subprocess resolve there, whichever toolchain the config selects). Per-dashboard
 roots nest under one ``C:\esphb`` parent rather than scattering ``C:\esphb-*`` across the drive
 root. Existing data is moved in once (best-effort) so warm caches survive: from the legacy flat
-``C:\esphb-<id8>`` of the first relocation release, else from ``<config>/.esphome`` +
-``~/.platformio``. Real dirs (no junction), so CMake's REALPATH can't reintroduce the spaced/long
+``C:\esphb-<id8>`` of the first relocation release, else from ``<config>/.esphome``,
+``~/.platformio`` and esphome's machine-global IDF cache. Real dirs (no junction), so CMake's
+REALPATH can't reintroduce the spaced/long
 path. The tree is left on uninstall (a reinstall keeps the warm toolchain); delete ``C:\esphb`` by
 hand to reclaim space. No-op off Windows (including a Linux Docker container on Windows -- the
 gate is ``os.name == "nt"``), and skipped if the user already set ``ESPHOME_DATA_DIR`` (a
@@ -47,7 +51,7 @@ _RELOCATED_MARKER = ".device-builder-relocated.json"
 
 @contextmanager
 def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
-    """Point ESPHOME_DATA_DIR + PLATFORMIO_CORE_DIR at a short space-free root for the block."""
+    """Point the build-data + toolchain env vars at a short space-free root for the block."""
     if not _is_windows() or "ESPHOME_DATA_DIR" in os.environ:
         yield
         return
@@ -78,23 +82,37 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
         yield
         return
     pio = root / "pio"
+    idf = root / "idf"
 
     os.environ["ESPHOME_DATA_DIR"] = str(root)
-    # Relocate the toolchain unless the user deliberately set PLATFORMIO_CORE_DIR (leave their
-    # choice and their ~/.platformio untouched), or a corrupt partial copy can't be made clean.
+    # Relocate each toolchain unless the user deliberately set its env var (leave their choice
+    # and their existing install untouched), or a corrupt partial copy can't be made clean.
     user_set_pio = "PLATFORMIO_CORE_DIR" in os.environ
     override_pio = not user_set_pio and _relocate_into(pio, _platformio_dir())
     if override_pio:
         os.environ["PLATFORMIO_CORE_DIR"] = str(pio)
-    _LOGGER.info("Windows build data at %s (core %s)", root, pio if override_pio else "default")
+    user_set_idf = "ESPHOME_ESP_IDF_PREFIX" in os.environ
+    idf_cache = _default_idf_cache()
+    idf_sources = (idf_cache,) if idf_cache is not None else ()
+    override_idf = not user_set_idf and _relocate_into(idf, *idf_sources)
+    if override_idf:
+        os.environ["ESPHOME_ESP_IDF_PREFIX"] = str(idf)
+    _LOGGER.info(
+        "Windows build data at %s (pio %s, idf %s)",
+        root,
+        pio if override_pio else "default",
+        idf if override_idf else "default",
+    )
     try:
         yield
     finally:
-        # Both vars were unset on entry (ESPHOME_DATA_DIR guarded above; PLATFORMIO_CORE_DIR only
-        # overridden when it was absent), so popping is the right restore.
+        # All three vars were unset on entry (ESPHOME_DATA_DIR guarded above; the toolchain vars
+        # only overridden when absent), so popping is the right restore.
         os.environ.pop("ESPHOME_DATA_DIR", None)
         if override_pio:
             os.environ.pop("PLATFORMIO_CORE_DIR", None)
+        if override_idf:
+            os.environ.pop("ESPHOME_ESP_IDF_PREFIX", None)
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +133,17 @@ def _is_windows() -> bool:
 def _platformio_dir() -> Path:
     """Default toolchain dir to migrate from (a seam; tests avoid the real ~/.platformio)."""
     return Path.home() / ".platformio"
+
+
+def _default_idf_cache() -> Path | None:
+    """Esphome's machine-global native-IDF install dir to migrate from (a seam for tests)."""
+    # platformdirs ships with the esphome extra, not this package; without it there is no
+    # existing install to migrate, but the relocated dir is still created and pointed at.
+    try:
+        import platformdirs  # noqa: PLC0415
+    except ImportError:
+        return None
+    return Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
 
 
 def _relocate_into(dst: Path, *sources: Path) -> bool:

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -97,6 +97,7 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     # empty/whitespace ESPHOME_ESP_IDF_PREFIX as unset — mirror that or an empty var would
     # silently fall back to the long + spaced machine-global cache this exists to avoid.
     user_set_idf = bool(os.environ.get("ESPHOME_ESP_IDF_PREFIX", "").strip())
+    prev_idf = os.environ.get("ESPHOME_ESP_IDF_PREFIX")  # may be present-but-empty; kept verbatim
     idf_cache = _default_idf_cache()
     idf_sources = (idf_cache,) if idf_cache is not None else ()
     override_idf = not user_set_idf and _relocate_into(idf, *idf_sources)
@@ -111,14 +112,7 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     try:
         yield
     finally:
-        # All three vars were unset on entry (ESPHOME_DATA_DIR guarded above; the toolchain vars
-        # only overridden when absent — or, for the IDF prefix, empty, which esphome also treats
-        # as unset), so popping is the right restore.
-        os.environ.pop("ESPHOME_DATA_DIR", None)
-        if override_pio:
-            os.environ.pop("PLATFORMIO_CORE_DIR", None)
-        if override_idf:
-            os.environ.pop("ESPHOME_ESP_IDF_PREFIX", None)
+        _restore_env(override_pio=override_pio, override_idf=override_idf, prev_idf=prev_idf)
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +133,25 @@ def _is_windows() -> bool:
 def _platformio_dir() -> Path:
     """Default toolchain dir to migrate from (a seam; tests avoid the real ~/.platformio)."""
     return Path.home() / ".platformio"
+
+
+def _restore_env(*, override_pio: bool, override_idf: bool, prev_idf: str | None) -> None:
+    """
+    Undo the relocation's env overrides on exit.
+
+    ESPHOME_DATA_DIR / PLATFORMIO_CORE_DIR were unset on entry (guarded before overriding), so
+    popping restores them. The IDF prefix may have been present-but-empty (esphome treats that as
+    unset, so it was still overridden) — the original value goes back verbatim.
+    """
+    os.environ.pop("ESPHOME_DATA_DIR", None)
+    if override_pio:
+        os.environ.pop("PLATFORMIO_CORE_DIR", None)
+    if not override_idf:
+        return
+    if prev_idf is None:
+        os.environ.pop("ESPHOME_ESP_IDF_PREFIX", None)
+    else:
+        os.environ["ESPHOME_ESP_IDF_PREFIX"] = prev_idf
 
 
 def _default_idf_cache() -> Path | None:
@@ -162,8 +175,10 @@ def _relocate_into(dst: Path, *sources: Path) -> bool:
     it is keyed off a source still existing, not bare ``dst.exists()``, so a marker write lost
     after a successful move never triggers a destructive re-relocation. Returns ``False`` when the
     move is incomplete -- a partial *dst* that could not be cleared, or a move that left the source
-    behind -- so the caller never points env at incomplete data or a corrupt toolchain. Used for
-    both the build root and the toolchain so the two paths cannot drift apart.
+    behind -- so the caller never points env at incomplete data or a corrupt toolchain. The one
+    exception: a failed move whose copy verifiably completed (:func:`_copy_completed`) adopts
+    *dst*, because there the half-deleted *source* is the damaged side. Used for both the build
+    root and the toolchains so the paths cannot drift apart.
     """
     marker = dst / _RELOCATED_MARKER
     if marker.is_file():
@@ -177,12 +192,29 @@ def _relocate_into(dst: Path, *sources: Path) -> bool:
             if dst.exists():
                 _LOGGER.warning("Could not clear partial %s; leaving %s in place", dst, src)
                 return False
+        adopted_dst = False
         try:
             dst.parent.mkdir(parents=True, exist_ok=True)  # nested rename target needs its parent
             shutil.move(str(src), str(dst))
         except OSError:
-            _LOGGER.warning("Could not move %s to %s; it will be rebuilt", src, dst)
-        if src.is_dir():
+            # A cross-volume move is copy-then-delete: when only the delete phase died, dst holds
+            # a complete copy and the source is already half-deleted — falling back would point
+            # the consumer at the damaged tree, so adopt dst instead. Any other failure (rename
+            # denied, copy died partway) leaves the source authoritative and dst discardable.
+            adopted_dst = _copy_completed(src, dst)
+            if adopted_dst:
+                shutil.rmtree(src, ignore_errors=True)
+                if src.is_dir():
+                    _LOGGER.exception(
+                        "Relocated %s to %s but the source could not be removed; delete %s "
+                        "manually to reclaim space",
+                        src,
+                        dst,
+                        src,
+                    )
+            else:
+                _LOGGER.warning("Could not move %s to %s; it will be rebuilt", src, dst)
+        if src.is_dir() and not adopted_dst:
             _LOGGER.warning("%s not relocated; source remains at %s", dst, src)
             return False
     # No source left here: none existed, the move just completed, or a prior run moved it and only
@@ -194,3 +226,31 @@ def _relocate_into(dst: Path, *sources: Path) -> bool:
         _LOGGER.warning("Could not finalize relocation dir %s", dst)
         return False
     return True
+
+
+def _copy_completed(src: Path, dst: Path) -> bool:
+    """
+    Whether every file still under *src* has an identical-size counterpart under *dst*.
+
+    Classifies a failed ``shutil.move``: a copy-phase death leaves the source complete and the
+    copy missing files (``False``, source is authoritative); a delete-phase death leaves only
+    already-copied leftovers under the source (``True``, the copy is complete). A source with no
+    files left is ambiguous — nothing distinguishes the phases — so it stays ``False`` and the
+    caller falls back fail-closed.
+    """
+    if not dst.is_dir():
+        return False
+    matched_file = False
+    try:
+        for current, _dirs, files in os.walk(src):
+            rel = Path(current).relative_to(src)
+            for name in files:
+                copied = dst / rel / name
+                if not copied.is_file():
+                    return False
+                if copied.stat().st_size != (Path(current) / name).stat().st_size:
+                    return False
+                matched_file = True
+    except OSError:
+        return False
+    return matched_file

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -31,8 +31,10 @@ import os
 import shutil
 import string
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
+
+from esphome.helpers import rmtree
 
 from .dashboard_identity import get_or_create_dashboard_id
 
@@ -166,10 +168,8 @@ def _relocate_into(dst: Path, *sources: Path | None) -> bool:
     it is keyed off a source still existing, not bare ``dst.exists()``, so a marker write lost
     after a successful move never triggers a destructive re-relocation. Returns ``False`` when the
     move is incomplete -- a partial *dst* that could not be cleared, or a move that left the source
-    behind -- so the caller never points env at incomplete data or a corrupt toolchain. The one
-    exception: a failed move whose copy verifiably completed (:func:`_copy_completed`) adopts
-    *dst*, because there the half-deleted *source* is the damaged side. Used for both the build
-    root and the toolchains so the paths cannot drift apart.
+    behind -- so the caller never points env at incomplete data or a corrupt toolchain. Used for
+    both the build root and the toolchains so the paths cannot drift apart.
     """
     marker = dst / _RELOCATED_MARKER
     if marker.is_file():
@@ -179,33 +179,17 @@ def _relocate_into(dst: Path, *sources: Path | None) -> bool:
         # Source still present, so the move never completed. A partial dst from an interrupted
         # cross-volume copy would nest the retry, so discard it before re-moving.
         if dst.exists():
-            shutil.rmtree(dst, ignore_errors=True)
+            with suppress(OSError):
+                rmtree(dst)  # esphome's rmtree clears the read-only flags toolchain trees carry
             if dst.exists():
                 _LOGGER.warning("Could not clear partial %s; leaving %s in place", dst, src)
                 return False
-        adopted_dst = False
         try:
             dst.parent.mkdir(parents=True, exist_ok=True)  # nested rename target needs its parent
             shutil.move(str(src), str(dst))
         except OSError:
-            # A cross-volume move is copy-then-delete: when only the delete phase died, dst holds
-            # a complete copy and the source is already half-deleted — falling back would point
-            # the consumer at the damaged tree, so adopt dst instead. Any other failure (rename
-            # denied, copy died partway) leaves the source authoritative and dst discardable.
-            adopted_dst = _copy_completed(src, dst)
-            if adopted_dst:
-                shutil.rmtree(src, ignore_errors=True)
-                if src.is_dir():
-                    _LOGGER.exception(
-                        "Relocated %s to %s but the source could not be removed; delete %s "
-                        "manually to reclaim space",
-                        src,
-                        dst,
-                        src,
-                    )
-            else:
-                _LOGGER.warning("Could not move %s to %s; it will be rebuilt", src, dst)
-        if not adopted_dst and src.is_dir():
+            _LOGGER.warning("Could not move %s to %s; it will be rebuilt", src, dst)
+        if src.is_dir():
             _LOGGER.warning("%s not relocated; source remains at %s", dst, src)
             return False
     # No source left here: none existed, the move just completed, or a prior run moved it and only
@@ -217,34 +201,3 @@ def _relocate_into(dst: Path, *sources: Path | None) -> bool:
         _LOGGER.warning("Could not finalize relocation dir %s", dst)
         return False
     return True
-
-
-def _copy_completed(src: Path, dst: Path) -> bool:
-    """
-    Whether every file still under *src* has an identical-size counterpart under *dst*.
-
-    A source with no files left is ambiguous — nothing distinguishes the move's phases — so it
-    stays ``False`` and the caller falls back fail-closed.
-    """
-    if not dst.is_dir():
-        return False
-    matched_file = False
-    try:
-        # onerror: os.walk silently skips unreadable subtrees by default, which would classify
-        # a copy missing that subtree as complete — re-raise so uncertainty stays fail-closed.
-        for current, _dirs, files in os.walk(src, onerror=_raise_walk_error):
-            dst_dir = dst / Path(current).relative_to(src)
-            for name in files:
-                copied = dst_dir / name
-                src_size = (Path(current) / name).stat().st_size
-                if not copied.is_file() or copied.stat().st_size != src_size:
-                    return False
-                matched_file = True
-    except OSError:
-        return False
-    return matched_file
-
-
-def _raise_walk_error(err: OSError) -> None:
-    """Surface an ``os.walk`` traversal error instead of the default silent skip."""
-    raise err

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -31,7 +31,7 @@ import os
 import shutil
 import string
 from collections.abc import Iterator
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from pathlib import Path
 
 from esphome.helpers import rmtree
@@ -191,10 +191,12 @@ def _relocate_into(dst: Path, *sources: Path | None) -> bool:
         # Source still present, so the move never completed. A partial dst from an interrupted
         # cross-volume copy would nest the retry, so discard it before re-moving.
         if dst.exists():
-            with suppress(OSError):
+            try:
                 rmtree(dst)  # esphome's rmtree clears the read-only flags toolchain trees carry
-            if dst.exists():
-                _LOGGER.warning("Could not clear partial %s; leaving %s in place", dst, src)
+            except OSError as err:
+                _LOGGER.warning(
+                    "Could not clear partial %s (%s); leaving %s in place", dst, err, src
+                )
                 return False
         try:
             dst.parent.mkdir(parents=True, exist_ok=True)  # nested rename target needs its parent

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -17,8 +17,7 @@ root. Existing data is moved in once (best-effort) so warm caches survive: from 
 ``~/.platformio`` and esphome's machine-global IDF cache. Sweeping the IDF cache in trades
 upstream's all-projects sharing for the space-free guarantee: the multi-GB install becomes
 per-dashboard, and a cache later repopulated by CLI use is not re-merged (the completion marker
-short-circuits). Real dirs (no junction), so CMake's
-REALPATH can't reintroduce the spaced/long
+short-circuits). Real dirs (no junction), so CMake's REALPATH can't reintroduce the spaced/long
 path. The tree is left on uninstall (a reinstall keeps the warm toolchain); delete ``C:\esphb`` by
 hand to reclaim space. No-op off Windows (including a Linux Docker container on Windows -- the
 gate is ``os.name == "nt"``), and skipped if the user already set ``ESPHOME_DATA_DIR`` (a

--- a/esphome_device_builder/helpers/windows_build_paths.py
+++ b/esphome_device_builder/helpers/windows_build_paths.py
@@ -86,22 +86,23 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     pio = root / "pio"
     idf = root / "idf"
 
+    saved: dict[str, str | None] = {"ESPHOME_DATA_DIR": None}  # absent on entry (guarded above)
     os.environ["ESPHOME_DATA_DIR"] = str(root)
     # Relocate each toolchain unless the user deliberately set its env var (leave their choice
     # and their existing install untouched), or a corrupt partial copy can't be made clean.
-    user_set_pio = "PLATFORMIO_CORE_DIR" in os.environ
-    override_pio = not user_set_pio and _relocate_into(pio, _platformio_dir())
+    override_pio = "PLATFORMIO_CORE_DIR" not in os.environ and _relocate_into(
+        pio, _platformio_dir()
+    )
     if override_pio:
+        saved["PLATFORMIO_CORE_DIR"] = None  # only overridden when absent
         os.environ["PLATFORMIO_CORE_DIR"] = str(pio)
     # Unlike ESPHOME_DATA_DIR (bare presence wins in CORE.data_dir), esphome treats an
     # empty/whitespace ESPHOME_ESP_IDF_PREFIX as unset — mirror that or an empty var would
     # silently fall back to the long + spaced machine-global cache this exists to avoid.
-    user_set_idf = bool(os.environ.get("ESPHOME_ESP_IDF_PREFIX", "").strip())
-    prev_idf = os.environ.get("ESPHOME_ESP_IDF_PREFIX")  # may be present-but-empty; kept verbatim
-    idf_cache = _default_idf_cache()
-    idf_sources = (idf_cache,) if idf_cache is not None else ()
-    override_idf = not user_set_idf and _relocate_into(idf, *idf_sources)
+    prev_idf = os.environ.get("ESPHOME_ESP_IDF_PREFIX")
+    override_idf = not (prev_idf and prev_idf.strip()) and _relocate_into(idf, _default_idf_cache())
     if override_idf:
+        saved["ESPHOME_ESP_IDF_PREFIX"] = prev_idf  # may be present-but-empty; kept verbatim
         os.environ["ESPHOME_ESP_IDF_PREFIX"] = str(idf)
     _LOGGER.info(
         "Windows build data at %s (pio %s, idf %s)",
@@ -112,7 +113,7 @@ def windows_short_build_paths(config_dir: Path) -> Iterator[None]:
     try:
         yield
     finally:
-        _restore_env(override_pio=override_pio, override_idf=override_idf, prev_idf=prev_idf)
+        _restore_env(saved)
 
 
 # ---------------------------------------------------------------------------
@@ -135,23 +136,13 @@ def _platformio_dir() -> Path:
     return Path.home() / ".platformio"
 
 
-def _restore_env(*, override_pio: bool, override_idf: bool, prev_idf: str | None) -> None:
-    """
-    Undo the relocation's env overrides on exit.
-
-    ESPHOME_DATA_DIR / PLATFORMIO_CORE_DIR were unset on entry (guarded before overriding), so
-    popping restores them. The IDF prefix may have been present-but-empty (esphome treats that as
-    unset, so it was still overridden) — the original value goes back verbatim.
-    """
-    os.environ.pop("ESPHOME_DATA_DIR", None)
-    if override_pio:
-        os.environ.pop("PLATFORMIO_CORE_DIR", None)
-    if not override_idf:
-        return
-    if prev_idf is None:
-        os.environ.pop("ESPHOME_ESP_IDF_PREFIX", None)
-    else:
-        os.environ["ESPHOME_ESP_IDF_PREFIX"] = prev_idf
+def _restore_env(saved: dict[str, str | None]) -> None:
+    """Put each overridden env var back exactly as found (``None`` means absent)."""
+    for var, prev in saved.items():
+        if prev is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = prev
 
 
 def _default_idf_cache() -> Path | None:
@@ -165,7 +156,7 @@ def _default_idf_cache() -> Path | None:
     return Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
 
 
-def _relocate_into(dst: Path, *sources: Path) -> bool:
+def _relocate_into(dst: Path, *sources: Path | None) -> bool:
     """
     Move the first existing of *sources* into *dst* once; return whether *dst* is trusted.
 
@@ -183,7 +174,7 @@ def _relocate_into(dst: Path, *sources: Path) -> bool:
     marker = dst / _RELOCATED_MARKER
     if marker.is_file():
         return True  # already relocated; trust dst, ignore any stale leftover at the source
-    src = next((s for s in sources if s.is_dir()), None)
+    src = next((s for s in sources if s is not None and s.is_dir()), None)
     if src is not None:
         # Source still present, so the move never completed. A partial dst from an interrupted
         # cross-volume copy would nest the retry, so discard it before re-moving.
@@ -214,7 +205,7 @@ def _relocate_into(dst: Path, *sources: Path) -> bool:
                     )
             else:
                 _LOGGER.warning("Could not move %s to %s; it will be rebuilt", src, dst)
-        if src.is_dir() and not adopted_dst:
+        if not adopted_dst and src.is_dir():
             _LOGGER.warning("%s not relocated; source remains at %s", dst, src)
             return False
     # No source left here: none existed, the move just completed, or a prior run moved it and only
@@ -232,25 +223,28 @@ def _copy_completed(src: Path, dst: Path) -> bool:
     """
     Whether every file still under *src* has an identical-size counterpart under *dst*.
 
-    Classifies a failed ``shutil.move``: a copy-phase death leaves the source complete and the
-    copy missing files (``False``, source is authoritative); a delete-phase death leaves only
-    already-copied leftovers under the source (``True``, the copy is complete). A source with no
-    files left is ambiguous — nothing distinguishes the phases — so it stays ``False`` and the
-    caller falls back fail-closed.
+    A source with no files left is ambiguous — nothing distinguishes the move's phases — so it
+    stays ``False`` and the caller falls back fail-closed.
     """
     if not dst.is_dir():
         return False
     matched_file = False
     try:
-        for current, _dirs, files in os.walk(src):
-            rel = Path(current).relative_to(src)
+        # onerror: os.walk silently skips unreadable subtrees by default, which would classify
+        # a copy missing that subtree as complete — re-raise so uncertainty stays fail-closed.
+        for current, _dirs, files in os.walk(src, onerror=_raise_walk_error):
+            dst_dir = dst / Path(current).relative_to(src)
             for name in files:
-                copied = dst / rel / name
-                if not copied.is_file():
-                    return False
-                if copied.stat().st_size != (Path(current) / name).stat().st_size:
+                copied = dst_dir / name
+                src_size = (Path(current) / name).stat().st_size
+                if not copied.is_file() or copied.stat().st_size != src_size:
                     return False
                 matched_file = True
     except OSError:
         return False
     return matched_file
+
+
+def _raise_walk_error(err: OSError) -> None:
+    """Surface an ``os.walk`` traversal error instead of the default silent skip."""
+    raise err

--- a/tests/e2e/slow/windows/test_windows_migration.py
+++ b/tests/e2e/slow/windows/test_windows_migration.py
@@ -66,6 +66,7 @@ def test_compiled_tree_survives_migration_from_original_dir(
         # ~/.platformio (the un-relocated state a never-updated user is in).
         monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
         monkeypatch.delenv("PLATFORMIO_CORE_DIR", raising=False)
+        monkeypatch.delenv("ESPHOME_ESP_IDF_PREFIX", raising=False)
         _compile(config, compose_subprocess_env(job), "original compile")
         assert (old_esphome / "build" / _NAME).is_dir()
         assert home_pio.is_dir()

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import textwrap
 from collections.abc import Iterator
 from pathlib import Path
 from typing import NamedTuple
@@ -38,7 +37,7 @@ _PROFILE = "First Last"
 
 
 class _Toolchain(NamedTuple):
-    yaml_line: str  # extra esp32-level option selecting the toolchain ("" = default)
+    option: str  # esp32-level option selecting the toolchain ("" = default)
     env_var: str  # the install-dir env var the relocation must set
     root_subdir: str  # the relocated install dir under the root
     build_subdir: str  # artifact dir under build/<name>/ proving the compile landed
@@ -48,13 +47,13 @@ class _Toolchain(NamedTuple):
 # can't express a hyphen — keep them underscore-only.
 _TOOLCHAINS = {
     "native_idf": _Toolchain(
-        yaml_line="",
+        option="",
         env_var="ESPHOME_ESP_IDF_PREFIX",
         root_subdir="idf",
         build_subdir="build",
     ),
     "platformio": _Toolchain(
-        yaml_line="  toolchain: platformio\n",
+        option="toolchain: platformio",
         env_var="PLATFORMIO_CORE_DIR",
         root_subdir="pio",
         build_subdir=".pioenvs",
@@ -63,30 +62,23 @@ _TOOLCHAINS = {
 
 
 def _config_yaml(toolchain: _Toolchain) -> str:
-    return (
-        textwrap.dedent(
-            f"""\
-            esphome:
-              name: {_NAME}
-            esp32:
-              board: esp32dev
-              framework:
-                type: esp-idf
-            """
-        )
-        + toolchain.yaml_line
-        + textwrap.dedent(
-            """\
-            logger:
-            wifi:
-              ssid: "probe-ssid"
-              password: "probe-password"
-            api:
-              encryption:
-                key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
-            """
-        )
-    )
+    lines = [
+        "esphome:",
+        f"  name: {_NAME}",
+        "esp32:",
+        "  board: esp32dev",
+        "  framework:",
+        "    type: esp-idf",
+        *([f"  {toolchain.option}"] if toolchain.option else []),
+        "logger:",
+        "wifi:",
+        '  ssid: "probe-ssid"',
+        '  password: "probe-password"',
+        "api:",
+        "  encryption:",
+        '    key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="',
+    ]
+    return "\n".join(lines) + "\n"
 
 
 class _Relocated(NamedTuple):
@@ -98,7 +90,7 @@ class _Relocated(NamedTuple):
     env: dict[str, str]
 
 
-@pytest.fixture(scope="module", params=sorted(_TOOLCHAINS), ids=sorted(_TOOLCHAINS))
+@pytest.fixture(scope="module", params=sorted(_TOOLCHAINS))
 def relocated_compile(
     request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
 ) -> Iterator[_Relocated]:
@@ -110,11 +102,10 @@ def relocated_compile(
     config.write_text(_config_yaml(tc), encoding="utf-8")
     assert " " in str(config_dir)  # the case the relocation must neutralize
 
-    prev = {
-        name: os.environ.pop(name, None)
-        for name in ("ESPHOME_DATA_DIR", "PLATFORMIO_CORE_DIR", "ESPHOME_ESP_IDF_PREFIX")
-    }
-    try:
+    # Module-scoped, so the function-scoped ``monkeypatch`` fixture can't be injected.
+    with pytest.MonkeyPatch.context() as mp:
+        for name in ("ESPHOME_DATA_DIR", "PLATFORMIO_CORE_DIR", "ESPHOME_ESP_IDF_PREFIX"):
+            mp.delenv(name, raising=False)
         with windows_short_build_paths(config_dir):
             root = Path(os.environ["ESPHOME_DATA_DIR"])
             toolchain_dir = Path(os.environ[tc.env_var])
@@ -137,12 +128,6 @@ def relocated_compile(
                 tc=tc,
                 env=env,
             )
-    finally:
-        for name, value in prev.items():
-            if value is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
 
 
 def test_compile_lands_under_relocated_root(relocated_compile: _Relocated) -> None:

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -44,8 +44,10 @@ class _Toolchain(NamedTuple):
     build_subdir: str  # artifact dir under build/<name>/ proving the compile landed
 
 
+# Keys double as pytest param ids the CI matrix selects with ``-k``, whose expression grammar
+# can't express a hyphen — keep them underscore-only.
 _TOOLCHAINS = {
-    "native-idf": _Toolchain(
+    "native_idf": _Toolchain(
         yaml_line="",
         env_var="ESPHOME_ESP_IDF_PREFIX",
         root_subdir="idf",

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -1,11 +1,11 @@
 """
-Pins the Windows build-data relocation against a real ESP-IDF toolchain.
+Pins the Windows build-data relocation against a real native ESP-IDF toolchain.
 
 One deep + spaced ESP-IDF compile (shared via a module-scoped fixture) lands its artifacts under
-the relocated root, proving MAX_PATH + the pioarduino whitespace guard are both neutralised. Three
-separately-reported tests then assert that the compile, ``esphome clean``, and ``esphome clean-all``
-all target the *relocated* dirs (``ESPHOME_DATA_DIR`` build tree + ``PLATFORMIO_CORE_DIR``
-toolchain), never the original config dir.
+the relocated root, proving MAX_PATH + ESP-IDF's no-spaces install requirement are both
+neutralised. Three separately-reported tests then assert that the compile, ``esphome clean``, and
+``esphome clean-all`` all target the *relocated* dirs (``ESPHOME_DATA_DIR`` build tree +
+``ESPHOME_ESP_IDF_PREFIX`` toolchain), never the original config dir.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ _MAX_PATH = 260
 _NAME = "maxpath-probe-esp32-idf"
 
 # Deliberately long AND space-bearing config dir: proves the relocation handles both the MAX_PATH
-# overflow and the pioarduino whitespace guard / -fdebug-prefix-map in a single real compile.
+# overflow and ESP-IDF's no-spaces install requirement in a single real compile.
 _PAD = "padding-" * 9  # 72 chars
 _PROFILE = "First Last"
 
@@ -57,7 +57,7 @@ class _Relocated(NamedTuple):
     config_dir: Path
     config: Path
     root: Path  # relocated ESPHOME_DATA_DIR
-    pio: Path  # relocated PLATFORMIO_CORE_DIR
+    idf: Path  # relocated ESPHOME_ESP_IDF_PREFIX
     env: dict[str, str]
 
 
@@ -72,23 +72,28 @@ def relocated_compile(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Rel
 
     prev_data = os.environ.pop("ESPHOME_DATA_DIR", None)
     prev_pio = os.environ.pop("PLATFORMIO_CORE_DIR", None)
+    prev_idf = os.environ.pop("ESPHOME_ESP_IDF_PREFIX", None)
     try:
         with windows_short_build_paths(config_dir):
             root = Path(os.environ["ESPHOME_DATA_DIR"])
-            pio = Path(os.environ["PLATFORMIO_CORE_DIR"])
+            idf = Path(os.environ["ESPHOME_ESP_IDF_PREFIX"])
             assert " " not in str(root)  # relocated to a short, space-free root
-            assert " " not in str(pio)
+            assert " " not in str(idf)
 
-            # PLATFORMIO_CORE_DIR flows in through os.environ, so the env carries it without a
+            # ESPHOME_ESP_IDF_PREFIX flows in through os.environ, so the env carries it without a
             # threaded argument.
             job = FirmwareJob(job_id="probe", configuration="probe.yaml", job_type=JobType.COMPILE)
             env = compose_subprocess_env(job)
-            assert env["PLATFORMIO_CORE_DIR"] == str(pio)
+            assert env["ESPHOME_ESP_IDF_PREFIX"] == str(idf)
 
             _run(["compile", str(config)], env, "compile")
-            yield _Relocated(config_dir=config_dir, config=config, root=root, pio=pio, env=env)
+            yield _Relocated(config_dir=config_dir, config=config, root=root, idf=idf, env=env)
     finally:
-        for name, value in (("ESPHOME_DATA_DIR", prev_data), ("PLATFORMIO_CORE_DIR", prev_pio)):
+        for name, value in (
+            ("ESPHOME_DATA_DIR", prev_data),
+            ("PLATFORMIO_CORE_DIR", prev_pio),
+            ("ESPHOME_ESP_IDF_PREFIX", prev_idf),
+        ):
             if value is None:
                 os.environ.pop(name, None)
             else:
@@ -98,22 +103,20 @@ def relocated_compile(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Rel
 def test_compile_lands_under_relocated_root(relocated_compile: _Relocated) -> None:
     """The compile's artifacts land under the relocated root, under MAX_PATH, not the config dir."""
     r = relocated_compile
-    assert (r.root / "build" / _NAME / ".pioenvs").is_dir(), "build tree not under relocated root"
+    assert (r.root / "build" / _NAME / "build").is_dir(), "build tree not under relocated root"
     assert not (r.config_dir / ".esphome").exists(), "nothing should build under the config dir"
-    assert r.pio.is_dir(), "toolchain not under the relocated PLATFORMIO_CORE_DIR"
+    assert r.idf.is_dir(), "toolchain not under the relocated ESPHOME_ESP_IDF_PREFIX"
     deepest = _deepest(r.root)
     assert deepest < _MAX_PATH, f"deepest relocated path is {deepest}"
 
 
 def test_clean_clears_relocated_build_tree(relocated_compile: _Relocated) -> None:
-    """``esphome clean`` removes the build trees under the relocated build path."""
+    """``esphome clean`` removes the build tree under the relocated build path."""
     r = relocated_compile
     build_path = r.root / "build" / _NAME
-    assert (build_path / ".pioenvs").is_dir()  # present before clean
+    assert (build_path / "build").is_dir()  # present before clean
     _run(["clean", str(r.config)], r.env, "clean")
-    assert not (build_path / ".pioenvs").is_dir()
-    assert not (build_path / ".piolibdeps").is_dir()
-    assert not (build_path / "build").is_dir()
+    assert not build_path.is_dir()
 
 
 def test_clean_all_clears_relocated_data_and_toolchain(relocated_compile: _Relocated) -> None:
@@ -123,10 +126,10 @@ def test_clean_all_clears_relocated_data_and_toolchain(relocated_compile: _Reloc
     (r.root / "keep.json").write_text("{}", encoding="utf-8")
     (r.root / "storage").mkdir(exist_ok=True)
     (r.root / "storage" / "probe.json").write_text("{}", encoding="utf-8")
-    assert r.pio.is_dir()  # toolchain present (clean leaves it; clean-all removes it)
+    assert r.idf.is_dir()  # toolchain present (clean leaves it; clean-all removes it)
 
     _run(["clean-all", str(r.config_dir)], r.env, "clean-all")
-    assert not r.pio.is_dir(), "clean-all did not remove the relocated PLATFORMIO_CORE_DIR"
+    assert not r.idf.is_dir(), "clean-all did not remove the relocated ESPHOME_ESP_IDF_PREFIX"
     assert not (r.root / "build").exists(), "clean-all did not clear the relocated build tree"
     assert (r.root / "keep.json").is_file(), "clean-all must preserve .json files"
     assert (r.root / "storage" / "probe.json").is_file(), "clean-all must preserve storage/"

--- a/tests/e2e/slow/windows/test_windows_short_paths.py
+++ b/tests/e2e/slow/windows/test_windows_short_paths.py
@@ -1,11 +1,12 @@
 """
-Pins the Windows build-data relocation against a real native ESP-IDF toolchain.
+Pins the Windows build-data relocation against both real ESP-IDF toolchains.
 
-One deep + spaced ESP-IDF compile (shared via a module-scoped fixture) lands its artifacts under
-the relocated root, proving MAX_PATH + ESP-IDF's no-spaces install requirement are both
-neutralised. Three separately-reported tests then assert that the compile, ``esphome clean``, and
+One deep + spaced esp32 ``esp-idf`` compile per toolchain — native ESP-IDF (the default) and the
+``toolchain: platformio`` opt-in — shared via a parametrized module-scoped fixture, lands its
+artifacts under the relocated root, proving MAX_PATH + spaced-path handling for each. Three
+separately-reported tests per toolchain then assert that the compile, ``esphome clean``, and
 ``esphome clean-all`` all target the *relocated* dirs (``ESPHOME_DATA_DIR`` build tree +
-``ESPHOME_ESP_IDF_PREFIX`` toolchain), never the original config dir.
+the toolchain's install dir), never the original config dir.
 """
 
 from __future__ import annotations
@@ -30,70 +31,112 @@ _MAX_PATH = 260
 _NAME = "maxpath-probe-esp32-idf"
 
 # Deliberately long AND space-bearing config dir: proves the relocation handles both the MAX_PATH
-# overflow and ESP-IDF's no-spaces install requirement in a single real compile.
+# overflow and the toolchains' spaced-path failure modes (ESP-IDF refuses spaced install paths;
+# pioarduino has a whitespace guard / -fdebug-prefix-map truncation) in a single real compile.
 _PAD = "padding-" * 9  # 72 chars
 _PROFILE = "First Last"
 
-_CONFIG = textwrap.dedent(
-    f"""\
-    esphome:
-      name: {_NAME}
-    esp32:
-      board: esp32dev
-      framework:
-        type: esp-idf
-    logger:
-    wifi:
-      ssid: "probe-ssid"
-      password: "probe-password"
-    api:
-      encryption:
-        key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
-    """
-)
+
+class _Toolchain(NamedTuple):
+    yaml_line: str  # extra esp32-level option selecting the toolchain ("" = default)
+    env_var: str  # the install-dir env var the relocation must set
+    root_subdir: str  # the relocated install dir under the root
+    build_subdir: str  # artifact dir under build/<name>/ proving the compile landed
+
+
+_TOOLCHAINS = {
+    "native-idf": _Toolchain(
+        yaml_line="",
+        env_var="ESPHOME_ESP_IDF_PREFIX",
+        root_subdir="idf",
+        build_subdir="build",
+    ),
+    "platformio": _Toolchain(
+        yaml_line="  toolchain: platformio\n",
+        env_var="PLATFORMIO_CORE_DIR",
+        root_subdir="pio",
+        build_subdir=".pioenvs",
+    ),
+}
+
+
+def _config_yaml(toolchain: _Toolchain) -> str:
+    return (
+        textwrap.dedent(
+            f"""\
+            esphome:
+              name: {_NAME}
+            esp32:
+              board: esp32dev
+              framework:
+                type: esp-idf
+            """
+        )
+        + toolchain.yaml_line
+        + textwrap.dedent(
+            """\
+            logger:
+            wifi:
+              ssid: "probe-ssid"
+              password: "probe-password"
+            api:
+              encryption:
+                key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+            """
+        )
+    )
 
 
 class _Relocated(NamedTuple):
     config_dir: Path
     config: Path
     root: Path  # relocated ESPHOME_DATA_DIR
-    idf: Path  # relocated ESPHOME_ESP_IDF_PREFIX
+    toolchain_dir: Path  # relocated install dir for the active toolchain
+    tc: _Toolchain
     env: dict[str, str]
 
 
-@pytest.fixture(scope="module")
-def relocated_compile(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Relocated]:
-    """Relocate, compile a deep + spaced ESP-IDF config once, and share the result module-wide."""
+@pytest.fixture(scope="module", params=sorted(_TOOLCHAINS), ids=sorted(_TOOLCHAINS))
+def relocated_compile(
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[_Relocated]:
+    """Relocate, compile a deep + spaced esp32 config once per toolchain, share module-wide."""
+    tc = _TOOLCHAINS[request.param]
     config_dir = tmp_path_factory.mktemp("win") / _PAD / _PROFILE / "esphome"
     config_dir.mkdir(parents=True, exist_ok=True)
     config = config_dir / "probe.yaml"
-    config.write_text(_CONFIG, encoding="utf-8")
+    config.write_text(_config_yaml(tc), encoding="utf-8")
     assert " " in str(config_dir)  # the case the relocation must neutralize
 
-    prev_data = os.environ.pop("ESPHOME_DATA_DIR", None)
-    prev_pio = os.environ.pop("PLATFORMIO_CORE_DIR", None)
-    prev_idf = os.environ.pop("ESPHOME_ESP_IDF_PREFIX", None)
+    prev = {
+        name: os.environ.pop(name, None)
+        for name in ("ESPHOME_DATA_DIR", "PLATFORMIO_CORE_DIR", "ESPHOME_ESP_IDF_PREFIX")
+    }
     try:
         with windows_short_build_paths(config_dir):
             root = Path(os.environ["ESPHOME_DATA_DIR"])
-            idf = Path(os.environ["ESPHOME_ESP_IDF_PREFIX"])
+            toolchain_dir = Path(os.environ[tc.env_var])
+            assert toolchain_dir == root / tc.root_subdir
             assert " " not in str(root)  # relocated to a short, space-free root
-            assert " " not in str(idf)
+            assert " " not in str(toolchain_dir)
 
-            # ESPHOME_ESP_IDF_PREFIX flows in through os.environ, so the env carries it without a
+            # The toolchain env var flows in through os.environ, so the env carries it without a
             # threaded argument.
             job = FirmwareJob(job_id="probe", configuration="probe.yaml", job_type=JobType.COMPILE)
             env = compose_subprocess_env(job)
-            assert env["ESPHOME_ESP_IDF_PREFIX"] == str(idf)
+            assert env[tc.env_var] == str(toolchain_dir)
 
             _run(["compile", str(config)], env, "compile")
-            yield _Relocated(config_dir=config_dir, config=config, root=root, idf=idf, env=env)
+            yield _Relocated(
+                config_dir=config_dir,
+                config=config,
+                root=root,
+                toolchain_dir=toolchain_dir,
+                tc=tc,
+                env=env,
+            )
     finally:
-        for name, value in (
-            ("ESPHOME_DATA_DIR", prev_data),
-            ("PLATFORMIO_CORE_DIR", prev_pio),
-            ("ESPHOME_ESP_IDF_PREFIX", prev_idf),
-        ):
+        for name, value in prev.items():
             if value is None:
                 os.environ.pop(name, None)
             else:
@@ -103,9 +146,10 @@ def relocated_compile(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Rel
 def test_compile_lands_under_relocated_root(relocated_compile: _Relocated) -> None:
     """The compile's artifacts land under the relocated root, under MAX_PATH, not the config dir."""
     r = relocated_compile
-    assert (r.root / "build" / _NAME / "build").is_dir(), "build tree not under relocated root"
+    build_marker = r.root / "build" / _NAME / r.tc.build_subdir
+    assert build_marker.is_dir(), "build tree not under relocated root"
     assert not (r.config_dir / ".esphome").exists(), "nothing should build under the config dir"
-    assert r.idf.is_dir(), "toolchain not under the relocated ESPHOME_ESP_IDF_PREFIX"
+    assert r.toolchain_dir.is_dir(), f"toolchain not under the relocated {r.tc.env_var}"
     deepest = _deepest(r.root)
     assert deepest < _MAX_PATH, f"deepest relocated path is {deepest}"
 
@@ -114,7 +158,7 @@ def test_clean_clears_relocated_build_tree(relocated_compile: _Relocated) -> Non
     """``esphome clean`` removes the build tree under the relocated build path."""
     r = relocated_compile
     build_path = r.root / "build" / _NAME
-    assert (build_path / "build").is_dir()  # present before clean
+    assert (build_path / r.tc.build_subdir).is_dir()  # present before clean
     _run(["clean", str(r.config)], r.env, "clean")
     assert not build_path.is_dir()
 
@@ -126,10 +170,10 @@ def test_clean_all_clears_relocated_data_and_toolchain(relocated_compile: _Reloc
     (r.root / "keep.json").write_text("{}", encoding="utf-8")
     (r.root / "storage").mkdir(exist_ok=True)
     (r.root / "storage" / "probe.json").write_text("{}", encoding="utf-8")
-    assert r.idf.is_dir()  # toolchain present (clean leaves it; clean-all removes it)
+    assert r.toolchain_dir.is_dir()  # toolchain present (clean leaves it; clean-all removes it)
 
     _run(["clean-all", str(r.config_dir)], r.env, "clean-all")
-    assert not r.idf.is_dir(), "clean-all did not remove the relocated ESPHOME_ESP_IDF_PREFIX"
+    assert not r.toolchain_dir.is_dir(), f"clean-all did not remove the relocated {r.tc.env_var}"
     assert not (r.root / "build").exists(), "clean-all did not clear the relocated build tree"
     assert (r.root / "keep.json").is_file(), "clean-all must preserve .json files"
     assert (r.root / "storage" / "probe.json").is_file(), "clean-all must preserve storage/"

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -49,22 +49,27 @@ def fake_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(wbp, "_LEGACY_ROOT_BASE", root_base)
     monkeypatch.setattr(wbp, "get_or_create_dashboard_id", lambda _config_dir: _ID)
     monkeypatch.setattr(wbp, "_platformio_dir", lambda: tmp_path / "home_platformio")
+    monkeypatch.setattr(wbp, "_default_idf_cache", lambda: tmp_path / "cache_idf")
     monkeypatch.delenv("ESPHOME_DATA_DIR", raising=False)
     monkeypatch.delenv("PLATFORMIO_CORE_DIR", raising=False)
+    monkeypatch.delenv("ESPHOME_ESP_IDF_PREFIX", raising=False)
     return root_base
 
 
 def test_relocates_env_to_short_root_and_restores(tmp_path: Path, fake_windows: Path) -> None:
-    """Inside the block both env vars point at the short root; both are cleared on exit."""
+    """Inside the block all three env vars point at the short root; all are cleared on exit."""
     config_dir = tmp_path / "First Last" / "esphome"
     root = fake_windows / "esphb" / _ID8
     with windows_short_build_paths(config_dir):
         assert os.environ["ESPHOME_DATA_DIR"] == str(root)
         assert os.environ["PLATFORMIO_CORE_DIR"] == str(root / "pio")
+        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(root / "idf")
         assert root.is_dir()
         assert (root / "pio").is_dir()
+        assert (root / "idf").is_dir()
     assert "ESPHOME_DATA_DIR" not in os.environ
     assert "PLATFORMIO_CORE_DIR" not in os.environ
+    assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ
 
 
 def test_root_uses_first_8_chars_of_dashboard_id(tmp_path: Path, fake_windows: Path) -> None:
@@ -125,26 +130,67 @@ def test_respects_user_set_platformio_core_dir(
     assert home_pio.is_dir()  # user's toolchain left untouched
 
 
+def test_respects_user_set_esp_idf_prefix(
+    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user-set ESPHOME_ESP_IDF_PREFIX is left alone (data still relocates)."""
+    chosen = tmp_path / "chosen_idf"
+    cache_idf = tmp_path / "cache_idf"
+    cache_idf.mkdir()  # would be swept if we relocated; must stay put
+    monkeypatch.setenv("ESPHOME_ESP_IDF_PREFIX", str(chosen))
+    root = fake_windows / "esphb" / _ID8
+    with windows_short_build_paths(tmp_path / "First Last" / "esphome"):
+        assert os.environ["ESPHOME_DATA_DIR"] == str(root)
+        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(chosen)
+        assert not (root / "idf").exists()
+    assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(chosen)
+    assert cache_idf.is_dir()
+
+
 def test_platformio_dir_defaults_under_home() -> None:
     """The toolchain-source seam points at ~/.platformio by default."""
     assert wbp._platformio_dir() == Path.home() / ".platformio"
 
 
+def test_default_idf_cache_under_user_cache_dir() -> None:
+    """The idf-source seam points at esphome's machine-global cache dir."""
+    import platformdirs  # noqa: PLC0415
+
+    cache = wbp._default_idf_cache()
+    assert cache == Path(platformdirs.user_cache_dir("esphome", appauthor=False)) / "idf"
+
+
+def test_missing_platformdirs_still_relocates_idf(
+    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No migration source (platformdirs absent) still creates and points at the idf dir."""
+    monkeypatch.setattr(wbp, "_default_idf_cache", lambda: None)
+    root = fake_windows / "esphb" / _ID8
+    with windows_short_build_paths(tmp_path / "cfg"):
+        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(root / "idf")
+        assert (root / "idf").is_dir()
+
+
 def test_migrates_existing_data_and_toolchain(tmp_path: Path, fake_windows: Path) -> None:
-    """Existing ``<config>/.esphome`` and ``~/.platformio`` are moved into the root once."""
+    """Existing ``.esphome``, ``~/.platformio`` and the IDF cache are moved into the root once."""
     config_dir = tmp_path / "First Last" / "esphome"
     (config_dir / ".esphome").mkdir(parents=True)
     (config_dir / ".esphome" / "marker.txt").write_text("data", encoding="utf-8")
     home_pio = tmp_path / "home_platformio"
     home_pio.mkdir()
     (home_pio / "tool.txt").write_text("toolchain", encoding="utf-8")
+    cache_idf = tmp_path / "cache_idf"
+    cache_idf.mkdir()
+    (cache_idf / "idf.txt").write_text("idf-toolchain", encoding="utf-8")
 
     root = fake_windows / "esphb" / _ID8
     with windows_short_build_paths(config_dir):
         assert (root / "marker.txt").read_text(encoding="utf-8") == "data"
         assert (root / "pio" / "tool.txt").read_text(encoding="utf-8") == "toolchain"
+        assert (root / "idf" / "idf.txt").read_text(encoding="utf-8") == "idf-toolchain"
     assert not (config_dir / ".esphome").exists()
     assert not home_pio.exists()
+    assert not cache_idf.exists()
 
 
 def test_migrates_from_legacy_flat_root(tmp_path: Path, fake_windows: Path) -> None:

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -171,6 +171,44 @@ def test_missing_platformdirs_still_relocates_idf(
         assert (root / "idf").is_dir()
 
 
+def test_empty_esp_idf_prefix_is_not_user_set(
+    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty ESPHOME_ESP_IDF_PREFIX means unset to esphome, so relocation must still apply."""
+    monkeypatch.setenv("ESPHOME_ESP_IDF_PREFIX", "  ")
+    root = fake_windows / "esphb" / _ID8
+    with windows_short_build_paths(tmp_path / "cfg"):
+        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(root / "idf")
+        assert (root / "idf").is_dir()
+
+
+def test_failed_idf_relocation_leaves_prefix_unset(
+    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interrupted IDF-cache move leaves ESPHOME_ESP_IDF_PREFIX at the default, not corrupt."""
+    config_dir = tmp_path / "First Last" / "esphome"
+    (config_dir / ".esphome").mkdir(parents=True)
+    (tmp_path / "cache_idf").mkdir()
+
+    real_move = wbp.shutil.move
+
+    def _interrupted(src: str, dst: str, *args: object, **kwargs: object) -> object:
+        if "cache_idf" in str(src):
+            # A cross-volume copy that got partway then died: dst half-written, src left behind.
+            Path(dst).mkdir(parents=True, exist_ok=True)
+            (Path(dst) / "half.txt").write_text("partial", encoding="utf-8")
+            msg = "interrupted"
+            raise OSError(msg)
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(wbp.shutil, "move", _interrupted)
+    root = fake_windows / "esphb" / _ID8
+    with windows_short_build_paths(config_dir):
+        assert os.environ["ESPHOME_DATA_DIR"] == str(root)  # build data still relocated
+        assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ  # corrupt toolchain not adopted
+    assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ
+
+
 def test_migrates_existing_data_and_toolchain(tmp_path: Path, fake_windows: Path) -> None:
     """Existing ``.esphome``, ``~/.platformio`` and the IDF cache are moved into the root once."""
     config_dir = tmp_path / "First Last" / "esphome"

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -180,6 +180,33 @@ def test_empty_esp_idf_prefix_is_not_user_set(
     with windows_short_build_paths(tmp_path / "cfg"):
         assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(root / "idf")
         assert (root / "idf").is_dir()
+    assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == "  "  # restored verbatim, not popped
+
+
+def test_delete_phase_failure_adopts_complete_copy(
+    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A move whose copy finished but whose source delete died adopts the copy, not the wreck."""
+    config_dir = tmp_path / "First Last" / "esphome"
+    (config_dir / ".esphome").mkdir(parents=True)
+    cache_idf = tmp_path / "cache_idf"
+    cache_idf.mkdir()
+    (cache_idf / "tool.txt").write_text("idf-toolchain", encoding="utf-8")
+
+    real_move = wbp.shutil.move
+
+    def _delete_died(src: str, dst: str, *args: object, **kwargs: object) -> object:
+        if "cache_idf" in str(src):
+            shutil.copytree(src, dst)  # the copy phase completed...
+            msg = "source delete died"
+            raise OSError(msg)  # ...the delete phase did not
+        return real_move(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(wbp.shutil, "move", _delete_died)
+    root = fake_windows / "esphb" / _ID8
+    with windows_short_build_paths(config_dir):
+        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(root / "idf")
+        assert (root / "idf" / "tool.txt").read_text(encoding="utf-8") == "idf-toolchain"
 
 
 def test_failed_idf_relocation_leaves_prefix_unset(

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -8,12 +8,14 @@ idempotence / env restore / fallback get fast-matrix coverage without a Windows 
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from esphome_device_builder.helpers import windows_build_paths as wbp
 from esphome_device_builder.helpers.windows_build_paths import windows_short_build_paths
@@ -113,38 +115,33 @@ def test_skips_relocation_when_user_set_data_dir(
     assert os.environ["ESPHOME_DATA_DIR"] == str(tmp_path / "chosen")
 
 
-def test_respects_user_set_platformio_core_dir(
-    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("env_var", "source_name", "subdir"),
+    [
+        pytest.param("PLATFORMIO_CORE_DIR", "home_platformio", "pio", id="pio"),
+        pytest.param("ESPHOME_ESP_IDF_PREFIX", "cache_idf", "idf", id="idf"),
+    ],
+)
+def test_respects_user_set_toolchain_var(
+    tmp_path: Path,
+    fake_windows: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    env_var: str,
+    source_name: str,
+    subdir: str,
 ) -> None:
-    """A user-set PLATFORMIO_CORE_DIR is left alone (data still relocates); toolchain untouched."""
-    chosen = tmp_path / "chosen_pio"
-    home_pio = tmp_path / "home_platformio"
-    home_pio.mkdir()  # would be swept if we relocated; must stay put
-    monkeypatch.setenv("PLATFORMIO_CORE_DIR", str(chosen))
+    """A user-set toolchain var is left alone (data still relocates); the install stays put."""
+    chosen = tmp_path / "chosen"
+    source = tmp_path / source_name
+    source.mkdir()  # would be swept if we relocated; must stay put
+    monkeypatch.setenv(env_var, str(chosen))
     root = fake_windows / "esphb" / _ID8
     with windows_short_build_paths(tmp_path / "First Last" / "esphome"):
         assert os.environ["ESPHOME_DATA_DIR"] == str(root)  # data dir still relocated
-        assert os.environ["PLATFORMIO_CORE_DIR"] == str(chosen)  # user choice respected
-        assert not (root / "pio").exists()  # we did not create/override the toolchain dir
-    assert os.environ["PLATFORMIO_CORE_DIR"] == str(chosen)
-    assert home_pio.is_dir()  # user's toolchain left untouched
-
-
-def test_respects_user_set_esp_idf_prefix(
-    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A user-set ESPHOME_ESP_IDF_PREFIX is left alone (data still relocates)."""
-    chosen = tmp_path / "chosen_idf"
-    cache_idf = tmp_path / "cache_idf"
-    cache_idf.mkdir()  # would be swept if we relocated; must stay put
-    monkeypatch.setenv("ESPHOME_ESP_IDF_PREFIX", str(chosen))
-    root = fake_windows / "esphb" / _ID8
-    with windows_short_build_paths(tmp_path / "First Last" / "esphome"):
-        assert os.environ["ESPHOME_DATA_DIR"] == str(root)
-        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(chosen)
-        assert not (root / "idf").exists()
-    assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(chosen)
-    assert cache_idf.is_dir()
+        assert os.environ[env_var] == str(chosen)  # user choice respected
+        assert not (root / subdir).exists()  # we did not create/override the toolchain dir
+    assert os.environ[env_var] == str(chosen)
+    assert source.is_dir()  # user's install left untouched
 
 
 def test_platformio_dir_defaults_under_home() -> None:
@@ -215,15 +212,19 @@ def test_failed_idf_relocation_leaves_prefix_unset(
     """An interrupted IDF-cache move leaves ESPHOME_ESP_IDF_PREFIX at the default, not corrupt."""
     config_dir = tmp_path / "First Last" / "esphome"
     (config_dir / ".esphome").mkdir(parents=True)
-    (tmp_path / "cache_idf").mkdir()
+    cache_idf = tmp_path / "cache_idf"
+    cache_idf.mkdir()
+    (cache_idf / "tool.txt").write_text("idf-toolchain", encoding="utf-8")
+    (cache_idf / "other.txt").write_text("more", encoding="utf-8")
 
     real_move = wbp.shutil.move
 
     def _interrupted(src: str, dst: str, *args: object, **kwargs: object) -> object:
         if "cache_idf" in str(src):
-            # A cross-volume copy that got partway then died: dst half-written, src left behind.
+            # A cross-volume copy that got partway then died: one of two files made it across,
+            # so the classifier must see the copy as incomplete, not take the empty-source out.
             Path(dst).mkdir(parents=True, exist_ok=True)
-            (Path(dst) / "half.txt").write_text("partial", encoding="utf-8")
+            shutil.copy2(Path(src) / "tool.txt", Path(dst) / "tool.txt")
             msg = "interrupted"
             raise OSError(msg)
         return real_move(src, dst, *args, **kwargs)
@@ -234,6 +235,35 @@ def test_failed_idf_relocation_leaves_prefix_unset(
         assert os.environ["ESPHOME_DATA_DIR"] == str(root)  # build data still relocated
         assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ  # corrupt toolchain not adopted
     assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ
+    assert (cache_idf / "other.txt").is_file()  # source stayed authoritative
+
+
+def test_size_mismatched_copy_not_adopted(tmp_path: Path) -> None:
+    """A same-name file that differs in size marks the copy incomplete."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "tool.txt").write_text("full-content", encoding="utf-8")
+    (dst / "tool.txt").write_text("part", encoding="utf-8")
+    assert not wbp._copy_completed(src, dst)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod 0 does not deny reads on Windows")
+def test_unreadable_source_subtree_fails_closed(tmp_path: Path) -> None:
+    """An unwalkable source subtree classifies the copy incomplete, never silently skipped."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    (src / "sub").mkdir(parents=True)
+    dst.mkdir()
+    (src / "top.txt").write_text("x", encoding="utf-8")
+    (dst / "top.txt").write_text("x", encoding="utf-8")  # everything visible matches...
+    (src / "sub" / "hidden.txt").write_text("y", encoding="utf-8")  # ...this never copied
+    (src / "sub").chmod(0)
+    try:
+        assert not wbp._copy_completed(src, dst)
+    finally:
+        (src / "sub").chmod(0o755)
 
 
 def test_migrates_existing_data_and_toolchain(tmp_path: Path, fake_windows: Path) -> None:
@@ -518,3 +548,23 @@ def test_root_creation_failure_falls_back_to_noop(
     with windows_short_build_paths(config_dir):
         assert "ESPHOME_DATA_DIR" not in os.environ
     assert "ESPHOME_DATA_DIR" not in os.environ
+
+
+def test_ci_matrix_covers_every_toolchain_param() -> None:
+    """A _TOOLCHAINS param without a windows-real-compile matrix suite would silently never run."""
+    repo = Path(__file__).parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "windows_short_paths_e2e",
+        repo / "tests" / "e2e" / "slow" / "windows" / "test_windows_short_paths.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    workflow = yaml.safe_load(
+        (repo / ".github" / "workflows" / "windows-real-compile.yml").read_text(encoding="utf-8")
+    )
+    suites = {
+        entry["suite"]
+        for entry in workflow["jobs"]["windows-maxpath"]["strategy"]["matrix"]["include"]
+    }
+    assert set(module._TOOLCHAINS) <= suites

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -444,7 +444,12 @@ def test_partial_root_discard_failure_stays_on_old_dir(
     root = fake_windows / "esphb" / _ID8
     root.mkdir(parents=True)
     (root / "half.txt").write_text("partial", encoding="utf-8")
-    monkeypatch.setattr(wbp.shutil, "rmtree", lambda *_a, **_k: None)  # discard fails to remove
+
+    def _denied(*_a: object, **_k: object) -> None:
+        msg = "denied"
+        raise OSError(msg)
+
+    monkeypatch.setattr(wbp, "rmtree", _denied)  # the partial discard fails
 
     with windows_short_build_paths(config_dir):
         assert "ESPHOME_DATA_DIR" not in os.environ

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -195,8 +195,8 @@ def test_failed_idf_relocation_leaves_prefix_unset(
 
     def _interrupted(src: str, dst: str, *args: object, **kwargs: object) -> object:
         if "cache_idf" in str(src):
-            # A cross-volume copy that got partway then died: one of two files made it across,
-            # so the classifier must see the copy as incomplete, not take the empty-source out.
+            # A cross-volume copy that died partway: dst half-written, src left behind. The
+            # partial dst is what makes the next run exercise the rmtree(dst) discard branch.
             Path(dst).mkdir(parents=True, exist_ok=True)
             shutil.copy2(Path(src) / "tool.txt", Path(dst) / "tool.txt")
             msg = "interrupted"

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -514,3 +514,9 @@ def test_ci_matrix_covers_every_toolchain_param() -> None:
         for entry in workflow["jobs"]["windows-maxpath"]["strategy"]["matrix"]["include"]
     }
     assert set(module._TOOLCHAINS) <= suites
+
+
+def test_default_idf_cache_without_platformdirs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No platformdirs (base install without the esphome extra) means no migration source."""
+    monkeypatch.setitem(sys.modules, "platformdirs", None)
+    assert wbp._default_idf_cache() is None

--- a/tests/test_windows_build_paths.py
+++ b/tests/test_windows_build_paths.py
@@ -180,32 +180,6 @@ def test_empty_esp_idf_prefix_is_not_user_set(
     assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == "  "  # restored verbatim, not popped
 
 
-def test_delete_phase_failure_adopts_complete_copy(
-    tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A move whose copy finished but whose source delete died adopts the copy, not the wreck."""
-    config_dir = tmp_path / "First Last" / "esphome"
-    (config_dir / ".esphome").mkdir(parents=True)
-    cache_idf = tmp_path / "cache_idf"
-    cache_idf.mkdir()
-    (cache_idf / "tool.txt").write_text("idf-toolchain", encoding="utf-8")
-
-    real_move = wbp.shutil.move
-
-    def _delete_died(src: str, dst: str, *args: object, **kwargs: object) -> object:
-        if "cache_idf" in str(src):
-            shutil.copytree(src, dst)  # the copy phase completed...
-            msg = "source delete died"
-            raise OSError(msg)  # ...the delete phase did not
-        return real_move(src, dst, *args, **kwargs)
-
-    monkeypatch.setattr(wbp.shutil, "move", _delete_died)
-    root = fake_windows / "esphb" / _ID8
-    with windows_short_build_paths(config_dir):
-        assert os.environ["ESPHOME_ESP_IDF_PREFIX"] == str(root / "idf")
-        assert (root / "idf" / "tool.txt").read_text(encoding="utf-8") == "idf-toolchain"
-
-
 def test_failed_idf_relocation_leaves_prefix_unset(
     tmp_path: Path, fake_windows: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -236,34 +210,6 @@ def test_failed_idf_relocation_leaves_prefix_unset(
         assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ  # corrupt toolchain not adopted
     assert "ESPHOME_ESP_IDF_PREFIX" not in os.environ
     assert (cache_idf / "other.txt").is_file()  # source stayed authoritative
-
-
-def test_size_mismatched_copy_not_adopted(tmp_path: Path) -> None:
-    """A same-name file that differs in size marks the copy incomplete."""
-    src = tmp_path / "src"
-    dst = tmp_path / "dst"
-    src.mkdir()
-    dst.mkdir()
-    (src / "tool.txt").write_text("full-content", encoding="utf-8")
-    (dst / "tool.txt").write_text("part", encoding="utf-8")
-    assert not wbp._copy_completed(src, dst)
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="chmod 0 does not deny reads on Windows")
-def test_unreadable_source_subtree_fails_closed(tmp_path: Path) -> None:
-    """An unwalkable source subtree classifies the copy incomplete, never silently skipped."""
-    src = tmp_path / "src"
-    dst = tmp_path / "dst"
-    (src / "sub").mkdir(parents=True)
-    dst.mkdir()
-    (src / "top.txt").write_text("x", encoding="utf-8")
-    (dst / "top.txt").write_text("x", encoding="utf-8")  # everything visible matches...
-    (src / "sub" / "hidden.txt").write_text("y", encoding="utf-8")  # ...this never copied
-    (src / "sub").chmod(0)
-    try:
-        assert not wbp._copy_completed(src, dst)
-    finally:
-        (src / "sub").chmod(0o755)
 
 
 def test_migrates_existing_data_and_toolchain(tmp_path: Path, fake_windows: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

esphome 2026.7.0 made the native ESP-IDF toolchain the default for esp32 `esp-idf` configs (2026.6.0 defaulted to PlatformIO). That toolchain installs into `platformdirs.user_cache_dir("esphome")/idf`, which on Windows is `C:\Users\<user>\AppData\Local\esphome\Cache\idf`; the install nests ~209 chars of paths below that, esphome only warns when the projection exceeds MAX_PATH, and ESP-IDF does not support spaced install paths (`First Last` profiles). Our Windows relocation covered `ESPHOME_DATA_DIR` and `PLATFORMIO_CORE_DIR` but not the IDF prefix, so the just-works guarantee had a hole for the new default toolchain.

`windows_short_build_paths` now also points `ESPHOME_ESP_IDF_PREFIX` at `C:\esphb\<id8>\idf`, with the same rules as the pio dir: a user-set var is respected, an existing default cache is migrated in once, and `esphome clean-all` removes the relocated dir (it resolves the toolchain path through the same env var).

This is also what broke the windows-real-compile job on #2133 (first run since 2026.7.0 shipped; the Monday scheduled run on main would have failed identically): the e2e pinned only the PlatformIO layout (`.pioenvs`, `PLATFORMIO_CORE_DIR`). Since both toolchains stay supported (`toolchain: platformio` is an esp32 opt-in, and pioarduino remains the path for other platforms), `test_windows_short_paths` now parametrizes its compile fixture over both: the native default and the PlatformIO opt-in each get the deep + spaced compile, `clean`, and `clean-all` assertions against their own layout. The workflow fans the suites out one per runner (native, platformio, migration) since each is a cold toolchain download plus a real compile and this is the longest CI job; wall clock stays at single-compile time. The esp8266 `test_windows_migration` keeps covering the `~/.platformio` migration path.

**Related issue or feature (if applicable):**

- unblocks the windows-real-compile job on #2133

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.

## Verification

Unit coverage in `tests/test_windows_build_paths.py` drives the new branch cross-platform (sets and restores the var, respects a user-set prefix, migrates the default cache, relocates with no migration source). The real proof is this PR's own windows-real-compile run, which the path filter triggers: a deep + spaced native ESP-IDF compile, then `clean` and `clean-all`, against the relocated dirs.
