### PR TITLE
Stage the exclusive-create write so a crash can't leave a partial file

### DIFF
--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -12,6 +12,7 @@ from esphome.helpers import friendly_name_slugify, sort_ip_addresses
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
+from ...helpers.atomic_io import atomic_write_exclusive
 from ...helpers.hostname import is_local_hostname, normalize_hostname
 from ...helpers.yaml import read_yaml_scalar, rewrite_name_or_substitution
 from ...models import ConfigEntryType, Device, ErrorCode
@@ -55,17 +56,16 @@ async def write_new_file_exclusive(
     path: Path, content: str, *, on_exists: Callable[[BaseException], NoReturn]
 ) -> None:
     """
-    Exclusive-create (``open("x")``) *content* at *path* off the event loop.
+    Exclusive-create *content* at *path* off the event loop; staged, atomic.
 
-    The ``x`` mode refuses to clobber an existing file with no TOCTOU
-    window; a check-then-write or staged-move shape would reopen the
-    race. A ``FileExistsError`` is delegated to *on_exists*, which
-    raises the caller's typed error.
+    The exclusive publish refuses to clobber an existing file with no
+    TOCTOU window, and the staging means a crash mid-write leaves no
+    partial target. A ``FileExistsError`` is delegated to *on_exists*,
+    which raises the caller's typed error.
     """
 
     def _write() -> None:
-        with path.open("x", encoding="utf-8") as f:
-            f.write(content)
+        atomic_write_exclusive(path, content.encode("utf-8"))
 
     try:
         await run_in_executor(_write)

