### PR TITLE
Share the read-side tarball primitives between pack and materialise

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -56,20 +56,20 @@ import logging
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from esphome.storage_json import StorageJSON
 
 from ...constants import TOOLCHAIN_ESP_IDF
 from ...helpers.build_artifacts import _firmware_offset_for_platform
 from ...helpers.cross_os_path import cross_os_basename
-from ...helpers.json import loads as json_loads
 from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
 from ...helpers.storage_path import (
     resolve_compiled_config_path,
     resolve_idedata_path,
     resolve_storage_path,
 )
+from ...helpers.tarball_read import parse_json_object, read_member
 from .artifact_platforms import build_files_for_platform
 
 if TYPE_CHECKING:
@@ -443,11 +443,13 @@ def _walk_artifacts_members(
     basename_origin: dict[str, str] = {}
     total_bytes = 0
     for member in tar:
-        _check_member_size(member, total_so_far=total_bytes)
-        payload = _read_tarball_member(tar, member)
-        total_bytes += len(payload)
+        payload, total_bytes = read_member(
+            tar, member, total_so_far=total_bytes, error_cls=UnpackArtifactsError
+        )
         if member.name == IDEDATA_MEMBER_NAME:
-            idedata = _parse_idedata(payload)
+            idedata = parse_json_object(
+                payload, label="idedata.json", error_cls=UnpackArtifactsError
+            )
             continue
         if member.name in _METADATA_MEMBERS:
             # storage.json + platformio.ini are materialiser-only.
@@ -474,65 +476,6 @@ def _relative_or_raise(path: Path, base: Path, *, configuration: str) -> str:
             f"build_path {base}; can't include in tarball"
         )
         raise RuntimeError(msg) from err
