### PR TITLE
Share the idedata flash_images walk via iter_flash_images

### DIFF
--- a/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
+++ b/esphome_device_builder/controllers/remote_build/artifacts_tarball.py
@@ -61,7 +61,7 @@ from typing import TYPE_CHECKING, Any
 from esphome.storage_json import StorageJSON
 
 from ...constants import TOOLCHAIN_ESP_IDF
-from ...helpers.build_artifacts import _firmware_offset_for_platform
+from ...helpers.build_artifacts import _firmware_offset_for_platform, iter_flash_images
 from ...helpers.cross_os_path import cross_os_basename
 from ...helpers.peer_link_bundle import FIRMWARE_MAX_TOTAL_BYTES
 from ...helpers.storage_path import (
@@ -505,16 +505,7 @@ def _build_images_response(
         msg = "artifacts tarball missing firmware.bin"
         raise UnpackArtifactsError(msg)
     images.append(_image_entry("firmware.bin", firmware_offset, firmware_bytes))
-    # Guard the chained ``.get`` — a non-dict ``extra`` field
-    # (``null`` / list / scalar) on a corrupt-but-parseable
-    # idedata would otherwise blow up on the second ``.get``
-    # with ``AttributeError`` and bypass the
-    # :class:`UnpackArtifactsError` mapping. Mirror the
-    # :func:`helpers.build_artifacts.load_build_artifacts`
-    # stance: treat non-dict as "no extras."
-    extra = idedata.get("extra")
-    extras_list = extra.get("flash_images") or [] if isinstance(extra, dict) else []
-    for entry in extras_list:
+    for entry in iter_flash_images(idedata):
         basename, offset = _flash_image_basename_offset(entry)
         image_bytes = image_bytes_by_name.pop(basename, None)
         if image_bytes is None:
@@ -562,10 +553,9 @@ def _rewrite_idedata_paths(idedata: dict[str, Any]) -> dict[str, Any]:
     extra = idedata.get("extra")
     if not isinstance(extra, dict):
         return idedata
-    flash_images = extra.get("flash_images") or []
     rewritten = [
         {**entry, "path": cross_os_basename(entry["path"])}
-        for entry in flash_images
+        for entry in iter_flash_images(idedata)
         if isinstance(entry, dict) and isinstance(entry.get("path"), str)
     ]
     return {**idedata, "extra": {**extra, "flash_images": rewritten}}

--- a/esphome_device_builder/helpers/build_artifacts.py
+++ b/esphome_device_builder/helpers/build_artifacts.py
@@ -49,8 +49,10 @@ canonical "firmware image" path which is the same value
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from esphome.helpers import rmtree
 from esphome.storage_json import StorageJSON
@@ -112,6 +114,19 @@ class BuildArtifacts:
 
     flash_images: list[FlashArtifact]
     idedata_bytes: bytes
+
+
+def iter_flash_images(idedata: dict[str, Any]) -> Iterator[Any]:
+    """
+    Yield raw ``idedata.extra.flash_images`` entries.
+
+    A non-dict ``extra`` (null / list / scalar on corrupt-but-parseable
+    idedata) and a missing / null list both yield nothing. Entries are
+    yielded unvalidated; each caller owns its malformed-entry policy.
+    """
+    extra = idedata.get("extra")
+    if isinstance(extra, dict):
+        yield from extra.get("flash_images") or []
 
 
 def load_build_artifacts(configuration: str) -> BuildArtifacts:
@@ -202,9 +217,7 @@ def load_build_artifacts(configuration: str) -> BuildArtifacts:
     # the StorageJSON sidecar and pick the offset.
     firmware_offset = _firmware_offset_for_platform(storage.target_platform)
     flash_images: list[FlashArtifact] = [FlashArtifact(path=firmware_bin, offset=firmware_offset)]
-    extra = idedata.get("extra")
-    raw_flash_images = extra.get("flash_images", []) if isinstance(extra, dict) else []
-    for entry in raw_flash_images:
+    for entry in iter_flash_images(idedata):
         # Defensive isinstance gate — a corrupt-but-parseable
         # ``flash_images`` entry (string / null / nested array)
         # would otherwise blow up on ``.get("path")`` with

--- a/esphome_device_builder/helpers/remote_artifacts_materialise.py
+++ b/esphome_device_builder/helpers/remote_artifacts_materialise.py
@@ -37,6 +37,7 @@ from ..controllers.remote_build.artifacts_tarball import (
     STORAGE_MEMBER_NAME,
     VALIDATED_YAML_MEMBER_NAME,
 )
+from .build_artifacts import iter_flash_images
 from .cross_os_path import receiver_pure_path_cls
 from .json import dumps_indent
 from .storage_path import (
@@ -359,9 +360,7 @@ def _remap_idedata_build_paths(
 
     if (prog := _remap(data.get("prog_path"))) is not None:
         data["prog_path"] = prog
-    extra = data.get("extra")
-    flash_images = extra.get("flash_images") if isinstance(extra, dict) else None
-    for image in flash_images or []:
+    for image in iter_flash_images(data):
         if not isinstance(image, dict):
             continue
         if (remapped := _remap(image.get("path"))) is not None:

--- a/tests/test_build_artifacts.py
+++ b/tests/test_build_artifacts.py
@@ -16,6 +16,7 @@ import pytest
 
 from esphome_device_builder.helpers.build_artifacts import (
     _firmware_offset_for_platform,
+    iter_flash_images,
     load_build_artifacts,
 )
 
@@ -202,3 +203,26 @@ def test_load_build_artifacts_handles_non_dict_extra(tmp_path: Path) -> None:
 def test_firmware_offset_for_platform(platform: str, expected_offset: str) -> None:
     """ESP32 family → ``0x10000``; everything else → ``0x0``."""
     assert _firmware_offset_for_platform(platform) == expected_offset
+
+
+@pytest.mark.parametrize(
+    "idedata",
+    [
+        {},
+        {"extra": None},
+        {"extra": []},
+        {"extra": "x"},
+        {"extra": {}},
+        {"extra": {"flash_images": None}},
+    ],
+    ids=["no-extra", "null-extra", "list-extra", "scalar-extra", "empty-extra", "null-list"],
+)
+def test_iter_flash_images_tolerates_malformed_extra(idedata: dict) -> None:
+    """Non-dict ``extra`` and missing / null lists yield nothing."""
+    assert list(iter_flash_images(idedata)) == []
+
+
+def test_iter_flash_images_yields_entries_verbatim() -> None:
+    """Entries come back raw and in declared order; validation is the caller's."""
+    entries = [{"path": "a.bin", "offset": "0x0"}, "malformed", {"path": "b.bin"}]
+    assert list(iter_flash_images({"extra": {"flash_images": entries}})) == entries


### PR DESCRIPTION
# What does this implement/fix?

The defensive walk of `idedata.extra.flash_images` (isinstance gate on `extra`, tolerate a missing or null list) was hand-rolled at four sites: `load_build_artifacts`, the tarball response builder, the tarball idedata path rewrite, and the materialiser's path remap. The subtle part, a non-dict `extra` on corrupt-but-parseable idedata bypassing the `.get` chain with `AttributeError`, had to be re-derived at each site and one comment already cross-referenced another site's stance to stay in sync.

This adds `iter_flash_images(idedata)` in `helpers/build_artifacts.py` owning that gate and yielding raw entries; the four sites collapse onto it. Entries stay unvalidated on purpose, the per-entry policies genuinely differ (warn and skip, raise a typed error, silently filter) and remain with each caller.

One deliberate hardening rides along: `load_build_artifacts` previously used `extra.get("flash_images", [])`, so a present-but-null `flash_images` crashed with `TypeError`; the shared gate uses `or []` like the other three sites already did, so that input now yields no extras. No other behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2164

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