--- a/esphome_device_builder/controllers/devices/helpers.py
+++ b/esphome_device_builder/controllers/devices/helpers.py
@@ -60,8 +60,10 @@ async def write_new_file_exclusive(
 
     The exclusive publish refuses to clobber an existing file with no
     TOCTOU window, and the staging means a crash mid-write leaves no
-    partial target. A ``FileExistsError`` is delegated to *on_exists*,
-    which raises the caller's typed error.
+    partial target (except on a hardlink-less mount, where
+    :func:`helpers.atomic_io.atomic_write_exclusive` degrades to a
+    direct exclusive write). A ``FileExistsError`` is delegated to
+    *on_exists*, which raises the caller's typed error.
     """
 
     def _write() -> None:

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
+import stat
 import tempfile
 import time
 from collections.abc import Callable
@@ -135,9 +136,11 @@ def _publish_exclusive(src: Path, dst: Path) -> None:
             return
         # Hardlink-less filesystem: keep the exclusive-open reach the
         # pre-staged write had, at the cost of unstaged bytes on this
-        # one exotic mount class.
+        # one exotic mount class. Mirror the staged file's mode; a
+        # fresh ``open("xb")`` would otherwise take the umask default.
         with dst.open("xb") as f:
             f.write(src.read_bytes())
+        dst.chmod(stat.S_IMODE(src.stat().st_mode))
         return
     # ``Path.rename`` on Windows refuses an existing destination
     # (``FileExistsError``, surfaced immediately, not a

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -14,6 +14,7 @@ Blocking I/O — call from ``run_in_executor``, not the loop.
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
 import tempfile
 import time
@@ -30,6 +31,9 @@ from pathlib import Path
 # before we give up — far cheaper than losing a metadata / preferences write
 # or failing a concurrent read.
 _IS_WINDOWS = os.name == "nt"
+# ``os.link`` failures that mean "this filesystem can't hard-link"
+# (SMB / FAT / some FUSE mounts) rather than a real error.
+_HARDLINK_UNSUPPORTED_ERRNOS = frozenset({errno.EPERM, errno.EOPNOTSUPP, errno.ENOSYS})
 _REPLACE_RETRIES = 15
 _REPLACE_RETRY_BACKOFF_S = 0.05
 _REPLACE_RETRY_BACKOFF_CAP_S = 0.5
@@ -120,7 +124,20 @@ def _publish_exclusive(src: Path, dst: Path) -> None:
     if not _IS_WINDOWS:
         # ``os.link`` is the POSIX exclusive primitive; the staged
         # source is unlinked by the caller's cleanup.
-        os.link(src, dst)
+        try:
+            os.link(src, dst)
+        except FileExistsError:
+            raise
+        except OSError as err:
+            if err.errno not in _HARDLINK_UNSUPPORTED_ERRNOS:
+                raise
+        else:
+            return
+        # Hardlink-less filesystem: keep the exclusive-open reach the
+        # pre-staged write had, at the cost of unstaged bytes on this
+        # one exotic mount class.
+        with dst.open("xb") as f:
+            f.write(src.read_bytes())
         return
     # ``Path.rename`` on Windows refuses an existing destination
     # (``FileExistsError``, surfaced immediately, not a

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -69,16 +69,7 @@ def atomic_write_exclusive(path: Path, data: bytes, *, mode: int = 0o644) -> Non
 
 def read_bytes_with_retry(path: Path) -> bytes:
     """Read *path*'s bytes, retried on a Windows handle race with a concurrent replace."""
-    for attempt in range(_REPLACE_RETRIES):
-        try:
-            return path.read_bytes()
-        except PermissionError:
-            # POSIX never hits this transiently, so a PermissionError there is
-            # real; re-raise. On Windows, back off and retry the open.
-            if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
-                raise
-            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
-    raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover
+    return _retry_windows_permission(path.read_bytes)
 
 
 def _staged_write(
@@ -132,30 +123,29 @@ def _publish_exclusive(src: Path, dst: Path) -> None:
         os.link(src, dst)
         return
     # ``Path.rename`` on Windows refuses an existing destination
-    # (``FileExistsError``, surfaced immediately); a transient
-    # ``PermissionError`` is an AV / indexer holding the staged file
-    # and gets the same retry policy as ``_replace_with_retry``.
-    for attempt in range(_REPLACE_RETRIES):
-        try:
-            src.rename(dst)
-        except PermissionError:
-            if attempt == _REPLACE_RETRIES - 1:
-                raise
-            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
-        else:
-            return
+    # (``FileExistsError``, surfaced immediately, not a
+    # ``PermissionError``); a transient hold by an AV / indexer gets
+    # the shared retry policy.
+    _retry_windows_permission(lambda: src.rename(dst))
 
 
 def _replace_with_retry(src: Path, dst: Path) -> None:
     """``Path.replace`` *src* onto *dst*, retried on a Windows handle race."""
+    _retry_windows_permission(lambda: src.replace(dst))
+
+
+def _retry_windows_permission[T](op: Callable[[], T]) -> T:
+    """
+    Run *op*, retrying a transient Windows ``PermissionError`` with backoff.
+
+    POSIX never hits the transient class, so a ``PermissionError``
+    there is real and surfaces without a retry.
+    """
     for attempt in range(_REPLACE_RETRIES):
         try:
-            src.replace(dst)
+            return op()
         except PermissionError:
-            # POSIX rename can't hit this transiently, so a PermissionError
-            # there is real; re-raise. On Windows, back off and retry.
             if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
                 raise
             time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
-        else:
-            return
+    raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -126,13 +126,24 @@ def _staged_write(
 
 def _publish_exclusive(src: Path, dst: Path) -> None:
     """Exclusive publish: refuses an existing *dst* with ``FileExistsError``."""
-    if _IS_WINDOWS:
-        # ``Path.rename`` on Windows refuses an existing destination.
-        src.rename(dst)
-    else:
+    if not _IS_WINDOWS:
         # ``os.link`` is the POSIX exclusive primitive; the staged
         # source is unlinked by the caller's cleanup.
         os.link(src, dst)
+        return
+    # ``Path.rename`` on Windows refuses an existing destination
+    # (``FileExistsError``, surfaced immediately); a transient
+    # ``PermissionError`` is an AV / indexer holding the staged file
+    # and gets the same retry policy as ``_replace_with_retry``.
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            src.rename(dst)
+        except PermissionError:
+            if attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
+        else:
+            return
 
 
 def _replace_with_retry(src: Path, dst: Path) -> None:

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -17,6 +17,7 @@ import contextlib
 import os
 import tempfile
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 # Windows raises ``PermissionError`` (WinError 5) on both sides of a
@@ -50,6 +51,51 @@ def atomic_write(
     """
     if make_parents:
         path.parent.mkdir(parents=True, exist_ok=True)
+    _staged_write(path, data, mode=mode, publish=_replace_with_retry)
+
+
+def atomic_write_exclusive(path: Path, data: bytes, *, mode: int = 0o644) -> None:
+    """
+    Write *data* to *path* atomically; ``FileExistsError`` when it exists.
+
+    Stages like :func:`atomic_write`, then publishes with an exclusive
+    primitive — ``os.link`` on POSIX, ``os.rename`` on Windows — both
+    of which refuse an existing target. The target only ever appears
+    fully written (a crash mid-write leaves no partial file) and a
+    concurrent creator loses cleanly with ``FileExistsError``.
+    """
+    _staged_write(path, data, mode=mode, publish=_publish_exclusive)
+
+
+def read_bytes_with_retry(path: Path) -> bytes:
+    """Read *path*'s bytes, retried on a Windows handle race with a concurrent replace."""
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            return path.read_bytes()
+        except PermissionError:
+            # POSIX never hits this transiently, so a PermissionError there is
+            # real; re-raise. On Windows, back off and retry the open.
+            if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
+    raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover
+
+
+def _staged_write(
+    path: Path,
+    data: bytes,
+    *,
+    mode: int | None,
+    publish: Callable[[Path, Path], None],
+) -> None:
+    """
+    Stage *data* in a sibling tempfile, then hand it to *publish*.
+
+    *publish* moves or links the staged file onto *path*; the staged
+    tempfile is cleaned up afterwards either way (a suppressed no-op
+    when the publish consumed it). Readers of *path* only ever see a
+    fully written file.
+    """
     fd, tmp_str = tempfile.mkstemp(
         prefix=path.name + ".",
         suffix=".tmp",
@@ -70,28 +116,23 @@ def atomic_write(
             if mode is not None:
                 tmp_path.chmod(mode)
             fh.write(data)
-        _replace_with_retry(tmp_path, path)
-    except Exception:
-        # Suppress all OSError on cleanup so the original write
-        # failure isn't masked by a secondary unlink permission
-        # error.
+        publish(tmp_path, path)
+    finally:
+        # Suppress all OSError on cleanup so a write failure isn't
+        # masked by a secondary unlink permission error.
         with contextlib.suppress(OSError):
             tmp_path.unlink()
-        raise
 
 
-def read_bytes_with_retry(path: Path) -> bytes:
-    """Read *path*'s bytes, retried on a Windows handle race with a concurrent replace."""
-    for attempt in range(_REPLACE_RETRIES):
-        try:
-            return path.read_bytes()
-        except PermissionError:
-            # POSIX never hits this transiently, so a PermissionError there is
-            # real; re-raise. On Windows, back off and retry the open.
-            if not _IS_WINDOWS or attempt == _REPLACE_RETRIES - 1:
-                raise
-            time.sleep(min(_REPLACE_RETRY_BACKOFF_S * 2**attempt, _REPLACE_RETRY_BACKOFF_CAP_S))
-    raise AssertionError("unreachable: loop returns or raises")  # pragma: no cover
+def _publish_exclusive(src: Path, dst: Path) -> None:
+    """Exclusive publish: refuses an existing *dst* with ``FileExistsError``."""
+    if _IS_WINDOWS:
+        # ``Path.rename`` on Windows refuses an existing destination.
+        src.rename(dst)
+    else:
+        # ``os.link`` is the POSIX exclusive primitive; the staged
+        # source is unlinked by the caller's cleanup.
+        os.link(src, dst)
 
 
 def _replace_with_retry(src: Path, dst: Path) -> None:

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -67,7 +67,10 @@ def atomic_write_exclusive(path: Path, data: bytes, *, mode: int = 0o644) -> Non
     primitive — ``os.link`` on POSIX, ``os.rename`` on Windows — both
     of which refuse an existing target. The target only ever appears
     fully written (a crash mid-write leaves no partial file) and a
-    concurrent creator loses cleanly with ``FileExistsError``.
+    concurrent creator loses cleanly with ``FileExistsError``. On a
+    hardlink-less POSIX filesystem (SMB / FAT) the publish degrades to
+    a direct exclusive write: still no-clobber, but a crash mid-write
+    can leave a partial target on that one mount class.
     """
     _staged_write(path, data, mode=mode, publish=_publish_exclusive)
 

--- a/tests/controllers/devices/test_clone.py
+++ b/tests/controllers/devices/test_clone.py
@@ -550,29 +550,24 @@ async def test_clone_device_handles_filesystem_race_on_target_filename(
 ) -> None:
     """A race that creates the target file between gather + commit raises ``INVALID_ARGS``.
 
-    The exclusive-create ``open(..., "x")`` is the actual race
-    defence — even if the gather pass found ``new_path`` missing,
-    a concurrent caller (another ``devices/clone`` request, the
-    user dropping a file via the editor) could create it before our
-    commit. The mode raises ``FileExistsError`` and we translate it
-    into the same ``INVALID_ARGS`` the preflight produces so the
-    frontend renders one consistent message.
+    The exclusive publish is the actual race defence — even if the
+    gather pass found ``new_path`` missing, a concurrent caller
+    (another ``devices/clone`` request, the user dropping a file via
+    the editor) could create it before our commit. It raises
+    ``FileExistsError`` and we translate it into the same
+    ``INVALID_ARGS`` the preflight produces so the frontend renders
+    one consistent message.
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
 
-    # Patch ``Path.open`` so the clone command's
-    # ``with new_path.open("x", ...)`` raises ``FileExistsError``
-    # without needing real cross-process scheduling.
-    real_open = Path.open
-
-    def _raising_open(self, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
-        if "x" in mode and str(self).endswith("bedroom-bulb.yaml"):
-            raise FileExistsError(str(self))
-        return real_open(self, mode, *args, **kwargs)
-
+    # Patch the staged writer to lose the race without needing real
+    # cross-process scheduling.
     with (
-        patch.object(Path, "open", _raising_open),
+        patch(
+            "esphome_device_builder.controllers.devices.helpers.atomic_write_exclusive",
+            side_effect=FileExistsError("bedroom-bulb.yaml"),
+        ),
         pytest.raises(CommandError) as excinfo,
     ):
         await ctrl.clone_device(configuration="kitchen.yaml", new_name="bedroom-bulb")

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -17,7 +17,7 @@ import warnings
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import esphome.config_validation as cv
 import pytest
@@ -829,12 +829,14 @@ async def test_create_device_write_race_surfaces_already_exists(
 ) -> None:
     """A file appearing between the pre-check and the exclusive write maps to ALREADY_EXISTS."""
     ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
-    fake = MagicMock()
-    fake.exists.return_value = False  # pre-check passes
-    fake.open.side_effect = FileExistsError  # the exclusive write loses the race
-    ctrl._db.settings.rel_path = lambda _filename: fake
 
-    with pytest.raises(CommandError) as excinfo:
+    with (
+        patch(
+            "esphome_device_builder.controllers.devices.helpers.atomic_write_exclusive",
+            side_effect=FileExistsError("kitchen.yaml"),  # the exclusive write loses the race
+        ),
+        pytest.raises(CommandError) as excinfo,
+    ):
         await ctrl.create_device(name="kitchen", file_content=VALID_FILE_CONTENT)
 
     assert excinfo.value.code == ErrorCode.ALREADY_EXISTS

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import stat
 import sys
@@ -353,5 +354,41 @@ def test_atomic_write_exclusive_windows_existing_target_fails_fast(
         atomic_write_exclusive(target, b"clobber")
 
     assert calls["n"] == 1  # no retry on an existing destination
+    assert target.read_bytes() == b"original"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX hardlink fallback")
+def test_atomic_write_exclusive_falls_back_on_hardlink_less_filesystem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A link-unsupported errno degrades to the exclusive-open write."""
+    target = tmp_path / "kitchen.yaml"
+
+    def _no_links(src: object, dst: object, **kwargs: object) -> None:
+        raise OSError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.os.link", _no_links)
+    atomic_write_exclusive(target, b"esphome:\n")
+
+    assert target.read_bytes() == b"esphome:\n"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX hardlink fallback")
+def test_atomic_write_exclusive_fallback_still_refuses_existing_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback keeps exclusivity: an existing target raises FileExistsError."""
+    target = tmp_path / "kitchen.yaml"
+    target.write_bytes(b"original")
+
+    def _no_links(src: object, dst: object, **kwargs: object) -> None:
+        raise OSError(errno.EPERM, "Operation not permitted")
+
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.os.link", _no_links)
+    with pytest.raises(FileExistsError):
+        atomic_write_exclusive(target, b"clobber")
+
     assert target.read_bytes() == b"original"
     assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -372,6 +372,7 @@ def test_atomic_write_exclusive_falls_back_on_hardlink_less_filesystem(
     atomic_write_exclusive(target, b"esphome:\n")
 
     assert target.read_bytes() == b"esphome:\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
     assert list(tmp_path.glob("*.tmp")) == []
 
 

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 import pytest
 
-from esphome_device_builder.helpers.atomic_io import atomic_write, read_bytes_with_retry
+from esphome_device_builder.helpers.atomic_io import (
+    atomic_write,
+    atomic_write_exclusive,
+    read_bytes_with_retry,
+)
 
 
 def test_atomic_write_cleans_up_tempfile_on_error(
@@ -236,3 +240,70 @@ def test_read_bytes_with_retry_does_not_retry_on_posix(
         read_bytes_with_retry(tmp_path / "demo.bin")
 
     assert calls["n"] == 1  # no retry on POSIX
+
+
+def test_atomic_write_exclusive_creates_fresh_file(tmp_path: Path) -> None:
+    """A fresh target gets the full payload, 0o644, and no staging litter."""
+    target = tmp_path / "kitchen.yaml"
+
+    atomic_write_exclusive(target, b"esphome:\n")
+
+    assert target.read_bytes() == b"esphome:\n"
+    if sys.platform != "win32":
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_exclusive_refuses_existing_target(tmp_path: Path) -> None:
+    """An existing target raises FileExistsError, keeps its bytes, leaves no litter."""
+    target = tmp_path / "kitchen.yaml"
+    target.write_bytes(b"original")
+
+    with pytest.raises(FileExistsError):
+        atomic_write_exclusive(target, b"clobber")
+
+    assert target.read_bytes() == b"original"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_exclusive_failed_publish_leaves_no_partial_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A publish failure surfaces, and neither a partial target nor staging litter remains."""
+    target = tmp_path / "kitchen.yaml"
+
+    def _fail(src: object, dst: object) -> None:
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.os.link", _fail)
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.os.rename", _fail)
+
+    with pytest.raises(OSError, match="No space left"):
+        atomic_write_exclusive(target, b"esphome:\n")
+
+    assert not target.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_exclusive_concurrent_creator_loses_cleanly(tmp_path: Path) -> None:
+    """A target appearing after staging (the TOCTOU window) still raises FileExistsError."""
+    target = tmp_path / "kitchen.yaml"
+    real_link = os.link
+    real_rename = os.rename
+
+    def _racing_link(src: object, dst: object, **kwargs: object) -> None:
+        target.write_bytes(b"raced")
+        real_link(src, dst, **kwargs)  # type: ignore[arg-type]
+
+    def _racing_rename(src: object, dst: object, **kwargs: object) -> None:
+        target.write_bytes(b"raced")
+        real_rename(src, dst, **kwargs)  # type: ignore[arg-type]
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("esphome_device_builder.helpers.atomic_io.os.link", _racing_link)
+        mp.setattr("esphome_device_builder.helpers.atomic_io.os.rename", _racing_rename)
+        with pytest.raises(FileExistsError):
+            atomic_write_exclusive(target, b"clobber")
+
+    assert target.read_bytes() == b"raced"
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -307,3 +307,51 @@ def test_atomic_write_exclusive_concurrent_creator_loses_cleanly(tmp_path: Path)
 
     assert target.read_bytes() == b"raced"
     assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_exclusive_retries_windows_scanner_hold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient Windows ``PermissionError`` on the exclusive publish is retried."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", True)
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io.time.sleep", lambda _s: None)
+    target = tmp_path / "kitchen.yaml"
+
+    real_rename = os.rename
+    calls = {"n": 0}
+
+    def _flaky(src: object, dst: object, **kwargs: object) -> None:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError(5, "Access is denied")
+        real_rename(src, dst, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("os.rename", _flaky)
+    atomic_write_exclusive(target, b"esphome:\n")
+
+    assert calls["n"] == 3  # failed twice, succeeded on the third
+    assert target.read_bytes() == b"esphome:\n"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_exclusive_windows_existing_target_fails_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``FileExistsError`` on the Windows publish surfaces immediately, no retry."""
+    monkeypatch.setattr("esphome_device_builder.helpers.atomic_io._IS_WINDOWS", True)
+    target = tmp_path / "kitchen.yaml"
+    target.write_bytes(b"original")
+
+    calls = {"n": 0}
+
+    def _refuse(src: object, dst: object, **kwargs: object) -> None:
+        calls["n"] += 1
+        raise FileExistsError(str(dst))
+
+    monkeypatch.setattr("os.rename", _refuse)
+    with pytest.raises(FileExistsError):
+        atomic_write_exclusive(target, b"clobber")
+
+    assert calls["n"] == 1  # no retry on an existing destination
+    assert target.read_bytes() == b"original"
+    assert list(tmp_path.glob("*.tmp")) == []


### PR DESCRIPTION
# What does this implement/fix?

The exclusive-create YAML write (`write_new_file_exclusive`, used by device create and clone) wrote with a bare `open(path, "x")`: exclusive, but a crash or full disk mid-write leaves a half-written YAML behind. This adds `atomic_write_exclusive` to `helpers/atomic_io.py` and swaps it in: the bytes stage in a sibling tempfile exactly like `atomic_write`, then publish with an exclusive primitive (`os.link` on POSIX, `Path.rename` on Windows), so the target only ever appears fully written and a concurrent creator still loses cleanly with `FileExistsError`. The staging core is shared; `atomic_write` and `atomic_write_exclusive` are now thin wrappers over one `_staged_write` differing only in the publish callable.

The published file is chmod 0o644, matching `esphome.helpers.write_file`'s contract for user YAML; the old `open("x")` honoured the umask, which lands at 0o644 in every shipped deployment shape. `write_new_file_exclusive`'s `on_exists` contract and both call sites are unchanged; the two race tests now patch the staged writer instead of `Path.open`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2183

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
