### PR TITLE
Add JobBuildSource.for_pairing for the triplicated server projection

### DIFF
--- a/esphome_device_builder/controllers/firmware/clean.py
+++ b/esphome_device_builder/controllers/firmware/clean.py
@@ -54,11 +54,7 @@ async def _fan_out_clean_to_connected_peers(
         remote_job = controller._create_job(
             configuration,
             JobType.CLEAN,
-            build_source=JobBuildSource.for_server(
-                pin_sha256=pairing.pin_sha256,
-                label=pairing.label,
-                esphome_version=pairing.esphome_version,
-            ),
+            build_source=JobBuildSource.for_pairing(pairing),
         )
         # ``supersede=False``: the fan-out batch is N+1 jobs sharing
         # one ``configuration``; default supersede would leave only

--- a/esphome_device_builder/controllers/firmware/remote_dispatch.py
+++ b/esphome_device_builder/controllers/firmware/remote_dispatch.py
@@ -161,13 +161,7 @@ def _dispatch_to_server(controller: FirmwareController, job: FirmwareJob, pin_sh
         # can't strand the compile (the next pass picks a live server).
         controller.state.remote_dispatch.wake.set()
         return
-    job.apply_build_source(
-        JobBuildSource.for_server(
-            pin_sha256=pairing.pin_sha256,
-            label=pairing.label,
-            esphome_version=pairing.esphome_version,
-        )
-    )
+    job.apply_build_source(JobBuildSource.for_pairing(pairing))
     # ``create_background_task`` is eager: ``_drive_remote`` runs its
     # ``begin_run`` prologue (stamps RUNNING, fires JOB_STARTED) synchronously
     # before ``start()`` records the in-flight entry. That's safe — no

--- a/esphome_device_builder/controllers/remote_build/submit_job_commands.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job_commands.py
@@ -95,11 +95,7 @@ async def reset_peer_build_env(controller: OffloaderController, *, pin_sha256: s
     job = firmware._create_job(
         "",
         JobType.RESET_BUILD_ENV,
-        build_source=JobBuildSource.for_server(
-            pin_sha256=clean_pin,
-            label=pairing.label,
-            esphome_version=pairing.esphome_version,
-        ),
+        build_source=JobBuildSource.for_pairing(pairing),
     )
     # supersede=False: reset jobs share the empty configuration key; the
     # default supersede would cancel an unrelated reset targeting another

--- a/esphome_device_builder/models/firmware.py
+++ b/esphome_device_builder/models/firmware.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import NamedTuple, TypedDict
+from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 from .common import DashboardModel, EventType
+
+if TYPE_CHECKING:
+    from .remote_build import StoredPairing
 
 
 def _now_iso() -> str:
@@ -126,6 +129,15 @@ class JobBuildSource:
             source_pin_sha256=pin_sha256,
             source_label=label,
             source_esphome_version=esphome_version,
+        )
+
+    @classmethod
+    def for_pairing(cls, pairing: StoredPairing) -> JobBuildSource:
+        """Bundle a REMOTE source bound to the server behind *pairing*."""
+        return cls.for_server(
+            pin_sha256=pairing.pin_sha256,
+            label=pairing.label,
+            esphome_version=pairing.esphome_version,
         )
 
 

--- a/tests/models/test_firmware_job.py
+++ b/tests/models/test_firmware_job.py
@@ -26,6 +26,7 @@ from esphome_device_builder.models.firmware import (
     JobStatus,
     JobType,
 )
+from esphome_device_builder.models.remote_build import StoredPairing
 
 
 def _make_job(**overrides: Any) -> FirmwareJob:
@@ -309,6 +310,25 @@ def test_for_server_bundles_a_remote_source() -> None:
     assert build_source.source_pin_sha256 == "a" * 64
     assert build_source.source_label == "desktop"
     assert build_source.source_esphome_version == "2026.5.0"
+
+
+def test_for_pairing_matches_for_server_field_for_field() -> None:
+    """``for_pairing`` projects exactly the fields ``for_server`` takes."""
+    pairing = StoredPairing(
+        receiver_hostname="r",
+        receiver_port=6055,
+        pin_sha256="a" * 64,
+        static_x25519_pub=b"\x01" * 32,
+        label="desktop",
+        paired_at=1.0,
+        esphome_version="2026.5.0",
+    )
+
+    assert JobBuildSource.for_pairing(pairing) == JobBuildSource.for_server(
+        pin_sha256=pairing.pin_sha256,
+        label=pairing.label,
+        esphome_version=pairing.esphome_version,
+    )
 
 
 def test_apply_build_source_stamps_the_job() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Three call sites built a server `JobBuildSource` from a pairing by spelling out the same three-field projection (`pin_sha256`, `label`, `esphome_version`): the clean fan-out, the remote reset command, and the dispatch pool's bind. A fourth field added to the server-source contract would have to be threaded through all three by hand. This adds `JobBuildSource.for_pairing(pairing)`, delegating to `for_server`, and collapses the three sites onto it. A model test pins `for_pairing` against `for_server` field for field. No behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2165

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
