### PR TITLE
Fail loud when ethernet predates the RP2 type split

### DIFF
--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -6427,17 +6427,12 @@ def _ethernet_type_platform_options() -> dict[str, list[dict[str, str]]]:
     Ethernet's per-platform ``type`` choices from the live module constants.
 
     The schema bundle ships a flat union; empty when esphome's ethernet
-    isn't importable or predates the split.
+    isn't importable.
     """
     try:
         from esphome.components import ethernet as _ethernet
     except ImportError:
         _LOGGER.warning("esphome ethernet not importable — type platform split skipped")
-        return {}
-    if not hasattr(_ethernet, "RP2_ETHERNET_TYPES"):
-        # Catalog syncs always run on 2026.7+; this only keeps test runs
-        # under an older interpreter (CI stable leg) from crashing.
-        _LOGGER.debug("installed esphome predates RP2_ETHERNET_TYPES — ethernet split skipped")
         return {}
     rp2 = set(_ethernet.RP2_ETHERNET_TYPES)
     # Everything except the RP2-only chips.

--- a/tests/test_sync_components_ethernet_types.py
+++ b/tests/test_sync_components_ethernet_types.py
@@ -34,9 +34,6 @@ def _values(options: list[dict]) -> list[str]:
 def test_options_derive_from_live_ethernet_module() -> None:
     ethernet = pytest.importorskip("esphome.components.ethernet")
     options = sync_components._ethernet_type_platform_options()
-    if not hasattr(ethernet, "RP2_ETHERNET_TYPES"):
-        assert options == {}
-        return
     assert _values(options["rp2040"]) == sorted(ethernet.RP2_ETHERNET_TYPES)
     esp32 = set(_values(options["esp32"]))
     assert esp32.isdisjoint(set(ethernet.RP2_ETHERNET_TYPES) - set(ethernet.SPI_ETHERNET_TYPES))


### PR DESCRIPTION
# What does this implement/fix?

Drops the `hasattr(_ethernet, "RP2_ETHERNET_TYPES")` guard in `_ethernet_type_platform_options`. Silently returning `{}` on an old esphome would ship a catalog PR missing the ethernet platform split, which is exactly the stale data the sync must not produce; a sync against a mismatched esphome already exits via `assert_installed_esphome` before generating anything, so the guard only masked stale-venv test runs. Now an esphome predating the split fails loud with an `AttributeError` instead. The test's absent branch goes with it.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
