### PR TITLE
Skip a sub-bullet's wrapped continuation lines in MDX field parsing

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1970,13 +1970,17 @@ def _parse_config_var_bullets(  # noqa: C901
     """Parse a flat ``- **name** (...): ...`` bullet list into a field map.
 
     One description per top-level bullet, joining indented continuation
-    prose, excluding nested sub-bullets, and stopping at block-quotes /
-    sub-headings. With *first_paragraph_only*, a blank line after the
-    first prose ends the field (drops trailing ``**Important:**`` notes).
+    prose, excluding nested sub-bullets (and their wrapped continuation
+    lines), and stopping at block-quotes / sub-headings. With
+    *first_paragraph_only*, a blank line after the first prose ends the
+    field (drops trailing ``**Important:**`` notes).
     """
     descriptions: dict[str, str] = {}
     current_key: str | None = None
     current_parts: list[str] = []
+    # Indent of the sub-bullet we're skipping, so its deeper-indented wrapped
+    # continuation lines are skipped too; None when not inside one.
+    sub_indent: int | None = None
 
     def commit() -> None:
         nonlocal current_key
@@ -1996,6 +2000,7 @@ def _parse_config_var_bullets(  # noqa: C901
             commit()
             current_key = m.group("name")
             current_parts = [m.group("desc").strip()] if m.group("desc").strip() else []
+            sub_indent = None
             continue
         if current_key is None:
             continue
@@ -2006,16 +2011,25 @@ def _parse_config_var_bullets(  # noqa: C901
                 commit()
                 current_key = None
                 current_parts = []
+                sub_indent = None
             continue
         # Block-quotes / GitHub alerts and sub-headings end the field.
         if stripped.startswith((">", "#")):
             commit()
             current_key = None
             current_parts = []
+            sub_indent = None
             continue
-        # Sub-bullets describe sub-fields — skip.
+        # Sub-bullets describe sub-fields — skip, and remember their indent so
+        # their wrapped continuation lines (indented deeper) are skipped too.
         if stripped.startswith(("- ", "* ", "+ ")):
+            sub_indent = len(line) - len(line.lstrip())
             continue
+        if sub_indent is not None:
+            if len(line) - len(line.lstrip()) > sub_indent:
+                continue
+            # Back at the parent indent — a trailing paragraph, not sub-bullet prose.
+            sub_indent = None
         current_parts.append(stripped)
 
     commit()

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2022,8 +2022,11 @@ def _parse_config_var_bullets(  # noqa: C901
             continue
         # Sub-bullets describe sub-fields — skip, and remember their indent so
         # their wrapped continuation lines (indented deeper) are skipped too.
+        # Only a genuinely nested (indented) bullet owns following prose; a
+        # top-level bullet must not swallow the field's own continuation.
         if stripped.startswith(("- ", "* ", "+ ")):
-            sub_indent = len(line) - len(line.lstrip())
+            indent = len(line) - len(line.lstrip())
+            sub_indent = indent if indent > 0 else None
             continue
         if sub_indent is not None:
             if len(line) - len(line.lstrip()) > sub_indent:

--- a/tests/test_sync_components_field_descriptions.py
+++ b/tests/test_sync_components_field_descriptions.py
@@ -164,3 +164,18 @@ def test_parse_bullets_skips_wrapped_sub_bullet_continuation() -> None:
     # The parent trailing paragraph (back at the parent indent) is still kept.
     assert "This trailing note stays with scroll_mode." in fields["scroll_mode"]
     assert fields["scroll_speed"].startswith("Set scroll speed")
+
+
+# A field continuation carrying a top-level (indent-0) non-field bullet: it must
+# not establish a skip context that swallows the field's own indented prose.
+_TOP_LEVEL_BULLET_BODY = """\
+- **mode** (*Optional*): Pick a mode.
+- a plain top-level bullet that is not a config var
+  This indented prose still belongs to mode.
+"""
+
+
+def test_parse_bullets_top_level_bullet_does_not_swallow_parent_prose() -> None:
+    """An indent-0 non-field bullet doesn't skip the field's own continuation."""
+    fields = _parse_config_var_bullets(_TOP_LEVEL_BULLET_BODY)
+    assert "This indented prose still belongs to mode." in fields["mode"]

--- a/tests/test_sync_components_field_descriptions.py
+++ b/tests/test_sync_components_field_descriptions.py
@@ -138,3 +138,29 @@ def test_parse_bullets_skips_sub_bullets_and_blockquotes() -> None:
     fields = _parse_config_var_bullets(_ADVANCED_BODY, first_paragraph_only=True)
     assert "signing_key" not in fields  # sub-bullet, not a top-level field
     assert "must not bleed" not in fields["signed_ota_verification"]  # blockquote excluded
+
+
+# max7219digit.mdx's ``scroll_mode``: a sub-bullet whose prose wraps onto a
+# deeper-indented line after a blank, then a parent trailing paragraph.
+_WRAPPED_SUB_BULLET_BODY = """\
+- **scroll_mode** (*Optional*): Set the scroll mode. One of `CONTINUOUS` or `STOP`.
+
+  - `CONTINUOUS`  : Always scrolls and the text repeats, you might need to add some
+
+      separation at the end.
+
+  - `STOP`  : When text is over it waits and scroll is set back to the start.
+
+  This trailing note stays with scroll_mode.
+
+- **scroll_speed** (*Optional*): Set scroll speed. Defaults to `250ms`.
+"""
+
+
+def test_parse_bullets_skips_wrapped_sub_bullet_continuation() -> None:
+    """A sub-bullet's deeper-indented wrapped line doesn't leak into the parent field."""
+    fields = _parse_config_var_bullets(_WRAPPED_SUB_BULLET_BODY)
+    assert "separation at the end" not in fields["scroll_mode"]
+    # The parent trailing paragraph (back at the parent indent) is still kept.
+    assert "This trailing note stays with scroll_mode." in fields["scroll_mode"]
+    assert fields["scroll_speed"].startswith("Set scroll speed")


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #2152. When the MDX config-variable extractor skips a nested sub-bullet, it dropped the line that starts the sub-bullet but not that sub-bullet's wrapped continuation line; after a blank line the continuation no longer looks like a bullet, so it was appended to the parent field's description. That is how `display.max7219digit.scroll_mode` picked up a dangling "separation at the end." in the #2153 sync. `_parse_config_var_bullets` now remembers the indent of the sub-bullet it is skipping and skips any deeper-indented follow-on lines, while a paragraph back at the parent indent is still kept as a trailing note. The corrected text reaches the catalog data on the next nightly sync.

**Related issue or feature (if applicable):**

- follow up to https://github.com/esphome/device-builder/pull/2152

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