-
-
-def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:
-    """
-    Reject a tarball member whose decompressed size would blow the cap.
-
-    Combines a per-member check (``member.size`` exceeds the
-    cap on its own) with a cumulative check
-    (``member.size + total_so_far`` would push the running
-    total past the cap). The receiver-side packer
-    (:func:`pack_build_artifacts`) enforces the same ceiling
-    on the way out, so a well-formed tarball never trips
-    this gate; a peer-controlled / malformed stream that
-    declares a multi-GiB member in the tar header bails
-    here before :meth:`tarfile.TarFile.extractfile` reads
-    a single byte.
-    """
-    if member.size > FIRMWARE_MAX_TOTAL_BYTES:
-        msg = (
-            f"tarball member {member.name!r} declares size {member.size} "
-            f"exceeding FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
-        )
-        raise UnpackArtifactsError(msg)
-    if total_so_far + member.size > FIRMWARE_MAX_TOTAL_BYTES:
-        msg = (
-            f"tarball cumulative size {total_so_far + member.size} "
-            f"exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
-        )
-        raise UnpackArtifactsError(msg)
-
-
-def _read_tarball_member(tar: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
-    """Read *member*'s bytes.
-
-    Raises :class:`UnpackArtifactsError` on directory entries
-    or any other non-regular tarball member type. Stdlib
-    ``tarfile`` guarantees ``extractfile()`` returns a
-    readable stream iff ``isfile()`` returns ``True`` —
-    ``extractfile`` only returns ``None`` for link / device /
-    FIFO members, every one of which ``isfile()`` already
-    rejects.
-    """
-    if not member.isfile():
-        msg = f"unexpected non-file tarball entry: {member.name!r}"
-        raise UnpackArtifactsError(msg)
-    return cast(io.BufferedReader, tar.extractfile(member)).read()
-
-
-def _parse_idedata(payload: bytes) -> dict[str, Any]:
-    """Parse *payload* as ``idedata.json``; raise on non-dict / invalid JSON."""
-    try:
-        parsed = json_loads(payload)
-    except ValueError as exc:
-        msg = f"idedata.json is not valid JSON: {exc}"
-        raise UnpackArtifactsError(msg) from exc
-    if not isinstance(parsed, dict):
-        msg = "idedata.json is not a JSON object"
-        raise UnpackArtifactsError(msg)
-    return parsed
 
 
 def _build_images_response(

--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -495,9 +495,9 @@ def _build_images_response(
     resolution and ``firmware.uf2`` for libretiny/RP2040
     ltchiptool flashing, neither of which is in
     ``idedata.extra.flash_images``) are ignored. The size cap
-    in :func:`_check_member_size` already gates total payload,
-    so we don't need a "no leftovers" check to reject a
-    bloated tarball.
+    in :func:`helpers.tarball_read.check_member_size` already
+    gates total payload, so we don't need a "no leftovers"
+    check to reject a bloated tarball.
     """
     images: list[dict[str, Any]] = []
     firmware_bytes = image_bytes_by_name.pop("firmware.bin", None)

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -240,8 +240,7 @@ def _read_member_required(
 
     *total_so_far* threads the cumulative-size accounting from the
     caller so successive metadata reads can't each fit under the
-    :data:`FIRMWARE_MAX_TOTAL_BYTES` cap individually while
-    collectively breaching it.
+    global tarball cap individually while collectively breaching it.
     """
     try:
         member = tar.getmember(name)

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -39,14 +39,13 @@ from ..controllers.remote_build.artifacts_tarball import (
 )
 from .cross_os_path import receiver_pure_path_cls
 from .json import dumps_indent
-from .json import loads as json_loads
-from .peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
 from .storage_path import (
     resolve_compiled_config_path,
     resolve_data_dir,
     resolve_idedata_path,
     resolve_storage_path,
 )
+from .tarball_read import check_member_size, parse_json_object, read_member
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -231,13 +230,7 @@ def _read_member_optional(
         member = tar.getmember(name)
     except KeyError:
         return None, total_so_far
-    if not member.isfile():
-        raise MaterialiseError(f"tarball member {name!r} is not a regular file")
-    _check_member_size(member, total_so_far=total_so_far)
-    payload = tar.extractfile(member)
-    if payload is None:
-        raise MaterialiseError(f"tarball member {name!r} unreadable")
-    return payload.read(), total_so_far + member.size
+    return read_member(tar, member, total_so_far=total_so_far, error_cls=MaterialiseError)
 
 
 def _read_member_required(
@@ -245,41 +238,16 @@ def _read_member_required(
 ) -> tuple[bytes, int]:
     """Read *name* or raise. Returns ``(payload, running total)``.
 
-    Caps the declared member size against
-    :data:`FIRMWARE_MAX_TOTAL_BYTES` before reading so a hostile
-    peer can't expand a tiny gzipped tarball into multi-GiB
-    memory by inflating a metadata-member header. *total_so_far*
-    threads the running cumulative-size accounting from the
-    caller; the cap is checked against
-    ``total_so_far + member.size`` so successive metadata reads
-    can't each fit under the cap individually while collectively
-    breaching it.
+    *total_so_far* threads the cumulative-size accounting from the
+    caller so successive metadata reads can't each fit under the
+    :data:`FIRMWARE_MAX_TOTAL_BYTES` cap individually while
+    collectively breaching it.
     """
     try:
         member = tar.getmember(name)
     except KeyError as err:
         raise MaterialiseError(f"tarball missing required member: {name!r}") from err
-    if not member.isfile():
-        raise MaterialiseError(f"tarball member {name!r} is not a regular file")
-    _check_member_size(member, total_so_far=total_so_far)
-    payload = tar.extractfile(member)
-    if payload is None:  # ``isfile()`` already gates this; defence
-        raise MaterialiseError(f"tarball member {name!r} unreadable")
-    return payload.read(), total_so_far + member.size
-
-
-def _check_member_size(member: tarfile.TarInfo, *, total_so_far: int) -> None:
-    """Reject tar members whose declared size would breach the global cap."""
-    if member.size > FIRMWARE_MAX_TOTAL_BYTES:
-        raise MaterialiseError(
-            f"tarball member {member.name!r} declares size {member.size} "
-            f"exceeding FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
-        )
-    if total_so_far + member.size > FIRMWARE_MAX_TOTAL_BYTES:
-        raise MaterialiseError(
-            f"tarball cumulative size {total_so_far + member.size} "
-            f"exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
-        )
+    return read_member(tar, member, total_so_far=total_so_far, error_cls=MaterialiseError)
 
 
 def _safe_extract_excluding(
@@ -302,7 +270,7 @@ def _safe_extract_excluding(
     for member in tar.getmembers():
         if member.name in exclude:
             continue
-        _check_member_size(member, total_so_far=total_bytes)
+        check_member_size(member, total_so_far=total_bytes, error_cls=MaterialiseError)
         total_bytes += member.size
         member_path = (dest / member.name).resolve()
         try:
@@ -318,13 +286,7 @@ def _safe_extract_excluding(
 
 def _parse_storage_json(payload: bytes) -> dict[str, Any]:
     """Parse the shipped storage.json into a dict for the pre-extract lookups."""
-    try:
-        parsed = json_loads(payload)
-    except ValueError as err:
-        raise MaterialiseError(f"tarball storage.json is not valid JSON: {err}") from err
-    if not isinstance(parsed, dict):
-        raise MaterialiseError("tarball storage.json is not a JSON object")
-    return parsed
+    return parse_json_object(payload, label="tarball storage.json", error_cls=MaterialiseError)
 
 
 def _stage_offloader_storage(
@@ -381,13 +343,7 @@ def _stage_offloader_idedata(
 
 def _parse_idedata_dict(payload: bytes) -> dict[str, Any]:
     """Parse the shipped idedata.json or raise MaterialiseError."""
-    try:
-        data = json_loads(payload)
-    except ValueError as err:
-        raise MaterialiseError(f"tarball idedata.json is not valid JSON: {err}") from err
-    if not isinstance(data, dict):
-        raise MaterialiseError("tarball idedata.json is not a JSON object")
-    return data
+    return parse_json_object(payload, label="tarball idedata.json", error_cls=MaterialiseError)
 
 
 def _remap_idedata_build_paths(

--- a/esphome_device_builder/helpers/tarball_read.py
+++ b/esphome_device_builder/helpers/tarball_read.py
@@ -1,0 +1,70 @@
+"""Read-side primitives shared by the remote-build tarball consumers."""
+
+from __future__ import annotations
+
+import tarfile
+from typing import Any
+
+from .json import loads as json_loads
+from .peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
+
+
+def check_member_size(
+    member: tarfile.TarInfo, *, total_so_far: int, error_cls: type[Exception]
+) -> None:
+    """
+    Reject a tarball member whose declared size would blow the cap.
+
+    Combines a per-member check with a cumulative check against
+    ``total_so_far``. Decompression-bomb guard: a hostile stream that
+    declares a multi-GiB member (or N just-under-cap members) bails
+    here before ``extractfile`` reads a single byte.
+    """
+    if member.size > FIRMWARE_MAX_TOTAL_BYTES:
+        msg = (
+            f"tarball member {member.name!r} declares size {member.size} "
+            f"exceeding FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+        raise error_cls(msg)
+    if total_so_far + member.size > FIRMWARE_MAX_TOTAL_BYTES:
+        msg = (
+            f"tarball cumulative size {total_so_far + member.size} "
+            f"exceeds FIRMWARE_MAX_TOTAL_BYTES {FIRMWARE_MAX_TOTAL_BYTES}"
+        )
+        raise error_cls(msg)
+
+
+def read_member(
+    tar: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    *,
+    total_so_far: int,
+    error_cls: type[Exception],
+) -> tuple[bytes, int]:
+    """
+    Read *member*'s bytes; returns ``(payload, new running total)``.
+
+    Rejects non-regular members (directories, links, devices) and any
+    member :func:`check_member_size` refuses. The ``extractfile`` None
+    branch is defence only — ``isfile()`` already gates every member
+    type it returns None for.
+    """
+    if not member.isfile():
+        raise error_cls(f"tarball member {member.name!r} is not a regular file")
+    check_member_size(member, total_so_far=total_so_far, error_cls=error_cls)
+    stream = tar.extractfile(member)
+    if stream is None:
+        raise error_cls(f"tarball member {member.name!r} unreadable")
+    payload = stream.read()
+    return payload, total_so_far + len(payload)
+
+
+def parse_json_object(payload: bytes, *, label: str, error_cls: type[Exception]) -> dict[str, Any]:
+    """Parse *payload* as a JSON object; raise *error_cls* on invalid / non-dict."""
+    try:
+        parsed = json_loads(payload)
+    except ValueError as err:
+        raise error_cls(f"{label} is not valid JSON: {err}") from err
+    if not isinstance(parsed, dict):
+        raise error_cls(f"{label} is not a JSON object")
+    return parsed

--- a/esphome_device_builder/helpers/tarball_read.py
+++ b/esphome_device_builder/helpers/tarball_read.py
@@ -13,12 +13,9 @@ def check_member_size(
     member: tarfile.TarInfo, *, total_so_far: int, error_cls: type[Exception]
 ) -> None:
     """
-    Reject a tarball member whose declared size would blow the cap.
+    Reject a member whose declared size breaches the cap, alone or cumulatively.
 
-    Combines a per-member check with a cumulative check against
-    ``total_so_far``. Decompression-bomb guard: a hostile stream that
-    declares a multi-GiB member (or N just-under-cap members) bails
-    here before ``extractfile`` reads a single byte.
+    Decompression-bomb guard; runs before ``extractfile`` reads a byte.
     """
     if member.size > FIRMWARE_MAX_TOTAL_BYTES:
         msg = (
@@ -55,8 +52,9 @@ def read_member(
     stream = tar.extractfile(member)
     if stream is None:
         raise error_cls(f"tarball member {member.name!r} unreadable")
-    payload = stream.read()
-    return payload, total_so_far + len(payload)
+    with stream:
+        payload = stream.read()
+    return payload, total_so_far + member.size
 
 
 def parse_json_object(payload: bytes, *, label: str, error_cls: type[Exception]) -> dict[str, Any]:

--- a/tests/helpers/test_tarball_read.py
+++ b/tests/helpers/test_tarball_read.py
@@ -1,0 +1,100 @@
+"""Tests for helpers.tarball_read."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from esphome_device_builder.helpers.tarball_read import (
+    check_member_size,
+    parse_json_object,
+    read_member,
+)
+
+
+class _CustomError(Exception):
+    pass
+
+
+def _tar_with(members: dict[str, bytes]) -> tarfile.TarFile:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+    buf.seek(0)
+    return tarfile.open(fileobj=buf, mode="r")
+
+
+def test_check_member_size_rejects_per_member_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES", 10)
+    info = tarfile.TarInfo(name="big.bin")
+    info.size = 11
+    with pytest.raises(_CustomError, match=r"exceeding FIRMWARE_MAX_TOTAL_BYTES"):
+        check_member_size(info, total_so_far=0, error_cls=_CustomError)
+
+
+def test_check_member_size_rejects_cumulative_over_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES", 10)
+    info = tarfile.TarInfo(name="second.bin")
+    info.size = 6
+    with pytest.raises(_CustomError, match=r"cumulative size"):
+        check_member_size(info, total_so_far=6, error_cls=_CustomError)
+
+
+def test_check_member_size_accepts_at_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES", 10)
+    info = tarfile.TarInfo(name="fits.bin")
+    info.size = 4
+    check_member_size(info, total_so_far=6, error_cls=_CustomError)
+
+
+def test_read_member_returns_payload_and_running_total() -> None:
+    with _tar_with({"a.bin": b"12345"}) as tar:
+        member = tar.getmember("a.bin")
+        payload, total = read_member(tar, member, total_so_far=7, error_cls=_CustomError)
+    assert payload == b"12345"
+    assert total == 12
+
+
+def test_read_member_rejects_non_regular_member() -> None:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name="some_dir/")
+        info.type = tarfile.DIRTYPE
+        tar.addfile(info)
+    buf.seek(0)
+    with tarfile.open(fileobj=buf, mode="r") as tar:
+        member = tar.getmembers()[0]
+        with pytest.raises(_CustomError, match=r"is not a regular file"):
+            read_member(tar, member, total_so_far=0, error_cls=_CustomError)
+
+
+def test_read_member_enforces_size_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES", 3)
+    with _tar_with({"a.bin": b"12345"}) as tar:
+        member = tar.getmember("a.bin")
+        with pytest.raises(_CustomError, match=r"exceeding FIRMWARE_MAX_TOTAL_BYTES"):
+            read_member(tar, member, total_so_far=0, error_cls=_CustomError)
+
+
+def test_parse_json_object_round_trips_a_dict() -> None:
+    assert parse_json_object(b'{"a": 1}', label="x.json", error_cls=_CustomError) == {"a": 1}
+
+
+@pytest.mark.parametrize("payload", [b"null", b"[1]", b'"x"', b"42"], ids=str)
+def test_parse_json_object_rejects_non_dict(payload: bytes) -> None:
+    with pytest.raises(_CustomError, match=r"x\.json is not a JSON object"):
+        parse_json_object(payload, label="x.json", error_cls=_CustomError)
+
+
+def test_parse_json_object_rejects_invalid_json() -> None:
+    with pytest.raises(_CustomError, match=r"x\.json is not valid JSON"):
+        parse_json_object(b"{not-json", label="x.json", error_cls=_CustomError)

--- a/tests/test_remote_artifacts_materialise.py
+++ b/tests/test_remote_artifacts_materialise.py
@@ -765,7 +765,7 @@ def test_materialise_rejects_oversized_member(
 ) -> None:
     """A member declaring more bytes than the cap is rejected as a decompression-bomb defence."""
     monkeypatch.setattr(
-        "esphome_device_builder.helpers.remote_artifacts_materialise.FIRMWARE_MAX_TOTAL_BYTES",
+        "esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES",
         16,
     )
     tarball = _synthetic_tarball()
@@ -926,7 +926,7 @@ def test_materialise_rejects_cumulative_member_size(
 ) -> None:
     """Two extract-side members whose sum breaches the cap raise on the second."""
     monkeypatch.setattr(
-        "esphome_device_builder.helpers.remote_artifacts_materialise.FIRMWARE_MAX_TOTAL_BYTES",
+        "esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES",
         500,
     )
     # storage / idedata read via _read_member_required (single-member
@@ -952,7 +952,7 @@ def test_materialise_rejects_cumulative_metadata_size(
     breach on the second read.
     """
     monkeypatch.setattr(
-        "esphome_device_builder.helpers.remote_artifacts_materialise.FIRMWARE_MAX_TOTAL_BYTES",
+        "esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES",
         500,
     )
     bloated = b"x" * 300

--- a/tests/test_remote_build_artifacts_download.py
+++ b/tests/test_remote_build_artifacts_download.py
@@ -965,7 +965,7 @@ def test_unpack_artifacts_response_directory_entry_raises() -> None:
         dir_info.type = tarfile.DIRTYPE
         tar.addfile(dir_info)
 
-    with pytest.raises(UnpackArtifactsError, match="non-file tarball entry"):
+    with pytest.raises(UnpackArtifactsError, match="is not a regular file"):
         unpack_artifacts_response(
             DownloadArtifactsResult(tarball=buf.getvalue(), firmware_offset="0x0"),
             job_id="j",
@@ -1165,8 +1165,7 @@ def test_read_artifacts_tarball_rejects_cumulative_size_over_cap(
     """
     # Patch the cap to a tiny value so the test stays cheap.
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
-        "FIRMWARE_MAX_TOTAL_BYTES",
+        "esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES",
         128,
     )
     members = {
@@ -1185,8 +1184,7 @@ def test_read_artifacts_tarball_rejects_per_member_size_over_cap(
 ) -> None:
     """A single member declaring more bytes than the cap is rejected."""
     monkeypatch.setattr(
-        "esphome_device_builder.controllers.remote_build.artifacts_tarball."
-        "FIRMWARE_MAX_TOTAL_BYTES",
+        "esphome_device_builder.helpers.tarball_read.FIRMWARE_MAX_TOTAL_BYTES",
         128,
     )
     tarball = _build_minimal_tarball(


### PR DESCRIPTION
# What does this implement/fix?

The tarball unpack path and the materialise-locally path each carried their own copy of the same three read primitives: the decompression-bomb size cap, the read-a-member gate, and parse-JSON-or-raise. The two `_check_member_size` copies were a security gate maintained in lockstep by hand across two files; this hoists all three into a shared `helpers/tarball_read.py` that takes the caller's exception class, so `UnpackArtifactsError` keeps its WS mapping and `MaterialiseError` keeps its runner mapping.

One visible string changed; the unpack side's non-regular-member error now reads "is not a regular file" like the materialise side, instead of "unexpected non-file tarball entry". No other behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2162

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
