### PR TITLE
Reload the renamed device past the scanner mtime cache so labels survive

### DIFF
--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -218,6 +218,10 @@ async def migrate_metadata_then_scan(
             old_configuration,
             new_configuration,
         )
+    # The renamed YAML was written before the migration (at queue time on
+    # the OTA path), so a poll scan has usually already indexed it
+    # label-less; force a reload so the migrated sidecar reaches RAM (#2151).
+    await controller._scanner.reload(new_configuration)
     await controller._scanner.scan()
 
 

--- a/esphome_device_builder/controllers/devices/firmware_sync.py
+++ b/esphome_device_builder/controllers/devices/firmware_sync.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from esphome.storage_json import StorageJSON
 
+from ...helpers.async_ import run_in_executor
 from ...helpers.config_hash import compute_yaml_config_hash
 from ...helpers.event_bus import Event
 from ...helpers.remote_build_layout import (
@@ -137,7 +138,8 @@ async def persist_expected_config_hash(controller: DevicesController, configurat
     malformed ``build_info.json`` so an upstream ESPHome
     shape change surfaces visibly.
     """
-    yaml_path = controller._db.settings.rel_path(configuration)
+    # ``rel_path`` resolves symlinks (blocking ``os.path.abspath``) — executor.
+    yaml_path = await run_in_executor(controller._db.settings.rel_path, configuration)
     new_hash = await compute_yaml_config_hash(yaml_path)
     if not new_hash:
         _LOGGER.warning(
@@ -220,7 +222,7 @@ async def migrate_metadata_then_scan(
         )
     # The renamed YAML was written before the migration (at queue time on
     # the OTA path), so a poll scan has usually already indexed it
-    # label-less; force a reload so the migrated sidecar reaches RAM (#2151).
+    # label-less; force a reload so the migrated sidecar reaches RAM.
     await controller._scanner.reload(new_configuration)
     await controller._scanner.scan()
 

--- a/tests/controllers/devices/test_rename.py
+++ b/tests/controllers/devices/test_rename.py
@@ -150,7 +150,7 @@ async def test_rename_underscore_name_to_hyphen_in_place(
     new_content = config.read_text(encoding="utf-8")
     assert read_yaml_scalar(new_content, ("esphome", "name")) == "test-1"
     assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Test_1"
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("reload", "test-1.yaml"), ("scan",)]
 
 
 async def test_rename_in_place_with_redundant_path_segments(

--- a/tests/controllers/devices/test_rename_config_only.py
+++ b/tests/controllers/devices/test_rename_config_only.py
@@ -42,7 +42,7 @@ async def test_config_only_rename_rewrites_name_and_renames_file(
     assert read_yaml_scalar(new_content, ("esphome", "name")) == "livingroom"
     # Untouched siblings survive the rewrite.
     assert read_yaml_scalar(new_content, ("esphome", "friendly_name")) == "Kitchen Light"
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
 
 
 async def test_config_only_rename_migrates_sidecar_metadata(
@@ -121,7 +121,7 @@ async def test_config_only_rename_survives_storage_migration_failure(
     assert result == {"configuration": "livingroom.yaml", "job": None}
     assert not (tmp_path / "kitchen.yaml").exists()
     assert (tmp_path / "livingroom.yaml").exists()
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
 
 
 async def test_config_only_rename_rejects_invalid_rewrite(

--- a/tests/controllers/devices/test_rename_metadata.py
+++ b/tests/controllers/devices/test_rename_metadata.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from esphome_device_builder.controllers._device_scanner import DeviceScanner
 from esphome_device_builder.controllers.config import (
     get_device_metadata,
     rename_device_metadata,
@@ -160,7 +161,7 @@ async def test_completed_rename_migrates_metadata_then_scans(
     moved = await controller._shared_sidecar.get("livingroom.yaml")
     assert moved.get("labels") == ["a"]
     assert moved.get("comment") == "downstairs"
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
 
 
 async def test_completed_rename_normalizes_new_name_with_extension(
@@ -213,7 +214,42 @@ async def test_completed_rename_scans_even_when_migration_fails(
     firmware_sync.on_job_completed(controller, Event(EventType.JOB_COMPLETED, {"job": job}))
 
     await scheduled[0]
-    assert controller._scanner.calls == [("scan",)]
+    assert controller._scanner.calls == [("reload", "livingroom.yaml"), ("scan",)]
+
+
+async def test_migrate_reloads_a_device_the_mtime_cache_would_skip(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A renamed YAML already indexed label-less picks up the migrated labels (#2151)."""
+    controller = make_controller(tmp_path)
+    controller._db.boards = None
+    scanner = DeviceScanner(
+        tmp_path,
+        get_metadata=controller._resolve_device_metadata,
+        on_change=lambda _kind, _device, _previous: None,
+    )
+    controller._scanner = scanner
+
+    (tmp_path / "kitchen.yaml").write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    await controller._shared_sidecar.update("kitchen.yaml", labels=["tag-bedroom"])
+    await scanner.scan()
+
+    # The OTA chain writes the renamed YAML at queue time; a poll scan
+    # indexes it with no labels while the chain compiles and flashes.
+    (tmp_path / "livingroom.yaml").write_text("esphome:\n  name: livingroom\n", encoding="utf-8")
+    await scanner.scan()
+    mid_chain = scanner.get_by_configuration("livingroom.yaml")
+    assert mid_chain is not None
+    assert list(mid_chain.labels) == []
+
+    # Tail completion: the old YAML is swapped out, then the migration runs.
+    (tmp_path / "kitchen.yaml").unlink()
+    await firmware_sync.migrate_metadata_then_scan(controller, "kitchen.yaml", "livingroom.yaml")
+
+    assert scanner.get_by_configuration("kitchen.yaml") is None
+    renamed = scanner.get_by_configuration("livingroom.yaml")
+    assert renamed is not None
+    assert list(renamed.labels) == ["tag-bedroom"]
 
 
 async def test_completed_rename_without_new_name_falls_back_to_scan(

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -393,9 +393,22 @@ def wire_real_queue(controller: FirmwareController) -> None:
     controller.state.cancel_events = {}
 
 
-def wire_background_tasks(controller: FirmwareController) -> None:
-    """Run work scheduled via ``create_background_task`` (e.g. the rename revert) for real."""
-    controller._db.create_background_task = asyncio.create_task
+def wire_background_tasks(controller: FirmwareController) -> list[asyncio.Task[Any]]:
+    """
+    Run work scheduled via ``create_background_task`` (e.g. the rename revert) for real.
+
+    Returns the spawned tasks so a test can ``gather`` them before asserting
+    on their side effects.
+    """
+    tasks: list[asyncio.Task[Any]] = []
+
+    def _spawn(coro: Any) -> asyncio.Task[Any]:
+        task = asyncio.get_running_loop().create_task(coro)
+        tasks.append(task)
+        return task
+
+    controller._db.create_background_task = _spawn
+    return tasks
 
 
 def upload_of(controller: FirmwareController, compile_job: FirmwareJob) -> FirmwareJob:

--- a/tests/controllers/firmware/test_rename_chain.py
+++ b/tests/controllers/firmware/test_rename_chain.py
@@ -11,11 +11,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from esphome_device_builder.controllers._device_scanner import DeviceScanner
+from esphome_device_builder.controllers.devices import DevicesController
+from esphome_device_builder.controllers.devices._metadata_store import DeviceMetadataStore
+from esphome_device_builder.controllers.devices._shared_sidecar import SharedSidecarClient
 from esphome_device_builder.controllers.firmware import persistence, rename_flow
 from esphome_device_builder.controllers.firmware.cli import build_command
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import (
     ErrorCode,
+    EventType,
     FirmwareJob,
     JobSource,
     JobStatus,
@@ -199,6 +204,59 @@ async def test_chain_success_flashes_old_address_and_swaps_files(
     assert not (tmp_path / ".esphome" / "build" / "kitchen").exists()
     assert (tmp_path / "livingroom.yaml").exists()
     assert len(captured["job_completed"]) == 2
+
+
+async def test_chain_success_carries_labels_to_the_renamed_device(
+    tmp_path: Path, firmware_controller_factory: FirmwareControllerFactory
+) -> None:
+    """A mid-chain scan of the queue-time YAML doesn't strand the renamed device label-less."""
+    controller = firmware_controller_factory(with_queue=True, with_real_bus=True)
+    wire_real_queue(controller)
+    background = wire_background_tasks(controller)
+    record_argv_esphome(controller.state, tmp_path / "argv.jsonl")
+    _seed_kitchen(tmp_path)
+
+    # Real devices-side slice: the JOB_COMPLETED listener, the metadata
+    # stores, and a real scanner with its mtime cache.
+    devices = DevicesController.__new__(DevicesController)
+    devices._db = controller._db
+    devices._db.boards = None
+    devices._build_size = MagicMock()
+    devices._metadata_store = DeviceMetadataStore(
+        config_dir=tmp_path,
+        data_dir=tmp_path,
+        shutdown_register=lambda _callback: None,
+    )
+    devices._shared_sidecar = SharedSidecarClient(tmp_path)
+    scanner = DeviceScanner(
+        tmp_path,
+        get_metadata=devices._resolve_device_metadata,
+        on_change=lambda _kind, _device, _previous: None,
+    )
+    devices._scanner = scanner
+    controller._db.bus.add_listener(EventType.JOB_COMPLETED, devices._on_firmware_job_completed)
+
+    await devices._shared_sidecar.update("kitchen.yaml", labels=["tag-bedroom"])
+    await scanner.scan()
+
+    head = await controller.rename(configuration="kitchen.yaml", new_name="livingroom")
+    tail = _tail_of(controller, head)
+    # ``begin_rename`` wrote livingroom.yaml at queue time; the periodic
+    # poll scan indexes it label-less while the chain compiles + flashes.
+    await scanner.scan()
+    mid_chain = scanner.get_by_configuration("livingroom.yaml")
+    assert mid_chain is not None
+    assert list(mid_chain.labels) == []
+
+    await run_until_terminal(controller)
+    await asyncio.gather(*background)
+
+    assert head.status is JobStatus.COMPLETED
+    assert tail.status is JobStatus.COMPLETED
+    assert scanner.get_by_configuration("kitchen.yaml") is None
+    renamed = scanner.get_by_configuration("livingroom.yaml")
+    assert renamed is not None
+    assert list(renamed.labels) == ["tag-bedroom"]
 
 
 async def test_compile_failure_cancels_tail_and_reverts(


### PR DESCRIPTION
# What does this implement/fix?

Renaming a device dropped its labels from the dashboard even though the sidecar migration worked. The rename chain writes the renamed YAML at queue time, so a periodic poll scan indexes the new device label-less while the chain compiles and flashes. When the tail completes, `migrate_metadata_then_scan` moves the `.device-builder.json` entry to the new filename and rescans, but the scan's `(inode, dev, mtime, size)` cache key for the new YAML is unchanged, so the file is skipped and the in-RAM `Device` keeps `labels=[]` until a restart or a YAML edit. The config-only rename path shares the helper and has the same hole as a race.

The fix forces one `scanner.reload(new_configuration)` after the migration, the documented escape hatch for sidecar-only changes; when the poll scan never indexed the new YAML, the reload is a no-op and the following scan picks it up fresh with the migrated labels. Covered by a unit regression test against a real `DeviceScanner` and a full-chain test (real queue, fake esphome subprocess, real devices-side listener and scanner); both fail without the fix.

**Related issue or feature (if applicable):**

- fixes #2151

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
