### PR TITLE
Preserve an operator-set secrets.yaml mode across rewrites

### DIFF
--- a/esphome_device_builder/controllers/devices/controller.py
+++ b/esphome_device_builder/controllers/devices/controller.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from esphome.core import CORE
-from esphome.helpers import write_file as atomic_write_file
 from esphome.zeroconf import AsyncEsphomeZeroconf
 
 from ...constants import is_secrets_file
@@ -36,6 +35,7 @@ from ...helpers.secrets_state import (
     write_wifi_secrets,
 )
 from ...helpers.storage import ShutdownCallback, drain_shutdown_callbacks
+from ...helpers.yaml import write_user_yaml
 from ...models import (
     OTA_PORT,
     AddComponentResponse,
@@ -999,9 +999,10 @@ class DevicesController(  # noqa: PLR0904 (grandfathered; new public methods nee
         Use this for any user-editable YAML write so a mid-write
         crash can't leave the file empty or half-written;
         ``Path.write_text`` truncates before writing and isn't
-        safe for those paths.
+        safe for those paths. An existing file's mode survives the
+        rewrite (an operator-tightened ``secrets.yaml`` stays 0600).
         """
-        await run_in_executor(atomic_write_file, path, content)
+        await run_in_executor(write_user_yaml, path, content)
 
     async def _persist_yaml_mutation(
         self, configuration: str, content: str, *, message: str | None = None

--- a/esphome_device_builder/controllers/devices/mutations_create.py
+++ b/esphome_device_builder/controllers/devices/mutations_create.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, NoReturn
 
-from esphome.helpers import write_file as atomic_write_file
 from esphome.storage_json import StorageJSON
 
 from ...helpers.api import CommandError
@@ -13,6 +12,7 @@ from ...helpers.async_ import run_in_executor
 from ...helpers.device_yaml import parse_platform_from_yaml
 from ...helpers.hostname import default_mdns_address
 from ...helpers.storage_path import resolve_storage_path
+from ...helpers.yaml import write_user_yaml
 from ...models import ErrorCode, WizardResponse
 from ..editor import IMPORT_VALIDATE_TIMEOUT
 from .helpers import (
@@ -178,7 +178,7 @@ async def create_device(  # noqa: C901, PLR0912
     if overwriting:
         # Atomic in-place rewrite (stage + move) so a crash can't leave a
         # half-written config; the user explicitly confirmed the overwrite.
-        await run_in_executor(atomic_write_file, config_path, yaml_content)
+        await run_in_executor(write_user_yaml, config_path, yaml_content)
     else:
         await write_new_file_exclusive(config_path, yaml_content, on_exists=_raise_already_exists)
 

--- a/esphome_device_builder/controllers/devices/mutations_import_bundle.py
+++ b/esphome_device_builder/controllers/devices/mutations_import_bundle.py
@@ -18,13 +18,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from esphome.core import EsphomeError
-from esphome.helpers import write_file as atomic_write_file
 
 from ...constants import SECRETS_FILENAME
 from ...helpers.api import CommandError
 from ...helpers.device_yaml import configuration_stem, parse_platform_from_yaml
 from ...helpers.secrets_state import merge_secrets_file
-from ...helpers.yaml import ESPHOME_FRIENDLY_NAME_PATH, read_yaml_scalar
+from ...helpers.yaml import ESPHOME_FRIENDLY_NAME_PATH, read_yaml_scalar, write_user_yaml
 from ...models import ErrorCode, ImportBundleResponse
 from .helpers import _validate_archive_configuration
 from .mutations_create import init_device_storage
@@ -200,7 +199,7 @@ def _stage_bundle(file_content_b64: str, config_dir: Path, overwrite: list[str] 
                 kept.append(rel)
                 continue
             dest.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write_file(dest, src.read_bytes())
+            write_user_yaml(dest, src.read_bytes())
             written.append(rel)
 
         # A new device gets a fresh sidecar; overwriting a live one keeps

--- a/esphome_device_builder/helpers/atomic_io.py
+++ b/esphome_device_builder/helpers/atomic_io.py
@@ -1,12 +1,13 @@
 """
 Atomic filesystem writes for dashboard-internal artefacts.
 
-For cert / key / token / metadata-sidecar files. User-editable
-YAML still goes through :func:`esphome.helpers.write_file`.
+For cert / key / token / metadata-sidecar files, plus the
+mode-preserving rewrite of user-editable YAML.
 
 Why not the upstream helper here: ``write_file``'s ``private``
 flag is binary (0o644 vs 0o600), and we need arbitrary modes for
-caller-controlled-mode shapes (cert / key + future token stores).
+caller-controlled-mode shapes (cert / key + future token stores)
+and for keeping an operator-set mode across a rewrite.
 
 Blocking I/O — call from ``run_in_executor``, not the loop.
 """
@@ -57,6 +58,21 @@ def atomic_write(
     if make_parents:
         path.parent.mkdir(parents=True, exist_ok=True)
     _staged_write(path, data, mode=mode, publish=_replace_with_retry)
+
+
+def atomic_write_preserving_mode(path: Path, data: bytes, *, default_mode: int = 0o644) -> None:
+    """
+    Atomically write *data*, keeping an existing *path*'s permission bits.
+
+    A rewrite must not reset an operator-tightened mode (e.g. a 0600
+    ``secrets.yaml``) back to world-readable; a missing (or unstatable)
+    *path* gets *default_mode*.
+    """
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        mode = default_mode
+    atomic_write(path, data, mode=mode)
 
 
 def atomic_write_exclusive(path: Path, data: bytes, *, mode: int = 0o644) -> None:

--- a/esphome_device_builder/helpers/secrets_state.py
+++ b/esphome_device_builder/helpers/secrets_state.py
@@ -32,7 +32,7 @@ from ruamel.yaml import YAML
 
 from ..constants import SECRETS_FILENAME
 from .async_ import run_in_executor
-from .yaml import load_yaml_fast_then_esphome
+from .yaml import load_yaml_fast_then_esphome, write_user_yaml
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -164,7 +164,7 @@ def merge_secrets_file(src: Path, dest: Path) -> None:
     YAML().dump(absent, buf)
     existing_text = dest.read_text("utf-8")
     separator = "" if not existing_text or existing_text.endswith("\n") else "\n"
-    atomic_write_file(dest, existing_text + separator + buf.getvalue())
+    write_user_yaml(dest, existing_text + separator + buf.getvalue())
 
 
 # ``key: value`` line. Captures: 1=indent, 2=key, 3=trailing
@@ -262,7 +262,7 @@ def migrate_placeholder_wifi_secrets(config_dir: Path) -> None:
         if not ((m := _SECRET_LINE_RE.match(line)) and m.group(2) in drop)
     )
     if updated != original:
-        atomic_write_file(secrets_path, updated)
+        write_user_yaml(secrets_path, updated)
 
 
 def write_wifi_secrets(config_dir: Path, ssid: str, password: str) -> None:
@@ -283,7 +283,7 @@ def write_wifi_secrets(config_dir: Path, ssid: str, password: str) -> None:
         "wifi_password",
         password,
     )
-    atomic_write_file(secrets_path, updated)
+    write_user_yaml(secrets_path, updated)
 
 
 def write_secret(config_dir: Path, key: str, value: str, *, overwrite: bool = True) -> bool:
@@ -302,7 +302,7 @@ def write_secret(config_dir: Path, key: str, value: str, *, overwrite: bool = Tr
         return False
     updated = _replace_or_append_secret(original, key, value)
     validate_secrets_content(updated, secrets_path)
-    atomic_write_file(secrets_path, updated)
+    write_user_yaml(secrets_path, updated)
     return not existed
 
 

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import yaml
 from esphome import yaml_util
+from esphome.core import EsphomeError
+
+from ..atomic_io import atomic_write_preserving_mode
 
 # Prefer the libyaml-backed C loader when PyYAML was built against
 # libyaml. On the M5 MacBook Pro, parsing the full board catalog
@@ -90,3 +93,18 @@ def load_yaml_fast_then_esphome(path: Path) -> Any:
             return yaml.load(f, Loader=FastestSafeLoader)  # noqa: S506
     except yaml.YAMLError:
         return yaml_util.load_yaml(path)
+
+
+def write_user_yaml(path: Path, content: str | bytes) -> None:
+    """
+    Atomically write user-editable YAML, keeping an existing *path*'s mode.
+
+    An operator-tightened mode (e.g. a 0600 ``secrets.yaml``) survives the
+    rewrite instead of being reset to 0644; a new file gets 0644. ``OSError``
+    is wrapped as ``EsphomeError``, matching ``esphome.helpers.write_file``.
+    """
+    data = content.encode() if isinstance(content, str) else content
+    try:
+        atomic_write_preserving_mode(path, data)
+    except OSError as err:
+        raise EsphomeError(f"Could not write file at {path}") from err

--- a/esphome_device_builder/helpers/yaml/__init__.py
+++ b/esphome_device_builder/helpers/yaml/__init__.py
@@ -99,9 +99,8 @@ def write_user_yaml(path: Path, content: str | bytes) -> None:
     """
     Atomically write user-editable YAML, keeping an existing *path*'s mode.
 
-    An operator-tightened mode (e.g. a 0600 ``secrets.yaml``) survives the
-    rewrite instead of being reset to 0644; a new file gets 0644. ``OSError``
-    is wrapped as ``EsphomeError``, matching ``esphome.helpers.write_file``.
+    A new file gets 0644. ``OSError`` is wrapped as ``EsphomeError``,
+    matching ``esphome.helpers.write_file``.
     """
     data = content.encode() if isinstance(content, str) else content
     try:

--- a/tests/controllers/devices/test_create.py
+++ b/tests/controllers/devices/test_create.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import asyncio
 import gzip
 import io
+import stat
+import sys
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
@@ -871,6 +873,23 @@ async def test_create_device_overwrite_preserves_metadata(
     assert post.get("comment") == "my note"
     assert post.get("board_id") == "esp32-pick"
     assert ctrl._scanner.calls == [("scan",)]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+async def test_create_device_overwrite_preserves_operator_mode(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A confirmed overwrite keeps the existing YAML's tightened mode."""
+    target = tmp_path / "kitchen.yaml"
+    target.write_text("esphome:\n  name: kitchen\n", "utf-8")
+    target.chmod(0o600)
+    ctrl = make_controller(tmp_path, with_state_monitor=True, with_boards=True)
+    new_content = "esphome:\n  name: kitchen\n  friendly_name: New\n"
+
+    await ctrl.create_device(name="kitchen", file_content=new_content, overwrite=True)
+
+    assert target.read_text("utf-8") == new_content
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
 async def test_create_device_with_board_id_overwrites_archived_board_id(

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -19,7 +19,7 @@ What we pin:
 
 from __future__ import annotations
 
-import shutil
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -661,38 +661,28 @@ async def test_edit_friendly_name_routes_through_atomic_write_helper(
 ) -> None:
     """Source YAML survives a mid-write crash inside the atomic helper.
 
-    The controller writes through ``esphome.helpers.write_file``,
-    which stages the new bytes in a sibling tempfile and then
-    ``shutil.move`` s into place. ``Path.write_text`` would
-    truncate the destination first, so a crash mid-write would
-    leave a partial / corrupt YAML. Pin that the controller uses
-    the atomic helper by patching ``shutil.move`` to raise during
-    the rename — the destination must come back unchanged and no
-    tempfile shrapnel can be left behind.
-
-    Patches at ``shutil.move`` rather than ``os.replace`` because
-    that's the exact entry point ``esphome.helpers.write_file``
-    routes through; a regression that swapped back to a
-    non-atomic path would skip ``shutil.move`` entirely and we'd
-    catch it as "the patched move was never called and the file
-    got modified anyway."
+    The controller writes through ``write_user_yaml``, which stages
+    the new bytes in a sibling tempfile and ``os.replace``s into
+    place. ``Path.write_text`` would truncate the destination first,
+    so a crash mid-write would leave a partial / corrupt YAML. Pin
+    that the controller uses the atomic helper by patching
+    ``os.replace`` to raise during the rename — the destination must
+    come back unchanged and no tempfile shrapnel can be left behind.
+    A regression that swapped back to a non-atomic path would skip
+    ``os.replace`` entirely and we'd catch it as "the patched replace
+    was never called and the file got modified anyway."
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")
 
     boom = RuntimeError("simulated mid-rename crash")
-    move_calls: list[tuple[str, str]] = []
+    replace_calls: list[tuple[str, str]] = []
 
-    def _exploding_move(src: str, dst: str) -> None:
-        move_calls.append((str(src), str(dst)))
-        # Mirror the cleanup the real ``shutil.move`` would have
-        # done if the rename had succeeded so the regression test
-        # observes "no leftover tempfile" via the helper's own
-        # finally-clause cleanup, not via the move itself.
-        Path(src).unlink(missing_ok=True)
+    def _exploding_replace(src: str, dst: str) -> None:
+        replace_calls.append((str(src), str(dst)))
         raise boom
 
-    monkeypatch.setattr(shutil, "move", _exploding_move)
+    monkeypatch.setattr(os, "replace", _exploding_replace)
     with pytest.raises(RuntimeError, match="simulated mid-rename"):
         await ctrl.edit_friendly_name(
             configuration="kitchen.yaml", new_friendly_name="Reading Lamp"
@@ -700,12 +690,12 @@ async def test_edit_friendly_name_routes_through_atomic_write_helper(
 
     # Source untouched — atomic-write contract held.
     assert (tmp_path / "kitchen.yaml").read_text("utf-8") == SOURCE_YAML
-    # No leftover tempfile siblings (write_file's finally cleans up).
+    # No leftover tempfile siblings (atomic_write's finally cleans up).
     leftover = [p.name for p in tmp_path.iterdir() if p.name != "kitchen.yaml"]
     assert leftover == []
     # Pin the helper got invoked — a regression that switched back
-    # to ``Path.write_text`` would skip ``shutil.move`` entirely.
-    assert len(move_calls) == 1
+    # to ``Path.write_text`` would skip ``os.replace`` entirely.
+    assert len(replace_calls) == 1
     _ = boom  # silence the unused-name complaint without a noqa
 
 

--- a/tests/controllers/devices/test_edit_friendly_name.py
+++ b/tests/controllers/devices/test_edit_friendly_name.py
@@ -661,16 +661,9 @@ async def test_edit_friendly_name_routes_through_atomic_write_helper(
 ) -> None:
     """Source YAML survives a mid-write crash inside the atomic helper.
 
-    The controller writes through ``write_user_yaml``, which stages
-    the new bytes in a sibling tempfile and ``os.replace``s into
-    place. ``Path.write_text`` would truncate the destination first,
-    so a crash mid-write would leave a partial / corrupt YAML. Pin
-    that the controller uses the atomic helper by patching
-    ``os.replace`` to raise during the rename — the destination must
-    come back unchanged and no tempfile shrapnel can be left behind.
-    A regression that swapped back to a non-atomic path would skip
-    ``os.replace`` entirely and we'd catch it as "the patched replace
-    was never called and the file got modified anyway."
+    ``os.replace`` is patched to raise mid-rename: the destination must
+    come back unchanged, with no tempfile shrapnel, and the patched
+    replace must have been called (a non-atomic path would skip it).
     """
     ctrl = make_controller(tmp_path, with_state_monitor=True)
     (tmp_path / "kitchen.yaml").write_text(SOURCE_YAML, "utf-8")

--- a/tests/controllers/devices/test_get_update_config.py
+++ b/tests/controllers/devices/test_get_update_config.py
@@ -26,6 +26,8 @@ Coverage targets:
 
 from __future__ import annotations
 
+import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -395,6 +397,23 @@ async def test_update_config_accepts_valid_secrets_yaml(
     await controller.update_config(configuration="secrets.yaml", content=content)
 
     assert (tmp_path / "secrets.yaml").read_text(encoding="utf-8") == content
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+async def test_update_config_secrets_save_preserves_operator_mode(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A whole-file secrets.yaml save keeps an operator-tightened mode."""
+    controller = make_controller(tmp_path)
+    _stub_regenerate(controller)
+    target = tmp_path / "secrets.yaml"
+    target.write_text("wifi_ssid: home\n", encoding="utf-8")
+    target.chmod(0o600)
+
+    await controller.update_config(configuration="secrets.yaml", content="wifi_ssid: new\n")
+
+    assert target.read_text(encoding="utf-8") == "wifi_ssid: new\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
 async def test_update_config_accepts_comment_only_secrets_yaml(

--- a/tests/controllers/devices/test_import_bundle.py
+++ b/tests/controllers/devices/test_import_bundle.py
@@ -7,6 +7,8 @@ import base64
 import gzip
 import io
 import json
+import stat
+import sys
 import tarfile
 from pathlib import Path
 
@@ -156,6 +158,25 @@ async def test_import_bundle_overwrite_replaces_only_chosen_files(
     assert result.written == ["kitchen.yaml"]
     assert result.kept == ["common/wifi.yaml"]
     assert ctrl._scanner.calls == [("scan",)]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+@pytest.mark.usefixtures("stub_create_device_metadata_helpers", "_bundle_storage_under_tmp")
+async def test_import_bundle_overwrite_preserves_operator_mode(
+    tmp_path: Path, make_controller: MakeControllerFactory
+) -> None:
+    """A confirmed bundle overwrite keeps the target's tightened mode."""
+    ctrl = make_controller(tmp_path, with_state_monitor=True)
+    target = tmp_path / "kitchen.yaml"
+    target.write_text("OLD\n", "utf-8")
+    target.chmod(0o600)
+    bundle = _make_bundle({"kitchen.yaml": MAIN_YAML}, config_filename="kitchen.yaml")
+
+    result = await ctrl.import_bundle(file_content_b64=_b64(bundle), overwrite=["kitchen.yaml"])
+
+    assert result.status == "imported"
+    assert target.read_text("utf-8") == MAIN_YAML
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
 @pytest.mark.usefixtures("stub_create_device_metadata_helpers", "_bundle_storage_under_tmp")

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -13,6 +13,7 @@ import pytest
 from esphome_device_builder.helpers.atomic_io import (
     atomic_write,
     atomic_write_exclusive,
+    atomic_write_preserving_mode,
     read_bytes_with_retry,
 )
 
@@ -51,6 +52,27 @@ def test_atomic_write_applies_mode(tmp_path: Path) -> None:
     atomic_write(target, b"payload", mode=0o600)
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert target.read_bytes() == b"payload"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+@pytest.mark.parametrize("mode", [pytest.param(0o600, id="0600"), pytest.param(0o640, id="0640")])
+def test_atomic_write_preserving_mode_keeps_existing_mode(tmp_path: Path, mode: int) -> None:
+    """A rewrite keeps the target's current permission bits."""
+    target = tmp_path / "secrets.yaml"
+    target.write_text("a: 1\n")
+    target.chmod(mode)
+    atomic_write_preserving_mode(target, b"b: 2\n")
+    assert target.read_bytes() == b"b: 2\n"
+    assert stat.S_IMODE(target.stat().st_mode) == mode
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+def test_atomic_write_preserving_mode_new_file_gets_default(tmp_path: Path) -> None:
+    """A missing target is created with ``default_mode``."""
+    target = tmp_path / "secrets.yaml"
+    atomic_write_preserving_mode(target, b"a: 1\n")
+    assert target.read_bytes() == b"a: 1\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
 
 
 def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:

--- a/tests/test_secrets_state.py
+++ b/tests/test_secrets_state.py
@@ -8,6 +8,9 @@ merge / line-based write helpers, and the secret-key rules.
 from __future__ import annotations
 
 import asyncio
+import stat
+import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -445,6 +448,59 @@ def test_write_wifi_secrets_preserves_other_keys_and_comments(tmp_path: Path) ->
 def test_write_wifi_secrets_escapes_double_quotes(tmp_path: Path) -> None:
     write_wifi_secrets(tmp_path, 'Net"x', "p")
     assert r'wifi_ssid: "Net\"x"' in _secrets(tmp_path).read_text("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# mode preservation — an operator-tightened secrets.yaml stays tight
+# ---------------------------------------------------------------------------
+
+
+def _merge_incoming(config_dir: Path) -> None:
+    src = config_dir / "incoming.yaml"
+    src.write_text("new_key: v\n", "utf-8")
+    merge_secrets_file(src, config_dir / "secrets.yaml")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+@pytest.mark.parametrize(
+    ("content", "mutate"),
+    [
+        pytest.param(
+            "api_key: v1\n",
+            lambda d: write_secret(d, "api_key", "v2"),
+            id="write_secret",
+        ),
+        pytest.param(
+            "api_key: v1\n",
+            lambda d: write_wifi_secrets(d, "MyAP", "pw"),
+            id="write_wifi_secrets",
+        ),
+        pytest.param(
+            f"wifi_ssid: {PLACEHOLDER_WIFI_SSID}\n",
+            migrate_placeholder_wifi_secrets,
+            id="migrate_placeholder",
+        ),
+        pytest.param(
+            "existing: v\n",
+            _merge_incoming,
+            id="merge_secrets_file",
+        ),
+    ],
+)
+def test_secrets_rewrites_preserve_operator_mode(
+    tmp_path: Path, content: str, mutate: Callable[[Path], object]
+) -> None:
+    secrets = _secrets(tmp_path)
+    secrets.write_text(content, "utf-8")
+    secrets.chmod(0o600)
+    mutate(tmp_path)
+    assert stat.S_IMODE(secrets.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't honor POSIX mode bits")
+def test_write_secret_creates_missing_file_with_default_mode(tmp_path: Path) -> None:
+    write_secret(tmp_path, "api_key", "v")
+    assert stat.S_IMODE(_secrets(tmp_path).stat().st_mode) == 0o644
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -55,6 +55,7 @@ from esphome_device_builder.helpers.yaml import (
     rewrite_rename_content,
     rewrite_yaml_scalar,
     upsert_yaml_leaf_under_top_block,
+    write_user_yaml,
 )
 from esphome_device_builder.helpers.yaml.component import _list_item_indent
 from esphome_device_builder.helpers.yaml.scalar import (
@@ -2142,3 +2143,9 @@ def test_load_yaml_fast_then_esphome_raises_on_broken_include(tmp_path: Path) ->
     path.write_text("<<: !include does_not_exist.yaml\n")
     with pytest.raises(EsphomeError):
         load_yaml_fast_then_esphome(path)
+
+
+def test_write_user_yaml_wraps_oserror_as_esphome_error(tmp_path: Path) -> None:
+    """A failed write surfaces as ``EsphomeError``, matching ``esphome.helpers.write_file``."""
+    with pytest.raises(EsphomeError, match="Could not write file"):
+        write_user_yaml(tmp_path / "missing" / "x.yaml", "a: 1\n")


### PR DESCRIPTION
# What does this implement/fix?

Not a security fix and not a regression. Writes to secrets.yaml and other user-editable YAML have always applied the 0644 default, matching the legacy dashboard, which kept that default deliberately so bind mount and PUID/NFS/SMB setups keep working. The quality-of-life gap was that an operator who chose to tighten secrets.yaml to 0640 or 0600 had that choice undone on the next rewrite (per-key set, wizard Wi-Fi save, placeholder migration, bundle merge, whole-file editor save). Rewrites now keep the file's existing permission bits; the mode is applied to the staging tempfile before the atomic rename, so there is no transient window. New files still get 0644 and nothing is tightened unless the operator does it themselves, so existing setups see no change at all.

Mechanics: a bytes-level `atomic_write_preserving_mode` in `helpers/atomic_io.py` plus a `write_user_yaml` wrapper in `helpers/yaml` that keeps the OSError to EsphomeError contract of `esphome.helpers.write_file`. All in-place rewrites of user-editable YAML route through it for consistency: the four secrets writers, the editor save path (`_write_yaml_atomic_async`, which also covers rename and version-history restore), the confirmed-overwrite branch of `devices/create`, and confirmed bundle-import overwrites. New-file creation paths are untouched.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2199

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
