### PR TITLE
Drop the esphome.bundle import fallback

### DIFF
--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -122,7 +122,7 @@ class _Outcome:
 
 def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] | None) -> _Outcome:
     """Decode, extract to a temp dir, then plan or place the files (blocking)."""
-    # Lazy: keeps esphome.bundle (and its yaml_util pull) off cold import.
+    # Lazy: keeps esphome.bundle off cold import.
     from esphome.bundle import (  # noqa: PLC0415
         MANIFEST_FILENAME,
         extract_bundle,

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -122,17 +122,12 @@ class _Outcome:
 
 def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] | None) -> _Outcome:
     """Decode, extract to a temp dir, then plan or place the files (blocking)."""
-    try:
-        from esphome.bundle import (  # noqa: PLC0415
-            MANIFEST_FILENAME,
-            extract_bundle,
-            read_bundle_manifest,
-        )
-    except ImportError as exc:  # pragma: no cover - pinned esphome ships bundle
-        raise CommandError(
-            ErrorCode.UNAVAILABLE,
-            "This ESPHome version doesn't support config bundles.",
-        ) from exc
+    # Lazy: keeps esphome.bundle (and its yaml_util pull) off cold import.
+    from esphome.bundle import (  # noqa: PLC0415
+        MANIFEST_FILENAME,
+        extract_bundle,
+        read_bundle_manifest,
+    )
 
     bundle_bytes = _decode_bundle(file_content_b64)
     overwrite_set = set(overwrite or [])


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #2200, the other fallback of the same class. `_stage_bundle` wrapped its `esphome.bundle` import in `try`/`except ImportError` raising "This ESPHome version doesn't support config bundles." The module hard-imports `esphome.core` and `esphome.helpers` at the top, and the 2026.7.0 tag (our `esphome>=2026.7.0` floor) ships `esphome/bundle.py`, so the arm is unreachable. The import stays function-local so `esphome.bundle` keeps off cold import.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [x] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
