### PR TITLE
DRY the monitor apply_* differ-check tail into _apply_observation

### DIFF
--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -444,9 +444,7 @@ class DeviceStateMonitor(TaskControllerBase):
         """Record a firmware version observation; True iff forwarded."""
         if not version or (forward := self._on_version_change) is None:
             return False
-        return self._apply_observation(
-            name, "deployed_version", version, partial(forward, name, version)
-        )
+        return self._apply_observation(name, "deployed_version", version, forward, name, version)
 
     def apply_api_encryption(self, name: str, encryption: str) -> bool:
         """
@@ -475,7 +473,7 @@ class DeviceStateMonitor(TaskControllerBase):
         if (forward := self._on_api_encryption_change) is None:
             return False
         return self._apply_observation(
-            name, "api_encryption_active", encryption, partial(forward, name, encryption)
+            name, "api_encryption_active", encryption, forward, name, encryption
         )
 
     def apply_config_hash(self, name: str, config_hash: str) -> bool:
@@ -488,7 +486,7 @@ class DeviceStateMonitor(TaskControllerBase):
         if not config_hash or (forward := self._on_config_hash_change) is None:
             return False
         return self._apply_observation(
-            name, "deployed_config_hash", config_hash, partial(forward, name, config_hash)
+            name, "deployed_config_hash", config_hash, forward, name, config_hash
         )
 
     def apply_mac_address(self, name: str, mac: str) -> bool:
@@ -506,9 +504,7 @@ class DeviceStateMonitor(TaskControllerBase):
         normalized = _normalize_mac(mac)
         if not normalized:
             return False
-        return self._apply_observation(
-            name, "mac_address", normalized, partial(forward, name, normalized)
-        )
+        return self._apply_observation(name, "mac_address", normalized, forward, name, normalized)
 
     def apply_deployed_identity_live(self, name: str, *, live: bool) -> bool:
         """
@@ -525,7 +521,7 @@ class DeviceStateMonitor(TaskControllerBase):
         if live and self._mdns_owns_api_identity(name):
             return False
         return self._apply_observation(
-            name, "deployed_identity_live", live, partial(forward, name, live=live)
+            name, "deployed_identity_live", live, forward, name, live=live
         )
 
     def _mdns_owns_api_identity(self, name: str) -> bool:
@@ -546,13 +542,23 @@ class DeviceStateMonitor(TaskControllerBase):
             device.api_enabled for device in self._get_devices_by_name(name)
         )
 
