### PR TITLE
Adopt the atomic write helpers at the remaining unsafe write sites

### DIFF
--- a/esphome_device_builder/controllers/devices/importable.py
+++ b/esphome_device_builder/controllers/devices/importable.py
@@ -11,6 +11,7 @@ from esphome.storage_json import ignored_devices_storage_path
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
+from ...helpers.atomic_io import atomic_write_exclusive
 from ...helpers.device_yaml import generate_adoption_yaml
 from ...helpers.json import JSONDecodeError, dumps_indent, loads
 from ...helpers.lazy_module import async_import_module
@@ -91,10 +92,9 @@ async def import_device(
             )
 
             def _write_exclusive() -> None:
-                # Exclusive-create, matching ``import_config``'s
+                # Staged exclusive-create, matching ``import_config``'s
                 # FileExistsError contract for a concurrent writer.
-                with path.open("x", encoding="utf-8") as f:
-                    f.write(content)
+                atomic_write_exclusive(path, content.encode("utf-8"))
 
             await run_in_executor(_write_exclusive)
     except FileExistsError as exc:

--- a/esphome_device_builder/controllers/version_history/git_repo.py
+++ b/esphome_device_builder/controllers/version_history/git_repo.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 import esphome_device_builder
 from esphome_device_builder.constants import is_secrets_file
+from esphome_device_builder.helpers.atomic_io import atomic_write
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -295,7 +296,9 @@ class GitRepo:
         self._ensure_local_excludes()
         gitignore = self.config_dir / ".gitignore"
         if not gitignore.exists():
-            gitignore.write_text(_DEFAULT_GITIGNORE, encoding="utf-8")
+            # ``mode=0o644``: mkstemp stages at 0o600, which would
+            # silently tighten a user-visible config-dir file.
+            atomic_write(gitignore, _DEFAULT_GITIGNORE.encode("utf-8"), mode=0o644)
         # ``.gitignore`` always exists here (just written or pre-existing),
         # so the seed is never empty.
         self._run(["add", "--", *self._seed_paths()], check=False)

--- a/esphome_device_builder/helpers/auth.py
+++ b/esphome_device_builder/helpers/auth.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from aiohttp import web
 
 from ..constants import HA_SUPERVISOR_IP
+from .atomic_io import atomic_write
 from .json import JSONDecodeError, dumps, loads
 
 _LOGGER = logging.getLogger(__name__)
@@ -183,10 +184,7 @@ class SessionStore:
 
     def _persist(self) -> None:
         data = {"sessions": [asdict(s) for s in self._sessions.values()]}
-        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-        tmp.write_bytes(dumps(data))
-        tmp.chmod(0o600)
-        tmp.replace(self._path)
+        atomic_write(self._path, dumps(data), mode=0o600)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What does this implement/fix?

The post-#2188 audit found three direct writes that should ride the atomic helpers; this adopts them.

- The adoption flow's device YAML now writes through `atomic_write_exclusive` instead of a bare `open("x")`, so a crash mid-adopt can't leave a partial YAML that blocks the retry; the `FileExistsError` contract is unchanged and the existing lose-the-race test now exercises the real exclusive publish.
- `SessionStore._persist` drops its hand-rolled tmp-write, chmod, replace for `atomic_write(path, data, mode=0o600)`, picking up the shared Windows transient-`PermissionError` retry it was missing; the existing test pins 0o600 on the persisted store.
- The one-time `.gitignore` seed uses `atomic_write` with an explicit `mode=0o644` (the staging tempfile is born 0o600, which would otherwise silently tighten a user-visible config-dir file).

The audited-and-fine sites are listed in the issue. No behaviour change beyond the crash-safety and the Windows retry.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2189

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable (the existing suites pin each site: the adopt lose-the-race test, the 0o600 session-store assertion, and the gitignore seed tests).
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
