### PR TITLE
Deliver queued updates to waking deep-sleep devices with 3 concurrent upload slots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,12 +325,25 @@ against legacy behaviour before assuming the simpler version suffices.
   emitter and walks `models.*` to assert coverage. New events ship with a
   TypedDict from day one and a row in `_PAYLOAD_FACTORIES`. Full
   rationale in `docs/ARCHITECTURE.md` "Event bus → Typing event payloads".
-- **Persistent firmware queue — two concurrent lanes.** A CPU/compile lane
-  and a network/upload lane each run one job at a time, but run
-  concurrently, so a slow upload doesn't block the next compile (#3702).
-  `FirmwareState.compile_lane` / `upload_lane` (`controllers/firmware/
-  _state.py`); `lane_for(job)` routes UPLOAD to the upload lane, everything
-  else to compile. `firmware/install` enqueues a COMPILE job + a dependent
+- **Persistent firmware queue — three concurrent lanes.** A CPU/compile
+  lane (one job at a time), a network/upload lane (up to
+  `MAX_CONCURRENT_UPLOADS` = 3 flashes at once — the cap bounds
+  subprocess-tree memory), and a single-slot thread upload lane, all
+  running concurrently, so a slow upload doesn't block the next compile
+  (#3702) or the next flash (esphome discussion #3781).
+  `FirmwareState.compile_lane` / `upload_lane` / `thread_upload_lane`
+  (`controllers/firmware/_state.py`); each lane spawns
+  `Lane.max_concurrency` workers off one FIFO queue, jobs occupying a
+  lane sit in `Lane.active` (job-id keyed), and running subprocesses live
+  in the job-keyed `FirmwareState.processes` registry so cancel
+  (`terminate_job_process`) signals exactly one job. `lane_for(job)`
+  routes a network flash of an OpenThread device to the thread lane
+  (Thread devices share one mesh/border router — concurrent OTAs starve
+  it) via `state.is_thread_configuration`, wired at `start()` before job
+  restore to `DevicesController.is_thread_device` (`"openthread" in
+  loaded_integrations`; unknown/never-compiled → normal upload lane).
+  Everything not a network flash runs on the compile lane.
+  `firmware/install` enqueues a COMPILE job + a dependent
   local UPLOAD job (`FirmwareJob.depends_on`); the upload is held off its
   lane until the compile succeeds (`lifecycle.release_dependents`), and a
   cancelled/failed compile cascades to cancel the held upload (so a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,10 @@ against legacy behaviour before assuming the simpler version suffices.
   `MAX_CONCURRENT_UPLOADS` = 3 flashes at once — the cap bounds
   subprocess-tree memory), and a single-slot thread upload lane, all
   running concurrently, so a slow upload doesn't block the next compile
-  (#3702) or the next flash (esphome discussion #3781).
+  (#3702) or the next flash. Upload concurrency exists for deep-sleep
+  wake delivery (esphome discussion #3781): several deep-sleep devices
+  waking at once must each get their queued update inside the wake
+  window, or they sleep again and the updates fail.
   `FirmwareState.compile_lane` / `upload_lane` / `thread_upload_lane`
   (`controllers/firmware/_state.py`); each lane spawns
   `Lane.max_concurrency` workers off one FIFO queue, jobs occupying a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,8 +342,8 @@ against legacy behaviour before assuming the simpler version suffices.
   (`terminate_job_process`) signals exactly one job. `lane_for(job)`
   routes a network flash of an OpenThread device to the thread lane
   (Thread devices share one mesh/border router — concurrent OTAs starve
-  it) via `state.is_thread_configuration`, wired at `start()` before job
-  restore to `DevicesController.is_thread_device` (`"openthread" in
+  it) via `state.is_thread_configuration`, wired at controller
+  construction to `DevicesController.is_thread_device` (`"openthread" in
   loaded_integrations`; unknown/never-compiled → normal upload lane).
   Everything not a network flash runs on the compile lane.
   `firmware/install` enqueues a COMPILE job + a dependent

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,6 +214,9 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   over the mesh starve each other, so `lane_for` routes a network flash
   whose device loads `openthread` (per `DevicesController.is_thread_device`,
   reading the last compile's `loaded_integrations`) to the thread lane.
+  That slot is deliberately global, not per-mesh: two independent Thread
+  networks serialize against each other too, because mesh membership
+  isn't data the dashboard has.
   A device never compiled yet routes to the normal upload lane — the
   lookup is wired into `FirmwareState.is_thread_configuration` at
   `start()`, before job restore, so restored flashes route the same way.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,7 +206,8 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   update must land inside its device's wake window — with one serial
   upload slot, the flashes behind a slow OTA missed their window, the
   devices went back to sleep, and their updates failed. The upload cap
-  bounds the combined memory of concurrent esphome subprocess trees; each lane spawns
+  bounds the combined memory of concurrent esphome subprocess trees
+  (peak concurrency is the cap plus one thread flash); each lane spawns
   `Lane.max_concurrency` workers off one FIFO queue, and running
   subprocesses live in the job-keyed `FirmwareState.processes` registry
   so cancel signals exactly one job. **OpenThread flashes serialize**:
@@ -218,8 +219,8 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   networks serialize against each other too, because mesh membership
   isn't data the dashboard has.
   A device never compiled yet routes to the normal upload lane — the
-  lookup is wired into `FirmwareState.is_thread_configuration` at
-  `start()`, before job restore, so restored flashes route the same way.
+  lookup is wired into `FirmwareState.is_thread_configuration` when the
+  controller constructs its state, so restored flashes route the same way.
   `install` splits into a COMPILE job + a dependent local UPLOAD job
   (`depends_on`): the upload is held until the compile succeeds, then
   runs on its upload lane; a cancelled/failed compile cascades to cancel

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,12 +196,27 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
                                      └──── persisted to disk ─────────────┘
 ```
 
-- Two concurrent lanes — a compile lane (CPU) and an upload lane (network).
-  Each runs one job at a time, but the lanes run in parallel so a slow
-  network flash doesn't block the next device's compile (#3702). `install`
-  splits into a COMPILE job + a dependent local UPLOAD job (`depends_on`):
-  the upload is held until the compile succeeds, then runs on the upload
-  lane; a cancelled/failed compile cascades to cancel the held upload.
+- Three concurrent lanes — a compile lane (CPU, one job at a time), an
+  upload lane (network, up to `MAX_CONCURRENT_UPLOADS` = 3 flashes at
+  once), and a single-slot thread upload lane. The lanes run in parallel
+  so a slow network flash doesn't block the next device's compile
+  (#3702), and slow OTAs don't block fast ones behind them
+  (esphome discussion #3781). The upload cap bounds the combined memory
+  of concurrent esphome subprocess trees; each lane spawns
+  `Lane.max_concurrency` workers off one FIFO queue, and running
+  subprocesses live in the job-keyed `FirmwareState.processes` registry
+  so cancel signals exactly one job. **OpenThread flashes serialize**:
+  Thread devices share one mesh / border router, and concurrent OTAs
+  over the mesh starve each other, so `lane_for` routes a network flash
+  whose device loads `openthread` (per `DevicesController.is_thread_device`,
+  reading the last compile's `loaded_integrations`) to the thread lane.
+  A device never compiled yet routes to the normal upload lane — the
+  lookup is wired into `FirmwareState.is_thread_configuration` at
+  `start()`, before job restore, so restored flashes route the same way.
+  `install` splits into a COMPILE job + a dependent local UPLOAD job
+  (`depends_on`): the upload is held until the compile succeeds, then
+  runs on its upload lane; a cancelled/failed compile cascades to cancel
+  the held upload.
 - **Rename is the same chain shape** (#1812): `devices/rename` rewrites
   `esphome.name` dashboard-side (`helpers.yaml.rewrite_rename_content`),
   writes `<new>.yaml` up-front, and queues a COMPILE of it (remote-eligible
@@ -217,8 +232,8 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   cancelling the tail cascades *up* to its compile. A persisted RENAME
   with no `depends_on` (pre-decomposition) still runs the fused
   `esphome rename` CLI on the compile lane.
-- Plus a **remote build-server pool** — a third consumer (`run_dispatch_loop`)
-  gathered alongside the two lanes. Compiles eligible for a paired server
+- Plus a **remote build-server pool** — one more consumer (`run_dispatch_loop`)
+  gathered alongside the lane workers. Compiles eligible for a paired server
   hold here (off the single compile lane) and run concurrently, one per
   connected server. See "Remote build-server pool" below.
 - Output buffered in `FirmwareJob.output` — survives disconnect

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,9 +200,13 @@ firmware/install {configuration} → QUEUED → RUNNING → output... → COMPLE
   upload lane (network, up to `MAX_CONCURRENT_UPLOADS` = 3 flashes at
   once), and a single-slot thread upload lane. The lanes run in parallel
   so a slow network flash doesn't block the next device's compile
-  (#3702), and slow OTAs don't block fast ones behind them
-  (esphome discussion #3781). The upload cap bounds the combined memory
-  of concurrent esphome subprocess trees; each lane spawns
+  (#3702), and OTAs don't serialize behind each other (esphome
+  discussion #3781). The concurrency exists for deep-sleep wake
+  delivery: when several deep-sleep devices wake at once, each queued
+  update must land inside its device's wake window — with one serial
+  upload slot, the flashes behind a slow OTA missed their window, the
+  devices went back to sleep, and their updates failed. The upload cap
+  bounds the combined memory of concurrent esphome subprocess trees; each lane spawns
   `Lane.max_concurrency` workers off one FIFO queue, and running
   subprocesses live in the job-keyed `FirmwareState.processes` registry
   so cancel signals exactly one job. **OpenThread flashes serialize**:

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -360,6 +360,11 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
             return []
         return self.get_address_cache_args(configuration)
 
+    def is_thread_device(self, configuration: str) -> bool:
+        """Whether *configuration*'s device loads ``openthread`` (per its last compile)."""
+        device = self._scanner.get_by_configuration(configuration)
+        return device is not None and "openthread" in device.loaded_integrations
+
     def set_queued_update(self, configuration: str) -> bool:
         """Arm *configuration*'s queued update; True when the flag flipped."""
         return self._set_queued_update(configuration, is_queued=True)

--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -362,7 +362,7 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
 
     def is_thread_device(self, configuration: str) -> bool:
         """Whether *configuration*'s device loads ``openthread`` (per its last compile)."""
-        device = self._scanner.get_by_configuration(configuration)
+        device = self.get_by_configuration(configuration)
         return device is not None and "openthread" in device.loaded_integrations
 
     def set_queued_update(self, configuration: str) -> bool:

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -14,8 +14,9 @@ from .constants import MAX_CONCURRENT_UPLOADS
 class Lane:
     """One work lane: its FIFO queue + the jobs occupying its slots now.
 
-    Lanes run concurrently — a compile lane (CPU) and an upload lane
-    (network) — so a slow network flash doesn't block the next compile.
+    Lanes run concurrently — a compile lane (CPU), an upload lane
+    (network), and a serialized OpenThread upload lane — so a slow
+    network flash doesn't block the next compile or flash.
     ``max_concurrency`` workers drain the queue; ``active`` holds the
     jobs currently running on the lane, keyed by ``job_id``.
     """
@@ -118,10 +119,9 @@ class FirmwareState:
     upload_lane: Lane = field(default_factory=lambda: Lane(max_concurrency=MAX_CONCURRENT_UPLOADS))
     thread_upload_lane: Lane = field(default_factory=Lane)
 
-    # Injected by the controller at ``start()`` (before job restore):
-    # sync RAM lookup for "does this configuration's device load
-    # ``openthread``". Default False routes every flash to the normal
-    # upload lane.
+    # Injected by the controller at construction: sync RAM lookup for
+    # "does this configuration's device load ``openthread``". Default
+    # False routes every flash to the normal upload lane.
     is_thread_configuration: Callable[[str], bool] = field(default=lambda _configuration: False)
 
     # Subprocesses spawned for running jobs, keyed by ``job_id`` — what

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 
 from ...models import FirmwareJob, JobSource, JobStatus, JobType
+from .constants import MAX_CONCURRENT_UPLOADS
 
 
 @dataclass
@@ -108,11 +109,20 @@ class FirmwareState:
     # picks first. ``cli`` reads it to build the subprocess argv.
     esphome_cmd: list[str] = field(default_factory=list)
 
-    # The concurrent lanes. Producers enqueue onto the lane a job's
-    # type maps to (``lane_for``); each lane spawns ``max_concurrency``
-    # worker tasks. All survive restarts via the on-disk persistence layer.
+    # The concurrent lanes. Producers enqueue onto the lane ``lane_for``
+    # maps a job to; each lane spawns ``max_concurrency`` worker tasks.
+    # All survive restarts via the on-disk persistence layer. The thread
+    # lane stays single-slot: OpenThread devices share one mesh / border
+    # router, and concurrent OTAs over the mesh starve each other.
     compile_lane: Lane = field(default_factory=Lane)
-    upload_lane: Lane = field(default_factory=Lane)
+    upload_lane: Lane = field(default_factory=lambda: Lane(max_concurrency=MAX_CONCURRENT_UPLOADS))
+    thread_upload_lane: Lane = field(default_factory=Lane)
+
+    # Injected by the controller at ``start()`` (before job restore):
+    # sync RAM lookup for "does this configuration's device load
+    # ``openthread``". Default False routes every flash to the normal
+    # upload lane.
+    is_thread_configuration: Callable[[str], bool] = field(default=lambda _configuration: False)
 
     # Subprocesses spawned for running jobs, keyed by ``job_id`` — what
     # ``firmware/cancel`` signals. Job-keyed rather than per-lane so an
@@ -149,11 +159,22 @@ class FirmwareState:
 
     def lanes(self) -> tuple[Lane, ...]:
         """Every lane, for slot scans and worker spawn."""
-        return (self.compile_lane, self.upload_lane)
+        return (self.compile_lane, self.upload_lane, self.thread_upload_lane)
 
     def lane_for(self, job: FirmwareJob) -> Lane:
-        """Return *job*'s lane: network flashes (UPLOAD, rename tail) upload, else compile."""
-        return self.upload_lane if job.is_network_flash else self.compile_lane
+        """
+        Return *job*'s lane: everything but a network flash (UPLOAD, rename tail) compiles.
+
+        A flash of an OpenThread device serializes on the thread lane;
+        keyed on ``configuration`` (not ``flash_configuration``) because
+        a rename tail's *old* name is the one with a Device entry and
+        mesh membership is a property of the physical device.
+        """
+        if not job.is_network_flash:
+            return self.compile_lane
+        if self.is_thread_configuration(job.configuration):
+            return self.thread_upload_lane
+        return self.upload_lane
 
     def place_on_lane(self, job: FirmwareJob) -> None:
         """Route *job* to its worker: the remote pool for a pending remote compile, else its lane.

--- a/esphome_device_builder/controllers/firmware/_state.py
+++ b/esphome_device_builder/controllers/firmware/_state.py
@@ -114,7 +114,9 @@ class FirmwareState:
     # maps a job to; each lane spawns ``max_concurrency`` worker tasks.
     # All survive restarts via the on-disk persistence layer. The thread
     # lane stays single-slot: OpenThread devices share one mesh / border
-    # router, and concurrent OTAs over the mesh starve each other.
+    # router, and concurrent OTAs over the mesh starve each other. The
+    # slot is deliberately global, not per-mesh — keying on mesh identity
+    # needs membership data the dashboard doesn't have.
     compile_lane: Lane = field(default_factory=Lane)
     upload_lane: Lane = field(default_factory=lambda: Lane(max_concurrency=MAX_CONCURRENT_UPLOADS))
     thread_upload_lane: Lane = field(default_factory=Lane)

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -25,6 +25,12 @@ from ...models import JobType
 # ``.device-builder.json``.
 _JOBS_KEY = "_firmware_jobs"
 
+# Upload-lane worker count — how many network flashes run at once.
+# Each flash is a full esphome subprocess tree; the cap bounds their
+# combined memory on small hosts. OpenThread flashes don't count
+# against it — they serialize on their own single-slot lane.
+MAX_CONCURRENT_UPLOADS = 3
+
 # Output patterns that indicate failure even when the subprocess
 # exit code is 0. Bare ``No module named`` is intentionally absent:
 # PlatformIO's ``[nanopb]`` extra-script emits it harmlessly (#918);

--- a/esphome_device_builder/controllers/firmware/constants.py
+++ b/esphome_device_builder/controllers/firmware/constants.py
@@ -25,10 +25,11 @@ from ...models import JobType
 # ``.device-builder.json``.
 _JOBS_KEY = "_firmware_jobs"
 
-# Upload-lane worker count — how many network flashes run at once.
-# Each flash is a full esphome subprocess tree; the cap bounds their
-# combined memory on small hosts. OpenThread flashes don't count
-# against it — they serialize on their own single-slot lane.
+# Upload-lane worker count — how many normal network flashes run at
+# once. Each flash is a full esphome subprocess tree; the cap bounds
+# their combined memory on small hosts. OpenThread flashes don't count
+# against it — they serialize on their own single-slot lane — so peak
+# concurrency is this plus one thread flash.
 MAX_CONCURRENT_UPLOADS = 3
 
 # Output patterns that indicate failure even when the subprocess

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -607,7 +607,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
     def _is_thread_configuration(self, configuration: str) -> bool:
         devices = self._db.devices
         if devices is None:
-            _LOGGER.debug("Devices controller unavailable; routing %s as non-thread", configuration)
+            _LOGGER.warning(
+                "Devices controller unavailable; %s flashes without thread serialization",
+                configuration,
+            )
             return False
         return devices.is_thread_device(configuration)
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -606,7 +606,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     def _is_thread_configuration(self, configuration: str) -> bool:
         devices = self._db.devices
-        return devices is not None and devices.is_thread_device(configuration)
+        if devices is None:
+            _LOGGER.debug("Devices controller unavailable; routing %s as non-thread", configuration)
+            return False
+        return devices.is_thread_device(configuration)
 
     async def _terminate_job_process(self, job: FirmwareJob) -> None:
         await lifecycle.terminate_job_process(self, job)

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -72,18 +72,19 @@ _LOGGER = logging.getLogger(__name__)
 
 class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods need a refactor first)
     """
-    Manage firmware build jobs with a persistent two-lane queue.
+    Manage firmware build jobs with a persistent three-lane queue.
 
-    A compile lane (CPU) and an upload lane (network) each run one job at a
-    time but run concurrently, so a slow upload doesn't block the next
-    compile. Jobs are persisted to disk so they survive page refreshes and
-    server restarts. Progress is broadcast via the event bus to all
-    connected clients.
+    A compile lane (CPU, one job at a time), an upload lane (network, up
+    to ``MAX_CONCURRENT_UPLOADS`` flashes at once), and a single-slot
+    OpenThread upload lane run concurrently, so a slow upload doesn't
+    block the next compile or flash. Jobs are persisted to disk so they
+    survive page refreshes and server restarts. Progress is broadcast via
+    the event bus to all connected clients.
     """
 
     def __init__(self, device_builder: DeviceBuilder) -> None:
         self._db = device_builder
-        self.state = FirmwareState()
+        self.state = FirmwareState(is_thread_configuration=self._is_thread_configuration)
         # Short-lived capability tokens for the HTTP artifact-download route.
         self.download_tokens = download_mod.DownloadTokens()
         self._runner_task: asyncio.Task | None = None
@@ -213,9 +214,6 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
                 "(e.g. ``pip install -e '.[esphome]'`` from the project root).",
                 detail,
             )
-        # Before ``_load_jobs`` so restored flashes route to the right
-        # upload lane; the devices controller has already scanned.
-        self.state.is_thread_configuration = self._is_thread_configuration
         await self._load_jobs()
         self._runner_task = self._db.create_background_task(self._run_queue())
 

--- a/esphome_device_builder/controllers/firmware/controller.py
+++ b/esphome_device_builder/controllers/firmware/controller.py
@@ -213,6 +213,9 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
                 "(e.g. ``pip install -e '.[esphome]'`` from the project root).",
                 detail,
             )
+        # Before ``_load_jobs`` so restored flashes route to the right
+        # upload lane; the devices controller has already scanned.
+        self.state.is_thread_configuration = self._is_thread_configuration
         await self._load_jobs()
         self._runner_task = self._db.create_background_task(self._run_queue())
 
@@ -602,6 +605,10 @@ class FirmwareController:  # noqa: PLR0904 (grandfathered; new public methods ne
 
     def _finalize_cancelled(self, job: FirmwareJob) -> None:
         lifecycle.finalize_cancelled(self, job)
+
+    def _is_thread_configuration(self, configuration: str) -> bool:
+        devices = self._db.devices
+        return devices is not None and devices.is_thread_device(configuration)
 
     async def _terminate_job_process(self, job: FirmwareJob) -> None:
         await lifecycle.terminate_job_process(self, job)

--- a/tests/controllers/devices/test_is_thread_device.py
+++ b/tests/controllers/devices/test_is_thread_device.py
@@ -1,0 +1,38 @@
+"""Tests for ``DevicesController.is_thread_device``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.conftest import make_device
+from tests.controllers.devices.conftest import MakeControllerFactory
+
+
+def test_openthread_in_loaded_integrations(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [
+        make_device("mesh", loaded_integrations=["api", "openthread"]),
+        make_device("kitchen", loaded_integrations=["api", "wifi"]),
+    ]
+
+    assert controller.is_thread_device("mesh.yaml") is True
+    assert controller.is_thread_device("kitchen.yaml") is False
+
+
+def test_unknown_configuration_is_not_thread(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    controller = make_controller(tmp_path)
+
+    assert controller.is_thread_device("ghost.yaml") is False
+
+
+def test_never_compiled_device_is_not_thread(
+    make_controller: MakeControllerFactory, tmp_path: Path
+) -> None:
+    controller = make_controller(tmp_path)
+    controller._scanner.devices = [make_device("fresh", loaded_integrations=[])]
+
+    assert controller.is_thread_device("fresh.yaml") is False

--- a/tests/controllers/devices/test_is_thread_device.py
+++ b/tests/controllers/devices/test_is_thread_device.py
@@ -15,10 +15,12 @@ def test_openthread_in_loaded_integrations(
     controller._scanner.devices = [
         make_device("mesh", loaded_integrations=["api", "openthread"]),
         make_device("kitchen", loaded_integrations=["api", "wifi"]),
+        make_device("fresh", loaded_integrations=[]),
     ]
 
     assert controller.is_thread_device("mesh.yaml") is True
     assert controller.is_thread_device("kitchen.yaml") is False
+    assert controller.is_thread_device("fresh.yaml") is False
 
 
 def test_unknown_configuration_is_not_thread(
@@ -27,12 +29,3 @@ def test_unknown_configuration_is_not_thread(
     controller = make_controller(tmp_path)
 
     assert controller.is_thread_device("ghost.yaml") is False
-
-
-def test_never_compiled_device_is_not_thread(
-    make_controller: MakeControllerFactory, tmp_path: Path
-) -> None:
-    controller = make_controller(tmp_path)
-    controller._scanner.devices = [make_device("fresh", loaded_integrations=[])]
-
-    assert controller.is_thread_device("fresh.yaml") is False

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -443,7 +443,7 @@ def wire_devices(controller: FirmwareController) -> None:
 
 
 def seed_yamls(tmp_path: Path, *names: str) -> None:
-    """Write a minimal valid ESPHome YAML per *names* into *tmp_path*."""
+    """Write a minimal ESPHome YAML stub per *names* into *tmp_path*."""
     for name in names:
         stem = name.removesuffix(".yaml")
         (tmp_path / name).write_text(f"esphome:\n  name: {stem}\n", encoding="utf-8")

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -416,6 +416,7 @@ class StubDevices:
     """
 
     devices: list[Any] = field(default_factory=list)
+    thread_configurations: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         """Build the configuration-keyed index, mirroring production's O(1) lookup."""
@@ -426,6 +427,9 @@ class StubDevices:
 
     def get_ota_address_cache_args(self, _configuration: str, _port: str) -> list[str]:
         return []
+
+    def is_thread_device(self, configuration: str) -> bool:
+        return configuration in self.thread_configurations
 
     def get_devices(self) -> list[Any]:
         return self.devices

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -416,7 +416,6 @@ class StubDevices:
     """
 
     devices: list[Any] = field(default_factory=list)
-    thread_configurations: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         """Build the configuration-keyed index, mirroring production's O(1) lookup."""
@@ -427,9 +426,6 @@ class StubDevices:
 
     def get_ota_address_cache_args(self, _configuration: str, _port: str) -> list[str]:
         return []
-
-    def is_thread_device(self, configuration: str) -> bool:
-        return configuration in self.thread_configurations
 
     def get_devices(self) -> list[Any]:
         return self.devices
@@ -444,6 +440,13 @@ class StubDevices:
 def wire_devices(controller: FirmwareController) -> None:
     """Attach a no-op ``DevicesController`` stub for ``_build_cache_args``."""
     controller._db.devices = StubDevices()  # type: ignore[attr-defined]
+
+
+def seed_yamls(tmp_path: Path, *names: str) -> None:
+    """Write a minimal valid ESPHome YAML per *names* into *tmp_path*."""
+    for name in names:
+        stem = name.removesuffix(".yaml")
+        (tmp_path / name).write_text(f"esphome:\n  name: {stem}\n", encoding="utf-8")
 
 
 def attach_device(controller: FirmwareController, configuration: str, state: DeviceState) -> None:

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -2,10 +2,11 @@
 
 Drives the real lane workers (via ``_run_queue``) against parking
 subprocesses, mirroring ``test_lane_concurrency_e2e``. Pins the
-esphome discussion #3781 shape: up to ``MAX_CONCURRENT_UPLOADS``
-network flashes overlap so a slow OTA doesn't block fast ones, while
-flashes of OpenThread devices — one shared mesh / border router —
-stay one-at-a-time on their own lane.
+deep-sleep wake-delivery shape (esphome discussion #3781): several
+woken devices' queued updates flash concurrently — up to
+``MAX_CONCURRENT_UPLOADS`` — instead of missing their wake windows
+behind one slow OTA, while flashes of OpenThread devices — one shared
+mesh / border router — stay one-at-a-time on their own lane.
 """
 
 from __future__ import annotations
@@ -20,6 +21,9 @@ from esphome_device_builder.controllers.firmware import controller as controller
 from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.controllers.firmware.constants import MAX_CONCURRENT_UPLOADS
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
+from tests.controllers.firmware.conftest import (
+    run_until_terminal,
+)
 from tests.controllers.firmware.conftest import (
     wire_devices as _wire_devices,
 )
@@ -178,6 +182,71 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
         runner.cancel()
         with suppress(asyncio.CancelledError):
             await runner
+
+
+# Each upload sleeps a per-device staggered duration, then exits 0 —
+# a burst of woken deep-sleep devices whose OTAs take different times.
+_STAGGERED_UPLOAD = (
+    "import os, sys, time\n"
+    "cfg = os.path.basename(next(a for a in sys.argv if a.endswith('.yaml')))\n"
+    "delays = {'u1.yaml': 0.2, 'u2.yaml': 0.05, 'u3.yaml': 0.35,"
+    " 'u4.yaml': 0.1, 'u5.yaml': 0.05, 'u6.yaml': 0.15}\n"
+    "print('INFO uploading', flush=True)\n"
+    "time.sleep(delays[cfg])\n"
+)
+
+
+async def test_six_uploads_drain_three_at_a_time(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Any
+) -> None:
+    """A 6-upload burst drains 3-at-a-time: overflow starts only as slots free.
+
+    The deep-sleep wake shape: six devices wake at once, each flash
+    finishing at its own staggered time. The lane must never exceed
+    3 concurrent flashes, the first 3 must all start before anything
+    finishes, and the k-th overflow upload starts only after k
+    earlier flashes completed (FIFO refill). All 6 land COMPLETED.
+    """
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller)
+    controller.state.esphome_cmd = [sys.executable, "-c", _STAGGERED_UPLOAD]
+    names = [f"u{i}.yaml" for i in range(1, 7)]
+    _seed_yamls(tmp_path, *names)
+
+    sequence: list[tuple[EventType, str]] = []
+    max_active = 0
+    bus = controller._db.bus
+    real_fire = bus.fire
+
+    def _record(event_type: EventType, data: dict) -> None:
+        nonlocal max_active
+        max_active = max(max_active, len(controller.state.upload_lane.active))
+        job = data.get("job") if isinstance(data, dict) else None
+        if job is not None:
+            sequence.append((event_type, job.configuration))
+        real_fire(event_type, data)
+
+    bus.fire = _record
+
+    jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
+    await run_until_terminal(controller)
+
+    assert all(job.status is JobStatus.COMPLETED for job in jobs)
+    assert max_active == MAX_CONCURRENT_UPLOADS
+
+    completions_before_start: dict[str, int] = {}
+    done = 0
+    for event_type, configuration in sequence:
+        if event_type is EventType.JOB_STARTED:
+            completions_before_start[configuration] = done
+        elif event_type is EventType.JOB_COMPLETED:
+            done += 1
+    # The first wave fills every slot before anything finishes...
+    assert [completions_before_start[name] for name in names[:3]] == [0, 0, 0]
+    # ...and each overflow upload waits for enough earlier flashes to land.
+    for k, name in enumerate(names[3:], start=1):
+        assert completions_before_start[name] >= k
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -301,3 +301,12 @@ def test_is_thread_configuration_defaults_false_without_devices(
 ) -> None:
     controller = firmware_controller_factory()
     assert controller._is_thread_configuration("anything.yaml") is False
+
+
+def test_is_thread_configuration_delegates_to_devices(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory()
+    controller._db.devices = MagicMock(is_thread_device=lambda c: c == "mesh.yaml")
+    assert controller._is_thread_configuration("mesh.yaml") is True
+    assert controller._is_thread_configuration("kitchen.yaml") is False

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -1,0 +1,264 @@
+"""Parallel-upload lanes: 3 concurrent normal flashes, OpenThread serialized.
+
+Drives the real lane workers (via ``_run_queue``) against parking
+subprocesses, mirroring ``test_lane_concurrency_e2e``. Pins the
+esphome discussion #3781 shape: up to ``MAX_CONCURRENT_UPLOADS``
+network flashes overlap so a slow OTA doesn't block fast ones, while
+flashes of OpenThread devices — one shared mesh / border router —
+stay one-at-a-time on their own lane.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+from esphome_device_builder.controllers.firmware import controller as controller_module
+from esphome_device_builder.controllers.firmware._state import FirmwareState
+from esphome_device_builder.controllers.firmware.constants import MAX_CONCURRENT_UPLOADS
+from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
+from tests.controllers.firmware.conftest import (
+    wire_devices as _wire_devices,
+)
+from tests.controllers.firmware.conftest import (
+    wire_real_queue as _wire_real_queue,
+)
+
+if TYPE_CHECKING:
+    from .conftest import FirmwareControllerFactory
+
+
+# Every upload parks (prints a line, then blocks) until terminated.
+_PARK_UPLOAD = "import sys, time\nprint('INFO uploading', flush=True)\ntime.sleep(30)\n"
+
+
+def _watch_started(controller: Any) -> dict[str, asyncio.Event]:
+    """Per-configuration JOB_STARTED events, auto-created on first fire."""
+    started: dict[str, asyncio.Event] = {}
+    bus = controller._db.bus
+    real_fire = bus.fire
+
+    def _capture(event_type: EventType, data: dict) -> None:
+        real_fire(event_type, data)
+        job = data.get("job") if isinstance(data, dict) else None
+        if job is not None and event_type is EventType.JOB_STARTED:
+            started.setdefault(job.configuration, asyncio.Event()).set()
+
+    bus.fire = _capture
+    return started
+
+
+def _seed_yamls(tmp_path: Any, *names: str) -> None:
+    for name in names:
+        stem = name.removesuffix(".yaml")
+        (tmp_path / name).write_text(f"esphome:\n  name: {stem}\n", encoding="utf-8")
+
+
+async def _wait_started(started: dict[str, asyncio.Event], *configurations: str) -> None:
+    async with asyncio.timeout(10):
+        for configuration in configurations:
+            await started.setdefault(configuration, asyncio.Event()).wait()
+
+
+async def test_three_uploads_overlap_and_fourth_queues(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Any
+) -> None:
+    """Three flashes occupy the upload lane at once; the fourth waits for a slot."""
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller)
+    controller.state.esphome_cmd = [sys.executable, "-c", _PARK_UPLOAD]
+    names = ["u1.yaml", "u2.yaml", "u3.yaml", "u4.yaml"]
+    _seed_yamls(tmp_path, *names)
+    started = _watch_started(controller)
+
+    jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
+
+    runner = asyncio.create_task(controller._run_queue())
+    try:
+        await _wait_started(started, *names[:MAX_CONCURRENT_UPLOADS])
+
+        lane = controller.state.upload_lane
+        assert len(lane.active) == MAX_CONCURRENT_UPLOADS
+        assert all(j.status is JobStatus.RUNNING for j in jobs[:MAX_CONCURRENT_UPLOADS])
+        assert jobs[3].status is JobStatus.QUEUED
+        assert lane.queue.qsize() == 1
+        status = controller.lane_status(lane)
+        assert status.running is True
+        assert status.idle is False
+
+        # Freeing one slot lets the fourth in.
+        controller.state.cancel_requested.add(jobs[0].job_id)
+        await controller._terminate_job_process(jobs[0])
+        await _wait_started(started, names[3])
+        assert jobs[3].status is JobStatus.RUNNING
+        assert jobs[0].status is JobStatus.CANCELLED
+    finally:
+        runner.cancel()
+        with suppress(asyncio.CancelledError):
+            await runner
+
+
+async def test_thread_uploads_serialize_beside_concurrent_normal_uploads(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Any
+) -> None:
+    """Two thread-device flashes take the thread lane one at a time; a normal flash overlaps."""
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller)
+    controller._db.devices.thread_configurations = {"mesh1.yaml", "mesh2.yaml"}
+    controller.state.is_thread_configuration = controller._is_thread_configuration
+    controller.state.esphome_cmd = [sys.executable, "-c", _PARK_UPLOAD]
+    _seed_yamls(tmp_path, "mesh1.yaml", "mesh2.yaml", "alpha.yaml")
+    started = _watch_started(controller)
+
+    mesh1 = await controller.upload(configuration="mesh1.yaml", port="OTA")
+    mesh2 = await controller.upload(configuration="mesh2.yaml", port="OTA")
+    alpha = await controller.upload(configuration="alpha.yaml", port="OTA")
+
+    runner = asyncio.create_task(controller._run_queue())
+    try:
+        await _wait_started(started, "mesh1.yaml", "alpha.yaml")
+
+        thread_lane = controller.state.thread_upload_lane
+        assert list(thread_lane.active) == [mesh1.job_id]
+        assert mesh2.status is JobStatus.QUEUED
+        assert thread_lane.queue.qsize() == 1
+        # The normal flash overlapped the thread flash on its own lane.
+        assert alpha.status is JobStatus.RUNNING
+        assert alpha.job_id in controller.state.upload_lane.active
+
+        # The thread lane frees serially: mesh2 starts only after mesh1 ends.
+        controller.state.cancel_requested.add(mesh1.job_id)
+        await controller._terminate_job_process(mesh1)
+        await _wait_started(started, "mesh2.yaml")
+        assert list(thread_lane.active) == [mesh2.job_id]
+    finally:
+        runner.cancel()
+        with suppress(asyncio.CancelledError):
+            await runner
+
+
+async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
+    firmware_controller_factory: FirmwareControllerFactory, tmp_path: Any
+) -> None:
+    """Cancelling one running upload signals only its own subprocess."""
+    controller = firmware_controller_factory(with_queue=True)
+    _wire_real_queue(controller)
+    _wire_devices(controller)
+    controller.state.esphome_cmd = [sys.executable, "-c", _PARK_UPLOAD]
+    names = ["u1.yaml", "u2.yaml", "u3.yaml"]
+    _seed_yamls(tmp_path, *names)
+    started = _watch_started(controller)
+
+    jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
+
+    runner = asyncio.create_task(controller._run_queue())
+    try:
+        await _wait_started(started, *names)
+        # JOB_STARTED fires before the spawn; wait for every registration.
+        async with asyncio.timeout(10):
+            while not all(job.job_id in controller.state.processes for job in jobs):
+                await asyncio.sleep(0.01)
+
+        await controller.cancel(job_id=jobs[1].job_id)
+        async with asyncio.timeout(10):
+            while jobs[1].status is not JobStatus.CANCELLED:
+                await asyncio.sleep(0.01)
+
+        # Siblings never saw a signal — still parked and RUNNING.
+        assert jobs[0].status is JobStatus.RUNNING
+        assert jobs[2].status is JobStatus.RUNNING
+        assert controller.state.processes[jobs[0].job_id].returncode is None
+        assert controller.state.processes[jobs[2].job_id].returncode is None
+    finally:
+        runner.cancel()
+        with suppress(asyncio.CancelledError):
+            await runner
+
+
+# ---------------------------------------------------------------------------
+# Routing units — lane_for / place_on_lane / start() wiring
+# ---------------------------------------------------------------------------
+
+
+def _upload(configuration: str) -> FirmwareJob:
+    return FirmwareJob(
+        job_id=f"j-{configuration}", configuration=configuration, job_type=JobType.UPLOAD
+    )
+
+
+def test_lane_for_routes_thread_flashes_to_the_thread_lane() -> None:
+    state = FirmwareState()
+    state.is_thread_configuration = lambda c: c == "mesh.yaml"
+
+    assert state.lane_for(_upload("mesh.yaml")) is state.thread_upload_lane
+    assert state.lane_for(_upload("kitchen.yaml")) is state.upload_lane
+    compile_job = FirmwareJob(job_id="c", configuration="mesh.yaml", job_type=JobType.COMPILE)
+    assert state.lane_for(compile_job) is state.compile_lane
+
+
+def test_lane_for_rename_tail_routes_on_the_old_name() -> None:
+    state = FirmwareState()
+    state.is_thread_configuration = lambda c: c == "old.yaml"
+    tail = FirmwareJob(
+        job_id="tail",
+        configuration="old.yaml",
+        job_type=JobType.RENAME,
+        depends_on="head",
+        new_name="fresh",
+    )
+
+    assert state.lane_for(tail) is state.thread_upload_lane
+
+
+def test_place_on_lane_enqueues_thread_flash_on_the_thread_queue() -> None:
+    """The restore / release_dependents router lands thread flashes on their lane."""
+    state = FirmwareState()
+    state.is_thread_configuration = lambda c: c == "mesh.yaml"
+
+    state.place_on_lane(_upload("mesh.yaml"))
+    state.place_on_lane(_upload("kitchen.yaml"))
+
+    assert state.thread_upload_lane.queue.qsize() == 1
+    assert state.upload_lane.queue.qsize() == 1
+
+
+def test_upload_lane_concurrency_defaults() -> None:
+    state = FirmwareState()
+    assert state.upload_lane.max_concurrency == MAX_CONCURRENT_UPLOADS
+    assert state.thread_upload_lane.max_concurrency == 1
+    assert state.compile_lane.max_concurrency == 1
+    assert state.thread_upload_lane in state.lanes()
+
+
+async def test_start_wires_thread_lookup_before_job_restore(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: Any,
+) -> None:
+    """Restored flashes must already route through the devices lookup."""
+    controller = firmware_controller_factory()
+    monkeypatch.setattr(controller_module, "_find_esphome_cmd", lambda: ["esphome"])
+    monkeypatch.setattr(
+        controller_module, "_verify_esphome_importable", AsyncMock(return_value=(True, "ok"))
+    )
+    seen: list[Any] = []
+
+    async def _load_jobs() -> None:
+        seen.append(controller.state.is_thread_configuration)
+
+    monkeypatch.setattr(controller, "_load_jobs", _load_jobs)
+
+    await controller.start()
+
+    assert seen == [controller._is_thread_configuration]
+
+
+def test_is_thread_configuration_defaults_false_without_devices(
+    firmware_controller_factory: FirmwareControllerFactory,
+) -> None:
+    controller = firmware_controller_factory()
+    assert controller._is_thread_configuration("anything.yaml") is False

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -15,21 +15,14 @@ import asyncio
 import sys
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
-from esphome_device_builder.controllers.firmware import controller as controller_module
+from esphome_device_builder.controllers.firmware import FirmwareController
 from esphome_device_builder.controllers.firmware._state import FirmwareState
 from esphome_device_builder.controllers.firmware.constants import MAX_CONCURRENT_UPLOADS
 from esphome_device_builder.models import EventType, FirmwareJob, JobStatus, JobType
-from tests.controllers.firmware.conftest import (
-    run_until_terminal,
-)
-from tests.controllers.firmware.conftest import (
-    wire_devices as _wire_devices,
-)
-from tests.controllers.firmware.conftest import (
-    wire_real_queue as _wire_real_queue,
-)
+from tests.controllers.firmware.conftest import run_until_terminal, seed_yamls, wire_real_queue
+from tests.controllers.firmware.conftest import wire_devices as _wire_devices
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -55,12 +48,6 @@ def _watch_started(controller: Any) -> dict[str, asyncio.Event]:
     return started
 
 
-def _seed_yamls(tmp_path: Any, *names: str) -> None:
-    for name in names:
-        stem = name.removesuffix(".yaml")
-        (tmp_path / name).write_text(f"esphome:\n  name: {stem}\n", encoding="utf-8")
-
-
 async def _wait_started(started: dict[str, asyncio.Event], *configurations: str) -> None:
     async with asyncio.timeout(10):
         for configuration in configurations:
@@ -72,11 +59,11 @@ async def test_three_uploads_overlap_and_fourth_queues(
 ) -> None:
     """Three flashes occupy the upload lane at once; the fourth waits for a slot."""
     controller = firmware_controller_factory(with_queue=True)
-    _wire_real_queue(controller)
+    wire_real_queue(controller)
     _wire_devices(controller)
     controller.state.esphome_cmd = [sys.executable, "-c", _PARK_UPLOAD]
     names = ["u1.yaml", "u2.yaml", "u3.yaml", "u4.yaml"]
-    _seed_yamls(tmp_path, *names)
+    seed_yamls(tmp_path, *names)
     started = _watch_started(controller)
 
     jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
@@ -111,12 +98,11 @@ async def test_thread_uploads_serialize_beside_concurrent_normal_uploads(
 ) -> None:
     """Two thread-device flashes take the thread lane one at a time; a normal flash overlaps."""
     controller = firmware_controller_factory(with_queue=True)
-    _wire_real_queue(controller)
+    wire_real_queue(controller)
     _wire_devices(controller)
-    controller._db.devices.thread_configurations = {"mesh1.yaml", "mesh2.yaml"}
-    controller.state.is_thread_configuration = controller._is_thread_configuration
+    controller.state.is_thread_configuration = lambda c: c in {"mesh1.yaml", "mesh2.yaml"}
     controller.state.esphome_cmd = [sys.executable, "-c", _PARK_UPLOAD]
-    _seed_yamls(tmp_path, "mesh1.yaml", "mesh2.yaml", "alpha.yaml")
+    seed_yamls(tmp_path, "mesh1.yaml", "mesh2.yaml", "alpha.yaml")
     started = _watch_started(controller)
 
     mesh1 = await controller.upload(configuration="mesh1.yaml", port="OTA")
@@ -151,11 +137,11 @@ async def test_cancel_one_of_three_concurrent_uploads_spares_siblings(
 ) -> None:
     """Cancelling one running upload signals only its own subprocess."""
     controller = firmware_controller_factory(with_queue=True)
-    _wire_real_queue(controller)
+    wire_real_queue(controller)
     _wire_devices(controller)
     controller.state.esphome_cmd = [sys.executable, "-c", _PARK_UPLOAD]
     names = ["u1.yaml", "u2.yaml", "u3.yaml"]
-    _seed_yamls(tmp_path, *names)
+    seed_yamls(tmp_path, *names)
     started = _watch_started(controller)
 
     jobs = [await controller.upload(configuration=name, port="OTA") for name in names]
@@ -208,11 +194,11 @@ async def test_six_uploads_drain_three_at_a_time(
     earlier flashes completed (FIFO refill). All 6 land COMPLETED.
     """
     controller = firmware_controller_factory(with_queue=True)
-    _wire_real_queue(controller)
+    wire_real_queue(controller)
     _wire_devices(controller)
     controller.state.esphome_cmd = [sys.executable, "-c", _STAGGERED_UPLOAD]
     names = [f"u{i}.yaml" for i in range(1, 7)]
-    _seed_yamls(tmp_path, *names)
+    seed_yamls(tmp_path, *names)
 
     sequence: list[tuple[EventType, str]] = []
     max_active = 0
@@ -304,26 +290,10 @@ def test_upload_lane_concurrency_defaults() -> None:
     assert state.thread_upload_lane in state.lanes()
 
 
-async def test_start_wires_thread_lookup_before_job_restore(
-    firmware_controller_factory: FirmwareControllerFactory,
-    monkeypatch: Any,
-) -> None:
-    """Restored flashes must already route through the devices lookup."""
-    controller = firmware_controller_factory()
-    monkeypatch.setattr(controller_module, "_find_esphome_cmd", lambda: ["esphome"])
-    monkeypatch.setattr(
-        controller_module, "_verify_esphome_importable", AsyncMock(return_value=(True, "ok"))
-    )
-    seen: list[Any] = []
-
-    async def _load_jobs() -> None:
-        seen.append(controller.state.is_thread_configuration)
-
-    monkeypatch.setattr(controller, "_load_jobs", _load_jobs)
-
-    await controller.start()
-
-    assert seen == [controller._is_thread_configuration]
+def test_controller_wires_thread_lookup_at_construction() -> None:
+    """Every route — including restore — sees the devices lookup, not the default."""
+    controller = FirmwareController(MagicMock())
+    assert controller.state.is_thread_configuration == controller._is_thread_configuration
 
 
 def test_is_thread_configuration_defaults_false_without_devices(

--- a/tests/controllers/firmware/test_parallel_uploads.py
+++ b/tests/controllers/firmware/test_parallel_uploads.py
@@ -298,9 +298,16 @@ def test_controller_wires_thread_lookup_at_construction() -> None:
 
 def test_is_thread_configuration_defaults_false_without_devices(
     firmware_controller_factory: FirmwareControllerFactory,
+    caplog: Any,
 ) -> None:
+    """A missing devices controller degrades loudly, not silently."""
     controller = firmware_controller_factory()
     assert controller._is_thread_configuration("anything.yaml") is False
+    assert any(
+        "without thread serialization" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
 
 
 def test_is_thread_configuration_delegates_to_devices(


### PR DESCRIPTION
# What does this implement/fix?

Fixes queued update delivery for deep sleep devices, on top of #2191. When several deep sleep devices wake at once, each queued update has to land inside its device's wake window; with the single serial upload slot, the flashes stuck behind a slow OTA missed their window, the devices went back to sleep, and their updates failed. The upload lane now runs up to `MAX_CONCURRENT_UPLOADS` (3) flashes at once; the cap bounds the combined memory of concurrent esphome subprocess trees. This happens to also answer the parallel uploads feature request in https://github.com/orgs/esphome/discussions/3781 (fast OTAs no longer serialize behind a device on crap wifi), but the deep sleep failure is why we are doing it.

OpenThread devices get their own single slot `thread_upload_lane` since they share one mesh and border router, concurrent OTAs over the mesh starve each other. The slot is deliberately global rather than per mesh; mesh membership is not data the dashboard has, and a single network is the common deployment. Routing keys on `DevicesController.is_thread_device` (`openthread` in the last compile's `loaded_integrations`), wired at construction so restored flashes route the same way; a never compiled device falls back to the normal upload lane. Compile lane and remote dispatch pool are unchanged.

Verified live against the real dashboard with a stubbed esphome CLI: an 8 device burst (6 wifi + 2 thread) drained 3 at a time plus one thread slot, mesh2 waited for mesh1, and cancelling one running upload spared its siblings.

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3781

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
