### PR TITLE
Strip leaked code fences and dangling list-introducers from descriptions

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2377,9 +2377,16 @@ def _tidy_description(text: str) -> str:
     """
     if not text:
         return text
-    tidied = _CODE_FENCE_RE.sub("", text)
+    # Collapse whitespace runs first. Real descriptions are already single-spaced
+    # (``clean_docs`` / the MDX parser normalize), so this is a no-op on them; it
+    # also bounds the fence regexes to linear time on a pathological long whitespace
+    # run (a multi-line unterminated fence under ``re.DOTALL``), which the atomic
+    # groups alone leave quadratic. A clean description is still returned verbatim
+    # via the ``changed`` guard below.
+    working = _MULTI_SPACE_RE.sub(" ", text)
+    tidied = _CODE_FENCE_RE.sub("", working)
     tidied = _CODE_FENCE_TAIL_RE.sub("", tidied)
-    changed = tidied != text
+    changed = tidied != working
     prev: str | None = None
     while prev != tidied:
         prev = tidied

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1991,9 +1991,7 @@ def _parse_config_var_bullets(  # noqa: C901
         if current_key is None:
             return
         joined = " ".join(p for p in current_parts if p)
-        cleaned = _clean_description_text(joined).rstrip(" .,:")
-        if cleaned and cleaned[-1] not in ".!?":
-            cleaned += "."
+        cleaned = _ensure_terminal_period(_clean_description_text(joined).rstrip(" .,:"))
         if cleaned:
             descriptions[current_key] = cleaned
 
@@ -2322,21 +2320,28 @@ def _clean_description_text(text: str) -> str:
     return text
 
 
+def _ensure_terminal_period(text: str) -> str:
+    """Append ``.`` unless *text* already ends in sentence-terminating punctuation."""
+    if text and text[-1] not in ".!?":
+        return text + "."
+    return text
+
+
 _CODE_LANG = (
     r"(?:yaml|yml|json|jsonc|c\+\+|cpp|c|python|py|bash|sh|shell|ini|toml|text|html|xml|cbp)"
 )
-# A fenced code example: ```lang ... ``` or ``lang ... ``, optionally introduced by
-# "Example:" / "e.g.". Only triple-fenced or language-tagged spans match, so inline
-# ``code`` (double-backtick, no language) is preserved.
+# Optional prose that introduces a code example, shared by both fence patterns.
+_CODE_FENCE_INTRO = r"\s*(?:for example|examples?|e\.g\.)?\s*:?\s*"
+# A fenced code example: ```lang ... ``` or ``lang ... ``. Only triple-fenced or
+# language-tagged spans match, so inline ``code`` (double-backtick, no language)
+# is preserved.
 _CODE_FENCE_RE = re.compile(
-    r"\s*(?:for example|examples?|e\.g\.|see)?\s*:?\s*"
-    r"(?:`{3,}\s*[a-z0-9+#]*\b.*?`{3,}|``\s*" + _CODE_LANG + r"\b.*?``)",
+    _CODE_FENCE_INTRO + r"(?:`{3,}\s*[a-z0-9+#]*\b.*?`{3,}|``\s*" + _CODE_LANG + r"\b.*?``)",
     re.IGNORECASE | re.DOTALL,
 )
 # A trailing, unterminated fence whose body lived on excluded sub-lines.
 _CODE_FENCE_TAIL_RE = re.compile(
-    r"\s*(?:for example|examples?|e\.g\.)?\s*:?\s*"
-    r"(?:`{3,}\s*[a-z0-9+#]*|``\s*" + _CODE_LANG + r"\b)[^`]*$",
+    _CODE_FENCE_INTRO + r"(?:`{3,}\s*[a-z0-9+#]*|``\s*" + _CODE_LANG + r"\b)[^`]*$",
     re.IGNORECASE,
 )
 # A trailing sentence that is just a list-introducer ending in ``:`` (its options
@@ -2375,8 +2380,7 @@ def _tidy_description(text: str) -> str:
     tidied = re.sub(r"\s+([.,;:])", r"\1", tidied)
     tidied = re.sub(r"([.!?])(?:\s*[.!?])+", r"\1", tidied)
     tidied = re.sub(r"\s{2,}", " ", tidied).strip().rstrip(",;:-").strip()
-    if tidied and tidied[-1] not in ".!?":
-        tidied += "."
+    tidied = _ensure_terminal_period(tidied)
     return tidied or text
 
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1356,7 +1356,8 @@ def build_catalog(
 
     # Final pass over every description (schema- and MDX-derived alike): strip
     # leaked fenced-code examples and dangling ``One of:`` list-introducers.
-    _tidy_all_descriptions(out)
+    tidied = _tidy_all_descriptions(out)
+    _LOGGER.info("Tidied %d description(s): stripped code fences / dangling introducers", tidied)
 
     return out
 
@@ -2331,17 +2332,19 @@ _CODE_LANG = (
     r"(?:yaml|yml|json|jsonc|c\+\+|cpp|c|python|py|bash|sh|shell|ini|toml|text|html|xml|cbp)"
 )
 # Optional prose that introduces a code example, shared by both fence patterns.
-_CODE_FENCE_INTRO = r"\s*(?:for example|examples?|e\.g\.)?\s*:?\s*"
-# A fenced code example: ```lang ... ``` or ``lang ... ``. Only triple-fenced or
-# language-tagged spans match, so inline ``code`` (double-backtick, no language)
+# The whitespace runs are atomic (``(?>\s*)``) so a run before an unterminated
+# fence can't be re-partitioned into exponentially many ways (ReDoS guard).
+_CODE_FENCE_INTRO = r"(?>\s*)(?:for example|examples?|e\.g\.)?(?>\s*):?(?>\s*)"
+# A fenced code example: ```...``` (any body) or ``lang ... ``. Only triple-fenced
+# or language-tagged spans match, so inline ``code`` (double-backtick, no language)
 # is preserved.
 _CODE_FENCE_RE = re.compile(
-    _CODE_FENCE_INTRO + r"(?:`{3,}\s*[a-z0-9+#]*\b.*?`{3,}|``\s*" + _CODE_LANG + r"\b.*?``)",
+    _CODE_FENCE_INTRO + r"(?:`{3,}.*?`{3,}|``\s*" + _CODE_LANG + r"\b.*?``)",
     re.IGNORECASE | re.DOTALL,
 )
 # A trailing, unterminated fence whose body lived on excluded sub-lines.
 _CODE_FENCE_TAIL_RE = re.compile(
-    _CODE_FENCE_INTRO + r"(?:`{3,}\s*[a-z0-9+#]*|``\s*" + _CODE_LANG + r"\b)[^`]*$",
+    _CODE_FENCE_INTRO + r"(?:`{3,}|``\s*" + _CODE_LANG + r"\b)[^`]*$",
     re.IGNORECASE,
 )
 # A trailing sentence that is just a list-introducer ending in ``:`` (its options
@@ -2357,6 +2360,12 @@ _BARE_ONE_OF_RE = re.compile(r"(?:(?<=[.!?])\s+|^)[^.!?]*\bone of\s*\.?\s*$", re
 _SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([.,;:])")
 _REPEATED_TERMINATOR_RE = re.compile(r"([.!?])(?:\s*[.!?])+")
 _MULTI_SPACE_RE = re.compile(r"\s{2,}")
+
+
+def _collapse_terminators(match: re.Match[str]) -> str:
+    """Collapse a run of sentence terminators to one, but keep a literal ``...``."""
+    run = match.group(0)
+    return run if run == "..." else match.group(1)
 
 
 def _tidy_description(text: str) -> str:
@@ -2382,7 +2391,7 @@ def _tidy_description(text: str) -> str:
     if not changed:
         return text
     tidied = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", tidied)
-    tidied = _REPEATED_TERMINATOR_RE.sub(r"\1", tidied)
+    tidied = _REPEATED_TERMINATOR_RE.sub(_collapse_terminators, tidied)
     tidied = _MULTI_SPACE_RE.sub(" ", tidied).strip().rstrip(",;:-").strip()
     tidied = _ensure_terminal_period(tidied)
     return tidied or text

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2353,6 +2353,10 @@ _LIST_INTRO_COLON_RE = re.compile(
     re.IGNORECASE,
 )
 _BARE_ONE_OF_RE = re.compile(r"(?:(?<=[.!?])\s+|^)[^.!?]*\bone of\s*\.?\s*$", re.IGNORECASE)
+# Tail clean-up after a fence/introducer removal leaves stray spacing/punctuation.
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([.,;:])")
+_REPEATED_TERMINATOR_RE = re.compile(r"([.!?])(?:\s*[.!?])+")
+_MULTI_SPACE_RE = re.compile(r"\s{2,}")
 
 
 def _tidy_description(text: str) -> str:
@@ -2377,9 +2381,9 @@ def _tidy_description(text: str) -> str:
         tidied = stripped.rstrip()
     if not changed:
         return text
-    tidied = re.sub(r"\s+([.,;:])", r"\1", tidied)
-    tidied = re.sub(r"([.!?])(?:\s*[.!?])+", r"\1", tidied)
-    tidied = re.sub(r"\s{2,}", " ", tidied).strip().rstrip(",;:-").strip()
+    tidied = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", tidied)
+    tidied = _REPEATED_TERMINATOR_RE.sub(r"\1", tidied)
+    tidied = _MULTI_SPACE_RE.sub(" ", tidied).strip().rstrip(",;:-").strip()
     tidied = _ensure_terminal_period(tidied)
     return tidied or text
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -2335,11 +2335,12 @@ _CODE_LANG = (
 # The whitespace runs are atomic (``(?>\s*)``) so a run before an unterminated
 # fence can't be re-partitioned into exponentially many ways (ReDoS guard).
 _CODE_FENCE_INTRO = r"(?>\s*)(?:for example|examples?|e\.g\.)?(?>\s*):?(?>\s*)"
-# A fenced code example: ```...``` (any body) or ``lang ... ``. Only triple-fenced
-# or language-tagged spans match, so inline ``code`` (double-backtick, no language)
-# is preserved.
+# A fenced code example: ```...``` (any body) or ``lang <body> ``. Only triple-fenced
+# or language-tagged spans match. The ``\s+`` after the language token requires a real
+# body, so inline ``code`` (double-backtick, no language) and an inline format-name
+# reference like ``json`` are both preserved.
 _CODE_FENCE_RE = re.compile(
-    _CODE_FENCE_INTRO + r"(?:`{3,}.*?`{3,}|``\s*" + _CODE_LANG + r"\b.*?``)",
+    _CODE_FENCE_INTRO + r"(?:`{3,}.*?`{3,}|``\s*" + _CODE_LANG + r"\s+.*?``)",
     re.IGNORECASE | re.DOTALL,
 )
 # A trailing, unterminated fence whose body lived on excluded sub-lines.

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -1354,6 +1354,10 @@ def build_catalog(
     # domains are unbounded YAML lists, so every platform entry is repeatable.
     _mark_platform_domains_multi_conf(out)
 
+    # Final pass over every description (schema- and MDX-derived alike): strip
+    # leaked fenced-code examples and dangling ``One of:`` list-introducers.
+    _tidy_all_descriptions(out)
+
     return out
 
 
@@ -2316,6 +2320,82 @@ def _clean_description_text(text: str) -> str:
             text = text[:1].upper() + text[1:] if text else text
             break
     return text
+
+
+_CODE_LANG = (
+    r"(?:yaml|yml|json|jsonc|c\+\+|cpp|c|python|py|bash|sh|shell|ini|toml|text|html|xml|cbp)"
+)
+# A fenced code example: ```lang ... ``` or ``lang ... ``, optionally introduced by
+# "Example:" / "e.g.". Only triple-fenced or language-tagged spans match, so inline
+# ``code`` (double-backtick, no language) is preserved.
+_CODE_FENCE_RE = re.compile(
+    r"\s*(?:for example|examples?|e\.g\.|see)?\s*:?\s*"
+    r"(?:`{3,}\s*[a-z0-9+#]*\b.*?`{3,}|``\s*" + _CODE_LANG + r"\b.*?``)",
+    re.IGNORECASE | re.DOTALL,
+)
+# A trailing, unterminated fence whose body lived on excluded sub-lines.
+_CODE_FENCE_TAIL_RE = re.compile(
+    r"\s*(?:for example|examples?|e\.g\.)?\s*:?\s*"
+    r"(?:`{3,}\s*[a-z0-9+#]*|``\s*" + _CODE_LANG + r"\b)[^`]*$",
+    re.IGNORECASE,
+)
+# A trailing sentence that is just a list-introducer ending in ``:`` (its options
+# are sub-bullets the field extractor drops), or a bare "... one of." with no values.
+_LIST_INTRO_COLON_RE = re.compile(
+    r"(?:(?<=[.!?])\s+|^)"
+    r"(?:can be|must be|one of|any of|choose from|possible values?|valid values?|either|select from)\b"
+    r"[^.!?]{0,45}:\s*$",
+    re.IGNORECASE,
+)
+_BARE_ONE_OF_RE = re.compile(r"(?:(?<=[.!?])\s+|^)[^.!?]*\bone of\s*\.?\s*$", re.IGNORECASE)
+
+
+def _tidy_description(text: str) -> str:
+    """
+    Strip leaked fenced-code examples and dangling list-introducers.
+
+    Returns *text* unchanged when neither is present, so a real sentence
+    that happens to end in ``:`` keeps its colon.
+    """
+    if not text:
+        return text
+    tidied = _CODE_FENCE_RE.sub("", text)
+    tidied = _CODE_FENCE_TAIL_RE.sub("", tidied)
+    changed = tidied != text
+    prev: str | None = None
+    while prev != tidied:
+        prev = tidied
+        stripped = _LIST_INTRO_COLON_RE.sub("", tidied)
+        stripped = _BARE_ONE_OF_RE.sub("", stripped)
+        if stripped != tidied:
+            changed = True
+        tidied = stripped.rstrip()
+    if not changed:
+        return text
+    tidied = re.sub(r"\s+([.,;:])", r"\1", tidied)
+    tidied = re.sub(r"([.!?])(?:\s*[.!?])+", r"\1", tidied)
+    tidied = re.sub(r"\s{2,}", " ", tidied).strip().rstrip(",;:-").strip()
+    if tidied and tidied[-1] not in ".!?":
+        tidied += "."
+    return tidied or text
+
+
+def _tidy_all_descriptions(node: object) -> int:
+    """Run ``_tidy_description`` over every ``description`` in the catalog tree."""
+    count = 0
+    if isinstance(node, dict):
+        desc = node.get("description")
+        if isinstance(desc, str):
+            tidied = _tidy_description(desc)
+            if tidied != desc:
+                node["description"] = tidied
+                count += 1
+        for value in node.values():
+            count += _tidy_all_descriptions(value)
+    elif isinstance(node, list):
+        for item in node:
+            count += _tidy_all_descriptions(item)
+    return count
 
 
 def load_image_map() -> dict[str, str]:

--- a/tests/test_sync_components_tidy_description.py
+++ b/tests/test_sync_components_tidy_description.py
@@ -62,13 +62,13 @@ def test_strips_untagged_triple_fence_with_brace_body() -> None:
 
 
 def test_no_catastrophic_backtracking_on_whitespace_run_and_open_fence() -> None:
-    """A long whitespace run before an unterminated fence tidies quickly (ReDoS guard)."""
-    payload = "State." + " " * 4000 + "```"
+    """A huge whitespace run before an unterminated fence tidies in linear time."""
+    payload = "State." + " " * 50000 + "```"
     start = time.perf_counter()
     out = _tidy_description(payload)
     elapsed = time.perf_counter() - start
-    assert elapsed < 1.0  # exponential backtracking would take minutes here
-    assert out.startswith("State.")
+    assert elapsed < 1.0  # exponential/quadratic scanning would take many seconds here
+    assert out == "State."
 
 
 def test_strips_cpp_fence_keeps_surrounding_prose() -> None:

--- a/tests/test_sync_components_tidy_description.py
+++ b/tests/test_sync_components_tidy_description.py
@@ -121,6 +121,9 @@ def test_trims_dangling_list_introducer(text: str, expected: str) -> None:
     [
         # inline double-backtick code is not a fenced block
         "Invert the logical level. ``true`` swaps high/low so an active-low button reads active.",
+        # inline double-backtick whose content is exactly a language name is still inline code
+        "The ``json`` key holds it.",
+        "Set the ``c`` register bit.",
         # "one of" inside a real sentence, not a dangling introducer
         "Pick one of the modes.",
         "This is one of the required fields.",

--- a/tests/test_sync_components_tidy_description.py
+++ b/tests/test_sync_components_tidy_description.py
@@ -1,0 +1,173 @@
+"""Unit tests for the description tidy-up pass (fences + dangling list-introducers)."""
+
+from __future__ import annotations
+
+import pytest
+
+from script.sync_components import (  # type: ignore[import-not-found]
+    _tidy_all_descriptions,
+    _tidy_description,
+)
+
+# --- Fenced-code removal -----------------------------------------------------
+
+
+def test_strips_triple_fenced_code_mid_sentence() -> None:
+    """A ```json``` example between two clauses is removed, the prose stays."""
+    text = (
+        "When set to `true`, state is published as one JSON object. "
+        'Example: ```json { "state": "open" } ``` '
+        "When `false`, values are published separately. Defaults to `false`."
+    )
+    out = _tidy_description(text)
+    assert out == (
+        "When set to `true`, state is published as one JSON object. "
+        "When `false`, values are published separately. Defaults to `false`."
+    )
+    assert '{ "state"' not in out  # fenced body gone
+    assert "`true`" in out and "`false`" in out  # inline code preserved
+
+
+def test_strips_language_tagged_double_fence() -> None:
+    """An ``yaml ... `` inline example block is removed with its ``Example:`` intro."""
+    text = (
+        "The ID of a led widget configured in LVGL, which will reflect the state "
+        "of the light. Example: ``yaml light: widget: led_id name: LVGL light ``."
+    )
+    out = _tidy_description(text)
+    assert out == (
+        "The ID of a led widget configured in LVGL, which will reflect the state of the light."
+    )
+
+
+def test_strips_unterminated_trailing_fence() -> None:
+    """An opening fence whose body was on excluded sub-lines is dropped from the tail."""
+    text = (
+        "Any command sent to the Modbus Select immediately updates the reported "
+        "state. Defaults to false. ```yaml."
+    )
+    out = _tidy_description(text)
+    assert out == (
+        "Any command sent to the Modbus Select immediately updates the reported "
+        "state. Defaults to false."
+    )
+
+
+def test_strips_cpp_fence_keeps_surrounding_prose() -> None:
+    """A ```c++``` formula block is removed but the explanation around it stays."""
+    text = (
+        "The compensated ambient temperature is calculated as follows: "
+        "```c++ T = T_Ambient + offset ``` "
+        "Where slope and offset are the values set with this command."
+    )
+    out = _tidy_description(text)
+    assert "```" not in out and "T_Ambient" not in out
+    assert out.startswith("The compensated ambient temperature is calculated as follows")
+    assert out.endswith("Where slope and offset are the values set with this command.")
+
+
+# --- Dangling list-introducer trimming --------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("The type of interrupt to use. One of:", "The type of interrupt to use."),
+        ("Operating mode. One of:", "Operating mode."),
+        (
+            "Output clock speed. Defaults to `20MHZ`. One of:",
+            "Output clock speed. Defaults to `20MHZ`.",
+        ),
+        (
+            "Sets the analog gain. Defaults to 1X. Must be one of.",
+            "Sets the analog gain. Defaults to 1X.",
+        ),
+        ("The metadata field to report. One of.", "The metadata field to report."),
+        ("The nrf-sdk version. One of.", "The nrf-sdk version."),
+        (
+            "The mode to use. Must be one of the following values:",
+            "The mode to use.",
+        ),
+    ],
+)
+def test_trims_dangling_list_introducer(text: str, expected: str) -> None:
+    """A trailing bare list-introducer (``One of:`` / ``one of.``) is dropped."""
+    assert _tidy_description(text) == expected
+
+
+# --- Preservation guards (must NOT change) ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # inline double-backtick code is not a fenced block
+        "Invert the logical level. ``true`` swaps high/low so an active-low button reads active.",
+        # "one of" inside a real sentence, not a dangling introducer
+        "Pick one of the modes.",
+        "This is one of the required fields.",
+        "The ID of the descriptor to set the value of.",
+        "Must be set to one of the supported values.",
+        # a real sentence that happens to end in a colon (list of items follows in the UI)
+        "It provides support for the following microcontrollers, commonly used in Tuya devices:",
+        "UART usually consists of 2 pins:",
+        "Only on ESP32, it is possible to specify run duration according to the wakeup reason:",
+        # already-clean prose
+        "The global log level. Any log message with a lower severity will not be shown.",
+        "The pin to use.",
+    ],
+)
+def test_leaves_legitimate_descriptions_unchanged(text: str) -> None:
+    """Inline code, real ``one of`` sentences, and legit trailing colons are preserved."""
+    assert _tidy_description(text) == text
+
+
+def test_empty_and_none_safe() -> None:
+    """Empty input is returned as-is without error."""
+    assert _tidy_description("") == ""
+
+
+def test_never_blanks_a_description() -> None:
+    """A description that is only an introducer falls back to the original, never empty."""
+    assert _tidy_description("One of:") == "One of:"
+
+
+# --- Whole-tree walker -------------------------------------------------------
+
+
+def test_tidy_all_descriptions_walks_nested_config_entries() -> None:
+    """The walker rewrites descriptions at every depth and counts the changes."""
+    catalog = [
+        {
+            "id": "demo",
+            "description": "A demo component. One of:",
+            "config_entries": [
+                {"key": "mode", "description": "Operating mode. One of:"},
+                {
+                    "key": "group",
+                    "description": "A clean container description.",
+                    "config_entries": [
+                        {"key": "inner", "description": "Inner field. Must be one of."},
+                    ],
+                },
+            ],
+        }
+    ]
+    changed = _tidy_all_descriptions(catalog)
+    assert changed == 3
+    assert catalog[0]["description"] == "A demo component."
+    assert catalog[0]["config_entries"][0]["description"] == "Operating mode."
+    assert catalog[0]["config_entries"][1]["description"] == "A clean container description."
+    assert catalog[0]["config_entries"][1]["config_entries"][0]["description"] == "Inner field."
+
+
+def test_tidy_all_descriptions_noop_on_clean_tree() -> None:
+    """A tree with no garbled descriptions is left untouched (zero changes)."""
+    catalog = [
+        {
+            "id": "x",
+            "description": "Clean.",
+            "config_entries": [{"key": "p", "description": "A pin."}],
+        }
+    ]
+    assert _tidy_all_descriptions(catalog) == 0

--- a/tests/test_sync_components_tidy_description.py
+++ b/tests/test_sync_components_tidy_description.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from script.sync_components import (  # type: ignore[import-not-found]
@@ -51,6 +53,22 @@ def test_strips_unterminated_trailing_fence() -> None:
         "Any command sent to the Modbus Select immediately updates the reported "
         "state. Defaults to false."
     )
+
+
+def test_strips_untagged_triple_fence_with_brace_body() -> None:
+    """A plain ```{...}``` fence with no language tag (body starts with `{`) is removed."""
+    text = 'The payload shape. Example: ```{ "state": "open" }``` See the notes.'
+    assert _tidy_description(text) == "The payload shape. See the notes."
+
+
+def test_no_catastrophic_backtracking_on_whitespace_run_and_open_fence() -> None:
+    """A long whitespace run before an unterminated fence tidies quickly (ReDoS guard)."""
+    payload = "State." + " " * 4000 + "```"
+    start = time.perf_counter()
+    out = _tidy_description(payload)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0  # exponential backtracking would take minutes here
+    assert out.startswith("State.")
 
 
 def test_strips_cpp_fence_keeps_surrounding_prose() -> None:
@@ -120,6 +138,13 @@ def test_trims_dangling_list_introducer(text: str, expected: str) -> None:
 def test_leaves_legitimate_descriptions_unchanged(text: str) -> None:
     """Inline code, real ``one of`` sentences, and legit trailing colons are preserved."""
     assert _tidy_description(text) == text
+
+
+def test_preserves_ellipsis_when_a_fence_is_stripped() -> None:
+    """A legitimate ``...`` survives the terminal-punctuation collapse after a strip."""
+    assert _tidy_description("Loading state... ```yaml x: 1``` then done.") == (
+        "Loading state... then done."
+    )
 
 
 def test_empty_and_none_safe() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #2155. Some ESPHome docs embed a fenced code example (` ```json ... ``` `, ` ``yaml ... `` `) or end a field on a bare `One of:` list-introducer whose options live in sub-bullets the extractor skips; both leak into the flattened description as garbled trailing fragments (for example `cover.*.mqtt_json_state_payload` carried a raw ` ```json {...}``` ` block, and dozens of fields dangled on `One of:` or `Must be one of.`). This adds a final `_tidy_description` normalization pass over every description, schema and MDX derived alike, that strips fenced-code examples and trims a trailing dangling list-introducer. It is deliberately conservative: only triple-fenced or language-tagged spans are removed so inline ` ``true`` ` code survives, and only a short introducer sentence is dropped so a real sentence that happens to end in a colon (for example "consists of 2 pins:") is kept. It rewrites 95 descriptions and returns everything else unchanged. The corrected text reaches the catalog data on the next nightly sync.

**Related issue or feature (if applicable):**

- follow up to https://github.com/esphome/device-builder/pull/2155

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
