### PR TITLE
Generalize firmware lanes to N slots with a job-keyed process registry

### DIFF
--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -11,16 +11,17 @@ from ...models import FirmwareJob, JobSource, JobStatus, JobType
 
 @dataclass
 class Lane:
-    """One serial work lane: its FIFO queue + the job/subprocess on it now.
+    """One work lane: its FIFO queue + the jobs occupying its slots now.
 
-    Two lanes run concurrently — a compile lane (CPU) and an upload lane
+    Lanes run concurrently — a compile lane (CPU) and an upload lane
     (network) — so a slow network flash doesn't block the next compile.
-    Within a lane work stays serialized (``current_job`` is the single slot).
+    ``max_concurrency`` workers drain the queue; ``active`` holds the
+    jobs currently running on the lane, keyed by ``job_id``.
     """
 
+    max_concurrency: int = 1
     queue: asyncio.Queue[FirmwareJob] = field(default_factory=asyncio.Queue)
-    current_job: FirmwareJob | None = None
-    current_process: asyncio.subprocess.Process | None = None
+    active: dict[str, FirmwareJob] = field(default_factory=dict)
 
 
 @dataclass
@@ -107,11 +108,16 @@ class FirmwareState:
     # picks first. ``cli`` reads it to build the subprocess argv.
     esphome_cmd: list[str] = field(default_factory=list)
 
-    # The two concurrent lanes. Producers enqueue onto the lane a job's
-    # type maps to (``_lane_for``); each lane has its own consumer task.
-    # Both survive restarts via the on-disk persistence layer.
+    # The concurrent lanes. Producers enqueue onto the lane a job's
+    # type maps to (``lane_for``); each lane spawns ``max_concurrency``
+    # worker tasks. All survive restarts via the on-disk persistence layer.
     compile_lane: Lane = field(default_factory=Lane)
     upload_lane: Lane = field(default_factory=Lane)
+
+    # Subprocesses spawned for running jobs, keyed by ``job_id`` — what
+    # ``firmware/cancel`` signals. Job-keyed rather than per-lane so an
+    # off-lane spawn (the remote-install local flash) is cancellable too.
+    processes: dict[str, asyncio.subprocess.Process] = field(default_factory=dict)
 
     # Active + recent jobs keyed by ``job_id``. ``persistence``
     # reads / writes on every state transition; ``clean``,
@@ -140,6 +146,10 @@ class FirmwareState:
 
     # Remote build-server pool (see :class:`RemoteDispatchState`).
     remote_dispatch: RemoteDispatchState = field(default_factory=RemoteDispatchState)
+
+    def lanes(self) -> tuple[Lane, ...]:
+        """Every lane, for slot scans and worker spawn."""
+        return (self.compile_lane, self.upload_lane)
 
     def lane_for(self, job: FirmwareJob) -> Lane:
         """Return *job*'s lane: network flashes (UPLOAD, rename tail) upload, else compile."""

--- a/esphome_device_builder/controllers/firmware/cli.py
+++ b/esphome_device_builder/controllers/firmware/cli.py
@@ -20,7 +20,6 @@ from .constants import _OTA_ADDRESS_CACHE_JOB_TYPES, ESPHOME_SUBPROCESS_ENV
 from .helpers import _find_esptool_cmd
 
 if TYPE_CHECKING:
-    from ._state import Lane
     from .controller import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,7 +111,7 @@ def build_cache_args(controller: FirmwareController, job: FirmwareJob) -> list[s
     return controller._db.devices.get_ota_address_cache_args(job.configuration, port)
 
 
-async def verify_chip(controller: FirmwareController, job: FirmwareJob, lane: Lane) -> None:
+async def verify_chip(controller: FirmwareController, job: FirmwareJob) -> None:
     """
     Run ``esptool chip-id`` against *job*'s port and raise on mismatch.
 
@@ -136,7 +135,7 @@ async def verify_chip(controller: FirmwareController, job: FirmwareJob, lane: La
     expected_platform = storage.target_platform.lower()
 
     async with controller._tracked_subprocess(
-        lane,
+        job,
         *_find_esptool_cmd(),
         "--port",
         job.port,

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -181,7 +181,7 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         runner's ``queue.get``, so a scheduler reading only ``running``
         would misclassify a loaded lane as accepting more work.
         """
-        running = lane.current_job is not None
+        running = bool(lane.active)
         queue_depth = lane.queue.qsize()
         idle = not running and queue_depth == 0
         return QueueStatus(idle=idle, running=running, queue_depth=queue_depth)
@@ -508,19 +508,21 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     # ------------------------------------------------------------------
 
     async def _run_queue(self) -> None:
-        """Run both lane consumers + the remote-dispatch loop; drain all on any exit.
+        """Run every lane worker + the remote-dispatch loop; drain all on any exit.
 
-        On shutdown-cancel or one task raising, cancel and await all three
+        Each lane gets ``max_concurrency`` workers sharing its queue. On
+        shutdown-cancel or one task raising, cancel and await them all
         before the error propagates — else a sibling is left orphaned
         mid-flight (subprocess not terminated, job not finalised). The
         remote-dispatch loop never returns on its own; cancelling it
         detaches its bus listeners.
         """
         queue_tasks = [
-            create_eager_task(runner.run_lane(self, self.state.compile_lane)),
-            create_eager_task(runner.run_lane(self, self.state.upload_lane)),
-            create_eager_task(remote_dispatch.run_dispatch_loop(self)),
+            create_eager_task(runner.run_lane(self, lane))
+            for lane in self.state.lanes()
+            for _ in range(lane.max_concurrency)
         ]
+        queue_tasks.append(create_eager_task(remote_dispatch.run_dispatch_loop(self)))
         try:
             await asyncio.gather(*queue_tasks)
         finally:
@@ -589,9 +591,9 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
         await runner.execute_remote_job(self, job)
 
     def _tracked_subprocess(
-        self, lane: Lane, *args: Any, **kwargs: Any
+        self, job: FirmwareJob, *args: Any, **kwargs: Any
     ) -> AbstractAsyncContextManager[asyncio.subprocess.Process]:
-        return runner.tracked_subprocess(self, lane, *args, **kwargs)
+        return runner.tracked_subprocess(self, job, *args, **kwargs)
 
     def _finalize_terminal(
         self, job: FirmwareJob, status: JobStatus, *, error: str | None = None
@@ -601,11 +603,11 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     def _finalize_cancelled(self, job: FirmwareJob) -> None:
         lifecycle.finalize_cancelled(self, job)
 
-    async def _terminate_current_process(self, lane: Lane) -> None:
-        await lifecycle.terminate_current_process(self, lane)
+    async def _terminate_job_process(self, job: FirmwareJob) -> None:
+        await lifecycle.terminate_job_process(self, job)
 
-    async def _verify_chip(self, job: FirmwareJob, lane: Lane) -> None:
-        await cli.verify_chip(self, job, lane)
+    async def _verify_chip(self, job: FirmwareJob) -> None:
+        await cli.verify_chip(self, job)
 
     def _compose_subprocess_env(self, job: FirmwareJob) -> dict[str, str]:
         return cli.compose_subprocess_env(job)

--- a/esphome_device_builder/controllers/firmware/jobs.py
+++ b/esphome_device_builder/controllers/firmware/jobs.py
@@ -18,16 +18,12 @@ from . import lifecycle, rename_flow
 from .helpers import _fire_job_lifecycle
 
 if TYPE_CHECKING:
-    from ._state import Lane
     from .controller import FirmwareController
 
 
-def _running_lane(controller: FirmwareController, job_id: str) -> Lane | None:
-    """Return the lane currently running *job_id*, or None if neither lane is."""
-    for lane in (controller.state.compile_lane, controller.state.upload_lane):
-        if lane.current_job is not None and lane.current_job.job_id == job_id:
-            return lane
-    return None
+def _job_is_on_a_lane(controller: FirmwareController, job_id: str) -> bool:
+    """Whether *job_id* currently occupies a lane slot."""
+    return any(job_id in lane.active for lane in controller.state.lanes())
 
 
 async def get_jobs(
@@ -152,13 +148,12 @@ async def cancel(controller: FirmwareController, *, job_id: str) -> None:
             # ``cancel_job``.
             controller.state.request_cancel(job_id)
             return
-        lane = _running_lane(controller, job_id)
-        if lane is None:
+        if not _job_is_on_a_lane(controller, job_id):
             msg = "Running job is not the active subprocess (state out of sync)"
             raise RuntimeError(msg)
         controller.state.request_cancel(job_id)
-        # Lane-scoped so cancelling an upload doesn't signal a concurrent compile.
-        await controller._terminate_current_process(lane)
+        # Job-scoped so cancelling an upload doesn't signal a concurrent compile.
+        await controller._terminate_job_process(job)
         return
 
     msg = f"Cannot cancel a {job.status.value} job"

--- a/esphome_device_builder/controllers/firmware/lifecycle.py
+++ b/esphome_device_builder/controllers/firmware/lifecycle.py
@@ -12,7 +12,6 @@ from .constants import _PREREQUISITE_FAILED_ERROR, _TARGET_OFFLINE_DEFERRED_ERRO
 from .helpers import _fire_job_lifecycle, _target_is_offline, _trim_job_output
 
 if TYPE_CHECKING:
-    from ._state import Lane
     from .controller import FirmwareController
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,9 +56,9 @@ async def begin_run(controller: FirmwareController, job: FirmwareJob) -> None:
     """Stamp *job* RUNNING, fire ``JOB_STARTED``, and persist — the shared run prologue.
 
     Both execution paths call this: the lane runner (after claiming its lane
-    slot, since the receiver's ``compile_queue_status`` reads ``current_job``
-    on ``JOB_STARTED``) and the off-lane dispatch pool. Keeping the prologue
-    here means a new field / gate is added once, not mirrored by hand.
+    slot, since the receiver's ``compile_queue_status`` reads the lane's
+    ``active`` on ``JOB_STARTED``) and the off-lane dispatch pool. Keeping the
+    prologue here means a new field / gate is added once, not mirrored by hand.
     """
     job.mark_running()
     _fire_job_lifecycle(job, controller._db.bus, EventType.JOB_STARTED)
@@ -70,7 +69,7 @@ async def end_run(controller: FirmwareController, job: FirmwareJob) -> None:
     """Terminal bookkeeping (trim + prune) then persist — the shared ``finally`` tail.
 
     The trim/prune is a no-op while the job is still active. Caller releases its
