### PR TITLE
DRY the shutdown-callback drain and unify listener bookkeeping

### DIFF
--- a/esphome_device_builder/controllers/config/controller.py
+++ b/esphome_device_builder/controllers/config/controller.py
@@ -19,7 +19,7 @@ from ...helpers.secrets_state import (
     write_secret,
     write_wifi_secrets,
 )
-from ...helpers.storage import ShutdownCallback
+from ...helpers.storage import ShutdownCallback, drain_shutdown_callbacks
 from ...helpers.storage_path import resolve_storage_path
 from ...models import ErrorCode, UserPreferences
 from ._preferences_store import PreferencesStore
@@ -51,8 +51,7 @@ class ConfigController:
 
     async def stop(self) -> None:
         """Flush the preferences store on shutdown."""
-        for callback in self._shutdown_callbacks:
-            await callback()
+        await drain_shutdown_callbacks(self._shutdown_callbacks)
 
     @api_command("config/version")
     async def get_version(self, **kwargs: Any) -> dict:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -35,7 +35,7 @@ from ...helpers.secrets_state import (
     wifi_secrets_defined,
     write_wifi_secrets,
 )
-from ...helpers.storage import ShutdownCallback
+from ...helpers.storage import ShutdownCallback, drain_shutdown_callbacks
 from ...models import (
     OTA_PORT,
     AddComponentResponse,
@@ -286,8 +286,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         await self._build_size.stop()
         await self._mqtt_coordinator.stop()
         await self._state_monitor.stop()
-        for callback in self._shutdown_callbacks:
-            await callback()
+        await drain_shutdown_callbacks(self._shutdown_callbacks)
 
     async def poll(self) -> None:
         """Poll for file changes; a no-op once stopped (don't re-arm during shutdown)."""

--- a/esphome_device_builder/controllers/remote_build/offloader.py
+++ b/esphome_device_builder/controllers/remote_build/offloader.py
@@ -32,7 +32,7 @@ from ...helpers.build_scheduler import BuildSchedulerInputs
 from ...helpers.dashboard_identity import get_or_create_identities
 from ...helpers.event_bus import Event
 from ...helpers.peer_link_resolver import make_peer_link_resolver
-from ...helpers.storage import Store
+from ...helpers.storage import Store, drain_shutdown_callbacks
 from ...models import (
     EventType,
     FirmwareJob,
@@ -155,8 +155,7 @@ class OffloaderController(_RemoteBuildBase):
         # on its heartbeat to time out.
         await drain_tasks(h.task for h in state.peer_link_clients.values())
         state.peer_link_clients.clear()
-        for callback in self._shutdown_callbacks:
-            await callback()
+        await drain_shutdown_callbacks(self._shutdown_callbacks)
         state.pairings.clear()
         state.peer_queue_status.clear()
         state.offloader_remote_jobs.clear()

--- a/esphome_device_builder/controllers/remote_build/receiver.py
+++ b/esphome_device_builder/controllers/remote_build/receiver.py
@@ -27,7 +27,7 @@ from esphome.const import __version__ as _installed_esphome_version
 from ...helpers.api import api_command
 from ...helpers.async_ import drain_tasks, run_in_executor
 from ...helpers.event_bus import Event
-from ...helpers.storage import Store
+from ...helpers.storage import Store, drain_shutdown_callbacks
 from ...models import (
     TERMINAL_JOB_EVENTS,
     EventType,
@@ -148,8 +148,7 @@ class ReceiverController(_RemoteBuildBase):  # noqa: PLR0904
         # in-flight pair_status long-polls on a still-alive bus
         # see the cancellation (matters for the soft-reload path).
         self._clear_pending_peers_on_window_close()
-        for callback in self._shutdown_callbacks:
-            await callback()
+        await drain_shutdown_callbacks(self._shutdown_callbacks)
         self.state.approved_peers.clear()
 
     async def _load_settings_async(self) -> RemoteBuildSettings:

--- a/esphome_device_builder/controllers/version_history/controller.py
+++ b/esphome_device_builder/controllers/version_history/controller.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from contextlib import ExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -23,8 +24,6 @@ from ...models import ErrorCode, EventType
 from .git_repo import GIT_COMMIT_ERRORS, GitIndexLockBusyError, GitRepo
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from ...device_builder import DeviceBuilder
     from ...helpers.event_bus import Event
     from ...models import DeviceEventData
@@ -71,7 +70,9 @@ class VersionHistoryController:
         self._db = device_builder
         self._repo = GitRepo(config_dir=device_builder.settings.config_dir)
         self._lock = asyncio.Lock()
-        self._unsubs: list[Callable[[], None]] = []
+        # ``EventBus.add_listener`` unsubscribes accumulate here;
+        # ``_teardown`` closes the stack (reusable across re-enable).
+        self._listeners = ExitStack()
         # configuration → pending commit message; last write wins.
         self._pending: dict[str, str] = {}
         self._flush_task: asyncio.Task[None] | None = None
@@ -139,7 +140,7 @@ class VersionHistoryController:
         # (which ride DEVICE_UPDATED) never reach us. Dashboard mutations have
         # already committed by the debounced flush, so those become no-ops.
         for event_type in _EXTERNAL_MESSAGE:
-            self._unsubs.append(self._db.bus.add_listener(event_type, self._on_disk_change))
+            self._listeners.callback(self._db.bus.add_listener(event_type, self._on_disk_change))
 
     async def set_auto_commit(self, *, enabled: bool) -> None:
         """
@@ -180,9 +181,7 @@ class VersionHistoryController:
         the queue is the only thing they treat differently (flush vs drop),
         so it stays with the callers.
         """
-        for unsub in self._unsubs:
-            unsub()
-        self._unsubs.clear()
+        self._listeners.close()
         task = self._flush_task
         self._flush_task = None
         if task is not None:

--- a/esphome_device_builder/helpers/storage.py
+++ b/esphome_device_builder/helpers/storage.py
@@ -56,7 +56,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from contextlib import suppress
 from pathlib import Path
 
@@ -69,6 +69,12 @@ _LOGGER = logging.getLogger(__name__)
 # ``Callable[[Callable[[], Awaitable[None]]], None]`` inline.
 type ShutdownCallback = Callable[[], Awaitable[None]]
 type ShutdownRegister = Callable[[ShutdownCallback], None]
+
+
+async def drain_shutdown_callbacks(callbacks: Iterable[ShutdownCallback]) -> None:
+    """Await each registered store shutdown callback in registration order."""
+    for callback in callbacks:
+        await callback()
 
 
 class Store[T]:

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -240,11 +240,11 @@ async def test_set_auto_commit_noop_when_value_unchanged(tmp_path: Path) -> None
     """Setting the current value again is a no-op: listeners and repo stay put."""
     controller = _make_controller(tmp_path)
     await controller.start()
-    unsubs_before = list(controller._unsubs)
+    listeners_before = len(controller._listeners._exit_callbacks)
 
     await controller.set_auto_commit(enabled=True)  # already enabled
 
-    assert controller._unsubs == unsubs_before
+    assert len(controller._listeners._exit_callbacks) == listeners_before
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
     assert await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
     await controller.stop()
@@ -605,7 +605,7 @@ async def test_stop_detaches_listeners_and_flushes_pending(
 
     await controller.stop()
 
-    assert controller._unsubs == []
+    assert not controller._listeners._exit_callbacks
     # The queued edit was flushed on shutdown rather than lost.
     assert await controller.list_versions(configuration="kitchen.yaml")
     # A post-stop event must not reach the (now detached) listener.

--- a/tests/controllers/version_history/test_controller.py
+++ b/tests/controllers/version_history/test_controller.py
@@ -240,11 +240,12 @@ async def test_set_auto_commit_noop_when_value_unchanged(tmp_path: Path) -> None
     """Setting the current value again is a no-op: listeners and repo stay put."""
     controller = _make_controller(tmp_path)
     await controller.start()
-    listeners_before = len(controller._listeners._exit_callbacks)
+    bus = controller._db.bus
+    listener_count_before = sum(len(bus._listeners.get(et, ())) for et in EventType)
 
     await controller.set_auto_commit(enabled=True)  # already enabled
 
-    assert len(controller._listeners._exit_callbacks) == listeners_before
+    assert sum(len(bus._listeners.get(et, ())) for et in EventType) == listener_count_before
     (tmp_path / "kitchen.yaml").write_text("v1\n", encoding="utf-8")
     assert await controller.record_configuration("kitchen.yaml", "Create kitchen.yaml")
     await controller.stop()
@@ -605,7 +606,6 @@ async def test_stop_detaches_listeners_and_flushes_pending(
 
     await controller.stop()
 
-    assert not controller._listeners._exit_callbacks
     # The queued edit was flushed on shutdown rather than lost.
     assert await controller.list_versions(configuration="kitchen.yaml")
     # A post-stop event must not reach the (now detached) listener.


### PR DESCRIPTION
# What does this implement/fix?

Controller stop paths repeated the store shutdown drain (`for callback in self._shutdown_callbacks: await callback()`) in four places, and listener bookkeeping existed in two idioms: the `ExitStack` shape (`remote_build/_shared.py`, `job_fanout.py`) and version_history's hand-rolled unsubscribe list.

This adds `drain_shutdown_callbacks` in `helpers/storage.py` next to `ShutdownCallback` and adopts it at the four drain sites, and converts version_history onto the `ExitStack` idiom the other sites already use. The issue's proposed `EventSubscriptions` wrapper class is deliberately not added; `ExitStack` is the stdlib helper for exactly this, and wrapping it would be a new abstraction over three lines. Two version_history tests that poked the old `_unsubs` list now check the stack. No behaviour change.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2174

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
