### PR TITLE
Burst the post-flash version reprobe for deep-sleep devices

### DIFF
--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -28,7 +28,7 @@ _POST_FLASH_VERSION_REPROBE_DELAY = 60
 
 # A deep-sleep device is only awake briefly after the reboot, so the single
 # 60s probe above would miss it. Fire a tight burst across the reboot + awake
-# window instead, stopping as soon as the device is seen.
+# window instead; each tick is a no-op once the device is re-seen over mDNS.
 _DEEP_SLEEP_REPROBE_FIRST_DELAY = 5
 _DEEP_SLEEP_REPROBE_INTERVAL = 5
 _DEEP_SLEEP_REPROBE_WINDOW = 40
@@ -198,10 +198,10 @@ def schedule_version_reprobe(controller: DevicesController, configuration: str) 
     A normal device gets one probe ~60s after the flash, letting it
     reboot into the new image before we connect. A deep-sleep device
     (``Device.uses_deep_sleep``) is only awake briefly, so it gets a
-    tight burst across the reboot + awake window that stops once the
-    device is seen. Either way the re-probe confirms the
-    optimistically-pinned version (and catches a rollback) where mDNS
-    can't reach us. Re-arming for the same configuration cancels the
+    tight burst across the reboot + awake window (each tick a no-op once
+    the device is re-seen over mDNS). Either way the re-probe confirms
+    the optimistically-pinned version (and catches a rollback) where
+    mDNS can't reach us. Re-arming for the same configuration cancels the
     prior timer so a rapid re-flash doesn't stack probes; the handle is
     tracked on the controller so ``stop`` can cancel anything still
     pending.

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -211,18 +211,16 @@ def schedule_version_reprobe(controller: DevicesController, configuration: str) 
         existing.cancel()
     device = controller._scanner.get_by_configuration(configuration)
     loop = asyncio.get_running_loop()
-    if device is None or not device.uses_deep_sleep:
-        controller._reprobe_timers[configuration] = loop.call_later(
-            _POST_FLASH_VERSION_REPROBE_DELAY, _fire_version_reprobe, controller, configuration
-        )
-        return
-    deadline = loop.time() + _DEEP_SLEEP_REPROBE_WINDOW
+    if device is not None and device.uses_deep_sleep:
+        # A deep-sleep device is only awake briefly; the deadline bounds the
+        # re-arming burst across the reboot + awake window.
+        delay = _DEEP_SLEEP_REPROBE_FIRST_DELAY
+        deadline = loop.time() + _DEEP_SLEEP_REPROBE_WINDOW
+    else:
+        delay = _POST_FLASH_VERSION_REPROBE_DELAY
+        deadline = None
     controller._reprobe_timers[configuration] = loop.call_later(
-        _DEEP_SLEEP_REPROBE_FIRST_DELAY,
-        _fire_version_reprobe_burst,
-        controller,
-        configuration,
-        deadline,
+        delay, _fire_version_reprobe, controller, configuration, deadline
     )
 
 
