### PR TITLE
Share the malformed-frame job_id fallback across receiver flows

### DIFF
--- a/esphome_device_builder/controllers/remote_build/reset_env.py
+++ b/esphome_device_builder/controllers/remote_build/reset_env.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from ...helpers.peer_link_frames import frame_schema, is_valid_frame
+from ...helpers.peer_link_frames import frame_schema, is_valid_frame, safe_job_id
 from ...models import JobType, ResetBuildEnvAckFrameData, ResetBuildEnvFrameData
 from .peer_link import TerminateReason
 
@@ -39,10 +39,9 @@ async def handle_reset_build_env(
             session.dashboard_id,
             frame,
         )
-        raw_job_id = frame.get("job_id")
         await _send_ack(
             session,
-            job_id=raw_job_id if isinstance(raw_job_id, str) else "",
+            job_id=safe_job_id(frame),
             accepted=False,
             reason=_REASON_INVALID_FRAME,
         )

--- a/esphome_device_builder/controllers/remote_build/submit_job.py
+++ b/esphome_device_builder/controllers/remote_build/submit_job.py
@@ -70,7 +70,7 @@ from ...helpers.peer_link_bundle import (
     BundleAssemblerErrorCode,
     decode_chunk,
 )
-from ...helpers.peer_link_frames import frame_schema, is_valid_frame
+from ...helpers.peer_link_frames import frame_schema, is_valid_frame, safe_job_id
 from ...helpers.remote_build_layout import REMOTE_BUILDS_SUBDIR, RemoteBuildPath
 from ...helpers.version_compat import coerce_pep440_version
 from ...models import (
@@ -406,10 +406,9 @@ class SubmitJobReceiver:
         # method operates on after the gate.
         raw = cast(dict[str, Any], frame)
         if not is_valid_frame(_SUBMIT_JOB_HEADER_SCHEMA, raw):
-            job_id = raw.get("job_id") if isinstance(raw.get("job_id"), str) else ""
             await self._reject(
                 session,
-                job_id=cast(str, job_id),
+                job_id=safe_job_id(raw),
                 reason=_REASON_INVALID_HEADER,
                 terminate_session=True,
             )
@@ -483,10 +482,9 @@ class SubmitJobReceiver:
         # and terminate.
         chunk_dict = cast(dict[str, Any], frame)
         if not is_valid_frame(_SUBMIT_JOB_CHUNK_SCHEMA, chunk_dict):
-            job_id = chunk_dict.get("job_id") if isinstance(chunk_dict.get("job_id"), str) else ""
             await self._reject(
                 session,
-                job_id=cast(str, job_id),
+                job_id=safe_job_id(chunk_dict),
                 reason=_REASON_INVALID_CHUNK,
                 drop_inflight=True,
                 terminate_session=True,

--- a/esphome_device_builder/helpers/peer_link_frames.py
+++ b/esphome_device_builder/helpers/peer_link_frames.py
@@ -64,6 +64,12 @@ def frame_schema(required: dict[str, Any]) -> vol.Schema:
     return vol.Schema(cooked, extra=vol.ALLOW_EXTRA, required=True)
 
 
+def safe_job_id(frame: dict[str, Any]) -> str:
+    """Best-effort ``job_id`` from a frame that failed its schema gate."""
+    job_id = frame.get("job_id")
+    return job_id if isinstance(job_id, str) else ""
+
+
 def is_valid_frame(schema: vol.Schema, frame: dict[str, Any]) -> bool:
     """Return ``True`` iff *frame* passes *schema*; swallow ``vol.Invalid``.
 

--- a/tests/test_peer_link_frames.py
+++ b/tests/test_peer_link_frames.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from esphome_device_builder.helpers.peer_link_frames import frame_schema, is_valid_frame
+from esphome_device_builder.helpers.peer_link_frames import (
+    frame_schema,
+    is_valid_frame,
+    safe_job_id,
+)
 
 
 def test_is_valid_frame_accepts_matching_required_fields() -> None:
@@ -52,3 +56,19 @@ def test_is_valid_frame_empty_required_passes_any_frame() -> None:
     schema = frame_schema({})
     assert is_valid_frame(schema, {}) is True
     assert is_valid_frame(schema, {"x": 1}) is True
+
+
+def test_safe_job_id_returns_string_job_id() -> None:
+    """A string ``job_id`` passes through."""
+    assert safe_job_id({"job_id": "j-1"}) == "j-1"
+
+
+def test_safe_job_id_falls_back_on_missing_key() -> None:
+    """A frame with no ``job_id`` yields the empty fallback."""
+    assert safe_job_id({}) == ""
+
+
+def test_safe_job_id_falls_back_on_non_string() -> None:
+    """A wrong-typed ``job_id`` yields the empty fallback."""
+    assert safe_job_id({"job_id": 42}) == ""
+    assert safe_job_id({"job_id": None}) == ""


### PR DESCRIPTION
# What does this implement/fix?

Every receiver flow's malformed-frame preamble hand-rolled the same best-effort `job_id` extraction (`frame.get("job_id") if isinstance(..., str) else ""`) before rejecting and terminating; three copies across the submit header, submit chunk, and reset handlers. This hoists it into `helpers.peer_link_frames.safe_job_id` next to the schema gate the same preambles already share, and drops the now-unneeded casts at the call sites.

The scope is deliberately just the preamble; the per-flow ack senders keep their distinct TypedDicts and behavior, and the reject reason strings stay a per-flow wire seam as documented in `_validators.py`. No behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2166

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
