### PR TITLE
Fail loud on degraded catalog-sync inputs

### DIFF
--- a/script/_light_schemas.py
+++ b/script/_light_schemas.py
@@ -99,25 +99,12 @@ def derive_light_platforms_from_dir(
 
 @cache
 def derive_light_platforms_by_schema() -> dict[str, frozenset[str]]:
-    """
-    Map each abstract light schema to the platform ids that use it.
+    """Map each abstract light schema to the platform ids that use it."""
+    import esphome
 
-    Empty when esphome isn't importable; an empty applies_to is
-    rendered as "no restriction" on the frontend.
-    """
-    try:
-        import esphome
-    except ImportError:
-        _LOG.warning("esphome not importable; light effects applies_to will be unrestricted")
-        return {}
     components_dir = Path(esphome.__file__).resolve().parent / "components"
     if not components_dir.is_dir():
-        _LOG.warning(
-            "esphome components directory missing at %s; "
-            "light effects applies_to will be unrestricted",
-            components_dir,
-        )
-        return {}
+        raise FileNotFoundError(f"esphome components directory missing at {components_dir}")
     return derive_light_platforms_from_dir(components_dir)
 
 

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -52,7 +52,7 @@ import zipfile
 from collections.abc import Callable, Collection, Iterable, Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
-from functools import cache, partial
+from functools import cache
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
@@ -6380,14 +6380,11 @@ def _logger_uart_platform_options() -> dict[str, list[dict[str, str]]]:
 
     A custom ``uart_selection`` validator gates the set, so the schema bundle
     can't carry it; introspected from ``UART_SELECTION_*`` and keyed via the
-    shared ``variant_to_key`` so lookups hit. Empty when esphome's logger
-    isn't importable; other failures propagate to fail the build loudly.
+    shared ``variant_to_key`` so lookups hit. Failures propagate to fail the
+    sync loudly.
     """
-    try:
-        from esphome.components import logger as _logger
-    except ImportError:
-        _LOGGER.warning("esphome logger not importable — hardware_uart combobox skipped")
-        return {}
+    from esphome.components import logger as _logger
+
     out: dict[str, list[dict[str, str]]] = {}
 
     def add(raw_key: str, values: list[str]) -> None:
@@ -6426,14 +6423,10 @@ def _ethernet_type_platform_options() -> dict[str, list[dict[str, str]]]:
     """
     Ethernet's per-platform ``type`` choices from the live module constants.
 
-    The schema bundle ships a flat union; empty when esphome's ethernet
-    isn't importable.
+    The schema bundle ships a flat union.
     """
-    try:
-        from esphome.components import ethernet as _ethernet
-    except ImportError:
-        _LOGGER.warning("esphome ethernet not importable — type platform split skipped")
-        return {}
+    from esphome.components import ethernet as _ethernet
+
     rp2 = set(_ethernet.RP2_ETHERNET_TYPES)
     # Everything except the RP2-only chips.
     esp32 = set(_ethernet.ETHERNET_TYPES) - (rp2 - set(_ethernet.SPI_ETHERNET_TYPES))
@@ -6491,17 +6484,12 @@ def _psram_config_entries() -> list[dict]:
     """
     Synthesize psram's structured editor from its ``CONFIG_SCHEMA``.
 
-    Prefers the static schema, where a variant enum exposes its
-    ``{value: [variants]}`` map via ``SCHEMA_EXTRACT``; falls back to the older
-    ``get_config_schema`` callable that builds a different schema per ESP32
-    variant. Empty when esphome isn't importable.
+    A variant enum exposes its ``{value: [variants]}`` map via
+    ``SCHEMA_EXTRACT``.
     """
-    try:
-        from esphome.components import psram as _psram
-    except ImportError:
-        _LOGGER.warning("esphome psram not importable — structured editor skipped")
-        return []
-    fields = _psram_static_fields(_psram.CONFIG_SCHEMA) or _psram_callable_fields(_psram)
+    from esphome.components import psram as _psram
+
+    fields = _psram_static_fields(_psram.CONFIG_SCHEMA)
     return _sort_entries([_psram_entry(name, field) for name, field in fields.items()])
 
 
@@ -6520,9 +6508,7 @@ def _psram_static_fields(config_schema: Any) -> dict[str, dict[str, Any]]:
             field["options"][value] = [v.lower() for v in variants]
 
     _walk_schema_keys(config_schema, visit)
-    # Empty unless this was the static form: the old callable schema isn't
-    # walkable, so it yields no options and the caller falls back to it.
-    return fields if any(field["options"] for field in fields.values()) else {}
+    return fields
 
 
 def _variant_enum_map(validator: Any) -> dict[str, list[str]]:
@@ -6539,53 +6525,9 @@ def _variant_enum_map(validator: Any) -> dict[str, list[str]]:
     return {}
 
 
-def _psram_callable_fields(_psram: Any) -> dict[str, dict[str, Any]]:
-    """Per-field map from the older per-variant ``get_config_schema`` callable.
-
-    Feed each variant in and capture the built ``vol.Schema`` (a one-shot subclass
-    whose ``__call__`` returns itself), unioning options / defaults across variants.
-    """
-
-    class _Capture(vol.Schema):
-        def __call__(self, data: Any) -> Any:
-            return self
-
-    fields: dict[str, dict[str, Any]] = {}
-    original_schema = _psram.cv.Schema
-    _psram.cv.Schema = _Capture
-    try:
-        for variant, modes in _psram.SPIRAM_MODES.items():
-            record = partial(_record_psram_field, fields, variant)
-            with _esp32_variant_context(variant):
-                _walk_schema_keys(_psram.get_config_schema({"mode": modes[0]}), record)
-    finally:
-        _psram.cv.Schema = original_schema
-    return fields
-
-
 def _psram_field(fields: dict[str, dict[str, Any]], key: Any, name: str) -> dict[str, Any]:
     """Get or create the per-key accumulator (default, is-bool, options)."""
     return fields.setdefault(name, {"default": _psram_default(key), "bool": False, "options": {}})
-
-
-def _record_psram_field(
-    fields: dict[str, dict[str, Any]],
-    variant: str,
-    key: Any,
-    name: str,
-    validator: Any,
-    path: tuple[str, ...],
-) -> None:
-    """Fold one captured schema key into *fields*, tagging each option's *variant*."""
-    if len(path) != 1 or name == "id":
-        return
-    field = _psram_field(fields, key, name)
-    if getattr(validator, "__name__", "") == "boolean":
-        field["bool"] = True
-    for option in _psram_one_of_options(validator):
-        variants = field["options"].setdefault(option, [])
-        if (low := variant.lower()) not in variants:
-            variants.append(low)
 
 
 def _psram_default(key: Any) -> Any:
@@ -6595,25 +6537,6 @@ def _psram_default(key: Any) -> Any:
         return None
     value = default() if callable(default) else default
     return None if value is vol.UNDEFINED else value
-
-
-def _psram_one_of_options(validator: Any) -> list[str | int]:
-    """
-    Read a ``cv.one_of`` validator's accepted values out of its closure.
-
-    Depends on ``cv.one_of``'s closure layout; the unioned-options tests pin
-    it, so an upstream refactor breaks CI rather than silently dropping the
-    options (the select would degrade to a free-text field).
-    """
-    for cell in getattr(validator, "__closure__", None) or ():
-        value = cell.cell_contents
-        if (
-            isinstance(value, (tuple, list))
-            and value
-            and all(isinstance(item, (str, int)) for item in value)
-        ):
-            return list(value)
-    return []
 
 
 def _psram_entry(name: str, field: dict[str, Any]) -> dict:

--- a/script/sync_components.py
+++ b/script/sync_components.py
@@ -6494,7 +6494,7 @@ def _psram_config_entries() -> list[dict]:
 
 
 def _psram_static_fields(config_schema: Any) -> dict[str, dict[str, Any]]:
-    """Per-field map from a static psram schema, or empty if it isn't extractable."""
+    """Per-field map from psram's static ``CONFIG_SCHEMA``."""
     fields: dict[str, dict[str, Any]] = {}
 
     def visit(key: Any, name: str, validator: Any, path: tuple[str, ...]) -> None:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -44,6 +44,10 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
+# Up here so a missing esphome fails at startup, not mid-run on the
+# first page with a ``substitutions:`` block.
+from esphome.components.substitutions import do_substitution_pass  # noqa: E402
+
 from esphome_device_builder.constants import (  # noqa: E402
     BOARD_PIN_KEYS,
     BUS_CATEGORIES,
@@ -424,13 +428,11 @@ def _resolve_page_substitutions(parsed: dict[str, Any], folder: str) -> dict[str
     Resolve the page's own ``substitutions:`` block over the config tree.
 
     Unresolved references stay literal; a failed pass returns *parsed*
-    unchanged. A missing esphome propagates.
+    unchanged.
     """
     subs = parsed.get("substitutions")
     if not isinstance(subs, dict) or not subs:
         return parsed
-    from esphome.components.substitutions import do_substitution_pass
-
     try:
         resolved = do_substitution_pass(OrderedDict(parsed))
     except Exception as err:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -428,11 +428,8 @@ def _resolve_page_substitutions(parsed: dict[str, Any], folder: str) -> dict[str
     subs = parsed.get("substitutions")
     if not isinstance(subs, dict) or not subs:
         return parsed
-    try:
-        from esphome.components.substitutions import do_substitution_pass
-    except ImportError:
-        _LOGGER.debug("esphome unavailable; skipping substitution pass (%s)", folder)
-        return parsed
+    from esphome.components.substitutions import do_substitution_pass
+
     try:
         resolved = do_substitution_pass(OrderedDict(parsed))
     except Exception as err:

--- a/script/sync_esphome_devices.py
+++ b/script/sync_esphome_devices.py
@@ -423,7 +423,8 @@ def _resolve_page_substitutions(parsed: dict[str, Any], folder: str) -> dict[str
     """
     Resolve the page's own ``substitutions:`` block over the config tree.
 
-    Unresolved references stay literal; any failure returns *parsed* unchanged.
+    Unresolved references stay literal; a failed pass returns *parsed*
+    unchanged. A missing esphome propagates.
     """
     subs = parsed.get("substitutions")
     if not isinstance(subs, dict) or not subs:

--- a/tests/test_light_schemas.py
+++ b/tests/test_light_schemas.py
@@ -161,9 +161,8 @@ def test_derive_light_platforms_from_dir_picks_up_fastled_transitively(
     )
 
 
-def test_derive_light_platforms_by_schema_falls_back_to_empty_when_esphome_missing(
+def test_derive_light_platforms_by_schema_propagates_when_esphome_missing(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # The cache survives across tests; clear it so this run sees the
     # forced ImportError instead of a cached real-esphome result.
@@ -176,10 +175,8 @@ def test_derive_light_platforms_by_schema_falls_back_to_empty_when_esphome_missi
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    with caplog.at_level(logging.WARNING, logger="script._light_schemas"):
-        out = derive_light_platforms_by_schema()
-    assert out == {}
-    assert any("esphome not importable" in r.message for r in caplog.records)
+    with pytest.raises(ImportError):
+        derive_light_platforms_by_schema()
     derive_light_platforms_by_schema.cache_clear()
 
 

--- a/tests/test_sync_components_psram.py
+++ b/tests/test_sync_components_psram.py
@@ -1,10 +1,10 @@
 """
 Tests for psram's synthesized structured editor.
 
-psram's ``CONFIG_SCHEMA`` is a per-variant callable the schema bundle dumps
-empty; ``_psram_config_entries`` recovers the fields by capturing the built
-``vol.Schema`` for every ESP32 variant and unioning the keys / options /
-defaults. Pins that union so the editor can't silently regress to YAML-only.
+The schema bundle dumps psram empty; ``_psram_config_entries`` recovers the
+fields from the static ``CONFIG_SCHEMA``, whose variant enums expose their
+``{value: [variants]}`` maps via ``SCHEMA_EXTRACT``. Pins that union so the
+editor can't silently regress to YAML-only.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
# What does this implement/fix?

A sync that silently skips a section ships a catalog PR with stale data, so every degraded-input fallback in the catalog sync path now fails loud instead. A sync against a mismatched or missing esphome already exits via `assert_installed_esphome` before generating anything; these guards only ever masked broken installs and stale-venv test runs.

Follow-up to #2203, sweeping the rest of the sync path. Dropped: the `ImportError` warn-and-skip arms for logger, ethernet and psram in `sync_components.py`; the `ImportError` and missing-components-dir fallbacks in `_light_schemas.py` (the latter now raises); the silent substitution-pass skip in `sync_esphome_devices.py`. Also removes psram's dead `get_config_schema` compat path, which our esphome floor no longer ships and which would have crashed if ever reached. Tests updated to pin propagation instead of the soft fallbacks.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