-    def _apply_observation(
-        self, name: str, attr: str, value: Any, forward: Callable[[], None]
+    def _apply_observation[**P](
+        self,
+        name: str,
+        attr: str,
+        value: Any,
+        forward: Callable[P, None],
+        *args: P.args,
+        **kwargs: P.kwargs,
     ) -> bool:
-        """Differ-gate an observation; invoke *forward* and return True iff it changed anything."""
+        """Differ-gate an observation; invoke *forward* and return True iff it changed anything.
+
+        Takes the callback and its arguments separately so the
+        steady-state dedupe path allocates no wrapper.
+        """
         if not self._any_matching_device_differs(name, attr, value):
             return False
-        forward()
+        forward(*args, **kwargs)
         return True
 
     def _any_matching_device_differs(self, name: str, attr: str, value: Any) -> bool:

--- a/esphome_device_builder/controllers/_device_state_monitor/controller.py
+++ b/esphome_device_builder/controllers/_device_state_monitor/controller.py
@@ -442,12 +442,11 @@ class DeviceStateMonitor(TaskControllerBase):
 
     def apply_version(self, name: str, version: str) -> bool:
         """Record a firmware version observation; True iff forwarded."""
-        if not version or self._on_version_change is None:
+        if not version or (forward := self._on_version_change) is None:
             return False
-        if not self._any_matching_device_differs(name, "deployed_version", version):
-            return False
-        self._on_version_change(name, version)
-        return True
+        return self._apply_observation(
+            name, "deployed_version", version, partial(forward, name, version)
+        )
 
     def apply_api_encryption(self, name: str, encryption: str) -> bool:
         """
@@ -473,12 +472,11 @@ class DeviceStateMonitor(TaskControllerBase):
         last-known truthy value and trip the "reinstall to apply"
         prompt.
         """
-        if self._on_api_encryption_change is None:
+        if (forward := self._on_api_encryption_change) is None:
             return False
-        if not self._any_matching_device_differs(name, "api_encryption_active", encryption):
-            return False
-        self._on_api_encryption_change(name, encryption)
-        return True
+        return self._apply_observation(
+            name, "api_encryption_active", encryption, partial(forward, name, encryption)
+        )
 
     def apply_config_hash(self, name: str, config_hash: str) -> bool:
         """
@@ -487,12 +485,11 @@ class DeviceStateMonitor(TaskControllerBase):
         Empty strings dropped so pre-#16145 firmware (no
         ``config_hash`` TXT) doesn't churn the callback.
         """
-        if not config_hash or self._on_config_hash_change is None:
+        if not config_hash or (forward := self._on_config_hash_change) is None:
             return False
-        if not self._any_matching_device_differs(name, "deployed_config_hash", config_hash):
-            return False
-        self._on_config_hash_change(name, config_hash)
-        return True
+        return self._apply_observation(
+            name, "deployed_config_hash", config_hash, partial(forward, name, config_hash)
+        )
 
     def apply_mac_address(self, name: str, mac: str) -> bool:
         """
@@ -504,15 +501,14 @@ class DeviceStateMonitor(TaskControllerBase):
         inputs are dropped so a broadcast that omits the ``mac``
         TXT (older firmware) doesn't blank an already-known value.
         """
-        if self._on_mac_address_change is None:
+        if (forward := self._on_mac_address_change) is None:
             return False
         normalized = _normalize_mac(mac)
         if not normalized:
             return False
-        if not self._any_matching_device_differs(name, "mac_address", normalized):
-            return False
-        self._on_mac_address_change(name, normalized)
-        return True
+        return self._apply_observation(
+            name, "mac_address", normalized, partial(forward, name, normalized)
+        )
 
     def apply_deployed_identity_live(self, name: str, *, live: bool) -> bool:
         """
@@ -524,14 +520,13 @@ class DeviceStateMonitor(TaskControllerBase):
         a stamp made under ownership would never see the
         transition-into-mdns clear in :meth:`_emit_source_change`.
         """
-        if self._on_deployed_identity_live_change is None:
+        if (forward := self._on_deployed_identity_live_change) is None:
             return False
         if live and self._mdns_owns_api_identity(name):
             return False
-        if not self._any_matching_device_differs(name, "deployed_identity_live", live):
-            return False
-        self._on_deployed_identity_live_change(name, live=live)
-        return True
+        return self._apply_observation(
+            name, "deployed_identity_live", live, partial(forward, name, live=live)
+        )
 
     def _mdns_owns_api_identity(self, name: str) -> bool:
         """
@@ -550,6 +545,15 @@ class DeviceStateMonitor(TaskControllerBase):
         return self.priority_for(name) is ReachabilitySource.MDNS and any(
             device.api_enabled for device in self._get_devices_by_name(name)
         )
+
+    def _apply_observation(
+        self, name: str, attr: str, value: Any, forward: Callable[[], None]
+    ) -> bool:
+        """Differ-gate an observation; invoke *forward* and return True iff it changed anything."""
+        if not self._any_matching_device_differs(name, attr, value):
+            return False
+        forward()
+        return True
 
     def _any_matching_device_differs(self, name: str, attr: str, value: Any) -> bool:
         """


### PR DESCRIPTION
# What does this implement/fix?

Five `DeviceStateMonitor.apply_*` methods ended with the same mechanical tail: `_any_matching_device_differs`, invoke the owner callback, return True. This hoists that ordering into one `_apply_observation(name, attr, value, forward)`; each `apply_*` keeps its source-specific prelude (empty-value drops, mac normalisation, the deployed_identity_live mDNS-ownership gate) and narrows its callback with a walrus before handing a `partial` to the helper, so every call stays fully typed, including the keyword-only `live=`. The differ-before-forward dedupe contract now lives in one place. No behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2168

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable (behaviour-free refactor; the existing monitor dedupe suites already pin the differ-before-forward contract).
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
