### PR TITLE
Document version history in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,65 @@ or `exact_required` — the last refuses to build rather than
 falling back to a local compile when no version-compatible
 receiver is paired.
 
+## Version history
+
+The dashboard keeps a local, git-backed history of your device
+configs. Every change to a YAML in the config directory is committed
+automatically shortly after it lands on disk, whether the edit came
+from the dashboard, an external editor, a script, or an AI agent
+working in the directory. The history powers viewing, diffing, and
+restoring earlier versions of a config, including bringing back a
+deleted one. Today those are exposed as the `version_history/*`
+commands in [docs/API.md](docs/API.md); a recovery UI in the
+dashboard is planned. Recording starts now precisely so that when
+that UI ships, your history is already there.
+
+**Why it's on by default.** A history only helps if it already
+exists the moment you need it, and that moment is always right
+after the bad edit or the accidental delete, never before. Making
+it opt-in would protect exactly the people who least need it: those
+who already knew the feature existed. For everyone else, the first
+bad edit would also be the moment they learn there was no history.
+So it stays on, quietly, like a backup should.
+
+**What it does on disk:**
+
+- If the config directory is not already a git repository, one is
+  created for it, with a `.gitignore` that keeps `secrets.yaml` out
+  of history.
+- If the directory already is a git work tree (or sits inside one,
+  as `/config/esphome` commonly does), it is adopted rather than
+  re-initialised. Automatic commits are scoped to exactly the files
+  that changed, so your own staged work is never swept into one,
+  and your `.gitignore` is never modified. Device Builder's own
+  machine state (sidecars, keys, pairing files) is kept out of
+  history via the repo-local `.git/info/exclude`.
+- Your secrets file is never committed.
+- Commits are authored as
+  `ESPHome Device Builder <device-builder@esphome.io>`, with hooks
+  and commit signing skipped (`--no-verify`,
+  `-c commit.gpgsign=false`). This is deliberate: these commits
+  happen unattended in the background, and an unattended commit
+  must never hang on a signing passphrase prompt or trip an
+  interactive hook. The identity is passed per invocation; your
+  global and per-repo git configuration is never written to.
+- If `git` isn't installed, the feature quietly stays off.
+
+**Turning it off.** Settings → enable **Expert mode** → turn off
+**Save version history**. (Programmatically: the
+`version_history_enabled` preference via `config/set_preferences`.)
+Turning it off stops new commits and creates no repository; an
+existing history stays readable and restorable. If your config
+directory lives in a git repository you manage yourself (your own
+identity, signing, hooks, branch protection) and you don't want
+automatic commits alongside yours, this toggle is for you.
+
+> **Policy note.** The default has been discussed and decided:
+> version history ships on. New issues asking to flip the default,
+> or relitigating the commit identity / signing / hook behaviour
+> described above, will be closed with a pointer to this section.
+> Bug reports about the feature misbehaving are always welcome.
+
 ## Roadmap
 
 - ✅ Standalone backend with WS-first API, persistent compile queue, mDNS device discovery


### PR DESCRIPTION
# What does this implement/fix?

Adds a `## Version history` section to the README. The feature has shipped since #1149 and the opt-out preference since #1785, but neither is documented anywhere user-facing, so surprised users keep filing issues about the automatic commits (#1214, #1718, #1719, #2095, #2193).

The new section covers:

- what the feature does (auto-commits YAML edits from any source; view/diff/restore via the `version_history/*` WS commands, recovery UI planned)
- why it's on by default (history has to exist before you need it)
- exactly what it does on disk (repo creation vs adoption, pathspec-scoped commits, `.git/info/exclude`, secrets never committed, the commit identity, why hooks and signing are skipped for unattended commits, git-absent no-op)
- how to turn it off (Settings → Expert mode → Save version history, or `version_history_enabled` via `config/set_preferences`)
- a policy note stating the default is settled and issues relitigating it will be closed, while bug reports remain welcome

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2193

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [x] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [ ] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
