### PR TITLE
Match markdown-bearing truncated schema descriptions to their MDX text

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1785,7 +1785,10 @@ def _is_truncated_prefix(existing: str, full: str) -> bool:
     """Whether *existing* is a mid-sentence (no terminal .!?:) leading slice of *full*."""
     # A trailing ``:`` is a list-introducer ("One of:") whose options live in MDX
     # sub-bullets the extractor skips, so joining yields garbage — leave it.
-    head = " ".join(existing.split())
+    # Schema ``docs`` keep markdown (`` `code` ``, ``[links]``) that the MDX
+    # ``full`` text has already flattened, so flatten the head too — else a
+    # truncated head carrying any markup never matches its fuller MDX text.
+    head = " ".join(_clean_description_text(existing).split())
     whole = " ".join(full.split())
     return (
         bool(head) and len(whole) > len(head) and whole.startswith(head) and head[-1] not in ".!?:"

--- a/tests/test_sync_components_field_descriptions.py
+++ b/tests/test_sync_components_field_descriptions.py
@@ -56,6 +56,22 @@ def test_truncated_prefix_false_when_not_a_prefix_or_not_longer() -> None:
     assert not _is_truncated_prefix("", "anything at all")
 
 
+# ``safe_mode.disabled`` as shipped: the schema truncates at "automatically" and
+# keeps markdown (`` `true` ``, ``[Ota](...)``); the MDX text is flattened plain.
+_SAFE_MODE_DISABLED_SCHEMA = (
+    "Set to `true` to disable safe_mode. [Ota](https://esphome.io/components/ota/) automatically"
+)
+_SAFE_MODE_DISABLED_MDX = (
+    "Set to true to disable safe_mode. Ota automatically sets up safe mode; "
+    "this allows disabling it if/when it is not wanted."
+)
+
+
+def test_truncated_prefix_matches_markdown_head() -> None:
+    """A truncated schema head with markup matches its flattened MDX text."""
+    assert _is_truncated_prefix(_SAFE_MODE_DISABLED_SCHEMA, _SAFE_MODE_DISABLED_MDX)
+
+
 def test_apply_field_descriptions_replaces_truncated_head() -> None:
     """The fuller MDX text supersedes a truncated schema description."""
     entries = [{"key": "level", "description": "The global log level. Any log message"}]
@@ -66,6 +82,13 @@ def test_apply_field_descriptions_replaces_truncated_head() -> None:
     assert entries[0]["description"] == full
     # The backfill stamps the configuration-variables fragment when unset.
     assert entries[0]["help_link"] == "https://esphome.io/components/logger#configuration-variables"
+
+
+def test_apply_field_descriptions_replaces_markdown_truncated_head() -> None:
+    """A markdown-bearing truncated schema head is superseded by the MDX text."""
+    entries = [{"key": "disabled", "description": _SAFE_MODE_DISABLED_SCHEMA}]
+    _apply_field_descriptions(entries, {"disabled": _SAFE_MODE_DISABLED_MDX}, docs_url="")
+    assert entries[0]["description"] == _SAFE_MODE_DISABLED_MDX
 
 
 def test_apply_field_descriptions_keeps_complete_description() -> None:


### PR DESCRIPTION
# What does this implement/fix?

`safe_mode.disabled`'s description was truncated mid-sentence in the structured editor, ending at "automatically", while the docs show the full sentence. The ESPHome schema ships a truncated `docs` for this field (it kept only the first wrapped line of the MDX bullet); the catalog already repairs that case by swapping in the fuller MDX text when `_is_truncated_prefix` sees the schema description as a leading slice of it. That repair silently missed here because the schema head keeps markdown (`` `true` ``, `[Ota](...)`) while the MDX text is already flattened, so the `startswith` prefix check compared markup against plain prose and never matched. This flattens the head with the same `_clean_description_text` the MDX side uses, so the comparison is like for like and the repair fires. The corrected description reaches the catalog data on the next nightly sync.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2147

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