-    own slot (lane ``current_job`` / pool entry) first.
+    own slot (lane ``active`` entry / pool entry) first.
     """
     if job.is_terminal:
         _trim_job_output(job)
@@ -95,12 +94,10 @@ def finalize_unexpected_error(
 
 
 def _release_lane_slot(controller: FirmwareController, job: FirmwareJob) -> None:
-    """Clear whichever lane was running *job*."""
-    for lane in (controller.state.compile_lane, controller.state.upload_lane):
-        if lane.current_job is job:
-            lane.current_job = None
-            lane.current_process = None
-            return
+    """Clear *job*'s lane slot and subprocess registration, if any."""
+    controller.state.processes.pop(job.job_id, None)
+    for lane in controller.state.lanes():
+        lane.active.pop(job.job_id, None)
 
 
 def release_dependents(controller: FirmwareController, job: FirmwareJob) -> bool:
@@ -170,23 +167,20 @@ def raise_if_cancelled(controller: FirmwareController, job: FirmwareJob, phase: 
         raise ValueError(msg)
 
 
-async def terminate_current_process(controller: FirmwareController, lane: Lane) -> None:
-    """Signal *lane*'s running subprocess + children; escalate if it lingers.
+async def terminate_job_process(controller: FirmwareController, job: FirmwareJob) -> None:
+    """Signal *job*'s running subprocess + children; escalate if it lingers.
 
     Walks the whole process group via
     :func:`terminate_subtree_with_grace` so SIGTERM reaches
     esphome → platformio → gcc / esptool on POSIX, ``taskkill /F
     /T`` on Windows. The runner loop is what actually finalises
-    the job on exit — this helper only nudges the process. Lane-scoped
+    the job on exit — this helper only nudges the process. Job-scoped
     so cancelling an upload never signals a concurrent compile.
     """
-    proc = lane.current_process
+    proc = controller.state.processes.get(job.job_id)
     if proc is None:
         return
-    await terminate_subtree_with_grace(
-        proc,
-        job_label=f"job {lane.current_job.job_id}" if lane.current_job else "job ?",
-    )
+    await terminate_subtree_with_grace(proc, job_label=f"job {job.job_id}")
 
 
 def _defer_install_if_target_offline(controller: FirmwareController, job: FirmwareJob) -> None:

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -127,7 +127,7 @@ async def run_remote_job(  # noqa: C901
     set ``status = RUNNING`` and fired ``JOB_STARTED``; this
     function is responsible for the entire run-and-finalise
     middle and leaves the outer ``finally`` block to clear
-    ``_current_job`` / persist.
+    the lane slot / persist.
 
     With ``retry_on_server_loss`` (the dispatch pool), a mid-build
     peer-link close raises :class:`RemoteServerLostError` instead of
@@ -211,7 +211,7 @@ async def run_remote_job(  # noqa: C901
     cancel_event = asyncio.Event()
     controller.state.cancel_events[job.job_id] = cancel_event
     # A cancel that landed during ``_execute_job``'s pre-runner
-    # phase (``_current_job = job`` is set before the persist
+    # phase (the lane slot is claimed before the persist
     # await, so the cancel handler accepts the request and
     # writes to ``_cancel_requested`` — but the runner hasn't
     # yet installed its event, so the handler's
@@ -768,16 +768,13 @@ async def _run_upload_subprocess(
     Mirrors the local subprocess path's per-line bookkeeping
     (``_ingest_output_line``) so the firmware-tasks UI sees
     one event stream regardless of which CPU produced the
-    bytes. ``_tracked_subprocess`` registers the spawn on the
-    compile lane's ``current_process`` so a concurrent
+    bytes. ``_tracked_subprocess`` registers the spawn in the
+    job-keyed process registry so a concurrent
     ``firmware/cancel`` lands SIGTERM on the upload chain
     just like it does for the local-only path.
     """
-    # Register the local flash on the job's own lane (``lane_for``); a remote
-    # install is an INSTALL job, so that resolves to the compile lane.
-    lane = controller.state.lane_for(job)
     async with controller._tracked_subprocess(
-        lane,
+        job,
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
@@ -792,7 +789,7 @@ async def _run_upload_subprocess(
         # this check, the subprocess gets started for a job
         # the user already aborted.
         if job.job_id in controller.state.cancel_requested:
-            await controller._terminate_current_process(lane)
+            await controller._terminate_job_process(job)
 
         assert proc.stdout is not None  # type narrowing
         async for line in iter_lines_with_progress(proc.stdout):

--- a/esphome_device_builder/controllers/firmware/runner.py
+++ b/esphome_device_builder/controllers/firmware/runner.py
@@ -42,7 +42,7 @@ async def _clean_provisioned_venvs(controller: FirmwareController) -> None:
 
 
 async def run_lane(controller: FirmwareController, lane: Lane) -> None:
-    """Background loop: process one job at a time on *lane* (concurrent with the other lane)."""
+    """Background loop: one lane worker, processing one job at a time off *lane*'s queue."""
     while True:
         job = await lane.queue.get()
         try:
@@ -82,9 +82,9 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
     controller: FirmwareController, job: FirmwareJob, lane: Lane
 ) -> None:
     """Execute a single firmware job on *lane*."""
-    # Claim the lane slot before JOB_STARTED fires — the receiver's
-    # ``compile_queue_status`` reads ``current_job`` reactively on that event.
-    lane.current_job = job
+    # Claim a lane slot before JOB_STARTED fires — the receiver's
+    # ``compile_queue_status`` reads ``active`` reactively on that event.
+    lane.active[job.job_id] = job
     _LOGGER.info(
         "Starting job %s: %s %s",
         job.job_id,
@@ -107,7 +107,7 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
 
         # Pre-flight: verify chip type for serial uploads
         if job.job_type in (JobType.UPLOAD, JobType.INSTALL):
-            await controller._verify_chip(job, lane)
+            await controller._verify_chip(job)
 
         # A rename tail runs as a plain ``esphome upload`` of the *renamed*
         # YAML; ``job.configuration`` stays the old filename (rename lock,
@@ -158,13 +158,13 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
                     return
 
         async with controller._tracked_subprocess(
-            lane,
+            job,
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             env=env,
             # Put the whole esphome → platformio → gcc tree in its
-            # own process group so ``_terminate_current_process``
+            # own process group so ``_terminate_job_process``
             # can signal the entire chain, not just the python
             # parent. Without this, killing the parent leaves the
             # compiler children orphaned and the build keeps
@@ -175,11 +175,11 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
             # Honour a cancel that landed in the gap between
             # ``_verify_chip`` finishing and ``create_subprocess_exec``
             # returning — without this, an early Stop click during
-            # the brief async window where ``_current_process`` was
-            # ``None`` lets the install run to completion before the
+            # the brief async window where no subprocess was
+            # registered lets the install run to completion before the
             # post-``proc.wait()`` cancel check sees the flag.
             if job.job_id in controller.state.cancel_requested:
-                await controller._terminate_current_process(lane)
+                await controller._terminate_job_process(job)
 
             assert proc.stdout is not None  # type narrowing
 
@@ -274,8 +274,7 @@ async def execute_job(  # noqa: PLR0915, PLR0912, C901
         # dispatch driver so both paths guarantee terminality identically.
         lifecycle.finalize_unexpected_error(controller, job, exc)
     finally:
-        lane.current_job = None
-        lane.current_process = None
+        lane.active.pop(job.job_id, None)
         await lifecycle.end_run(controller, job)
 
 
@@ -328,7 +327,7 @@ async def execute_remote_job(controller: FirmwareController, job: FirmwareJob) -
 
 @asynccontextmanager
 async def tracked_subprocess(
-    controller: FirmwareController, lane: Lane, *args: Any, **kwargs: Any
+    controller: FirmwareController, job: FirmwareJob, *args: Any, **kwargs: Any
 ) -> AsyncIterator[asyncio.subprocess.Process]:
     """
     Spawn a subprocess that's visible to ``firmware/cancel``.
@@ -336,19 +335,19 @@ async def tracked_subprocess(
     Required for every ``create_subprocess_exec`` call in the
     runner path — both the main install/upload spawn in
     ``_execute_job`` and pre-flight probes like
-    ``_verify_chip``. Setting ``_current_process`` is what lets
-    a concurrent ``firmware/cancel`` actually land SIGTERM on
-    the running spawn; a direct ``create_subprocess_exec`` call
-    without this registration silently regresses the
-    issue-#136 fix — the cancel handler walks
-    ``_current_process``, no-ops on ``None``, the user clicks
+    ``_verify_chip``. Registering in ``state.processes`` is what
+    lets a concurrent ``firmware/cancel`` actually land SIGTERM
+    on the running spawn; a direct ``create_subprocess_exec``
+    call without this registration silently regresses the
+    issue-#136 fix — the cancel handler looks up the job's
+    process, no-ops on a missing entry, the user clicks
     Stop, nothing visible happens, and the orphaned subprocess
     runs to completion in the background.
 
     Two cleanup contracts on exit:
 
     - Normal exit / non-cancellation exception: restore the
-      prior ``_current_process`` value so nested usage (a
+      prior registration so nested usage (a
       future spawn site that itself wraps another) doesn't
       accidentally null out an outer registration.
     - ``asyncio.CancelledError`` (runner-task shutdown):
@@ -369,14 +368,15 @@ async def tracked_subprocess(
     # traceback in the streamed job output instead.
     kwargs.setdefault("stdin", asyncio.subprocess.DEVNULL)
     proc = await create_subprocess_exec(*args, **kwargs)
-    prev = lane.current_process
-    lane.current_process = proc
+    processes = controller.state.processes
+    prev = processes.get(job.job_id)
+    processes[job.job_id] = proc
     try:
         yield proc
     except asyncio.CancelledError:
         # Runner-shutdown cancellation: the runner task itself
         # was cancelled (vs. a user-driven ``firmware/cancel``,
-        # which calls ``_terminate_current_process`` from the
+        # which calls ``_terminate_job_process`` from the
         # cancel handler directly). Reuse the same group-aware
         # termination helper here so SIGTERM walks the whole
         # process group (esphome → platformio → gcc / esptool).
@@ -384,7 +384,10 @@ async def tracked_subprocess(
         # parent — on POSIX with ``start_new_session=True``
         # that orphans the child tree and the build keeps
         # running until the children finish on their own.
-        await controller._terminate_current_process(lane)
+        await controller._terminate_job_process(job)
         raise
     finally:
-        lane.current_process = prev
+        if prev is None:
+            processes.pop(job.job_id, None)
+        else:
+            processes[job.job_id] = prev

--- a/esphome_device_builder/helpers/process.py
+++ b/esphome_device_builder/helpers/process.py
@@ -28,7 +28,7 @@ module:
 The orchestration helper ``terminate_subtree_with_grace`` ties those
 together: SIGTERM the group → wait the grace window → SIGKILL the
 group on POSIX; ``taskkill`` with a single-shot kill fallback on
-Windows. That's the shape ``FirmwareController._terminate_current_process``
+Windows. That's the shape ``FirmwareController._terminate_job_process``
 needs.
 
 POSIX vs Windows asymmetry is deliberate: the POSIX path has a

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -120,8 +120,7 @@ def firmware_controller_factory(
       enqueue a rejected request crash visibly.
 
     - ``with_terminate=False`` (default): when set ``True``,
-      install ``_current_job`` / ``_current_process`` /
-      ``_cancel_requested`` / ``_terminate_current_process``.
+      install ``_cancel_requested`` / ``_terminate_job_process``.
       Only ``cancel`` reaches into these.
 
     - ``with_real_persistence=False`` (default): ``_persist_jobs``
@@ -195,16 +194,6 @@ def firmware_controller_factory(
         # binding doesn't treat the lambda as an unbound method.
         controller._db.create_background_task = lambda coro: coro.close()
 
-        # ``_finalize_terminal`` releases the runner slot before
-        # firing — so ``_current_job`` / ``_current_process`` need
-        # to exist on every stub (default ``None``, matching
-        # production's ``__init__``) even on test paths that
-        # don't drive the runner. Without this, cancel-queued /
-        # supersede tests that fire JOB_CANCELLED through the
-        # helper crash on ``AttributeError``.
-        controller.state.compile_lane.current_job = None
-        controller.state.compile_lane.current_process = None
-
         if with_queue:
             # ``put_nowait`` / ``qsize`` are sync on a real Queue; keep them
             # sync here (the enqueue path uses ``put_nowait``) while ``get``
@@ -217,7 +206,7 @@ def firmware_controller_factory(
         if with_terminate:
             controller.state.cancel_requested = set()
             controller.state.cancel_events = {}
-            controller._terminate_current_process = AsyncMock()
+            controller._terminate_job_process = AsyncMock()
 
         return controller
 
@@ -234,7 +223,6 @@ def bare_firmware_controller_factory() -> BareFirmwareControllerFactory:
     def _make(
         *,
         esphome_cmd: list[str] | None = None,
-        current_job: object | None = None,
         with_mock_db: bool = False,
     ) -> FirmwareController:
         controller = FirmwareController.__new__(FirmwareController)
@@ -242,8 +230,6 @@ def bare_firmware_controller_factory() -> BareFirmwareControllerFactory:
         controller.download_tokens = DownloadTokens()
         if esphome_cmd is not None:
             controller.state.esphome_cmd = esphome_cmd
-        if current_job is not None:
-            controller.state.compile_lane.current_job = current_job
         if with_mock_db:
             controller._db = MagicMock()
             controller._db.devices = None
@@ -387,8 +373,6 @@ def wire_real_queue(controller: FirmwareController) -> None:
         return
 
     controller._supersede_active_jobs = _supersede  # type: ignore[assignment]
-    controller.state.compile_lane.current_job = None
-    controller.state.compile_lane.current_process = None
     controller.state.cancel_requested = set()
     controller.state.cancel_events = {}
 

--- a/tests/controllers/firmware/test_branches_coverage.py
+++ b/tests/controllers/firmware/test_branches_coverage.py
@@ -14,7 +14,7 @@ Surfaces touched here:
   for an unknown job id, ``follow_jobs`` early-returns when
   ``client`` is None.
 - **Runner internals**: queue runner skips a CANCELLED job
-  without spawning a subprocess, ``_terminate_current_process``
+  without spawning a subprocess, ``_terminate_job_process``
   is a no-op when no process is bound.
 - **Command building**: ``_build_command`` for ``RENAME`` appends
   ``new_name`` as a positional arg.
@@ -252,24 +252,22 @@ async def test_run_queue_cancels_sibling_lane_when_one_raises(
     assert sibling_cancelled.is_set()
 
 
-async def test_terminate_current_process_no_op_when_no_process(
+async def test_terminate_job_process_no_op_when_no_process(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """``_terminate_current_process`` returns cleanly when no process is bound.
+    """``_terminate_job_process`` returns cleanly when no process is bound.
 
-    The cancel handler always calls ``_terminate_current_process``
+    The cancel handler always calls ``_terminate_job_process``
     after flipping the status — but the QUEUED-cancel path runs
-    before the runner has spawned anything, so the controller's
-    ``_current_process`` is still ``None``. Pin the early return
+    before the runner has spawned anything, so ``state.processes``
+    has no entry for the job. Pin the early return
     so a regression that fell through to ``terminate_subtree_*``
     against ``None`` would surface as a hard error here.
     """
     controller = firmware_controller_factory()
-    controller.state.compile_lane.current_process = None
-    controller.state.compile_lane.current_job = None
 
     # Should return without raising; no process to terminate.
-    await controller._terminate_current_process(controller.state.compile_lane)
+    await controller._terminate_job_process(MagicMock(job_id="no-proc"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_cancel.py
+++ b/tests/controllers/firmware/test_cancel.py
@@ -14,7 +14,7 @@ The handler routes by job status:
   ``FAILED``-on-non-zero-exit.
 - Already terminal → reject with ``CommandError(INVALID_ARGS)``.
 - Unknown ``job_id`` → reject with ``CommandError(NOT_FOUND)``.
-- ``RUNNING`` but state out of sync (no ``_current_job`` or wrong
+- ``RUNNING`` but state out of sync (no lane slot or wrong
   id) → ``RuntimeError``. Defensive guard against a queue that
   thinks a job is running but the runner has moved on. Stays as
   ``RuntimeError`` (server bug, not user input) so the WS
@@ -143,17 +143,17 @@ async def test_cancel_queued_job_prunes_history_before_persisting(
     assert order == ["prune", "persist"]
 
 
-async def test_cancel_queued_does_not_touch_terminate_current_process(
+async def test_cancel_queued_does_not_touch_terminate_job_process(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
     """The QUEUED branch never reaches the subprocess terminator.
 
-    Belt-and-braces: ``_terminate_current_process`` walks
-    ``self.state.compile_lane.current_process`` and signals it. For a queued job
-    there is no subprocess (and ``_current_process`` is ``None``),
+    Belt-and-braces: ``_terminate_job_process`` looks up the job in
+    ``state.processes`` and signals it. For a queued job
+    there is no subprocess (no registry entry),
     so calling it here is at best a no-op; at worst a future
     refactor of the terminator that doesn't gracefully handle the
-    null case crashes the cancel.
+    missing case crashes the cancel.
     """
     job = _job("j-q", status=JobStatus.QUEUED)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
@@ -161,7 +161,7 @@ async def test_cancel_queued_does_not_touch_terminate_current_process(
 
     await controller.cancel(job_id="j-q")
 
-    controller._terminate_current_process.assert_not_called()
+    controller._terminate_job_process.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -182,12 +182,12 @@ async def test_cancel_running_job_records_intent_and_terminates(
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
-    controller.state.compile_lane.current_job = job
+    controller.state.compile_lane.active[job.job_id] = job
 
     await controller.cancel(job_id="j-r")
 
     assert "j-r" in controller.state.cancel_requested
-    controller._terminate_current_process.assert_awaited_once()
+    controller._terminate_job_process.assert_awaited_once()
 
 
 async def test_cancel_running_job_does_not_fire_event_directly(
@@ -204,7 +204,7 @@ async def test_cancel_running_job_does_not_fire_event_directly(
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
-    controller.state.compile_lane.current_job = job
+    controller.state.compile_lane.active[job.job_id] = job
     captured = capture_firmware_events(controller, EventType.JOB_CANCELLED)
 
     await controller.cancel(job_id="j-r")
@@ -214,10 +214,10 @@ async def test_cancel_running_job_does_not_fire_event_directly(
     assert job.status == JobStatus.RUNNING
 
 
-async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
+async def test_cancel_running_job_with_no_lane_slot_raises_runtime_error(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """RUNNING in ``_jobs`` but ``_current_job`` is None → state out of sync.
+    """RUNNING in ``_jobs`` but on no lane → state out of sync.
 
     Defensive: if we ever see a ``RUNNING`` status with no active
     subprocess, terminating "the current process" would either
@@ -227,17 +227,17 @@ async def test_cancel_running_job_with_no_current_job_raises_runtime_error(
     """
     job = _job("j-r", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, with_settings=False, with_terminate=True)
-    # ``_current_job`` left as ``None`` — out of sync.
+    # No lane ``active`` entry — out of sync.
 
     with pytest.raises(RuntimeError, match="state out of sync"):
         await controller.cancel(job_id="j-r")
-    controller._terminate_current_process.assert_not_called()
+    controller._terminate_job_process.assert_not_called()
 
 
-async def test_cancel_running_job_with_mismatched_current_job_raises(
+async def test_cancel_running_job_with_mismatched_lane_slot_raises(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """RUNNING ``job_id`` doesn't match ``_current_job.job_id`` → out of sync.
+    """RUNNING ``job_id`` isn't in any lane's ``active`` → out of sync.
 
     Same hazard as the no-current-job case: signalling the wrong
     process would terminate a different running job. Refuse the
@@ -246,11 +246,11 @@ async def test_cancel_running_job_with_mismatched_current_job_raises(
     job = _job("j-r", status=JobStatus.RUNNING)
     other = _job("j-other", status=JobStatus.RUNNING)
     controller = firmware_controller_factory(job, other, with_settings=False, with_terminate=True)
-    controller.state.compile_lane.current_job = other  # somebody else is running
+    controller.state.compile_lane.active[other.job_id] = other  # somebody else is running
 
     with pytest.raises(RuntimeError, match="state out of sync"):
         await controller.cancel(job_id="j-r")
-    controller._terminate_current_process.assert_not_called()
+    controller._terminate_job_process.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -284,5 +284,5 @@ async def test_cancel_terminal_job_raises_invalid_args(
         await controller.cancel(job_id="j-t")
     assert exc.value.code == ErrorCode.INVALID_ARGS
     assert f"Cannot cancel a {status.value} job" in exc.value.message
-    controller._terminate_current_process.assert_not_called()
+    controller._terminate_job_process.assert_not_called()
     assert captured == []

--- a/tests/controllers/firmware/test_clean.py
+++ b/tests/controllers/firmware/test_clean.py
@@ -273,7 +273,7 @@ async def test_clean_supersedes_other_active_clean_on_same_configuration(
     controller = firmware_controller_factory(with_queue=True, with_terminate=True)
     first = await controller.clean(configuration="kitchen.yaml")
     first.status = JobStatus.RUNNING
-    controller.state.compile_lane.current_job = first
+    controller.state.compile_lane.active[first.job_id] = first
 
     second = await controller.clean(configuration="kitchen.yaml")
 

--- a/tests/controllers/firmware/test_execute_job_e2e.py
+++ b/tests/controllers/firmware/test_execute_job_e2e.py
@@ -309,10 +309,10 @@ async def test_compile_mid_run_cancel_marks_cancelled(
     - JOB_STARTED fires *before* the subprocess spawn (the runner
       flips the status before it ``await``s ``create_subprocess_exec``).
       Synchronising on it would race the spawn and we'd terminate
-      a process that hasn't been assigned to ``_current_process``
+      a process that hasn't been registered in ``state.processes``
       yet. So we wait for the first JOB_OUTPUT instead — that's
       the earliest signal the subprocess is alive AND the
-      ``_current_process`` attribute has been written.
+      registry entry has been written.
     - We must wait for JOB_CANCELLED to fire *before* cancelling
       the runner task. Otherwise ``runner_task.cancel()`` triggers
       ``_execute_job``'s own ``except asyncio.CancelledError``
@@ -342,7 +342,7 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         captured.append({"type": event_type, "data": data})
         # First JOB_OUTPUT line means the subprocess is up,
         # streaming through ``iter_lines_with_progress``, and
-        # ``self.state.compile_lane.current_process`` has been assigned.
+        # ``state.processes[job_id]`` has been registered.
         if event_type == EventType.JOB_OUTPUT:
             proc_alive.set()
         elif event_type == EventType.JOB_CANCELLED:
@@ -359,8 +359,8 @@ async def test_compile_mid_run_cancel_marks_cancelled(
         # up the cancel flag when it loops back to read the next
         # line and sees EOF.
         controller.state.cancel_requested.add(job.job_id)
-        assert controller.state.compile_lane.current_process is not None
-        controller.state.compile_lane.current_process.terminate()
+        assert job.job_id in controller.state.processes
+        controller.state.processes[job.job_id].terminate()
 
         # Wait for the cancel event from the runner's natural
         # post-``proc.wait()`` path, NOT from ``runner_task.cancel()``
@@ -399,7 +399,7 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     surrounding runner loop unwinds.
 
     Sequencing: wait for the first JOB_OUTPUT (proves the subprocess
-    is up *and* ``_current_process`` has been assigned) before
+    is up *and* registered in ``state.processes``) before
     cancelling, otherwise we'd race the subprocess spawn and either
     leak the process or hit the cancel before the try-block had
     entered.
@@ -439,8 +439,8 @@ async def test_execute_job_runner_shutdown_terminates_and_marks_cancelled(
     runner_task = asyncio.create_task(controller._run_queue())
     try:
         await asyncio.wait_for(proc_alive.wait(), timeout=10.0)
-        assert controller.state.compile_lane.current_process is not None
-        proc = controller.state.compile_lane.current_process
+        assert job.job_id in controller.state.processes
+        proc = controller.state.processes[job.job_id]
 
         # Cancel the runner task itself — this is the shutdown shape,
         # not the user-cancel one. Nothing is added to
@@ -477,7 +477,7 @@ async def test_execute_job_runner_shutdown_kills_subprocess_group(
     Pre-refactor regression hazard: an earlier draft used
     ``proc.terminate()`` (signals only the python parent) inside
     the helper's ``CancelledError`` branch instead of
-    ``_terminate_current_process`` (which uses
+    ``_terminate_job_process`` (which uses
     ``terminate_subtree_with_grace`` →
     ``os.killpg(getpgid(pid), SIGTERM)`` to walk the group).
     With ``start_new_session=True`` the build's children

--- a/tests/controllers/firmware/test_lane_concurrency_e2e.py
+++ b/tests/controllers/firmware/test_lane_concurrency_e2e.py
@@ -92,15 +92,14 @@ async def test_parked_upload_does_not_block_a_compile(
         # upload is still RUNNING on the other lane — they overlapped.
         assert compile_job.status == JobStatus.COMPLETED
         assert upload.status == JobStatus.RUNNING
-        assert controller.state.upload_lane.current_job is not None
-        assert controller.state.upload_lane.current_job.job_id == upload.job_id
+        assert upload.job_id in controller.state.upload_lane.active
         # The compile lane freed itself the instant the compile finished,
         # ready for the next device rather than waiting on the upload.
-        assert controller.state.compile_lane.current_job is None
+        assert not controller.state.compile_lane.active
 
         # Release the parked upload and let it unwind cleanly.
         controller.state.cancel_requested.add(upload.job_id)
-        await controller._terminate_current_process(controller.state.upload_lane)
+        await controller._terminate_job_process(upload)
         async with asyncio.timeout(10):
             await upload_terminal.wait()
         assert upload.status == JobStatus.CANCELLED

--- a/tests/controllers/firmware/test_queue_status.py
+++ b/tests/controllers/firmware/test_queue_status.py
@@ -58,7 +58,8 @@ def test_compile_queue_status_idle() -> None:
 def test_compile_queue_status_running_only() -> None:
     """Runner busy with no backlog: idle=False, running=True, depth=0."""
     controller = _make_controller()
-    controller.state.compile_lane.current_job = _job()
+    job = _job()
+    controller.state.compile_lane.active[job.job_id] = job
     idle, running, queue_depth = controller.compile_queue_status()
     assert idle is False
     assert running is True
@@ -87,7 +88,8 @@ def test_compile_queue_status_queued_but_not_running() -> None:
 def test_compile_queue_status_running_and_queued() -> None:
     """Runner busy AND backlog: idle=False, running=True, depth>0."""
     controller = _make_controller()
-    controller.state.compile_lane.current_job = _job("active")
+    active = _job("active")
+    controller.state.compile_lane.active[active.job_id] = active
     controller.state.compile_lane.queue.put_nowait(_job("waiting"))
     idle, running, queue_depth = controller.compile_queue_status()
     assert idle is False
@@ -119,8 +121,6 @@ def _make_controller_with_real_bus() -> FirmwareController:
     controller._db = db
     controller.state.jobs = {}
     controller.state.compile_lane.queue = asyncio.Queue()
-    controller.state.compile_lane.current_job = None
-    controller.state.compile_lane.current_process = None
     controller.state.cancel_requested = set()
     controller.state.cancel_events = {}
     return controller
@@ -160,30 +160,31 @@ def test_finalize_terminal_releases_slot_before_listener_fires(
     """Listener-during-fire sees ``running=False`` for every terminal status.
 
     The bug this pins: the runner used to fire the terminal
-    event while ``_current_job`` was still set (the ``finally``
+    event while the lane slot was still claimed (the ``finally``
     cleanup ran *afterwards*). The remote-build broadcaster
     captured ``running=True`` and the offloader's
     ``_peer_queue_status`` cache froze there, silently routing
     every subsequent install to LOCAL.
     """
     controller = _make_controller_with_real_bus()
-    controller.state.compile_lane.current_job = _job()
-    controller.state.compile_lane.current_process = MagicMock()
+    job = _job()
+    controller.state.compile_lane.active[job.job_id] = job
+    controller.state.processes[job.job_id] = MagicMock()
     captured = _capture_snapshot_in_listener(controller, event_type)
 
-    controller._finalize_terminal(controller.state.compile_lane.current_job, status)
+    controller._finalize_terminal(job, status)
 
     assert captured == [(True, False, 0)]
     # And the slot stays released after the fire returns.
-    assert controller.state.compile_lane.current_job is None
-    assert controller.state.compile_lane.current_process is None
+    assert not controller.state.compile_lane.active
+    assert job.job_id not in controller.state.processes
 
 
-def test_finalize_terminal_skips_release_when_job_not_current() -> None:
-    """A finalise on a non-current job leaves the running slot alone.
+def test_finalize_terminal_skips_release_when_job_not_active() -> None:
+    """A finalise on a job with no lane slot leaves the running slot alone.
 
     The QUEUED-cancel path goes through ``cancel`` (not
-    ``_finalize_terminal``), but the helper's ``is job`` guard
+    ``_finalize_terminal``), but the helper's job-id keying
     is still load-bearing: a future caller that passes a
     different job must not evict whatever's actually running.
     The listener still fires — just with the running slot
@@ -192,13 +193,13 @@ def test_finalize_terminal_skips_release_when_job_not_current() -> None:
     controller = _make_controller_with_real_bus()
     running = _job("running")
     other = _job("other")
-    controller.state.compile_lane.current_job = running
+    controller.state.compile_lane.active[running.job_id] = running
     captured = _capture_snapshot_in_listener(controller, EventType.JOB_FAILED)
 
     controller._finalize_terminal(other, JobStatus.FAILED)
 
     assert captured == [(False, True, 0)]
-    assert controller.state.compile_lane.current_job is running
+    assert controller.state.compile_lane.active == {running.job_id: running}
 
 
 def test_finalize_terminal_rejects_non_terminal_status() -> None:
@@ -211,12 +212,13 @@ def test_finalize_terminal_rejects_non_terminal_status() -> None:
     would crash later with a less-actionable ``KeyError``).
     """
     controller = _make_controller_with_real_bus()
-    controller.state.compile_lane.current_job = _job()
+    job = _job()
+    controller.state.compile_lane.active[job.job_id] = job
 
     with pytest.raises(ValueError, match="non-terminal status"):
-        controller._finalize_terminal(controller.state.compile_lane.current_job, JobStatus.RUNNING)
+        controller._finalize_terminal(job, JobStatus.RUNNING)
     # Slot intact — we raised before the release.
-    assert controller.state.compile_lane.current_job is not None
+    assert job.job_id in controller.state.compile_lane.active
 
 
 @pytest.mark.parametrize(
@@ -239,13 +241,9 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
     path.
     """
     controller = _make_controller_with_real_bus()
-    # Save the job reference before ``_finalize_terminal``
-    # clears ``_current_job``; the post-fire assertions need
-    # to inspect the same FirmwareJob instance the helpers
-    # operated on.
     job = _job()
-    controller.state.compile_lane.current_job = job
-    controller.state.compile_lane.current_process = MagicMock()
+    controller.state.compile_lane.active[job.job_id] = job
+    controller.state.processes[job.job_id] = MagicMock()
     captured = _capture_snapshot_in_listener(controller, event_type)
 
     if fn_name == "_finalize_success":
@@ -254,8 +252,8 @@ def test_remote_runner_terminal_helpers_release_slot_before_fire(
         remote_runner._fail_locally(controller, job, reason="boom")
 
     assert captured == [(True, False, 0)]
-    assert controller.state.compile_lane.current_job is None
-    assert controller.state.compile_lane.current_process is None
+    assert not controller.state.compile_lane.active
+    assert job.job_id not in controller.state.processes
     assert job.status is status
     if status is JobStatus.FAILED:
         # ``_fail_locally`` stamps ``job.error`` before
@@ -274,7 +272,8 @@ def test_compile_queue_status_ignores_a_busy_upload_lane() -> None:
     frozen-running silent-LOCAL-fallback bug).
     """
     controller = _make_controller()
-    controller.state.upload_lane.current_job = _job("uploading")
+    uploading = _job("uploading")
+    controller.state.upload_lane.active[uploading.job_id] = uploading
 
     compile_status = controller.compile_queue_status()
     assert compile_status.idle is True

--- a/tests/controllers/firmware/test_remote_dispatch.py
+++ b/tests/controllers/firmware/test_remote_dispatch.py
@@ -367,7 +367,7 @@ async def test_compile_lane_completion_wakes_dispatcher_when_pending(
     pool.wake.clear()
 
     async def _noop_execute(job: FirmwareJob, lane: Any) -> None:
-        lane.current_job = None  # mirror execute_job's finally clearing the slot
+        lane.active.pop(job.job_id, None)  # mirror execute_job's finally clearing the slot
 
     monkeypatch.setattr(controller, "_execute_job", _noop_execute)
     lane_job = FirmwareJob(

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -31,7 +31,6 @@ import pytest
 from esphome.const import __version__ as _esphome_version
 
 from esphome_device_builder.controllers.firmware import remote_runner
-from esphome_device_builder.controllers.firmware._state import Lane
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsError,
     DownloadArtifactsResult,
@@ -259,7 +258,7 @@ def _request_remote_cancel(controller: Any, job: FirmwareJob) -> None:
     through the helper (rather than calling ``controller.cancel``
     directly) keeps the test focused on the runner under test
     without bringing in the cancel handler's QUEUED-job and
-    ``_terminate_current_process`` branches that don't apply
+    ``_terminate_job_process`` branches that don't apply
     on the remote path.
     """
     controller.state.cancel_requested.add(job.job_id)
@@ -1373,7 +1372,7 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     A cancel landed before the runner registered its event still fires the wire cancel.
 
     The race the event-driven design opened up: between
-    ``_execute_job`` setting ``_current_job = job`` and the
+    ``_execute_job`` claiming the lane slot and the
     runner registering its ``cancel_event`` on the
     controller, the WS cancel handler may run. It would
     happily ``_cancel_requested.add(job_id)`` and then find
@@ -1446,20 +1445,20 @@ async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     _wire_remote_build(controller, client=client)
     job = _make_remote_job()
 
-    # The WS cancel handler refuses non-existent jobs and the
-    # ``_current_job`` mismatch is a hard error — wire both so
+    # The WS cancel handler refuses non-existent jobs and a
+    # missing lane slot is a hard error — wire both so
     # the handler's ``RUNNING`` branch runs.
     controller.state.jobs[job.job_id] = job
     job.status = JobStatus.RUNNING
-    controller.state.compile_lane.current_job = job
+    controller.state.compile_lane.active[job.job_id] = job
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
 
     # Drive through the real handler — the cancel-event
     # signal is its only job for the REMOTE path (the
-    # ``_terminate_current_process`` call is a no-op because
-    # ``_current_process`` is None).
+    # ``_terminate_job_process`` call is a no-op because
+    # no subprocess is registered).
     await controller.cancel(job_id=job.job_id)
     await _wait_for_wire_cancel(client)
     client.cancel_job.assert_awaited_once_with(job_id=job.job_id)
@@ -1544,7 +1543,7 @@ def _wire_upload_subprocess(
     runner doesn't reach into the (absent in unit tests)
     devices controller's address cache. The runner's
     ``_tracked_subprocess`` is the real method — it
-    registers the spawn with ``_current_process`` so the
+    registers the spawn in ``state.processes`` so the
     cancel-during-upload tests can SIGTERM the chain.
     """
     quoted_stdout = repr(stdout)
@@ -1786,9 +1785,9 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     User Stop during the ``esphome upload`` subprocess finalises as CANCELLED.
 
     The runner's ``_tracked_subprocess`` registers the
-    upload spawn with ``controller.state.compile_lane.current_process``, and
+    upload spawn in ``controller.state.processes``, and
     ``FirmwareController.cancel``'s
-    ``_terminate_current_process`` lands SIGTERM on the
+    ``_terminate_job_process`` lands SIGTERM on the
     spawned tree. The subprocess exits non-zero (terminated
     by signal); the runner's post-spawn cancel-check
     routes through ``_finalize_cancelled`` rather than the
@@ -1817,11 +1816,12 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
         "sys.stdout.flush(); time.sleep(30)",
     ]
 
-    async def _terminate(lane: Lane) -> None:
-        assert lane.current_process is not None  # type narrowing
-        lane.current_process.terminate()
+    async def _terminate(target: FirmwareJob) -> None:
+        proc = controller.state.processes.get(target.job_id)
+        assert proc is not None  # type narrowing
+        proc.terminate()
 
-    controller._terminate_current_process = _terminate  # type: ignore[method-assign]
+    controller._terminate_job_process = _terminate  # type: ignore[method-assign]
     job = _make_remote_install_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
@@ -1829,11 +1829,11 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     _fire_state(controller, job_id=job.job_id, status="completed")
 
     # Wait until the subprocess is up.
-    while controller.state.compile_lane.current_process is None:
+    while job.job_id not in controller.state.processes:
         await asyncio.sleep(0.01)
 
     _request_remote_cancel(controller, job)
-    await controller._terminate_current_process(controller.state.compile_lane)
+    await controller._terminate_job_process(job)
     await asyncio.wait_for(runner, timeout=5.0)
 
     assert job.status == JobStatus.CANCELLED
@@ -1846,7 +1846,7 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Cancel landing during the staging executor hops fires ``_terminate_current_process`` post-spawn.
+    Cancel landing during the staging executor hops fires ``_terminate_job_process`` post-spawn.
 
     The runner has two cancel-check sites for this path:
 
@@ -1864,7 +1864,7 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     ``firmware_path.write_bytes`` (via ``Path.write_bytes``)
     to flip ``_cancel_requested`` as a side effect — so by
     the time the spawn returns, the in-context check sees
-    the flag and fires ``_terminate_current_process``.
+    the flag and fires ``_terminate_job_process``.
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
@@ -1874,10 +1874,10 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
 
     terminate_calls: list[None] = []
 
-    async def _terminate(_lane: Lane) -> None:
+    async def _terminate(_job: FirmwareJob) -> None:
         terminate_calls.append(None)
 
-    controller._terminate_current_process = _terminate  # type: ignore[method-assign]
+    controller._terminate_job_process = _terminate  # type: ignore[method-assign]
     # Subprocess emits one line + exits 0 — the
     # cancel-aware finalise routes through CANCELLED
     # regardless of the exit.
@@ -1896,9 +1896,9 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     await remote_runner._fetch_and_run_local_upload(controller=controller, job=job, client=client)
 
     # The post-spawn check inside ``_run_upload_subprocess``
-    # called ``_terminate_current_process``.
+    # called ``_terminate_job_process``.
     assert terminate_calls, (
-        "expected _terminate_current_process to fire from the in-context-manager cancel check"
+        "expected _terminate_job_process to fire from the in-context-manager cancel check"
     )
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1

--- a/tests/controllers/firmware/test_stop.py
+++ b/tests/controllers/firmware/test_stop.py
@@ -6,7 +6,7 @@ the build keeps running until they finish on their own — exactly the
 "hit Stop, build kept going" symptom from production.
 
 Drives the regression by spawning a tiny shell script that itself
-spawns a long-running grandchild, calling our ``_terminate_current_process``,
+spawns a long-running grandchild, calling our ``_terminate_job_process``,
 and asserting both pids are gone shortly after.
 """
 
@@ -138,7 +138,7 @@ def test_signal_process_group_returns_false_on_permission_error(
 
 
 # ---------------------------------------------------------------------------
-# _terminate_current_process — full integration
+# _terminate_job_process — full integration
 # ---------------------------------------------------------------------------
 
 
@@ -147,7 +147,7 @@ def controller(
     bare_firmware_controller_factory: BareFirmwareControllerFactory,
 ) -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
-    return bare_firmware_controller_factory(current_job=MagicMock(job_id="test-job"))
+    return bare_firmware_controller_factory()
 
 
 async def test_terminate_kills_grandchild_via_process_group(
@@ -198,7 +198,8 @@ async def test_terminate_kills_grandchild_via_process_group(
         stderr=asyncio.subprocess.STDOUT,
         start_new_session=True,
     )
-    controller.state.compile_lane.current_process = proc  # type: ignore[attr-defined]
+    job = MagicMock(job_id="test-job")
+    controller.state.processes[job.job_id] = proc  # type: ignore[assignment]
 
     try:
         # Read the two pid lines from stdout so we know what to verify.
@@ -223,7 +224,7 @@ async def test_terminate_kills_grandchild_via_process_group(
         # Hit Stop. Both pids must die — SIGTERM is ignored, so the
         # controller's grace window expires and SIGKILL escalates to
         # the whole process group.
-        await controller._terminate_current_process(controller.state.compile_lane)
+        await controller._terminate_job_process(job)
         await proc.wait()
 
         assert await _wait_dead(parent_pid), f"parent pid {parent_pid} still alive after stop"

--- a/tests/controllers/firmware/test_stop_windows.py
+++ b/tests/controllers/firmware/test_stop_windows.py
@@ -2,7 +2,7 @@
 
 The POSIX path (``test_firmware_stop.py``) relies on process groups
 and ``killpg`` — primitives that don't exist on Windows. This module
-covers the Windows-specific branch in ``_terminate_current_process``:
+covers the Windows-specific branch in ``_terminate_job_process``:
 ``taskkill`` walks the kernel's parent-PID tree and force-kills the
 whole subtree in one shot.
 """
@@ -22,7 +22,7 @@ from esphome_device_builder.helpers.subprocess import create_subprocess_exec
 from tests.controllers.firmware.conftest import BareFirmwareControllerFactory
 
 # Only the integration test below — which spawns a real subprocess
-# and exercises ``_terminate_current_process``'s Windows branch end
+# and exercises ``_terminate_job_process``'s Windows branch end
 # to end — needs the Windows-only guard. The unit tests for
 # ``_terminate_subtree_windows`` patch out ``create_subprocess_exec``
 # entirely, so they're cross-platform-safe and contribute Windows-
@@ -38,7 +38,7 @@ def controller(
     bare_firmware_controller_factory: BareFirmwareControllerFactory,
 ) -> FirmwareController:
     """Stand up a FirmwareController shell — only the bits termination touches."""
-    return bare_firmware_controller_factory(current_job=MagicMock(job_id="test-job"))
+    return bare_firmware_controller_factory()
 
 
 @windows_only
@@ -53,10 +53,11 @@ async def test_terminate_kills_subprocess_via_taskkill(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )
-    controller.state.compile_lane.current_process = proc  # type: ignore[attr-defined]
+    job = MagicMock(job_id="test-job")
+    controller.state.processes[job.job_id] = proc  # type: ignore[assignment]
 
     try:
-        await controller._terminate_current_process(controller.state.compile_lane)
+        await controller._terminate_job_process(job)
         # taskkill /F /T schedules termination synchronously; the
         # subprocess should exit within seconds.
         await asyncio.wait_for(proc.wait(), timeout=5.0)

--- a/tests/controllers/firmware/test_supersede.py
+++ b/tests/controllers/firmware/test_supersede.py
@@ -12,7 +12,7 @@ the user-visible contract is:
 - Submit two compiles for *different* configurations: both
   stay ``QUEUED`` (supersede is per-configuration).
 - A running job for the same configuration gets cancelled
-  the same way (the runner's ``_terminate_current_process``
+  the same way (the runner's ``_terminate_job_process``
   fires).
 - The ``exclude_job_id`` guard keeps the new submission from
   cancelling itself — without it, ``_supersede_active_jobs``
@@ -114,12 +114,12 @@ async def test_resubmit_cancels_running_predecessor(
     The same supersede policy applies whether the predecessor
     is queued or running. For a running job, ``cancel`` records
     intent in ``_cancel_requested`` and calls
-    ``_terminate_current_process`` (which signals the
+    ``_terminate_job_process`` (which signals the
     subprocess); the runner's ``finally`` finalises with
     status ``CANCELLED`` on the next turn.
 
     This test simulates the runner being mid-build by mutating
-    ``_jobs[id].status`` directly + setting ``_current_job``,
+    ``_jobs[id].status`` directly + claiming the lane slot,
     same approach as the persistence test (no public API for
     "make the runner mid-build" without a real ``esphome``).
     """
@@ -132,16 +132,16 @@ async def test_resubmit_cancels_running_predecessor(
     # justified seam as ``test_persistence.py``'s RUNNING-carryover
     # test).
     first.status = JobStatus.RUNNING
-    controller.state.compile_lane.current_job = first
+    controller.state.compile_lane.active[first.job_id] = first
 
     second = await controller.compile(configuration="kitchen.yaml")
 
     # Cancel intent recorded for the predecessor — the runner's
     # ``finally`` would convert this into terminal CANCELLED on
-    # the next turn (not exercised here; ``_terminate_current_process``
+    # the next turn (not exercised here; ``_terminate_job_process``
     # is the AsyncMock from ``with_terminate=True``).
     assert first.job_id in controller.state.cancel_requested
-    controller._terminate_current_process.assert_awaited()
+    controller._terminate_job_process.assert_awaited()
     # Second submission queued normally.
     jobs = {j.job_id: j for j in await controller.get_jobs()}
     assert jobs[second.job_id].status == JobStatus.QUEUED

--- a/tests/controllers/firmware/test_verify_chip_e2e.py
+++ b/tests/controllers/firmware/test_verify_chip_e2e.py
@@ -70,9 +70,10 @@ import pytest
 
 from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware import runner as runner_module
-from esphome_device_builder.controllers.firmware._state import Lane
 from esphome_device_builder.models import (
+    FirmwareJob,
     JobStatus,
+    JobType,
 )
 from tests._storage_fixtures import write_storage_json
 from tests.controllers.firmware.conftest import (
@@ -99,6 +100,10 @@ if TYPE_CHECKING:
 
 def _seed_yaml(tmp_path: Path, name: str = "kitchen.yaml") -> None:
     (tmp_path / name).write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+
+
+def _make_job(job_id: str) -> FirmwareJob:
+    return FirmwareJob(job_id=job_id, configuration="kitchen.yaml", job_type=JobType.UPLOAD)
 
 
 def _seed_storage(
@@ -496,8 +501,8 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     The user-visible regression from issue #136: pick the wrong
     serial port, esptool hangs talking to a non-ESP device for
     ~30s, user clicks Stop, **nothing happens** — the cancel
-    flag was set but ``_current_process`` was ``None`` (the main
-    install hadn't spawned yet) so ``_terminate_current_process``
+    flag was set but no subprocess was registered (the main
+    install hadn't spawned yet) so ``_terminate_job_process``
     no-op'd. The verify subprocess kept running until esptool
     gave up on its own.
 
@@ -507,8 +512,8 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     handler, and assert the job reaches CANCELLED in well under
     the sleep duration. The only way that's possible is if the
     SIGTERM actually landed on the verify subprocess — which
-    requires the spawn to have been registered as
-    ``_current_process``.
+    requires the spawn to have been registered in
+    ``state.processes``.
     """
     controller = firmware_controller_factory(with_queue=True)
     _wire_real_queue(controller)
@@ -547,16 +552,16 @@ async def test_cancel_during_hanging_verify_chip_terminates_subprocess(
     # finishes when JOB_CANCELLED lands.
     async def _cancel_when_verify_starts() -> None:
         await verify_spawned.wait()
-        # Wait until the runner has assigned the verify subprocess
-        # to ``_current_process``. The wrapper's ``verify_spawned``
+        # Wait until the runner has registered the verify subprocess
+        # in ``state.processes``. The wrapper's ``verify_spawned``
         # fires INSIDE the ``await create_subprocess_exec`` call —
         # ``_verify_chip`` hasn't received the proc back yet, so
         # firing the cancel right here would hit the very race we're
-        # trying to guard against (``_current_process`` still None,
-        # ``_terminate_current_process`` no-ops). The poll proves the
+        # trying to guard against (no registry entry yet,
+        # ``_terminate_job_process`` no-ops). The poll proves the
         # registration happens BEFORE the runner waits on the proc,
         # which is the contract that makes mid-verify cancel work.
-        while controller.state.upload_lane.current_process is None:
+        while job.job_id not in controller.state.processes:
             await asyncio.sleep(0.01)
         await controller.cancel(job_id=job.job_id)
 
@@ -583,7 +588,7 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
     Repros issue #136: the user picks a serial port, the runner
     enters ``_verify_chip`` and spawns esptool against it, the
     user clicks Stop, the WS handler sets ``_cancel_requested``
-    and terminates ``_current_process`` (the esptool spawn
+    and terminates the registered subprocess (the esptool spawn
     courtesy of the registration covered by the previous test).
     Once esptool is gone, ``_verify_chip`` raises ValueError to
     short-circuit the main install spawn, and ``_execute_job``'s
@@ -608,8 +613,8 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
             # before the verify subprocess returns. The fake exits
             # quickly (no real hang) so the runner reaches the post-
             # wait cancel check inside ``_verify_chip`` and raises.
-            upload_job = controller.state.upload_lane.current_job
-            if upload_job is not None:
+            active = controller.state.upload_lane.active
+            for upload_job in active.values():
                 controller.state.cancel_requested.add(upload_job.job_id)
                 cancel_armed = True
             return await real(
@@ -645,83 +650,74 @@ async def test_cancel_during_verify_chip_marks_job_cancelled(
 # ---------------------------------------------------------------------------
 
 
-async def test_tracked_subprocess_registers_and_clears_current_process(
+async def test_tracked_subprocess_registers_and_clears_process(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """``_tracked_subprocess`` parks the spawned process on the controller.
+    """``_tracked_subprocess`` parks the spawned process in the registry.
 
     This is the helper that future pre-flight checks
     (``_verify_chip``-style) MUST go through to keep
     ``firmware/cancel`` working — a fresh probe that calls
     ``create_subprocess_exec`` directly would silently regress
-    the issue-#136 fix because the cancel handler walks
-    ``_current_process`` and no-ops on ``None``.
+    the issue-#136 fix because the cancel handler looks up the
+    job's process and no-ops on a missing entry.
 
     Pin the contract:
 
-    1. Inside the ``async with`` block, ``_current_process`` IS
-       the spawned proc (so SIGTERM via ``cancel`` lands on it).
-    2. After the block exits cleanly, the field returns to its
-       prior value (``None`` here, but the helper restores
-       whatever was there to compose safely with future nested
-       use).
+    1. Inside the ``async with`` block, ``state.processes[job_id]``
+       IS the spawned proc (so SIGTERM via ``cancel`` lands on it).
+    2. After the block exits cleanly, the entry returns to its
+       prior value (absent here, but the helper restores
+       whatever was there to compose safely with nested use).
     """
-    # ``with_terminate=True`` initialises ``_current_process = None``
-    # and ``_cancel_requested = set()`` so the helper has a clean
-    # slate to assign onto. The mocked ``_terminate_current_process``
-    # is unused by this test (we never trip the CancelledError or
-    # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    assert controller.state.compile_lane.current_process is None
+    job = _make_job("j1")
+    assert job.job_id not in controller.state.processes
 
     async with controller._tracked_subprocess(
-        controller.state.compile_lane,
+        job,
         sys.executable,
         "-c",
         "import sys\nsys.exit(0)\n",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller.state.compile_lane.current_process is proc
+        assert controller.state.processes[job.job_id] is proc
         await proc.wait()
 
     # Restored on exit.
-    assert controller.state.compile_lane.current_process is None
+    assert job.job_id not in controller.state.processes
 
 
 async def test_tracked_subprocess_restores_prior_value_on_exit(
     firmware_controller_factory: FirmwareControllerFactory,
 ) -> None:
-    """``_tracked_subprocess`` restores the prior ``_current_process``.
+    """``_tracked_subprocess`` restores the prior registry entry.
 
     The helper saves whatever was registered before it spawned
     and restores it on exit, so a future caller that uses the
     helper inside an outer one (or just after another spawn site
-    that's already populated the field) doesn't accidentally
-    null out the active process reference. ``None`` is the
+    that's already populated the entry) doesn't accidentally
+    drop the active process reference. Absent is the
     common case but the contract is "restore the prior value".
     """
-    # ``with_terminate=True`` initialises ``_current_process = None``
-    # and ``_cancel_requested = set()`` so the helper has a clean
-    # slate to assign onto. The mocked ``_terminate_current_process``
-    # is unused by this test (we never trip the CancelledError or
-    # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
+    job = _make_job("j1")
     sentinel = object()
-    controller.state.compile_lane.current_process = sentinel  # type: ignore[assignment]
+    controller.state.processes[job.job_id] = sentinel  # type: ignore[assignment]
 
     async with controller._tracked_subprocess(
-        controller.state.compile_lane,
+        job,
         sys.executable,
         "-c",
         "import sys\nsys.exit(0)\n",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     ) as proc:
-        assert controller.state.compile_lane.current_process is proc  # registered for the duration
+        assert controller.state.processes[job.job_id] is proc  # registered for the duration
         await proc.wait()
 
-    assert controller.state.compile_lane.current_process is sentinel  # restored
+    assert controller.state.processes[job.job_id] is sentinel  # restored
 
 
 async def test_tracked_subprocess_restores_prior_value_on_exception(
@@ -731,22 +727,18 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
 
     Without the ``try/finally`` shape inside the helper, an
     exception thrown inside the ``async with`` body would leave
-    the controller pointing at a defunct process — the next
-    ``firmware/cancel`` would either no-op (if the field went
-    back to ``None``) or signal the wrong process (if it stayed
+    the registry pointing at a defunct process — the next
+    ``firmware/cancel`` would either no-op (if the entry went
+    away) or signal the wrong process (if it stayed
     pointing at the dead one). Pin both halves.
     """
-    # ``with_terminate=True`` initialises ``_current_process = None``
-    # and ``_cancel_requested = set()`` so the helper has a clean
-    # slate to assign onto. The mocked ``_terminate_current_process``
-    # is unused by this test (we never trip the CancelledError or
-    # post-spawn cancel paths) but is harmless.
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
-    assert controller.state.compile_lane.current_process is None
+    job = _make_job("j1")
+    assert job.job_id not in controller.state.processes
 
     with pytest.raises(RuntimeError, match="boom"):
         async with controller._tracked_subprocess(
-            controller.state.compile_lane,
+            job,
             sys.executable,
             "-c",
             "import sys\nsys.exit(0)\n",
@@ -763,7 +755,7 @@ async def test_tracked_subprocess_restores_prior_value_on_exception(
             msg = "boom"
             raise RuntimeError(msg)
 
-    assert controller.state.compile_lane.current_process is None
+    assert job.job_id not in controller.state.processes
 
 
 async def test_tracked_subprocess_gets_devnull_stdin(
@@ -773,7 +765,7 @@ async def test_tracked_subprocess_gets_devnull_stdin(
     controller = firmware_controller_factory(with_settings=False, with_terminate=True)
 
     async with controller._tracked_subprocess(
-        controller.state.compile_lane,
+        _make_job("j1"),
         sys.executable,
         "-c",
         "import sys\nprint(repr(sys.stdin.read()))\n",
@@ -797,7 +789,7 @@ async def test_tracked_subprocess_defaults_stdin_to_devnull(
         "esphome_device_builder.controllers.firmware.runner.create_subprocess_exec",
         new=AsyncMock(),
     ) as spawn:
-        async with controller._tracked_subprocess(controller.state.compile_lane, "/bin/true"):
+        async with controller._tracked_subprocess(_make_job("j1"), "/bin/true"):
             pass
     assert spawn.await_args is not None
     assert spawn.await_args.kwargs["stdin"] is asyncio.subprocess.DEVNULL
@@ -813,7 +805,7 @@ async def test_tracked_subprocess_stdin_override_wins(
         new=AsyncMock(),
     ) as spawn:
         async with controller._tracked_subprocess(
-            controller.state.compile_lane, "/bin/true", stdin=asyncio.subprocess.PIPE
+            _make_job("j1"), "/bin/true", stdin=asyncio.subprocess.PIPE
         ):
             pass
     assert spawn.await_args is not None
@@ -827,14 +819,14 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
 ) -> None:
     """A cancel landed during the verify→main-spawn gap → terminate fires.
 
-    The runner's tracked-subprocess block clears
-    ``_current_process`` on ``_verify_chip`` exit, then assigns the
-    main install subprocess to ``_current_process`` a moment later.
+    The runner's tracked-subprocess block clears the job's
+    registry entry on ``_verify_chip`` exit, then registers the
+    main install subprocess a moment later.
     A ``firmware/cancel`` that arrived in that gap sets
-    ``_cancel_requested`` but ``_terminate_current_process`` walked
-    a ``None`` field and no-op'd. Without the post-spawn flag check
+    ``_cancel_requested`` but ``_terminate_job_process`` found
+    no registry entry and no-op'd. Without the post-spawn flag check
     inside ``_execute_job`` (the ``if job.job_id in
-    self.state.cancel_requested: await self._terminate_current_process()``
+    self.state.cancel_requested: await self._terminate_job_process(job)``
     branch right after the main spawn), the install would run to
     completion before the post-``proc.wait()`` cancel handler saw
     the flag — the issue-#136 symptom for the "cancel arrived
@@ -842,16 +834,16 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
 
     Drive that path: pre-load the cancel flag from inside the
     ``create_subprocess_exec`` substitute so by the time the
-    runner re-enters ``_execute_job`` and assigns
-    ``_current_process``, the flag is set. The immediate post-
-    spawn check should fire ``_terminate_current_process`` on the
+    runner re-enters ``_execute_job`` and registers the spawn,
+    the flag is set. The immediate post-
+    spawn check should fire ``_terminate_job_process`` on the
     (test fake) build subprocess. Spy on the terminate call to
     pin both halves of the contract:
 
-    1. ``_terminate_current_process`` runs at the gap-check
+    1. ``_terminate_job_process`` runs at the gap-check
        site (counter increments).
-    2. It runs against a non-``None`` ``_current_process`` —
-       i.e. the post-spawn assignment happened first, so the
+    2. It runs against a registered subprocess —
+       i.e. the post-spawn registration happened first, so the
        SIGTERM has somewhere to land.
     """
     controller = firmware_controller_factory(with_queue=True)
@@ -866,13 +858,13 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
 
     real = runner_module.create_subprocess_exec
     terminate_calls: list[asyncio.subprocess.Process | None] = []
-    real_terminate = controller._terminate_current_process
+    real_terminate = controller._terminate_job_process
 
-    async def _spy_terminate(lane: Lane) -> None:
-        terminate_calls.append(lane.current_process)
-        await real_terminate(lane)
+    async def _spy_terminate(target: FirmwareJob) -> None:
+        terminate_calls.append(controller.state.processes.get(target.job_id))
+        await real_terminate(target)
 
-    monkeypatch.setattr(controller, "_terminate_current_process", _spy_terminate)
+    monkeypatch.setattr(controller, "_terminate_job_process", _spy_terminate)
 
     async def _wrapper(*args: Any, **kwargs: Any) -> Any:
         # OTA port → ``_verify_chip`` returns before any spawn,
@@ -881,8 +873,8 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
         # returning the proc — this is the "cancel arrived in
         # the verify→main-spawn gap" scenario the post-spawn
         # check guards.
-        if controller.state.compile_lane.current_job is not None:
-            controller.state.cancel_requested.add(controller.state.compile_lane.current_job.job_id)
+        for active_job in controller.state.compile_lane.active.values():
+            controller.state.cancel_requested.add(active_job.job_id)
         return await real(sys.executable, "-c", _BUILD_SCRIPT_OK, **kwargs)
 
     monkeypatch.setattr(runner_module, "create_subprocess_exec", _wrapper)
@@ -894,8 +886,8 @@ async def test_cancel_in_gap_between_verify_and_main_spawn_terminates(
     # against the just-assigned build subprocess (not ``None``).
     assert len(terminate_calls) == 1, "post-spawn cancel check should fire terminate once"
     assert terminate_calls[0] is not None, (
-        "_current_process must be set when terminate fires — that's the whole point of "
-        "the post-spawn check (vs. the no-op None path)"
+        "the process must be registered when terminate fires — that's the whole point of "
+        "the post-spawn check (vs. the no-op missing-entry path)"
     )
     # Job finalises as CANCELLED via the post-``proc.wait()`` cancel
     # handler, not FAILED.


### PR DESCRIPTION
# What does this implement/fix?

Behavior neutral refactor preparing for parallel uploads (esphome/discussions#3781). `Lane` grows a `max_concurrency` field (still 1 everywhere) and its single `current_job` slot becomes an `active` dict keyed by job id, with `_run_queue` spawning `max_concurrency` workers per lane. Subprocess tracking moves off the lane into a job keyed `FirmwareState.processes` registry, so cancel is per job (`terminate_job_process`) instead of per lane. That also models the remote install local flash correctly; it used to park its subprocess on the compile lane's `current_process` without ever being that lane's `current_job`, so cancelling a concurrent local compile could have signalled the remote install's flash. `QueueStatus` shape and the `compile_queue_status` peer link contract are unchanged (compile lane stays a single slot).

The feature PR on top of this adds the 3 slot upload lane plus a serialized OpenThread lane.

**Related issue or feature (if applicable):**

- part of https://github.com/orgs/esphome/discussions/3781

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