@@ -243,46 +241,32 @@ async def migrate_metadata_then_scan(
     await controller._scanner.scan()
 
 
-def _fire_version_reprobe(controller: DevicesController, configuration: str) -> None:
+def _fire_version_reprobe(
+    controller: DevicesController, configuration: str, deadline: float | None = None
+) -> None:
     """
     Timer callback: ask the monitor to verify the device's running version.
 
-    A no-op if the device vanished in the interim. The request still
-    honours the monitor's ``priority_for != MDNS`` guard, so a device
-    already seen over mDNS by now is skipped rather than probed.
-    """
-    controller._reprobe_timers.pop(configuration, None)
-    device = controller._scanner.get_by_configuration(configuration)
-    if device is not None:
-        controller._state_monitor.api_info.request_reprobe(device.name)
-
-
-def _fire_version_reprobe_burst(
-    controller: DevicesController, configuration: str, deadline: float
-) -> None:
-    """
-    Deep-sleep re-probe tick: probe, then re-arm until *deadline* passes.
-
-    Same probe as ``_fire_version_reprobe``, repeated across the reboot +
-    awake window because a deep-sleep device is only awake briefly. Does
-    not short-circuit on the device's ONLINE state: right after a flash
-    that reading is the stale pre-reboot one, so aborting on it would
-    skip the whole window. The monitor's ``priority_for != MDNS`` guard
-    in ``request_reprobe`` already skips a device seen fresh over mDNS.
+    A no-op if the device vanished. ``request_reprobe`` honours the
+    monitor's ``priority_for != MDNS`` guard, so a device already seen
+    fresh over mDNS is skipped. When *deadline* is set (a deep-sleep
+    device's brief awake window), re-arm every
+    ``_DEEP_SLEEP_REPROBE_INTERVAL`` until it passes, since one probe
+    would miss the window. It deliberately does not short-circuit on the
+    device's ONLINE state, which right after a flash is the stale
+    pre-reboot reading.
     """
     controller._reprobe_timers.pop(configuration, None)
     device = controller._scanner.get_by_configuration(configuration)
     if device is None:
         return
     controller._state_monitor.api_info.request_reprobe(device.name)
+    if deadline is None:
+        return
     loop = asyncio.get_running_loop()
     if loop.time() + _DEEP_SLEEP_REPROBE_INTERVAL <= deadline:
         controller._reprobe_timers[configuration] = loop.call_later(
-            _DEEP_SLEEP_REPROBE_INTERVAL,
-            _fire_version_reprobe_burst,
-            controller,
-            configuration,
-            deadline,
+            _DEEP_SLEEP_REPROBE_INTERVAL, _fire_version_reprobe, controller, configuration, deadline
         )
 
 

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -260,6 +260,15 @@ def _fire_version_reprobe(
     until the deadline passes, since one probe would miss the window. It
     deliberately does not short-circuit on the device's ONLINE state,
     which right after a flash is the stale pre-reboot reading.
+
+    What bounds the reprobe count: each tick force-requests a probe,
+    which intentionally bypasses the api-info failure cooldown so a
+    still-rebooting device isn't backed off past its wake. The *deadline*
+    (not the cooldown) is the bound, to ~``window / interval`` probes.
+    ``request_reprobe`` keys a set, so repeated ticks don't stack; the
+    monitor's mDNS-ownership gate turns the remaining ticks into no-ops
+    once the device re-announces; and the api-info sweep serialises and
+    caps probes, so this never fans out into concurrent dials.
     """
     controller._reprobe_timers.pop(configuration, None)
     device = controller._scanner.get_by_configuration(configuration)

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -27,9 +27,9 @@ _LOGGER = logging.getLogger(__name__)
 _POST_FLASH_VERSION_REPROBE_DELAY = 60
 
 # A deep-sleep device is only awake briefly after the reboot, so the single
-# 60s probe above would miss it. Fire a tight burst across the reboot + awake
-# window instead; each tick is a no-op once the device is re-seen over mDNS.
-_DEEP_SLEEP_REPROBE_FIRST_DELAY = 5
+# 60s probe above would miss it. Fire a tight burst on this cadence across the
+# reboot + awake window instead; each tick is a no-op once the device is
+# re-seen over mDNS.
 _DEEP_SLEEP_REPROBE_INTERVAL = 5
 _DEEP_SLEEP_REPROBE_WINDOW = 40
 
@@ -211,16 +211,19 @@ def schedule_version_reprobe(controller: DevicesController, configuration: str) 
         existing.cancel()
     device = controller._scanner.get_by_configuration(configuration)
     loop = asyncio.get_running_loop()
+    delay: float
+    deadline: float | None
+    interval: float | None
     if device is not None and device.uses_deep_sleep:
-        # A deep-sleep device is only awake briefly; the deadline bounds the
-        # re-arming burst across the reboot + awake window.
-        delay = _DEEP_SLEEP_REPROBE_FIRST_DELAY
+        # A deep-sleep device is only awake briefly; probe on the burst cadence,
+        # re-arming until the awake-window deadline passes.
+        delay = interval = _DEEP_SLEEP_REPROBE_INTERVAL
         deadline = loop.time() + _DEEP_SLEEP_REPROBE_WINDOW
     else:
         delay = _POST_FLASH_VERSION_REPROBE_DELAY
-        deadline = None
+        interval = deadline = None
     controller._reprobe_timers[configuration] = loop.call_later(
-        delay, _fire_version_reprobe, controller, configuration, deadline
+        delay, _fire_version_reprobe, controller, configuration, deadline, interval
     )
 
 
@@ -242,31 +245,33 @@ async def migrate_metadata_then_scan(
 
 
 def _fire_version_reprobe(
-    controller: DevicesController, configuration: str, deadline: float | None = None
+    controller: DevicesController,
+    configuration: str,
+    deadline: float | None = None,
+    interval: float | None = None,
 ) -> None:
     """
     Timer callback: ask the monitor to verify the device's running version.
 
     A no-op if the device vanished. ``request_reprobe`` honours the
     monitor's ``priority_for != MDNS`` guard, so a device already seen
-    fresh over mDNS is skipped. When *deadline* is set (a deep-sleep
-    device's brief awake window), re-arm every
-    ``_DEEP_SLEEP_REPROBE_INTERVAL`` until it passes, since one probe
-    would miss the window. It deliberately does not short-circuit on the
-    device's ONLINE state, which right after a flash is the stale
-    pre-reboot reading.
+    fresh over mDNS is skipped. When *deadline* / *interval* are given (a
+    deep-sleep device's brief awake window), re-arm every *interval*
+    until the deadline passes, since one probe would miss the window. It
+    deliberately does not short-circuit on the device's ONLINE state,
+    which right after a flash is the stale pre-reboot reading.
     """
     controller._reprobe_timers.pop(configuration, None)
     device = controller._scanner.get_by_configuration(configuration)
     if device is None:
         return
     controller._state_monitor.api_info.request_reprobe(device.name)
-    if deadline is None:
+    if deadline is None or interval is None:
         return
     loop = asyncio.get_running_loop()
-    if loop.time() + _DEEP_SLEEP_REPROBE_INTERVAL <= deadline:
+    if loop.time() + interval <= deadline:
         controller._reprobe_timers[configuration] = loop.call_later(
-            _DEEP_SLEEP_REPROBE_INTERVAL, _fire_version_reprobe, controller, configuration, deadline
+            interval, _fire_version_reprobe, controller, configuration, deadline, interval
         )
 
 

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -15,13 +15,7 @@ from ...helpers.remote_build_layout import (
     parse_from_configuration as parse_remote_build_path,
 )
 from ...helpers.storage_path import resolve_storage_path
-from ...models import (
-    COMPILING_JOB_TYPES,
-    DeviceState,
-    JobLifecycleData,
-    JobStatus,
-    JobType,
-)
+from ...models import COMPILING_JOB_TYPES, JobLifecycleData, JobStatus, JobType
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -267,15 +261,18 @@ def _fire_version_reprobe_burst(
     controller: DevicesController, configuration: str, deadline: float
 ) -> None:
     """
-    Deep-sleep re-probe tick: probe, then re-arm until the device is seen or *deadline* passes.
+    Deep-sleep re-probe tick: probe, then re-arm until *deadline* passes.
 
-    Stops early once the device is ONLINE (an announce or an earlier
-    probe landed); the ``priority_for != MDNS`` guard in
-    ``request_reprobe`` still skips a device already seen over mDNS.
+    Same probe as ``_fire_version_reprobe``, repeated across the reboot +
+    awake window because a deep-sleep device is only awake briefly. Does
+    not short-circuit on the device's ONLINE state: right after a flash
+    that reading is the stale pre-reboot one, so aborting on it would
+    skip the whole window. The monitor's ``priority_for != MDNS`` guard
+    in ``request_reprobe`` already skips a device seen fresh over mDNS.
     """
     controller._reprobe_timers.pop(configuration, None)
     device = controller._scanner.get_by_configuration(configuration)
-    if device is None or device.runtime_state.state is DeviceState.ONLINE:
+    if device is None:
         return
     controller._state_monitor.api_info.request_reprobe(device.name)
     loop = asyncio.get_running_loop()

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -15,7 +15,13 @@ from ...helpers.remote_build_layout import (
     parse_from_configuration as parse_remote_build_path,
 )
 from ...helpers.storage_path import resolve_storage_path
-from ...models import COMPILING_JOB_TYPES, JobLifecycleData, JobStatus, JobType
+from ...models import (
+    COMPILING_JOB_TYPES,
+    DeviceState,
+    JobLifecycleData,
+    JobStatus,
+    JobType,
+)
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -25,6 +31,13 @@ _LOGGER = logging.getLogger(__name__)
 # Delay before the post-flash Native-API version re-probe so the device
 # has time to reboot into the new image before we connect.
 _POST_FLASH_VERSION_REPROBE_DELAY = 60
+
+# A deep-sleep device is only awake briefly after the reboot, so the single
+# 60s probe above would miss it. Fire a tight burst across the reboot + awake
+# window instead, stopping as soon as the device is seen.
+_DEEP_SLEEP_REPROBE_FIRST_DELAY = 5
+_DEEP_SLEEP_REPROBE_INTERVAL = 5
+_DEEP_SLEEP_REPROBE_WINDOW = 40
 
 
 def on_job_completed(controller: DevicesController, event: Event[JobLifecycleData]) -> None:
@@ -186,21 +199,36 @@ async def sync_deployed_state_after_flash(
 
 def schedule_version_reprobe(controller: DevicesController, configuration: str) -> None:
     """
-    Arm a one-shot Native-API version re-probe ~60s after a flash.
+    Arm the post-flash Native-API version re-probe(s).
 
-    The delay lets the device reboot into the new image before we
-    connect; the re-probe then confirms the optimistically-pinned
-    version (and catches a rollback) where mDNS can't reach us.
-    Re-arming for the same configuration cancels the prior timer so a
-    rapid re-flash doesn't stack probes; the handle is tracked on the
-    controller so ``stop`` can cancel anything still pending.
+    A normal device gets one probe ~60s after the flash, letting it
+    reboot into the new image before we connect. A deep-sleep device
+    (``Device.uses_deep_sleep``) is only awake briefly, so it gets a
+    tight burst across the reboot + awake window that stops once the
+    device is seen. Either way the re-probe confirms the
+    optimistically-pinned version (and catches a rollback) where mDNS
+    can't reach us. Re-arming for the same configuration cancels the
+    prior timer so a rapid re-flash doesn't stack probes; the handle is
+    tracked on the controller so ``stop`` can cancel anything still
+    pending.
     """
     existing = controller._reprobe_timers.pop(configuration, None)
     if existing is not None:
         existing.cancel()
+    device = controller._scanner.get_by_configuration(configuration)
     loop = asyncio.get_running_loop()
+    if device is None or not device.uses_deep_sleep:
+        controller._reprobe_timers[configuration] = loop.call_later(
+            _POST_FLASH_VERSION_REPROBE_DELAY, _fire_version_reprobe, controller, configuration
+        )
+        return
+    deadline = loop.time() + _DEEP_SLEEP_REPROBE_WINDOW
     controller._reprobe_timers[configuration] = loop.call_later(
-        _POST_FLASH_VERSION_REPROBE_DELAY, _fire_version_reprobe, controller, configuration
+        _DEEP_SLEEP_REPROBE_FIRST_DELAY,
+        _fire_version_reprobe_burst,
+        controller,
+        configuration,
+        deadline,
     )
 
 
@@ -233,6 +261,32 @@ def _fire_version_reprobe(controller: DevicesController, configuration: str) -> 
     device = controller._scanner.get_by_configuration(configuration)
     if device is not None:
         controller._state_monitor.api_info.request_reprobe(device.name)
+
+
+def _fire_version_reprobe_burst(
+    controller: DevicesController, configuration: str, deadline: float
+) -> None:
+    """
+    Deep-sleep re-probe tick: probe, then re-arm until the device is seen or *deadline* passes.
+
+    Stops early once the device is ONLINE (an announce or an earlier
+    probe landed); the ``priority_for != MDNS`` guard in
+    ``request_reprobe`` still skips a device already seen over mDNS.
+    """
+    controller._reprobe_timers.pop(configuration, None)
+    device = controller._scanner.get_by_configuration(configuration)
+    if device is None or device.runtime_state.state is DeviceState.ONLINE:
+        return
+    controller._state_monitor.api_info.request_reprobe(device.name)
+    loop = asyncio.get_running_loop()
+    if loop.time() + _DEEP_SLEEP_REPROBE_INTERVAL <= deadline:
+        controller._reprobe_timers[configuration] = loop.call_later(
+            _DEEP_SLEEP_REPROBE_INTERVAL,
+            _fire_version_reprobe_burst,
+            controller,
+            configuration,
+            deadline,
+        )
 
 
 def _read_compiled_esphome_version(configuration: str) -> str:

--- a/esphome_device_builder/helpers/device_yaml/_loading.py
+++ b/esphome_device_builder/helpers/device_yaml/_loading.py
@@ -323,6 +323,11 @@ def load_device_from_storage(
             if resolved_config is not None
             else yaml_has_top_level_block(yaml_content, "mqtt")
         ),
+        uses_deep_sleep=(
+            config_has_top_level_block(resolved_config, "deep_sleep")
+            if resolved_config is not None
+            else yaml_has_top_level_block(yaml_content, "deep_sleep")
+        ),
         api_enabled=api_enabled,
         api_encrypted=api_encrypted,
         mac_address=mac_address,

--- a/esphome_device_builder/models/devices.py
+++ b/esphome_device_builder/models/devices.py
@@ -148,6 +148,7 @@ class Device(DashboardModel):
     pending_changes_via_hash: bool = False
     update_available: bool = False  # True if compiled with older ESPHome version
     uses_mqtt: bool = False  # True if the YAML declares a top-level mqtt: block
+    uses_deep_sleep: bool = False  # True if the YAML declares a top-level deep_sleep: block
     # Native API surface flags — drive the lock-icon indicator in
     # the device list. Both fields are computed in
     # ``helpers.device_yaml.load_device_from_storage`` as the

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -680,8 +680,8 @@ async def test_burst_requests_and_rearms_until_deadline() -> None:
     controller._cancel_reprobe_timers()
 
 
-async def test_burst_stops_once_device_online() -> None:
-    """The burst stops re-probing and re-arming once the device is back ONLINE."""
+async def test_burst_probes_despite_stale_online_reading() -> None:
+    """Right after a flash the ONLINE reading is stale (pre-reboot); the burst still probes."""
     controller = _reprobe_controller(_device(state=DeviceState.ONLINE))
     loop = asyncio.get_running_loop()
 
@@ -689,8 +689,9 @@ async def test_burst_stops_once_device_online() -> None:
         controller, "kitchen.yaml", deadline=loop.time() + 1000
     )
 
-    controller._state_monitor.api_info.request_reprobe.assert_not_called()
-    assert controller._reprobe_timers == {}  # not re-armed
+    controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
+    assert "kitchen.yaml" in controller._reprobe_timers  # re-armed, not aborted
+    controller._cancel_reprobe_timers()
 
 
 async def test_burst_stops_at_deadline() -> None:

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -705,6 +705,19 @@ async def test_burst_stops_at_deadline() -> None:
     assert controller._reprobe_timers == {}  # deadline passed, not re-armed
 
 
+async def test_burst_unknown_configuration_is_noop() -> None:
+    """The device vanished mid-burst → nothing to probe and no re-arm."""
+    controller = _reprobe_controller(None)
+    loop = asyncio.get_running_loop()
+
+    firmware_sync._fire_version_reprobe_burst(
+        controller, "kitchen.yaml", deadline=loop.time() + 1000
+    )
+
+    controller._state_monitor.api_info.request_reprobe.assert_not_called()
+    assert controller._reprobe_timers == {}
+
+
 # ----------------------------------------------------------------------
 # Helpers: _read_compiled_esphome_version + DeviceScanner.get_by_configuration
 # ----------------------------------------------------------------------

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -671,9 +671,7 @@ async def test_burst_requests_and_rearms_until_deadline() -> None:
     controller = _reprobe_controller(_device())  # default state UNKNOWN
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe_burst(
-        controller, "kitchen.yaml", deadline=loop.time() + 1000
-    )
+    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() + 1000)
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
     assert "kitchen.yaml" in controller._reprobe_timers  # re-armed
@@ -685,9 +683,7 @@ async def test_burst_probes_despite_stale_online_reading() -> None:
     controller = _reprobe_controller(_device(state=DeviceState.ONLINE))
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe_burst(
-        controller, "kitchen.yaml", deadline=loop.time() + 1000
-    )
+    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() + 1000)
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
     assert "kitchen.yaml" in controller._reprobe_timers  # re-armed, not aborted
@@ -699,7 +695,7 @@ async def test_burst_stops_at_deadline() -> None:
     controller = _reprobe_controller(_device())
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe_burst(controller, "kitchen.yaml", deadline=loop.time() - 1)
+    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() - 1)
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
     assert controller._reprobe_timers == {}  # deadline passed, not re-armed
@@ -710,9 +706,7 @@ async def test_burst_unknown_configuration_is_noop() -> None:
     controller = _reprobe_controller(None)
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe_burst(
-        controller, "kitchen.yaml", deadline=loop.time() + 1000
-    )
+    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() + 1000)
 
     controller._state_monitor.api_info.request_reprobe.assert_not_called()
     assert controller._reprobe_timers == {}

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -577,6 +577,7 @@ async def test_sync_after_flash_unknown_configuration_is_noop(monkeypatch: Any) 
 _DELAY = (
     "esphome_device_builder.controllers.devices.firmware_sync._POST_FLASH_VERSION_REPROBE_DELAY"
 )
+_INTERVAL = firmware_sync._DEEP_SLEEP_REPROBE_INTERVAL
 
 
 def _reprobe_controller(device: Device | None) -> Any:
@@ -648,7 +649,7 @@ async def test_deep_sleep_arms_burst_not_single_probe() -> None:
     controller._schedule_version_reprobe("kitchen.yaml")
 
     handle = controller._reprobe_timers["kitchen.yaml"]
-    expected = firmware_sync._DEEP_SLEEP_REPROBE_FIRST_DELAY
+    expected = firmware_sync._DEEP_SLEEP_REPROBE_INTERVAL
     assert handle.when() - loop.time() == pytest.approx(expected, abs=1)
     controller._cancel_reprobe_timers()
 
@@ -671,7 +672,9 @@ async def test_burst_requests_and_rearms_until_deadline() -> None:
     controller = _reprobe_controller(_device())  # default state UNKNOWN
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() + 1000)
+    firmware_sync._fire_version_reprobe(
+        controller, "kitchen.yaml", deadline=loop.time() + 1000, interval=_INTERVAL
+    )
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
     assert "kitchen.yaml" in controller._reprobe_timers  # re-armed
@@ -683,7 +686,9 @@ async def test_burst_probes_despite_stale_online_reading() -> None:
     controller = _reprobe_controller(_device(state=DeviceState.ONLINE))
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() + 1000)
+    firmware_sync._fire_version_reprobe(
+        controller, "kitchen.yaml", deadline=loop.time() + 1000, interval=_INTERVAL
+    )
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
     assert "kitchen.yaml" in controller._reprobe_timers  # re-armed, not aborted
@@ -695,7 +700,9 @@ async def test_burst_stops_at_deadline() -> None:
     controller = _reprobe_controller(_device())
     loop = asyncio.get_running_loop()
 
-    firmware_sync._fire_version_reprobe(controller, "kitchen.yaml", deadline=loop.time() - 1)
+    firmware_sync._fire_version_reprobe(
+        controller, "kitchen.yaml", deadline=loop.time() - 1, interval=_INTERVAL
+    )
 
     controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
     assert controller._reprobe_timers == {}  # deadline passed, not re-armed

--- a/tests/controllers/firmware/test_refresh.py
+++ b/tests/controllers/firmware/test_refresh.py
@@ -43,6 +43,7 @@ from esphome_device_builder.controllers.devices._metadata_store import DeviceMet
 from esphome_device_builder.helpers.event_bus import Event
 from esphome_device_builder.models import (
     Device,
+    DeviceState,
     EventType,
     FirmwareJob,
     JobStatus,
@@ -637,6 +638,70 @@ async def test_cancel_reprobe_timers_cancels_pending(monkeypatch: Any) -> None:
 
     assert handle.cancelled()
     assert controller._reprobe_timers == {}
+
+
+async def test_deep_sleep_arms_burst_not_single_probe() -> None:
+    """A ``uses_deep_sleep`` device arms the first burst tick at the short delay, not 60s."""
+    controller = _reprobe_controller(_device(uses_deep_sleep=True))
+    loop = asyncio.get_running_loop()
+
+    controller._schedule_version_reprobe("kitchen.yaml")
+
+    handle = controller._reprobe_timers["kitchen.yaml"]
+    expected = firmware_sync._DEEP_SLEEP_REPROBE_FIRST_DELAY
+    assert handle.when() - loop.time() == pytest.approx(expected, abs=1)
+    controller._cancel_reprobe_timers()
+
+
+async def test_non_deep_sleep_arms_single_probe(monkeypatch: Any) -> None:
+    """A device without ``deep_sleep:`` keeps the single ~60s probe."""
+    monkeypatch.setattr(_DELAY, 60)
+    controller = _reprobe_controller(_device(uses_deep_sleep=False))
+    loop = asyncio.get_running_loop()
+
+    controller._schedule_version_reprobe("kitchen.yaml")
+
+    handle = controller._reprobe_timers["kitchen.yaml"]
+    assert handle.when() - loop.time() == pytest.approx(60, abs=1)
+    controller._cancel_reprobe_timers()
+
+
+async def test_burst_requests_and_rearms_until_deadline() -> None:
+    """Each burst tick re-probes an offline device and re-arms while inside the window."""
+    controller = _reprobe_controller(_device())  # default state UNKNOWN
+    loop = asyncio.get_running_loop()
+
+    firmware_sync._fire_version_reprobe_burst(
+        controller, "kitchen.yaml", deadline=loop.time() + 1000
+    )
+
+    controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
+    assert "kitchen.yaml" in controller._reprobe_timers  # re-armed
+    controller._cancel_reprobe_timers()
+
+
+async def test_burst_stops_once_device_online() -> None:
+    """The burst stops re-probing and re-arming once the device is back ONLINE."""
+    controller = _reprobe_controller(_device(state=DeviceState.ONLINE))
+    loop = asyncio.get_running_loop()
+
+    firmware_sync._fire_version_reprobe_burst(
+        controller, "kitchen.yaml", deadline=loop.time() + 1000
+    )
+
+    controller._state_monitor.api_info.request_reprobe.assert_not_called()
+    assert controller._reprobe_timers == {}  # not re-armed
+
+
+async def test_burst_stops_at_deadline() -> None:
+    """The last tick before the deadline re-probes but does not re-arm."""
+    controller = _reprobe_controller(_device())
+    loop = asyncio.get_running_loop()
+
+    firmware_sync._fire_version_reprobe_burst(controller, "kitchen.yaml", deadline=loop.time() - 1)
+
+    controller._state_monitor.api_info.request_reprobe.assert_called_once_with("kitchen")
+    assert controller._reprobe_timers == {}  # deadline passed, not re-armed
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_device_yaml.py
+++ b/tests/test_device_yaml.py
@@ -982,6 +982,19 @@ def test_load_device_from_storage_resolves_config_once_for_packages(tmp_path: Pa
     assert spy.call_count == 1
 
 
+def test_load_device_from_storage_detects_deep_sleep(tmp_path: Path) -> None:
+    """A top-level ``deep_sleep:`` block sets ``uses_deep_sleep``; its absence clears it."""
+    sleeper = tmp_path / "sleeper.yaml"
+    sleeper.write_text(
+        "esphome:\n  name: sleeper\ndeep_sleep:\n  sleep_duration: 60s\n", encoding="utf-8"
+    )
+    assert load_device_from_storage(sleeper).uses_deep_sleep is True
+
+    awake = tmp_path / "awake.yaml"
+    awake.write_text("esphome:\n  name: awake\napi:\n", encoding="utf-8")
+    assert load_device_from_storage(awake).uses_deep_sleep is False
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [


### PR DESCRIPTION
# What does this implement/fix?

A deep sleep device is only awake for a short window after the OTA reboot, so the single ~60s post-flash version reprobe sleeps through it; the dashboard can't confirm the running version or catch a rollback until the device wakes again, sometimes much later.

Deep sleep is now detected once at scan time from a top-level `deep_sleep:` block and cached on `Device.uses_deep_sleep`, alongside `uses_mqtt`. When such a device is flashed, the single 60s reprobe is replaced with a tight burst across the reboot plus awake window that stops as soon as the device is seen. Non deep sleep devices keep the single 60s probe unchanged.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
