### PR TITLE
Drop the placeholder-constant import fallback

### DIFF
--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from esphome import yaml_util
+from esphome.const import PLACEHOLDER_WIFI_PASSWORD, PLACEHOLDER_WIFI_SSID
 from esphome.core import EsphomeError
 from esphome.helpers import write_file as atomic_write_file
 from ruamel.yaml import YAML
@@ -45,19 +46,6 @@ async def write_secrets_locked[T](lock: asyncio.Lock, fn: Callable[..., T], *arg
     """
     async with lock:
         return await run_in_executor(fn, *args)
-
-
-# Bootstrap placeholder strings. Upstream now exports these from
-# ``esphome.const``; fall back to local literals on older releases
-# that predate the promotion.
-try:
-    from esphome.const import (
-        PLACEHOLDER_WIFI_PASSWORD,
-        PLACEHOLDER_WIFI_SSID,
-    )
-except ImportError:
-    PLACEHOLDER_WIFI_SSID = "REPLACE_WITH_YOUR_WIFI_NETWORK"
-    PLACEHOLDER_WIFI_PASSWORD = "REPLACE_WITH_YOUR_WIFI_PASSWORD"  # noqa: S105
 
 
 def read_secrets_yaml(config_dir: Path) -> dict | None:


### PR DESCRIPTION
# What does this implement/fix?

Drops the `try`/`except ImportError` fallback around the `PLACEHOLDER_WIFI_SSID` / `PLACEHOLDER_WIFI_PASSWORD` import in `helpers/secrets_state.py` and imports them from `esphome.const` directly. The fallback is unreachable; the module hard-imports esphome a few lines up, and the 2026.7.0 tag (exactly our `esphome>=2026.7.0` floor) already exports both constants.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
