### PR TITLE
DRY the archive filesystem-error translation into one contextmanager

### DIFF
--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -33,10 +33,9 @@ _LOGGER = logging.getLogger(__name__)
 @contextmanager
 def _translate_archive_fs_errors(configuration: str, *, archived: bool = False) -> Iterator[None]:
     """
-    Map filesystem races onto the wire contract.
+    Map ``FileExistsError`` to INVALID_ARGS and ``FileNotFoundError`` to NOT_FOUND.
 
-    A concurrent delete can win between an archive op's pre-check and
-    its move / unlink; keep the not_found surface stable.
+    *archived* selects the "Archived file" not-found prefix.
     """
     try:
         yield

--- a/esphome_device_builder/controllers/devices/archive.py
+++ b/esphome_device_builder/controllers/devices/archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from esphome.storage_json import StorageJSON
@@ -22,11 +23,28 @@ from ...models import ErrorCode
 from .helpers import _validate_archive_configuration, require_file_exists
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Awaitable, Callable, Iterator, Sequence
 
     from .controller import DevicesController
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@contextmanager
+def _translate_archive_fs_errors(configuration: str, *, archived: bool = False) -> Iterator[None]:
+    """
+    Map filesystem races onto the wire contract.
+
+    A concurrent delete can win between an archive op's pre-check and
+    its move / unlink; keep the not_found surface stable.
+    """
+    try:
+        yield
+    except FileExistsError as exc:
+        raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
+    except FileNotFoundError as exc:
+        prefix = "Archived file" if archived else "File"
+        raise CommandError(ErrorCode.NOT_FOUND, f"{prefix} not found: {configuration}") from exc
 
 
 async def archive_single(controller: DevicesController, configuration: str) -> None:
@@ -64,14 +82,8 @@ async def archive_single(controller: DevicesController, configuration: str) -> N
     # concurrent editor save to the same config can't interleave with the
     # archive's removal commit (same serialisation as ``_persist_yaml_mutation``).
     async with controller._yaml_write_lock(configuration):
-        try:
+        with _translate_archive_fs_errors(configuration):
             await run_in_executor(_archive_sync)
-        except FileExistsError as exc:
-            raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
-        except FileNotFoundError as exc:
-            # A concurrent delete can win between the pre-check and the
-            # move; keep the not_found surface stable.
-            raise CommandError(ErrorCode.NOT_FOUND, f"File not found: {configuration}") from exc
         # Drop volatile fields across both stores: live mDNS state and
         # build-dir caches in the data_dir store, plus ``mac_address``
         # in the shared sidecar (intrinsic to the physical board, but
@@ -101,15 +113,8 @@ async def unarchive_single(controller: DevicesController, configuration: str) ->
             raise FileExistsError(msg)
         shutil.move(str(archive_path), str(target))
 
-    try:
+    with _translate_archive_fs_errors(configuration, archived=True):
         await run_in_executor(_unarchive_sync)
-    except FileExistsError as exc:
-        raise CommandError(ErrorCode.INVALID_ARGS, str(exc)) from exc
-    except FileNotFoundError as exc:
-        # A concurrent delete can win between the pre-check and the move.
-        raise CommandError(
-            ErrorCode.NOT_FOUND, f"Archived file not found: {configuration}"
-        ) from exc
 
 
 def list_archived_sync(controller: DevicesController) -> list[dict[str, Any]]:
@@ -165,13 +170,8 @@ async def delete_archived_single(controller: DevicesController, configuration: s
         unlink_compiled_config(configuration)
         return True
 
-    try:
+    with _translate_archive_fs_errors(configuration, archived=True):
         sidecars_purged = await run_in_executor(_delete_all)
-    except FileNotFoundError as exc:
-        # A concurrent delete can win between the pre-check and the unlink.
-        raise CommandError(
-            ErrorCode.NOT_FOUND, f"Archived file not found: {configuration}"
-        ) from exc
     if sidecars_purged:
         # Drop the per-device metadata entry (both the store +
         # shared identity sidecar) on the event loop side and


### PR DESCRIPTION
# What does this implement/fix?

The three archive handlers copy-pasted the same filesystem-error to `CommandError` translation around their executor hop, each with its own copy of the "a concurrent delete can win between the pre-check and the move" rationale; the not-found prefix was the only variation. This hoists it into a `_translate_archive_fs_errors(configuration, archived=...)` contextmanager beside the handlers, so the NOT_FOUND / INVALID_ARGS wire mapping lives once. The delete path never raises `FileExistsError`, so its now-shared mapping for that case is inert. No behaviour change; the existing archive error-path tests pin both codes and messages.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2169

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable (behaviour-free refactor; the existing archive error-path tests pin both error codes and messages).
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
