### PR TITLE
Share the exclusive-create YAML write between create and clone

### DIFF
--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -57,8 +57,10 @@ async def write_new_file_exclusive(
     """
     Exclusive-create (``open("x")``) *content* at *path* off the event loop.
 
-    A ``FileExistsError`` is delegated to *on_exists*, which raises the
-    caller's typed error.
+    The ``x`` mode refuses to clobber an existing file with no TOCTOU
+    window; a check-then-write or staged-move shape would reopen the
+    race. A ``FileExistsError`` is delegated to *on_exists*, which
+    raises the caller's typed error.
     """
 
     def _write() -> None:

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -11,13 +11,14 @@ from esphome.core.config import FRIENDLY_NAME_MAX_LEN
 from esphome.helpers import friendly_name_slugify, sort_ip_addresses
 
 from ...helpers.api import CommandError
+from ...helpers.async_ import run_in_executor
 from ...helpers.hostname import is_local_hostname, normalize_hostname
 from ...helpers.yaml import read_yaml_scalar, rewrite_name_or_substitution
 from ...models import ConfigEntryType, Device, ErrorCode
 from .constants import _CONCEALED_SECRET_RE
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from ...models import ComponentCatalogEntry, ConfigEntry
     from .._device_state_monitor import DeviceStateMonitor
@@ -43,10 +44,31 @@ __all__ = [
     "raise_device_not_found",
     "require_file_exists",
     "slugify_hostname",
+    "write_new_file_exclusive",
 ]
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def write_new_file_exclusive(
+    path: Path, content: str, *, on_exists: Callable[[BaseException], NoReturn]
+) -> None:
+    """
+    Exclusive-create (``open("x")``) *content* at *path* off the event loop.
+
+    A ``FileExistsError`` is delegated to *on_exists*, which raises the
+    caller's typed error.
+    """
+
+    def _write() -> None:
+        with path.open("x", encoding="utf-8") as f:
+            f.write(content)
+
+    try:
+        await run_in_executor(_write)
+    except FileExistsError as exc:
+        on_exists(exc)
 
 
 def raise_device_not_found(

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -69,6 +69,7 @@ async def write_new_file_exclusive(
         await run_in_executor(_write)
     except FileExistsError as exc:
         on_exists(exc)
+        raise
 
 
 def raise_device_not_found(

--- a/esphome_device_builder/controllers/devices/mutations_clone.py
+++ b/esphome_device_builder/controllers/devices/mutations_clone.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
@@ -20,6 +20,7 @@ from .helpers import (
     clean_friendly_name,
     friendly_name_slugify,
     raise_device_name_exists,
+    write_new_file_exclusive,
 )
 
 if TYPE_CHECKING:
@@ -141,18 +142,14 @@ async def clone_device(  # noqa: C901
     carry_board_id = source_meta.get("board_id") if source_meta else None
     carry_user_set = source_meta.get("board_id_user_set") if source_meta else None
 
-    def _commit() -> None:
-        with new_path.open("x", encoding="utf-8") as f:
-            f.write(new_content)
-
-    try:
-        await run_in_executor(_commit)
-    except FileExistsError as exc:
+    def _raise_name_exists(exc: BaseException) -> NoReturn:
         # Race: another caller created the file between our
         # gather pass and the ``open(... "x")``. Surface as the
         # same INVALID_ARGS the preflight produces so the
         # frontend renders a single message.
         raise_device_name_exists(new_filename, from_exc=exc)
+
+    await write_new_file_exclusive(new_path, new_content, on_exists=_raise_name_exists)
     if carry_board_id and carry_user_set is True:
         await controller._persist_device_metadata_async(
             new_filename, board_id=carry_board_id, board_id_user_set=True

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON
@@ -15,7 +15,12 @@ from ...helpers.hostname import default_mdns_address
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, WizardResponse
 from ..editor import IMPORT_VALIDATE_TIMEOUT
-from .helpers import _looks_binary, clean_friendly_name, slugify_hostname
+from .helpers import (
+    _looks_binary,
+    clean_friendly_name,
+    slugify_hostname,
+    write_new_file_exclusive,
+)
 
 if TYPE_CHECKING:
     from .controller import DevicesController
@@ -165,12 +170,9 @@ async def create_device(  # noqa: C901, PLR0912
     if not board_id:
         parsed_platform, _pio_board, _variant = parse_platform_from_yaml(yaml_content)
 
-    def _write_exclusive() -> None:
-        # Exclusive-create so a concurrent ``devices/create`` (or
-        # any other writer) can't slip between a preflight check
-        # and the write and silently clobber an in-flight config.
-        with config_path.open("x", encoding="utf-8") as f:
-            f.write(yaml_content)
+    def _raise_already_exists(exc: BaseException) -> NoReturn:
+        msg = f"Configuration {filename} already exists"
+        raise CommandError(ErrorCode.ALREADY_EXISTS, msg) from exc
 
     overwriting = overwrite and file_existed
     if overwriting:
@@ -178,11 +180,7 @@ async def create_device(  # noqa: C901, PLR0912
         # half-written config; the user explicitly confirmed the overwrite.
         await run_in_executor(atomic_write_file, config_path, yaml_content)
     else:
-        try:
-            await run_in_executor(_write_exclusive)
-        except FileExistsError as exc:
-            msg = f"Configuration {filename} already exists"
-            raise CommandError(ErrorCode.ALREADY_EXISTS, msg) from exc
+        await write_new_file_exclusive(config_path, yaml_content, on_exists=_raise_already_exists)
 
     # Overwriting an existing device keeps its StorageJSON (build state)
     # and dashboard metadata; only a fresh device gets a new sidecar.

--- a/tests/controllers/devices/test_error_helpers.py
+++ b/tests/controllers/devices/test_error_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING, NoReturn, cast
 
 import pytest
 
@@ -11,9 +12,13 @@ from esphome_device_builder.controllers.devices.helpers import (
     raise_device_name_exists,
     raise_device_not_found,
     require_file_exists,
+    write_new_file_exclusive,
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.models import ErrorCode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def test_raise_device_not_found_code_and_message() -> None:
@@ -55,3 +60,47 @@ def test_require_file_exists_archived_prefix(tmp_path: Path) -> None:
     ) as exc_info:
         require_file_exists(tmp_path / "living.yaml", "living.yaml", archived=True)
     assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+
+async def test_write_new_file_exclusive_writes_and_skips_on_exists(tmp_path: Path) -> None:
+    """A fresh path is written; ``on_exists`` is never consulted."""
+    target = tmp_path / "kitchen.yaml"
+
+    def _fail(exc: BaseException) -> NoReturn:
+        raise AssertionError("on_exists must not run for a fresh path")
+
+    await write_new_file_exclusive(target, "esphome:\n", on_exists=_fail)
+
+    assert target.read_text(encoding="utf-8") == "esphome:\n"
+
+
+async def test_write_new_file_exclusive_delegates_existing_to_on_exists(tmp_path: Path) -> None:
+    """An existing target raises the caller's typed error and keeps its content."""
+    target = tmp_path / "kitchen.yaml"
+    target.write_text("original", encoding="utf-8")
+
+    def _raise(exc: BaseException) -> NoReturn:
+        raise_device_name_exists("kitchen.yaml", from_exc=exc)
+
+    with pytest.raises(CommandError) as exc_info:
+        await write_new_file_exclusive(target, "clobber", on_exists=_raise)
+
+    assert exc_info.value.code is ErrorCode.INVALID_ARGS
+    assert target.read_text(encoding="utf-8") == "original"
+
+
+async def test_write_new_file_exclusive_reraises_when_on_exists_returns(tmp_path: Path) -> None:
+    """A contract-violating ``on_exists`` that returns can't swallow the failure."""
+    target = tmp_path / "kitchen.yaml"
+    target.write_text("original", encoding="utf-8")
+    seen: list[BaseException] = []
+
+    with pytest.raises(FileExistsError):
+        await write_new_file_exclusive(
+            target,
+            "clobber",
+            on_exists=cast("Callable[[BaseException], NoReturn]", seen.append),
+        )
+
+    assert len(seen) == 1
+    assert target.read_text(encoding="utf-8") == "original"


### PR DESCRIPTION
# What does this implement/fix?

Device create and device clone both defined an inner sync closure doing an exclusive-create write (`open(path, "x")`), ran it in the executor, and translated `FileExistsError` into their own name-taken `CommandError`, duplicating the anti-clobber contract. This hoists the shared half into `write_new_file_exclusive(path, content, on_exists=...)` in `controllers/devices/helpers.py`; each caller passes its typed-error raiser, so create keeps ALREADY_EXISTS and clone keeps the preflight-matching INVALID_ARGS via `raise_device_name_exists`.

This is deliberately not `esphome.helpers.write_file` (the atomic in-place rewrite): its stage-and-move replaces an existing file, while new-file creation needs `open("x")` to refuse the clobber without a TOCTOU window. Create's explicit-overwrite branch still uses the atomic rewrite, unchanged. No behaviour change; the existing create and clone collision tests pin both error codes.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2170

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
