### PR TITLE
Share the top-level automation list-block parser skeleton

### DIFF
--- a/esphome_device_builder/controllers/automations/parsing.py
+++ b/esphome_device_builder/controllers/automations/parsing.py
@@ -177,67 +177,34 @@ def _parse_device_level(root: Any) -> list[ParsedAutomation]:
     return out
 
 
-def _parse_top_level_scripts(root: Any) -> list[ParsedAutomation]:
-    """Parse top-level ``script:`` list blocks."""
-    if not isinstance(root, dict):
-        return []
-    scripts = root.get("script")
-    if not isinstance(scripts, list):
-        return []
+def _parse_automation_list(
+    items: list[Any],
+    *,
+    describe: Callable[[dict[str, Any], int], tuple[AutomationLocation, str] | None],
+    params_of: Callable[[dict[str, Any]], dict[str, Any]],
+) -> list[ParsedAutomation]:
+    """
+    Parse one top-level list block of trigger-less automations.
+
+    *describe* returns the item's ``(location, label)`` or ``None`` to
+    skip it; *params_of* collects the item's params for the tree build.
+    """
     out: list[ParsedAutomation] = []
-    for idx, item in enumerate(scripts):
+    for idx, item in enumerate(items):
         if not isinstance(item, dict):
             continue
-        script_id = item.get("id") or f"script_{idx}"
-        from_line, to_line = _item_range(scripts, idx)
+        described = describe(item, idx)
+        if described is None:
+            continue
+        location, label = described
+        from_line, to_line = _item_range(items, idx)
         tree, error, unsupported = _safe_tree(
-            partial(
-                _block_tree,
-                _collect_block_params(item, action_list_keys={"then"}),
-                item.get("then"),
-            ),
+            partial(_block_tree, params_of(item), item.get("then")),
             trigger_id=None,
         )
         out.append(
             ParsedAutomation(
-                location=ScriptLocation(id=str(script_id)),
-                label=f"Script: {script_id}",
-                automation=tree,
-                from_line=from_line,
-                to_line=to_line,
-                raw_yaml=_dump_slice([item]),
-                error=error,
-                unsupported=unsupported,
-            )
-        )
-    return out
-
-
-def _parse_top_level_intervals(root: Any) -> list[ParsedAutomation]:
-    """Parse top-level ``interval:`` list blocks."""
-    if not isinstance(root, dict):
-        return []
-    intervals = root.get("interval")
-    if not isinstance(intervals, list):
-        return []
-    out: list[ParsedAutomation] = []
-    for idx, item in enumerate(intervals):
-        if not isinstance(item, dict):
-            continue
-        from_line, to_line = _item_range(intervals, idx)
-        every = item.get("interval")
-        label = f"Interval: every {every}" if every else f"Interval #{idx + 1}"
-        tree, error, unsupported = _safe_tree(
-            partial(
-                _block_tree,
-                _collect_block_params(item, action_list_keys={"then"}),
-                item.get("then"),
-            ),
-            trigger_id=None,
-        )
-        out.append(
-            ParsedAutomation(
-                location=IntervalLocation(index=idx),
+                location=location,
                 label=label,
                 automation=tree,
                 from_line=from_line,
@@ -248,6 +215,45 @@ def _parse_top_level_intervals(root: Any) -> list[ParsedAutomation]:
             )
         )
     return out
+
+
+def _parse_top_level_scripts(root: Any) -> list[ParsedAutomation]:
+    """Parse top-level ``script:`` list blocks."""
+    if not isinstance(root, dict):
+        return []
+    scripts = root.get("script")
+    if not isinstance(scripts, list):
+        return []
+
+    def _describe(item: dict[str, Any], idx: int) -> tuple[AutomationLocation, str]:
+        script_id = item.get("id") or f"script_{idx}"
+        return ScriptLocation(id=str(script_id)), f"Script: {script_id}"
+
+    return _parse_automation_list(
+        scripts,
+        describe=_describe,
+        params_of=partial(_collect_block_params, action_list_keys={"then"}),
+    )
+
+
+def _parse_top_level_intervals(root: Any) -> list[ParsedAutomation]:
+    """Parse top-level ``interval:`` list blocks."""
+    if not isinstance(root, dict):
+        return []
+    intervals = root.get("interval")
+    if not isinstance(intervals, list):
+        return []
+
+    def _describe(item: dict[str, Any], idx: int) -> tuple[AutomationLocation, str]:
+        every = item.get("interval")
+        label = f"Interval: every {every}" if every else f"Interval #{idx + 1}"
+        return IntervalLocation(index=idx), label
+
+    return _parse_automation_list(
+        intervals,
+        describe=_describe,
+        params_of=partial(_collect_block_params, action_list_keys={"then"}),
+    )
 
 
 def _parse_api_actions(root: Any) -> list[ParsedAutomation]:
@@ -268,31 +274,15 @@ def _parse_api_actions(root: Any) -> list[ParsedAutomation]:
     actions = api_block.get("actions")
     if not isinstance(actions, list):
         return []
-    out: list[ParsedAutomation] = []
-    for idx, item in enumerate(actions):
-        if not isinstance(item, dict):
-            continue
+
+    def _describe(item: dict[str, Any], idx: int) -> tuple[AutomationLocation, str] | None:
+        del idx
         action_name = item.get("action") or item.get("service")
         if not action_name:
-            continue
-        from_line, to_line = _item_range(actions, idx)
-        tree, error, unsupported = _safe_tree(
-            partial(_block_tree, _collect_api_action_params(item), item.get("then")),
-            trigger_id=None,
-        )
-        out.append(
-            ParsedAutomation(
-                location=ApiActionLocation(action_name=str(action_name)),
-                label=f"API: {action_name}",
-                automation=tree,
-                from_line=from_line,
-                to_line=to_line,
-                raw_yaml=_dump_slice([item]),
-                error=error,
-                unsupported=unsupported,
-            )
-        )
-    return out
+            return None
+        return ApiActionLocation(action_name=str(action_name)), f"API: {action_name}"
+
+    return _parse_automation_list(actions, describe=_describe, params_of=_collect_api_action_params)
 
 
 def singleton_component_id(section: dict, domain: str) -> str:


### PR DESCRIPTION
# What does this implement/fix?

The three top-level trigger-less parsers in `controllers/automations/parsing.py` (`script:`, `interval:`, `api.actions:`) shared the same skeleton: enumerate the list, skip non-dict items, `_item_range`, `_safe_tree(partial(_block_tree, ...))`, then a `ParsedAutomation` whose six of eight fields were identical. This hoists the skeleton into `_parse_automation_list(items, describe=..., params_of=...)`; each parser keeps only its container lookup and a small typed `describe` returning `(location, label)` (or `None` to skip, which carries the api name gate).

Two parts of issue #2173 are deliberately not taken: the five catalog `get_*` handlers (a helper call would replace a one-line comprehension, and table-driven registration would lose the per-command docstring surface), and the similar-but-not-identical shapes later in the file, which can adopt the shared assembly opportunistically. No behaviour change; the automations parsing round-trip suites pass unchanged.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2173

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable (behaviour-free refactor; the parsing round-trip suites pin every branch, including the api name gate and the interval label fallback).
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
