### PR TITLE
Stream esphome bundle output and diagnostics into the remote-build job log

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -633,7 +633,7 @@ Install is **one user-visible flow**: the user clicks Install on a device card, 
 * **LOCAL** — runs the existing `esphome run` subprocess pipeline unchanged.
 * **REMOTE** — hops into `controllers/firmware/remote_runner.py`, which:
   1. Looks up the open `PeerLinkClient` against the pin in `job.source_pin_sha256`.
-  2. Builds the bundle via `helpers/config_bundle.build_yaml_bundle` (`helpers/config_bundle` is the single bundling path).
+  2. Builds the bundle via `helpers/config_bundle.build_yaml_bundle` (`helpers/config_bundle` is the single bundling path), streaming the `esphome bundle` output into the job log with phase-marker and heartbeat notices (`controllers/firmware/bundle_phase.py`) so slow validation is visible before `submit_job`; a Stop click cancels the bundle subprocess immediately.
   3. Dispatches a peer-link `submit_job` with `target="compile"`.
   4. Subscribes to `OFFLOADER_JOB_STATE_CHANGED` + `OFFLOADER_JOB_OUTPUT` filtered to its dispatch's `job_id`, updates the same `FirmwareJob`'s status / output / progress as wire events arrive, and fires the same `JOB_*` events on its lifecycle that the local path would.
   5. On `OFFLOADER_JOB_STATE_CHANGED{completed}` fires `download_artifacts` against the receiver, stages `firmware.bin` to a per-job tmpdir, and spawns a local `esphome upload --file <staged>` subprocess to flash the device.

--- a/esphome_device_builder/controllers/firmware/bundle_phase.py
+++ b/esphome_device_builder/controllers/firmware/bundle_phase.py
@@ -1,0 +1,63 @@
+"""Offloader-side bundle phase: build the YAML bundle with live job-log output."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ...helpers.async_ import run_in_executor
+from ...helpers.config_bundle import build_yaml_bundle
+from .helpers import _ingest_notice_line, _ingest_output_line
+
+if TYPE_CHECKING:
+    from ...models.firmware import FirmwareJob
+    from .controller import FirmwareController
+
+_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
+async def run_bundle_phase(
+    controller: FirmwareController, job: FirmwareJob, cancel_event: asyncio.Event
+) -> bytes | None:
+    """
+    Build *job*'s YAML bundle, streaming subprocess output into the job log.
+
+    Returns the bundle bytes, or ``None`` when *cancel_event* fired first
+    (the caller finalises the cancel). ``FileNotFoundError`` /
+    ``BundleBuildError`` from the build propagate. A heartbeat notice
+    ticks while the bundle runs so a silent validator still shows liveness.
+    """
+    yaml_path = await run_in_executor(controller._db.settings.rel_path, job.configuration)
+    bus = controller.bus
+    _ingest_notice_line(job, bus, "building configuration bundle for remote build")
+    loop = asyncio.get_running_loop()
+    bundle_task = loop.create_task(
+        build_yaml_bundle(yaml_path, on_output=lambda line: _ingest_output_line(job, bus, line))
+    )
+    cancel_wait = loop.create_task(cancel_event.wait())
+    heartbeat = loop.create_task(_run_heartbeat(controller, job))
+    try:
+        await asyncio.wait({bundle_task, cancel_wait}, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        heartbeat.cancel()
+        cancel_wait.cancel()
+        if not bundle_task.done():
+            bundle_task.cancel()
+        await asyncio.gather(bundle_task, heartbeat, cancel_wait, return_exceptions=True)
+    if bundle_task.cancelled():
+        return None
+    bundle_bytes = bundle_task.result()
+    _ingest_notice_line(
+        job, bus, f"bundle ready ({len(bundle_bytes) / 1024:.0f} KiB); sending to build server"
+    )
+    return bundle_bytes
+
+
+async def _run_heartbeat(controller: FirmwareController, job: FirmwareJob) -> None:
+    """Tick a synthetic still-building notice into the job log every interval."""
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    while True:
+        await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+        elapsed = round(loop.time() - started)
+        _ingest_notice_line(job, controller.bus, f"still building bundle ({elapsed}s elapsed)")

--- a/esphome_device_builder/controllers/firmware/bundle_phase.py
+++ b/esphome_device_builder/controllers/firmware/bundle_phase.py
@@ -41,10 +41,10 @@ async def run_bundle_phase(
     finally:
         heartbeat.cancel()
         cancel_wait.cancel()
-        if not bundle_task.done():
-            bundle_task.cancel()
+        bundle_task.cancel()
         await asyncio.gather(bundle_task, heartbeat, cancel_wait, return_exceptions=True)
-    if bundle_task.cancelled():
+    # Cancel wins even when the bundle finished in the same tick.
+    if cancel_event.is_set():
         return None
     bundle_bytes = bundle_task.result()
     _ingest_notice_line(

--- a/esphome_device_builder/controllers/firmware/bundle_phase.py
+++ b/esphome_device_builder/controllers/firmware/bundle_phase.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
-from ...helpers.async_ import run_in_executor
+from ...helpers.async_ import drain_tasks, run_in_executor
 from ...helpers.config_bundle import build_yaml_bundle
 from .helpers import _ingest_notice_line, _ingest_output_line
 
 if TYPE_CHECKING:
+    from ...helpers.event_bus import EventBus
     from ...models.firmware import FirmwareJob
     from .controller import FirmwareController
 
@@ -30,19 +31,15 @@ async def run_bundle_phase(
     yaml_path = await run_in_executor(controller._db.settings.rel_path, job.configuration)
     bus = controller.bus
     _ingest_notice_line(job, bus, "building configuration bundle for remote build")
-    loop = asyncio.get_running_loop()
-    bundle_task = loop.create_task(
+    bundle_task = asyncio.create_task(
         build_yaml_bundle(yaml_path, on_output=lambda line: _ingest_output_line(job, bus, line))
     )
-    cancel_wait = loop.create_task(cancel_event.wait())
-    heartbeat = loop.create_task(_run_heartbeat(controller, job))
+    cancel_wait = asyncio.create_task(cancel_event.wait())
+    heartbeat = asyncio.create_task(_run_heartbeat(job, bus))
     try:
         await asyncio.wait({bundle_task, cancel_wait}, return_when=asyncio.FIRST_COMPLETED)
     finally:
-        heartbeat.cancel()
-        cancel_wait.cancel()
-        bundle_task.cancel()
-        await asyncio.gather(bundle_task, heartbeat, cancel_wait, return_exceptions=True)
+        await drain_tasks((bundle_task, heartbeat, cancel_wait))
     # Cancel wins even when the bundle finished in the same tick.
     if cancel_event.is_set():
         return None
@@ -53,11 +50,11 @@ async def run_bundle_phase(
     return bundle_bytes
 
 
-async def _run_heartbeat(controller: FirmwareController, job: FirmwareJob) -> None:
+async def _run_heartbeat(job: FirmwareJob, bus: EventBus) -> None:
     """Tick a synthetic still-building notice into the job log every interval."""
     loop = asyncio.get_running_loop()
     started = loop.time()
     while True:
         await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
         elapsed = round(loop.time() - started)
-        _ingest_notice_line(job, controller.bus, f"still building bundle ({elapsed}s elapsed)")
+        _ingest_notice_line(job, bus, f"still building bundle ({elapsed}s elapsed)")

--- a/esphome_device_builder/controllers/firmware/helpers.py
+++ b/esphome_device_builder/controllers/firmware/helpers.py
@@ -405,6 +405,12 @@ def _ingest_output_line(job: FirmwareJob, bus: EventBus, line: str) -> None:
     _fire_job_progress(job, bus, progress)
 
 
+def _ingest_notice_line(job: FirmwareJob, bus: EventBus, text: str) -> None:
+    """Ingest a synthetic ``*** text ***`` line, separating it from an unterminated tail."""
+    prefix = "\n" if job.output and not job.output[-1].endswith(("\n", "\r")) else ""
+    _ingest_output_line(job, bus, f"{prefix}*** {text} ***\n")
+
+
 def _is_compile_start_line(line: str) -> bool:
     """
     Whether *line* proves compilation has begun.

--- a/esphome_device_builder/controllers/firmware/remote_dispatch.py
+++ b/esphome_device_builder/controllers/firmware/remote_dispatch.py
@@ -32,7 +32,7 @@ from ...models import (
     JobStatus,
 )
 from . import lifecycle
-from .helpers import _ingest_output_line
+from .helpers import _ingest_notice_line
 from .remote_runner import ProvisionUnavailableError, RemoteServerLostError, run_remote_job
 
 if TYPE_CHECKING:
@@ -234,10 +234,8 @@ def _requeue_after_server_loss(
         controller._finalize_terminal(job, JobStatus.FAILED, error=error)
         pool.forget_losses(job.job_id)
         return
-    _ingest_output_line(
-        job,
-        controller.bus,
-        f"\n*** build server lost ({reason}); re-routing to another worker ***\n",
+    _ingest_notice_line(
+        job, controller.bus, f"build server lost ({reason}); re-routing to another worker"
     )
     _return_to_pool(controller, job)
     _LOGGER.info("Remote compile %s: server lost, re-routing (attempt %d)", job.job_id, attempt)
@@ -253,10 +251,10 @@ def _requeue_after_provision_failure(
     server loss, which re-routes REMOTE→REMOTE). Logged both to the job's output
     stream (visible in the dialog) and the server log.
     """
-    _ingest_output_line(
+    _ingest_notice_line(
         job,
         controller.bus,
-        f"\n*** receiver couldn't provision esphome ({reason}); building locally instead ***\n",
+        f"receiver couldn't provision esphome ({reason}); building locally instead",
     )
     job.clear_run_state()
     _fallback_to_local(controller, job)

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -37,7 +37,7 @@ from esphome.const import __version__ as _offloader_esphome_version
 
 from ...helpers.api import CommandError
 from ...helpers.async_ import run_in_executor
-from ...helpers.config_bundle import BundleBuildError, build_yaml_bundle
+from ...helpers.config_bundle import BundleBuildError
 from ...helpers.remote_artifacts_materialise import (
     MaterialiseError,
     materialise_remote_artifacts,
@@ -64,8 +64,9 @@ from ..remote_build.peer_link_client import (
     SubmitJobTimeoutError,
 )
 from . import lifecycle
+from .bundle_phase import run_bundle_phase
 from .constants import ESPHOME_SUBPROCESS_ENV
-from .helpers import _fire_job_progress, _ingest_output_line
+from .helpers import _fire_job_progress, _ingest_notice_line, _ingest_output_line
 
 if TYPE_CHECKING:
     from ...helpers.event_bus import Event, EventBus
@@ -301,7 +302,7 @@ async def _dispatch_and_drive(
         if not await _send_reset_to_receiver(controller=controller, job=job, client=client):
             return
     else:
-        bundle_bytes = await _build_bundle_or_fail(controller, job)
+        bundle_bytes = await _build_bundle_or_fail(controller, job, cancel_event)
         if bundle_bytes is None:
             return
         client = _open_peer_link_client_or_fail(controller, job)
@@ -327,16 +328,22 @@ async def _dispatch_and_drive(
     await _finalise_after_receiver_completed(controller=controller, job=job, client=client)
 
 
-async def _build_bundle_or_fail(controller: FirmwareController, job: FirmwareJob) -> bytes | None:
-    """Build the YAML bundle; ``None`` + ``_fail_locally`` on failure."""
-    yaml_path = await run_in_executor(controller._db.settings.rel_path, job.configuration)
+async def _build_bundle_or_fail(
+    controller: FirmwareController, job: FirmwareJob, cancel_event: asyncio.Event
+) -> bytes | None:
+    """Build the YAML bundle with live log output; ``None`` + finalise on failure/cancel."""
     try:
-        return await build_yaml_bundle(yaml_path)
+        bundle_bytes = await run_bundle_phase(controller, job, cancel_event)
     except FileNotFoundError:
         _fail_locally(controller, job, reason=f"configuration not found: {job.configuration}")
+        return None
     except BundleBuildError as exc:
-        _fail_locally(controller, job, reason=f"bundle failed: {exc.output or exc}")
-    return None
+        _ingest_notice_line(job, controller.bus, f"bundle failed: {exc}")
+        _fail_locally(controller, job, reason=f"bundle failed: {exc}")
+        return None
+    if bundle_bytes is None:
+        lifecycle.cancel_if_requested(controller, job)
+    return bundle_bytes
 
 
 def _open_peer_link_client_or_fail(
@@ -575,21 +582,10 @@ async def _await_terminal(
                 # let the embedded ``text`` carry the specific
                 # cause, instead of falsely framing every close
                 # as a connection loss.
-                #
-                # Leading-newline avoidance: only insert a
-                # separator newline when the previous buffered
-                # output line doesn't already end with one. The
-                # receiver-side compile streams ``\n``-terminated
-                # lines, so the common case skips the prefix and
-                # the synthetic line lands flush against the
-                # last compile output rather than adding a blank
-                # line.
-                prefix = "" if job.output and job.output[-1].endswith(("\n", "\r")) else "\n"
-                _ingest_output_line(
+                _ingest_notice_line(
                     job,
                     controller.bus,
-                    f"{prefix}*** remote build session closed ({text}); "
-                    "the build was aborted ***\n",
+                    f"remote build session closed ({text}); the build was aborted",
                 )
                 _fail_locally(
                     controller,

--- a/esphome_device_builder/controllers/firmware/remote_runner.py
+++ b/esphome_device_builder/controllers/firmware/remote_runner.py
@@ -338,8 +338,9 @@ async def _build_bundle_or_fail(
         _fail_locally(controller, job, reason=f"configuration not found: {job.configuration}")
         return None
     except BundleBuildError as exc:
-        _ingest_notice_line(job, controller.bus, f"bundle failed: {exc}")
-        _fail_locally(controller, job, reason=f"bundle failed: {exc}")
+        reason = f"bundle failed: {exc}"
+        _ingest_notice_line(job, controller.bus, reason)
+        _fail_locally(controller, job, reason=reason)
         return None
     if bundle_bytes is None:
         lifecycle.cancel_if_requested(controller, job)

--- a/esphome_device_builder/helpers/config_bundle.py
+++ b/esphome_device_builder/helpers/config_bundle.py
@@ -2,10 +2,10 @@
 Build a self-contained ESPHome bundle from a YAML on disk.
 
 Wraps the ``esphome bundle <yaml> -o <tarball>`` CLI for the
-offloader-side ``submit_job`` flow (issue #106): the remote
-runner hands a YAML path, this module returns the gzipped-
-tar bytes ready for chunking onto the peer-link, streaming
-the subprocess output to an optional per-line callback.
+offloader-side ``submit_job`` flow: the remote runner hands a
+YAML path, this module returns the gzipped-tar bytes ready
+for chunking onto the peer-link, streaming the subprocess
+output to an optional per-line callback.
 
 Subprocess rather than in-process
 :class:`esphome.bundle.ConfigBundleCreator` so the bundle
@@ -43,7 +43,6 @@ Errors:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import tempfile
 from collections import deque
@@ -52,7 +51,7 @@ from pathlib import Path
 
 from ..controllers.firmware.helpers import _find_esphome_cmd
 from .async_ import run_in_executor
-from .subprocess import create_subprocess_exec, iter_lines_with_progress, kill_quietly
+from .subprocess import run_subprocess_capture
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,48 +112,35 @@ async def build_yaml_bundle(
     # hops so the dashboard's other tasks keep moving on slow
     # disks.
     cmd, output_path = await run_in_executor(_prepare_build_bundle, yaml_path)
+    tail: deque[str] = deque(maxlen=_OUTPUT_TAIL_CHUNKS)
+
+    def _collect(chunk: str) -> None:
+        tail.append(chunk)
+        if on_output is not None:
+            on_output(chunk)
+
     try:
-        returncode, output, timed_out = await _stream_bundle_subprocess(
-            [*cmd, "bundle", str(yaml_path), "-o", str(output_path)], on_output
+        result = await run_subprocess_capture(
+            *cmd,
+            "bundle",
+            str(yaml_path),
+            "-o",
+            str(output_path),
+            timeout=_BUNDLE_BUILD_TIMEOUT_SECONDS,
+            on_line=_collect,
         )
-        if timed_out:
+        if result.timed_out:
             raise BundleBuildError(
                 f"esphome bundle timed out after {_BUNDLE_BUILD_TIMEOUT_SECONDS:.0f}s",
-                output=output.strip(),
+                output="".join(tail).strip(),
             )
-        if returncode != 0:
-            raise BundleBuildError(f"esphome bundle exited {returncode}", output=output.strip())
+        if result.returncode != 0:
+            raise BundleBuildError(
+                f"esphome bundle exited {result.returncode}", output="".join(tail).strip()
+            )
         return await run_in_executor(output_path.read_bytes)
     finally:
         await run_in_executor(_unlink_quietly, output_path)
-
-
-async def _stream_bundle_subprocess(
-    args: list[str], on_output: Callable[[str], None] | None
-) -> tuple[int | None, str, bool]:
-    """Run the bundle subprocess; return ``(returncode, output tail, timed_out)``."""
-    proc = await create_subprocess_exec(
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-    )
-    tail: deque[str] = deque(maxlen=_OUTPUT_TAIL_CHUNKS)
-    try:
-        async with asyncio.timeout(_BUNDLE_BUILD_TIMEOUT_SECONDS):
-            assert proc.stdout is not None
-            async for chunk in iter_lines_with_progress(proc.stdout):
-                tail.append(chunk)
-                if on_output is not None:
-                    on_output(chunk)
-            returncode = await proc.wait()
-    except TimeoutError:
-        kill_quietly(proc)
-        await proc.wait()
-        return proc.returncode, "".join(tail), True
-    except asyncio.CancelledError:
-        kill_quietly(proc)
-        raise
-    return returncode, "".join(tail), False
 
 
 def _prepare_build_bundle(yaml_path: Path) -> tuple[list[str], Path]:

--- a/esphome_device_builder/helpers/config_bundle.py
+++ b/esphome_device_builder/helpers/config_bundle.py
@@ -2,9 +2,10 @@
 Build a self-contained ESPHome bundle from a YAML on disk.
 
 Wraps the ``esphome bundle <yaml> -o <tarball>`` CLI for the
-offloader-side ``submit_job`` flow (issue #106): the WS
-handler hands a YAML path, this module returns the gzipped-
-tar bytes ready for chunking onto the peer-link.
+offloader-side ``submit_job`` flow (issue #106): the remote
+runner hands a YAML path, this module returns the gzipped-
+tar bytes ready for chunking onto the peer-link, streaming
+the subprocess output to an optional per-line callback.
 
 Subprocess rather than in-process
 :class:`esphome.bundle.ConfigBundleCreator` so the bundle
@@ -31,47 +32,51 @@ build:
 Errors:
 
 * :class:`FileNotFoundError` from missing YAML — propagated;
-  the WS layer maps to ``CommandError(NOT_FOUND)``.
+  the caller fails the job as configuration-not-found.
 * :class:`BundleBuildError` — esphome bundle exited non-zero
   (typically schema-invalid YAML, missing include, malformed
-  secret); the message carries stdout/stderr verbatim. The
-  WS layer maps to ``CommandError(INVALID_ARGS)`` so the
-  user sees the validator's diagnostic.
+  secret) or timed out; :attr:`BundleBuildError.output`
+  carries the stdout/stderr tail.
 * :class:`OSError` from the spawn itself (e.g. ``esphome``
-  not on PATH) propagates; the WS dispatcher's outer
-  ``except Exception`` surfaces it as ``INTERNAL_ERROR``.
+  not on PATH) propagates.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import tempfile
+from collections import deque
+from collections.abc import Callable
 from pathlib import Path
 
 from ..controllers.firmware.helpers import _find_esphome_cmd
 from .async_ import run_in_executor
-from .subprocess import run_subprocess_capture
+from .subprocess import create_subprocess_exec, iter_lines_with_progress, kill_quietly
 
 _LOGGER = logging.getLogger(__name__)
 
 # Bound for the ``esphome bundle`` subprocess. Bundle build
 # is dominated by ``read_config`` (parses every include,
-# resolves every component schema) + tar packing; a typical
-# ~50-file config completes in <2s, an exotic image-heavy
-# include tree can hit ~10s. 60s gives generous headroom for
-# a slow disk / contended CPU without letting a wedged
-# subprocess pin the offloader's submit handler forever.
-# Mismatch with the receiver-side
-# :data:`_SUBMIT_JOB_ACK_TIMEOUT_SECONDS` (also 60s) is
-# coincidental — these bound different stages of the flow.
-_BUNDLE_BUILD_TIMEOUT_SECONDS = 60.0
+# resolves every component schema, may fetch remote packages)
+# + tar packing; a typical ~50-file config completes in <2s,
+# but heavy include trees with slow validation legitimately
+# run for minutes (the 60s original stranded a real user's
+# remote builds). The output streams into the job log, so a
+# long wait is visible; the bound only stops a truly wedged
+# subprocess from pinning the job forever.
+_BUNDLE_BUILD_TIMEOUT_SECONDS = 300.0
+
+# Retained-output bound for the BundleBuildError diagnostic;
+# each entry is one line/CR chunk from the subprocess.
+_OUTPUT_TAIL_CHUNKS = 200
 
 
 class BundleBuildError(RuntimeError):
-    """``esphome bundle`` subprocess exited non-zero.
+    """``esphome bundle`` subprocess failed or timed out.
 
-    Carries the captured stdout/stderr in :attr:`output` so
-    the WS layer can surface the validator's diagnostic
+    Carries the captured stdout/stderr tail in :attr:`output`
+    so the caller can surface the validator's diagnostic
     verbatim to the user.
     """
 
@@ -80,20 +85,23 @@ class BundleBuildError(RuntimeError):
         self.output = output
 
 
-async def build_yaml_bundle(yaml_path: Path) -> bytes:
+async def build_yaml_bundle(
+    yaml_path: Path, *, on_output: Callable[[str], None] | None = None
+) -> bytes:
     """Build a gzipped-tar bundle for *yaml_path* and return its raw bytes.
 
     Spawns ``esphome bundle <yaml_path> -o <tmp.tar.gz>``,
+    streams each output chunk to *on_output* as it arrives,
     awaits completion, reads the resulting bytes back, and
     deletes the temp file. The temp file lives in the
     platform's default tmp dir (typically ``/tmp/`` or
     ``$TMPDIR``); the dashboard never writes user-visible
     files outside ``config_dir``.
 
-    Cancellation-safe: the temp file is unlinked in a
-    ``finally`` regardless of how the function exits
-    (including ``CancelledError`` from the WS handler being
-    cancelled mid-build).
+    Cancellation-safe: the subprocess is killed and the temp
+    file is unlinked in a ``finally`` regardless of how the
+    function exits (including ``CancelledError`` from the
+    caller being cancelled mid-build).
     """
     # Every filesystem syscall here (``is_file`` → ``os.stat``,
     # ``_find_esphome_cmd`` → ``Path.exists`` → ``os.stat``,
@@ -106,25 +114,47 @@ async def build_yaml_bundle(yaml_path: Path) -> bytes:
     # disks.
     cmd, output_path = await run_in_executor(_prepare_build_bundle, yaml_path)
     try:
-        result = await run_subprocess_capture(
-            *cmd,
-            "bundle",
-            str(yaml_path),
-            "-o",
-            str(output_path),
-            timeout=_BUNDLE_BUILD_TIMEOUT_SECONDS,
+        returncode, output, timed_out = await _stream_bundle_subprocess(
+            [*cmd, "bundle", str(yaml_path), "-o", str(output_path)], on_output
         )
-        if result.timed_out:
+        if timed_out:
             raise BundleBuildError(
                 f"esphome bundle timed out after {_BUNDLE_BUILD_TIMEOUT_SECONDS:.0f}s",
-                output="",
+                output=output.strip(),
             )
-        if result.returncode != 0:
-            output = result.stdout.decode("utf-8", errors="replace").strip()
-            raise BundleBuildError(f"esphome bundle exited {result.returncode}", output=output)
+        if returncode != 0:
+            raise BundleBuildError(f"esphome bundle exited {returncode}", output=output.strip())
         return await run_in_executor(output_path.read_bytes)
     finally:
         await run_in_executor(_unlink_quietly, output_path)
+
+
+async def _stream_bundle_subprocess(
+    args: list[str], on_output: Callable[[str], None] | None
+) -> tuple[int | None, str, bool]:
+    """Run the bundle subprocess; return ``(returncode, output tail, timed_out)``."""
+    proc = await create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    tail: deque[str] = deque(maxlen=_OUTPUT_TAIL_CHUNKS)
+    try:
+        async with asyncio.timeout(_BUNDLE_BUILD_TIMEOUT_SECONDS):
+            assert proc.stdout is not None
+            async for chunk in iter_lines_with_progress(proc.stdout):
+                tail.append(chunk)
+                if on_output is not None:
+                    on_output(chunk)
+            returncode = await proc.wait()
+    except TimeoutError:
+        kill_quietly(proc)
+        await proc.wait()
+        return proc.returncode, "".join(tail), True
+    except asyncio.CancelledError:
+        kill_quietly(proc)
+        raise
+    return returncode, "".join(tail), False
 
 
 def _prepare_build_bundle(yaml_path: Path) -> tuple[list[str], Path]:

--- a/esphome_device_builder/helpers/config_bundle.py
+++ b/esphome_device_builder/helpers/config_bundle.py
@@ -36,7 +36,7 @@ Errors:
 * :class:`BundleBuildError` — esphome bundle exited non-zero
   (typically schema-invalid YAML, missing include, malformed
   secret) or timed out; :attr:`BundleBuildError.output`
-  carries the stdout/stderr tail.
+  carries the captured stdout/stderr unless streamed.
 * :class:`OSError` from the spawn itself (e.g. ``esphome``
   not on PATH) propagates.
 """
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import logging
 import tempfile
-from collections import deque
 from collections.abc import Callable
 from pathlib import Path
 
@@ -66,17 +65,13 @@ _LOGGER = logging.getLogger(__name__)
 # subprocess from pinning the job forever.
 _BUNDLE_BUILD_TIMEOUT_SECONDS = 300.0
 
-# Retained-output bound for the BundleBuildError diagnostic;
-# each entry is one line/CR chunk from the subprocess.
-_OUTPUT_TAIL_CHUNKS = 200
-
 
 class BundleBuildError(RuntimeError):
     """``esphome bundle`` subprocess failed or timed out.
 
-    Carries the captured stdout/stderr tail in :attr:`output`
-    so the caller can surface the validator's diagnostic
-    verbatim to the user.
+    :attr:`output` carries the captured stdout/stderr for a
+    non-streaming caller; with *on_output* the callback owns
+    retention and :attr:`output` is empty.
     """
 
     def __init__(self, message: str, *, output: str) -> None:
@@ -112,13 +107,6 @@ async def build_yaml_bundle(
     # hops so the dashboard's other tasks keep moving on slow
     # disks.
     cmd, output_path = await run_in_executor(_prepare_build_bundle, yaml_path)
-    tail: deque[str] = deque(maxlen=_OUTPUT_TAIL_CHUNKS)
-
-    def _collect(chunk: str) -> None:
-        tail.append(chunk)
-        if on_output is not None:
-            on_output(chunk)
-
     try:
         result = await run_subprocess_capture(
             *cmd,
@@ -127,17 +115,16 @@ async def build_yaml_bundle(
             "-o",
             str(output_path),
             timeout=_BUNDLE_BUILD_TIMEOUT_SECONDS,
-            on_line=_collect,
+            on_line=on_output,
         )
+        output = result.stdout.decode("utf-8", errors="replace").strip()
         if result.timed_out:
             raise BundleBuildError(
                 f"esphome bundle timed out after {_BUNDLE_BUILD_TIMEOUT_SECONDS:.0f}s",
-                output="".join(tail).strip(),
+                output=output,
             )
         if result.returncode != 0:
-            raise BundleBuildError(
-                f"esphome bundle exited {result.returncode}", output="".join(tail).strip()
-            )
+            raise BundleBuildError(f"esphome bundle exited {result.returncode}", output=output)
         return await run_in_executor(output_path.read_bytes)
     finally:
         await run_in_executor(_unlink_quietly, output_path)
@@ -148,7 +135,7 @@ def _prepare_build_bundle(yaml_path: Path) -> tuple[list[str], Path]:
 
     Bundles every upfront blocking syscall into one executor
     hop. Raises :class:`FileNotFoundError` if *yaml_path*
-    doesn't exist; the WS layer maps that to NOT_FOUND.
+    doesn't exist.
     """
     if not yaml_path.is_file():
         msg = f"YAML not found: {yaml_path}"

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -134,6 +134,7 @@ async def run_subprocess_capture(
     if stdin_data is not None:
         writer = asyncio.get_running_loop().create_task(_write_stdin(proc, stdin_data))
     buf = bytearray()
+    timed_out = False
     try:
         async with asyncio.timeout(timeout):
             assert proc.stdout is not None
@@ -142,19 +143,21 @@ async def run_subprocess_capture(
             if writer is not None:
                 await writer
     except TimeoutError:
-        kill_quietly(proc)
-        if writer is not None:
-            writer.cancel()
+        timed_out = True
+    finally:
+        # The single kill site: timeout, cancellation, or an *on_line*
+        # callback raising all land here with the child still running.
+        # Sync only, so a propagating CancelledError is never swallowed
+        # or stalled.
+        if proc.returncode is None:
+            kill_quietly(proc)
+            if writer is not None:
+                writer.cancel()
+    if timed_out:
         await proc.wait()
         if writer is not None:
             await asyncio.gather(writer, return_exceptions=True)
-        return CapturedSubprocess(returncode=proc.returncode, stdout=bytes(buf), timed_out=True)
-    except asyncio.CancelledError:
-        kill_quietly(proc)
-        if writer is not None:
-            writer.cancel()
-        raise
-    return CapturedSubprocess(returncode=proc.returncode, stdout=bytes(buf), timed_out=False)
+    return CapturedSubprocess(returncode=proc.returncode, stdout=bytes(buf), timed_out=timed_out)
 
 
 async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterator[str]:
@@ -215,9 +218,9 @@ async def _consume_stdout(
 ) -> None:
     """Drain *stdout* into *buf*, or per line to *on_line* when set.
 
-    Mutates the caller-owned *buf* rather than returning bytes so a
-    timeout cancelling this coroutine still leaves the partial
-    output readable.
+    Capture mode mutates the caller-owned *buf* rather than returning
+    bytes so a timeout cancelling this coroutine still leaves the
+    partial output readable; streaming mode never touches *buf*.
     """
     if on_line is None:
         while data := await stdout.read(_STREAM_READ_SIZE):

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -13,7 +13,7 @@ the same pattern in ``esphome.dashboard.util.subprocess``.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
@@ -83,20 +83,25 @@ async def run_subprocess_capture(
     timeout: float,
     stdin_data: bytes | None = None,
     merge_stderr: bool = True,
+    on_line: Callable[[str], None] | None = None,
 ) -> CapturedSubprocess:
     """Spawn *args*, await completion (or *timeout*), capture stdout.
 
     Shared shape between every "run a command to completion and
     inspect its exit code + output" caller (currently
-    :func:`controllers.firmware.helpers._verify_esphome_importable`
-    and the Native-API info worker in
+    :func:`controllers.firmware.helpers._verify_esphome_importable`,
+    :func:`helpers.config_bundle.build_yaml_bundle`, and the
+    Native-API info worker in
     :class:`controllers._device_state_monitor.api_info.ApiInfoSource`).
 
     *stdin_data*, when given, is written to the child's stdin (stdin is
     opened as a pipe only then). *merge_stderr* (default) redirects
     stderr onto stdout for a unified stream; pass ``False`` to discard
     stderr so stdout carries only the child's real output (e.g. a clean
-    JSON payload).
+    JSON payload). *on_line*, when given, streams each output chunk
+    (split via :func:`iter_lines_with_progress`, terminators kept) to
+    the callback as it arrives instead of capturing — ``stdout`` on the
+    result is then empty; the callback owns retention.
 
     Timeout handling: on expiry we :func:`kill_quietly` the process,
     await its ``wait()`` so the OS resources release, and return
@@ -106,9 +111,6 @@ async def run_subprocess_capture(
     inspects ``timed_out`` rather than handling a raised
     exception, which keeps the common shape "one return, check
     flags" instead of try/except at every call site.
-
-    No retry, no streaming — callers that need either pattern
-    use :func:`create_subprocess_exec` directly.
 
     Cancellation-safe: if the awaiting task is cancelled mid-read,
     ``kill_quietly`` fires SIGKILL and the :class:`CancelledError`
@@ -135,8 +137,7 @@ async def run_subprocess_capture(
     try:
         async with asyncio.timeout(timeout):
             assert proc.stdout is not None
-            while data := await proc.stdout.read(_STREAM_READ_SIZE):
-                buf += data
+            await _consume_stdout(proc.stdout, on_line, buf)
             await proc.wait()
             if writer is not None:
                 await writer
@@ -207,6 +208,23 @@ async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterato
             chunk = buf[:end]
             buf = buf[end:]
             yield chunk.decode("utf-8", errors="replace")
+
+
+async def _consume_stdout(
+    stdout: asyncio.StreamReader, on_line: Callable[[str], None] | None, buf: bytearray
+) -> None:
+    """Drain *stdout* into *buf*, or per line to *on_line* when set.
+
+    Mutates the caller-owned *buf* rather than returning bytes so a
+    timeout cancelling this coroutine still leaves the partial
+    output readable.
+    """
+    if on_line is None:
+        while data := await stdout.read(_STREAM_READ_SIZE):
+            buf += data
+        return
+    async for chunk in iter_lines_with_progress(stdout):
+        on_line(chunk)
 
 
 async def _write_stdin(proc: asyncio.subprocess.Process, data: bytes) -> None:

--- a/esphome_device_builder/helpers/subprocess.py
+++ b/esphome_device_builder/helpers/subprocess.py
@@ -88,9 +88,8 @@ async def run_subprocess_capture(
 
     Shared shape between every "run a command to completion and
     inspect its exit code + output" caller (currently
-    :func:`controllers.firmware.helpers._verify_esphome_importable`,
-    :func:`helpers.config_bundle.build_yaml_bundle`, and the
-    Native-API info worker in
+    :func:`controllers.firmware.helpers._verify_esphome_importable`
+    and the Native-API info worker in
     :class:`controllers._device_state_monitor.api_info.ApiInfoSource`).
 
     *stdin_data*, when given, is written to the child's stdin (stdin is
@@ -99,10 +98,11 @@ async def run_subprocess_capture(
     stderr so stdout carries only the child's real output (e.g. a clean
     JSON payload).
 
-    Timeout handling: :func:`asyncio.wait_for` raises
-    :class:`TimeoutError`; we :func:`kill_quietly` the process,
+    Timeout handling: on expiry we :func:`kill_quietly` the process,
     await its ``wait()`` so the OS resources release, and return
-    a :class:`CapturedSubprocess` with ``timed_out=True``. Caller
+    a :class:`CapturedSubprocess` with ``timed_out=True`` carrying
+    whatever stdout arrived before the kill — the partial output is
+    the only diagnostic a hung subprocess leaves behind. Caller
     inspects ``timed_out`` rather than handling a raised
     exception, which keeps the common shape "one return, check
     flags" instead of try/except at every call site.
@@ -110,10 +110,9 @@ async def run_subprocess_capture(
     No retry, no streaming — callers that need either pattern
     use :func:`create_subprocess_exec` directly.
 
-    Cancellation-safe: if the awaiting task is cancelled while
-    ``proc.communicate()`` is in flight, ``kill_quietly`` fires
-    SIGKILL and the :class:`CancelledError` re-raises
-    immediately. The dead subprocess is reaped by asyncio's
+    Cancellation-safe: if the awaiting task is cancelled mid-read,
+    ``kill_quietly`` fires SIGKILL and the :class:`CancelledError`
+    re-raises immediately. The dead subprocess is reaped by asyncio's
     child watcher in the background — we deliberately don't
     ``await proc.wait()`` here because that would either swallow
     the second cancellation (violating
@@ -127,16 +126,34 @@ async def run_subprocess_capture(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT if merge_stderr else asyncio.subprocess.DEVNULL,
     )
+    # A dedicated writer task preserves ``communicate()``'s deadlock
+    # avoidance: the child may not drain stdin until its stdout is read.
+    writer: asyncio.Task[None] | None = None
+    if stdin_data is not None:
+        writer = asyncio.get_running_loop().create_task(_write_stdin(proc, stdin_data))
+    buf = bytearray()
     try:
-        stdout, _ = await asyncio.wait_for(proc.communicate(stdin_data), timeout=timeout)
+        async with asyncio.timeout(timeout):
+            assert proc.stdout is not None
+            while data := await proc.stdout.read(_STREAM_READ_SIZE):
+                buf += data
+            await proc.wait()
+            if writer is not None:
+                await writer
     except TimeoutError:
         kill_quietly(proc)
+        if writer is not None:
+            writer.cancel()
         await proc.wait()
-        return CapturedSubprocess(returncode=proc.returncode, stdout=b"", timed_out=True)
+        if writer is not None:
+            await asyncio.gather(writer, return_exceptions=True)
+        return CapturedSubprocess(returncode=proc.returncode, stdout=bytes(buf), timed_out=True)
     except asyncio.CancelledError:
         kill_quietly(proc)
+        if writer is not None:
+            writer.cancel()
         raise
-    return CapturedSubprocess(returncode=proc.returncode, stdout=stdout, timed_out=False)
+    return CapturedSubprocess(returncode=proc.returncode, stdout=bytes(buf), timed_out=False)
 
 
 async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterator[str]:
@@ -190,3 +207,15 @@ async def iter_lines_with_progress(stream: asyncio.StreamReader) -> AsyncIterato
             chunk = buf[:end]
             buf = buf[end:]
             yield chunk.decode("utf-8", errors="replace")
+
+
+async def _write_stdin(proc: asyncio.subprocess.Process, data: bytes) -> None:
+    """Write *data* to *proc*'s stdin and close it, tolerating an early-exiting child."""
+    assert proc.stdin is not None
+    try:
+        proc.stdin.write(data)
+        await proc.stdin.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        return
+    finally:
+        proc.stdin.close()

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -45,6 +45,7 @@ from esphome_device_builder.models import (
     DeviceState,
     EventType,
     FirmwareJob,
+    JobSource,
     JobType,
     PeerQueueStatusSnapshotEntry,
     PeerStatus,
@@ -578,3 +579,48 @@ def stub_offloader(controller: Any, snapshot: BuildSchedulerInputs) -> MagicMock
     offloader.get_pairing.side_effect = _get_pairing
     controller._db.remote_build_offloader = offloader
     return offloader
+
+
+_PIN = "a" * 64
+
+
+def _make_remote_job(*, job_id: str = "remote-1") -> FirmwareJob:
+    """Build a REMOTE-source COMPILE job matching the peer-link test wiring."""
+    return FirmwareJob(
+        job_id=job_id,
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        source=JobSource.REMOTE,
+        source_pin_sha256=_PIN,
+        source_label="desktop",
+    )
+
+
+def _capture_local_events(
+    controller: Any,
+) -> dict[EventType, list[dict[str, Any]]]:
+    """Subscribe a real ``EventBus`` to the local ``JOB_*`` events.
+
+    Returns a captured-events dict the assertion side can index
+    by event type. The helper installs the bus on
+    ``controller._db.bus`` so the runner's fires land here.
+    """
+    bus = EventBus()
+    captured: dict[EventType, list[dict[str, Any]]] = {
+        EventType.JOB_OUTPUT: [],
+        EventType.JOB_PROGRESS: [],
+        EventType.JOB_COMPLETED: [],
+        EventType.JOB_FAILED: [],
+        EventType.JOB_CANCELLED: [],
+    }
+
+    def _make_listener(key: EventType) -> Any:
+        def _listen(event: Any) -> None:
+            captured[key].append(event.data)
+
+        return _listen
+
+    for et in captured:
+        bus.add_listener(et, _make_listener(et))
+    controller._db.bus = bus
+    return captured

--- a/tests/controllers/firmware/conftest.py
+++ b/tests/controllers/firmware/conftest.py
@@ -581,22 +581,22 @@ def stub_offloader(controller: Any, snapshot: BuildSchedulerInputs) -> MagicMock
     return offloader
 
 
-_PIN = "a" * 64
+REMOTE_PIN = "a" * 64
 
 
-def _make_remote_job(*, job_id: str = "remote-1") -> FirmwareJob:
+def make_remote_job(*, job_id: str = "remote-1") -> FirmwareJob:
     """Build a REMOTE-source COMPILE job matching the peer-link test wiring."""
     return FirmwareJob(
         job_id=job_id,
         configuration="kitchen.yaml",
         job_type=JobType.COMPILE,
         source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
+        source_pin_sha256=REMOTE_PIN,
         source_label="desktop",
     )
 
 
-def _capture_local_events(
+def capture_local_events(
     controller: Any,
 ) -> dict[EventType, list[dict[str, Any]]]:
     """Subscribe a real ``EventBus`` to the local ``JOB_*`` events.

--- a/tests/controllers/firmware/test_bundle_phase.py
+++ b/tests/controllers/firmware/test_bundle_phase.py
@@ -1,0 +1,117 @@
+"""Tests for the offloader-side bundle phase's job-log streaming."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from esphome_device_builder.controllers.firmware import bundle_phase
+from esphome_device_builder.models import (
+    EventType,
+    FirmwareJob,
+    JobSource,
+    JobType,
+)
+
+from .test_remote_runner import _capture_local_events
+
+if TYPE_CHECKING:
+    from .conftest import FirmwareControllerFactory
+
+
+def _make_remote_job() -> FirmwareJob:
+    return FirmwareJob(
+        job_id="remote-1",
+        configuration="kitchen.yaml",
+        job_type=JobType.COMPILE,
+        source=JobSource.REMOTE,
+        source_pin_sha256="a" * 64,
+        source_label="desktop",
+    )
+
+
+async def test_run_bundle_phase_streams_output_and_notices(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bundle output lands in ``job.output`` live, framed by phase notices."""
+    controller = firmware_controller_factory()
+    captured = _capture_local_events(controller)
+
+    async def _fake_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
+        assert on_output is not None
+        on_output("INFO Reading configuration...\n")
+        return b"FAKEBUNDLE"
+
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _fake_bundle)
+    job = _make_remote_job()
+
+    result = await bundle_phase.run_bundle_phase(controller, job, asyncio.Event())
+
+    assert result == b"FAKEBUNDLE"
+    assert job.output[0] == "*** building configuration bundle for remote build ***\n"
+    assert "INFO Reading configuration...\n" in job.output
+    assert "bundle ready (0 KiB); sending to build server" in job.output[-1]
+    assert any(
+        e["line"] == "INFO Reading configuration...\n" for e in captured[EventType.JOB_OUTPUT]
+    )
+
+
+async def test_run_bundle_phase_cancel_event_cancels_bundle(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A set cancel event wins the race and the bundle task is cancelled."""
+    controller = firmware_controller_factory()
+    _capture_local_events(controller)
+    bundle_cancelled = asyncio.Event()
+
+    async def _hang_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            bundle_cancelled.set()
+            raise
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _hang_bundle)
+    job = _make_remote_job()
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+
+    result = await bundle_phase.run_bundle_phase(controller, job, cancel_event)
+
+    assert result is None
+    assert bundle_cancelled.is_set()
+
+
+async def test_run_bundle_phase_heartbeat_ticks_while_bundle_runs(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A silent bundle still produces still-building notices in the job log."""
+    controller = firmware_controller_factory()
+    _capture_local_events(controller)
+    monkeypatch.setattr(bundle_phase, "_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    release = asyncio.Event()
+
+    async def _slow_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
+        await release.wait()
+        return b"FAKEBUNDLE"
+
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _slow_bundle)
+    job = _make_remote_job()
+
+    task = asyncio.get_running_loop().create_task(
+        bundle_phase.run_bundle_phase(controller, job, asyncio.Event())
+    )
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if any("still building bundle" in line for line in job.output):
+            break
+    release.set()
+
+    assert await task == b"FAKEBUNDLE"
+    assert any("still building bundle (" in line for line in job.output)

--- a/tests/controllers/firmware/test_bundle_phase.py
+++ b/tests/controllers/firmware/test_bundle_phase.py
@@ -10,7 +10,7 @@ import pytest
 from esphome_device_builder.controllers.firmware import bundle_phase
 from esphome_device_builder.models import EventType
 
-from .conftest import _capture_local_events, _make_remote_job
+from .conftest import capture_local_events, make_remote_job
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -22,7 +22,7 @@ async def test_run_bundle_phase_streams_output_and_notices(
 ) -> None:
     """Bundle output lands in ``job.output`` live, framed by phase notices."""
     controller = firmware_controller_factory()
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
 
     async def _fake_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
         assert on_output is not None
@@ -30,7 +30,7 @@ async def test_run_bundle_phase_streams_output_and_notices(
         return b"FAKEBUNDLE"
 
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _fake_bundle)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     result = await bundle_phase.run_bundle_phase(controller, job, asyncio.Event())
 
@@ -49,7 +49,7 @@ async def test_run_bundle_phase_cancel_event_cancels_bundle(
 ) -> None:
     """A set cancel event wins the race and the bundle task is cancelled."""
     controller = firmware_controller_factory()
-    _capture_local_events(controller)
+    capture_local_events(controller)
     bundle_cancelled = asyncio.Event()
 
     async def _hang_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
@@ -58,10 +58,9 @@ async def test_run_bundle_phase_cancel_event_cancels_bundle(
         except asyncio.CancelledError:
             bundle_cancelled.set()
             raise
-        raise AssertionError("unreachable")
 
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _hang_bundle)
-    job = _make_remote_job()
+    job = make_remote_job()
     cancel_event = asyncio.Event()
     cancel_event.set()
 
@@ -77,13 +76,13 @@ async def test_run_bundle_phase_cancel_wins_even_when_bundle_completes(
 ) -> None:
     """A cancel landing in the same tick as bundle completion still cancels."""
     controller = firmware_controller_factory()
-    _capture_local_events(controller)
+    capture_local_events(controller)
 
     async def _instant_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
         return b"FAKEBUNDLE"
 
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _instant_bundle)
-    job = _make_remote_job()
+    job = make_remote_job()
     cancel_event = asyncio.Event()
     cancel_event.set()
 
@@ -97,7 +96,7 @@ async def test_run_bundle_phase_heartbeat_ticks_while_bundle_runs(
 ) -> None:
     """A silent bundle still produces still-building notices in the job log."""
     controller = firmware_controller_factory()
-    _capture_local_events(controller)
+    capture_local_events(controller)
     monkeypatch.setattr(bundle_phase, "_HEARTBEAT_INTERVAL_SECONDS", 0.01)
     release = asyncio.Event()
 
@@ -106,7 +105,7 @@ async def test_run_bundle_phase_heartbeat_ticks_while_bundle_runs(
         return b"FAKEBUNDLE"
 
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _slow_bundle)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     task = asyncio.get_running_loop().create_task(
         bundle_phase.run_bundle_phase(controller, job, asyncio.Event())

--- a/tests/controllers/firmware/test_bundle_phase.py
+++ b/tests/controllers/firmware/test_bundle_phase.py
@@ -8,28 +8,12 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from esphome_device_builder.controllers.firmware import bundle_phase
-from esphome_device_builder.models import (
-    EventType,
-    FirmwareJob,
-    JobSource,
-    JobType,
-)
+from esphome_device_builder.models import EventType
 
-from .test_remote_runner import _capture_local_events
+from .conftest import _capture_local_events, _make_remote_job
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
-
-
-def _make_remote_job() -> FirmwareJob:
-    return FirmwareJob(
-        job_id="remote-1",
-        configuration="kitchen.yaml",
-        job_type=JobType.COMPILE,
-        source=JobSource.REMOTE,
-        source_pin_sha256="a" * 64,
-        source_label="desktop",
-    )
 
 
 async def test_run_bundle_phase_streams_output_and_notices(
@@ -85,6 +69,26 @@ async def test_run_bundle_phase_cancel_event_cancels_bundle(
 
     assert result is None
     assert bundle_cancelled.is_set()
+
+
+async def test_run_bundle_phase_cancel_wins_even_when_bundle_completes(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel landing in the same tick as bundle completion still cancels."""
+    controller = firmware_controller_factory()
+    _capture_local_events(controller)
+
+    async def _instant_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
+        return b"FAKEBUNDLE"
+
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _instant_bundle)
+    job = _make_remote_job()
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+
+    assert await bundle_phase.run_bundle_phase(controller, job, cancel_event) is None
+    assert not any("bundle ready" in line for line in job.output)
 
 
 async def test_run_bundle_phase_heartbeat_ticks_while_bundle_runs(

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -39,7 +39,6 @@ from esphome_device_builder.controllers.remote_build.peer_link_client import (
 )
 from esphome_device_builder.helpers.api import CommandError
 from esphome_device_builder.helpers.config_bundle import BundleBuildError
-from esphome_device_builder.helpers.event_bus import EventBus
 from esphome_device_builder.helpers.remote_artifacts_materialise import MaterialiseError
 from esphome_device_builder.models import (
     ErrorCode,
@@ -51,22 +50,10 @@ from esphome_device_builder.models import (
     JobType,
 )
 
+from .conftest import _PIN, _capture_local_events, _make_remote_job
+
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
-
-
-_PIN = "a" * 64
-
-
-def _make_remote_job(*, job_id: str = "remote-1") -> FirmwareJob:
-    return FirmwareJob(
-        job_id=job_id,
-        configuration="kitchen.yaml",
-        job_type=JobType.COMPILE,
-        source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
-        source_label="desktop",
-    )
 
 
 def _wire_remote_build(
@@ -168,36 +155,6 @@ def patch_bundle(monkeypatch: pytest.MonkeyPatch) -> Any:
     mock = AsyncMock(return_value=b"FAKEBUNDLE")
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", mock)
     return mock
-
-
-def _capture_local_events(
-    controller: Any,
-) -> dict[EventType, list[dict[str, Any]]]:
-    """Subscribe a real ``EventBus`` to the local ``JOB_*`` events.
-
-    Returns a captured-events dict the assertion side can index
-    by event type. The fixture installs the bus on
-    ``controller._db.bus`` so the runner's fires land here.
-    """
-    bus = EventBus()
-    captured: dict[EventType, list[dict[str, Any]]] = {
-        EventType.JOB_OUTPUT: [],
-        EventType.JOB_PROGRESS: [],
-        EventType.JOB_COMPLETED: [],
-        EventType.JOB_FAILED: [],
-        EventType.JOB_CANCELLED: [],
-    }
-
-    def _make_listener(key: EventType) -> Any:
-        def _listen(event: Any) -> None:
-            captured[key].append(event.data)
-
-        return _listen
-
-    for et in captured:
-        bus.add_listener(et, _make_listener(et))
-    controller._db.bus = bus
-    return captured
 
 
 def _fire_state(
@@ -1417,9 +1374,9 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     ``_cancel_requested`` and self-fires the event if the
     cancel already arrived. This test pins that path by
     flipping ``_cancel_requested`` before the runner
-    starts, then asserting the runner still translates the
-    cancel onto the wire (instead of hanging on its newly-
-    created event).
+    starts, then asserting the runner honours the cancel
+    during the bundle phase (instead of hanging on its
+    newly-created event).
     """
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
@@ -1434,19 +1391,15 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     controller.state.cancel_requested.add(job.job_id)
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
-    # The runner's bundle build + submit will still complete
-    # (the cancel-aware ``_fail_locally`` short-circuit only
-    # kicks in when one of those branches raises). The
-    # registration's self-fire is what keeps the happy
-    # dispatch path from hanging on the cancel event.
-    await _wait_for_wire_cancel(client)
-    client.cancel_job.assert_awaited_once_with(job_id=job.job_id)
-
-    _fire_state(controller, job_id=job.job_id, status="cancelled")
+    # The registration's self-fire hands the already-set event to the
+    # bundle phase, which aborts before any wire traffic — nothing is
+    # submitted, so there's no receiver-side job to cancel.
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.CANCELLED
     assert len(captured[EventType.JOB_CANCELLED]) == 1
+    client.submit_job.assert_not_awaited()
+    client.cancel_job.assert_not_awaited()
 
 
 async def test_firmware_cancel_handler_wakes_remote_runner_via_event(

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -30,7 +30,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from esphome.const import __version__ as _esphome_version
 
-from esphome_device_builder.controllers.firmware import remote_runner
+from esphome_device_builder.controllers.firmware import bundle_phase, remote_runner
 from esphome_device_builder.controllers.remote_build.peer_link_client import (
     DownloadArtifactsError,
     DownloadArtifactsResult,
@@ -166,7 +166,7 @@ def patch_bundle(monkeypatch: pytest.MonkeyPatch) -> Any:
     need an actual esphome install + a real YAML).
     """
     mock = AsyncMock(return_value=b"FAKEBUNDLE")
-    monkeypatch.setattr(remote_runner, "build_yaml_bundle", mock)
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", mock)
     return mock
 
 
@@ -381,7 +381,11 @@ async def test_remote_compile_translates_output_and_completes(
     await asyncio.wait_for(runner, timeout=2.0)
 
     assert job.status == JobStatus.COMPLETED
-    assert [d["line"] for d in captured[EventType.JOB_OUTPUT]] == [
+    # The bundle phase frames the receiver's lines with its own notices.
+    lines = [d["line"] for d in captured[EventType.JOB_OUTPUT]]
+    assert lines[0] == "*** building configuration bundle for remote build ***\n"
+    assert "bundle ready" in lines[1]
+    assert lines[2:] == [
         "Reading configuration\n",
         "Compile finished\n",
     ]
@@ -605,7 +609,8 @@ async def test_remote_compile_ignores_events_for_other_jobs(
     _fire_output(controller, job_id="someone-else", line="other job output\n")
     _fire_state(controller, job_id="someone-else", status="completed")
     await asyncio.sleep(0)
-    assert captured[EventType.JOB_OUTPUT] == []
+    # Only the bundle phase's own notices — no stray line leaked in.
+    assert all(d["line"].startswith("***") for d in captured[EventType.JOB_OUTPUT])
     assert captured[EventType.JOB_COMPLETED] == []
     assert not runner.done()
 
@@ -913,9 +918,7 @@ async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
     # not on disk). Combined, the runner's failure path should
     # route through the cancel-aware branch.
     _request_remote_cancel(controller, job)
-    monkeypatch.setattr(
-        remote_runner, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError)
-    )
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError))
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -937,9 +940,7 @@ async def test_remote_compile_bundle_file_missing_fires_job_failed(
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
-    monkeypatch.setattr(
-        remote_runner, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError)
-    )
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError))
     job = _make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
@@ -953,21 +954,50 @@ async def test_remote_compile_bundle_build_error_fires_job_failed(
     firmware_controller_factory: FirmwareControllerFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``BundleBuildError.output`` surfaces in ``job.error`` for the user."""
+    """``BundleBuildError`` fails the job; the log closes with a bundle-failed notice."""
     controller = firmware_controller_factory(with_terminate=True)
     captured = _capture_local_events(controller)
     _wire_remote_build(controller)
     bundle_error = BundleBuildError(
         "bundle subprocess failed", output="ERROR: syntax in kitchen.yaml"
     )
-    monkeypatch.setattr(remote_runner, "build_yaml_bundle", AsyncMock(side_effect=bundle_error))
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", AsyncMock(side_effect=bundle_error))
     job = _make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
     assert job.status == JobStatus.FAILED
-    assert job.error is not None and "syntax in kitchen.yaml" in job.error
+    assert job.error is not None and "bundle subprocess failed" in job.error
+    assert job.output[-1] == "*** bundle failed: bundle subprocess failed ***\n"
     assert len(captured[EventType.JOB_FAILED]) == 1
+
+
+async def test_remote_compile_stop_during_bundle_cancels_promptly(
+    firmware_controller_factory: FirmwareControllerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Stop click mid-bundle cancels the bundle task instead of waiting it out."""
+    controller = firmware_controller_factory(with_terminate=True)
+    captured = _capture_local_events(controller)
+    _wire_remote_build(controller)
+    bundle_started = asyncio.Event()
+
+    async def _hang_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
+        bundle_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _hang_bundle)
+    job = _make_remote_job()
+
+    runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
+    await asyncio.wait_for(bundle_started.wait(), timeout=2.0)
+    _request_remote_cancel(controller, job)
+    await asyncio.wait_for(runner, timeout=2.0)
+
+    assert job.status == JobStatus.CANCELLED
+    assert captured[EventType.JOB_FAILED] == []
+    assert len(captured[EventType.JOB_CANCELLED]) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/firmware/test_remote_runner.py
+++ b/tests/controllers/firmware/test_remote_runner.py
@@ -50,7 +50,7 @@ from esphome_device_builder.models import (
     JobType,
 )
 
-from .conftest import _PIN, _capture_local_events, _make_remote_job
+from .conftest import REMOTE_PIN, capture_local_events, make_remote_job
 
 if TYPE_CHECKING:
     from .conftest import FirmwareControllerFactory
@@ -162,7 +162,7 @@ def _fire_state(
     *,
     job_id: str,
     status: str,
-    pin: str = _PIN,
+    pin: str = REMOTE_PIN,
     error_message: str = "",
     failure_reason: JobFailureReason = JobFailureReason.NONE,
 ) -> None:
@@ -185,7 +185,7 @@ def _fire_output(
     *,
     job_id: str,
     line: str,
-    pin: str = _PIN,
+    pin: str = REMOTE_PIN,
     stream: str = "stdout",
 ) -> None:
     controller._db.bus.fire(
@@ -285,7 +285,7 @@ async def _wait_for_wire_cancel(client: Any, *, timeout: float = 1.0) -> None:
 def _fire_session_closed(
     controller: Any,
     *,
-    pin: str = _PIN,
+    pin: str = REMOTE_PIN,
     reason: str = "transport_error",
     error_detail: str = "",
 ) -> None:
@@ -321,10 +321,10 @@ async def test_remote_compile_translates_output_and_completes(
     regardless of which CPU compiled the bytes.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     # Yield until the runner is parked waiting on the terminal future.
@@ -381,7 +381,7 @@ async def test_remote_clean_dispatches_with_clean_target_and_finalises_on_comple
     a failure.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
     job = FirmwareJob(
@@ -389,7 +389,7 @@ async def test_remote_clean_dispatches_with_clean_target_and_finalises_on_comple
         configuration="kitchen.yaml",
         job_type=JobType.CLEAN,
         source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
+        source_pin_sha256=REMOTE_PIN,
     )
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
@@ -435,7 +435,7 @@ async def test_remote_compile_plumbs_device_names_from_local_scanner(
     parsing the YAML on the receiver) would surface here.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
 
@@ -449,7 +449,7 @@ async def test_remote_compile_plumbs_device_names_from_local_scanner(
     )
     controller._db.devices = devices_stub
 
-    job = _make_remote_job()
+    job = make_remote_job()
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
@@ -474,7 +474,7 @@ async def test_remote_compile_falls_through_when_no_device_matches(
 ) -> None:
     """``submit_job`` ships empty names when the local scanner has no entry for the YAML."""
     controller = firmware_controller_factory(with_terminate=True)
-    _capture_local_events(controller)
+    capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
 
@@ -488,7 +488,7 @@ async def test_remote_compile_falls_through_when_no_device_matches(
     )
     controller._db.devices = devices_stub
 
-    job = _make_remote_job()
+    job = make_remote_job()
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
     _fire_state(controller, job_id=job.job_id, status="completed")
@@ -520,9 +520,9 @@ async def test_remote_compile_progress_translates_to_local_progress_event(
     ones.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -554,9 +554,9 @@ async def test_remote_compile_ignores_events_for_other_jobs(
     terminal.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job(job_id="ours")
+    job = make_remote_job(job_id="ours")
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -588,9 +588,9 @@ async def test_remote_compile_failed_status_fires_job_failed(
 ) -> None:
     """A receiver ``failed`` terminal lands as local ``JOB_FAILED`` with the error text."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -613,9 +613,9 @@ async def test_remote_compile_provision_failure_raises_when_retryable(
 ) -> None:
     """A ``PROVISION`` terminal raises ProvisionUnavailableError in the pool."""
     controller = firmware_controller_factory(with_terminate=True)
-    _capture_local_events(controller)
+    capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(
         remote_runner.run_remote_job(controller, job, retry_on_server_loss=True)
@@ -638,9 +638,9 @@ async def test_remote_compile_provision_failure_fails_without_retry(
 ) -> None:
     """Off the dispatch pool (no retry), a provision failure just fails the job."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -663,10 +663,10 @@ async def test_remote_compile_rejected_ack_fires_job_failed(
 ) -> None:
     """``submit_job`` rejection (``accepted=False``) finalises locally with the reason."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client(accepted=False, reason="receiver queue full")
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -681,10 +681,10 @@ async def test_remote_compile_rejected_ack_without_reason_uses_fallback(
 ) -> None:
     """A rejected ack carrying no ``reason`` field fails with the fallback text."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client(accepted=False)
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -699,12 +699,12 @@ async def test_remote_compile_receiver_unreachable_fires_job_failed(
 ) -> None:
     """A missing peer-link client finalises the job as FAILED with the lookup error."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _wire_remote_build(
         controller,
         lookup_error=CommandError(ErrorCode.PRECONDITION_FAILED, "session not connected"),
     )
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -727,14 +727,14 @@ async def test_remote_compile_unsupported_job_type_fails_locally(
     path with the wrong target.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    _capture_local_events(controller)
+    capture_local_events(controller)
     _wire_remote_build(controller)
     job = FirmwareJob(
         job_id="x",
         configuration="kitchen.yaml",
         job_type=JobType.RENAME,
         source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
+        source_pin_sha256=REMOTE_PIN,
     )
 
     await remote_runner.run_remote_job(controller, job)
@@ -762,10 +762,10 @@ async def test_remote_compile_local_cancel_translates_to_wire_cancel_job(
     frame finalises the local job as CANCELLED.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -801,10 +801,10 @@ async def test_remote_compile_cancel_beats_receiver_completed(
     they explicitly asked to abort.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -837,9 +837,9 @@ async def test_remote_compile_receiver_initiated_cancel_finalises_as_cancelled(
     rather than misroute it as ``FAILED``.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -866,9 +866,9 @@ async def test_remote_compile_cancel_during_bundle_build_finalises_as_cancelled(
     ``_finalize_cancelled`` instead.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     # Cancel was already requested by the time we get to bundle
     # build — and the bundle build itself fails (configuration
@@ -895,10 +895,10 @@ async def test_remote_compile_bundle_file_missing_fires_job_failed(
 ) -> None:
     """``FileNotFoundError`` from the bundle subprocess surfaces in ``job.error``."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _wire_remote_build(controller)
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", AsyncMock(side_effect=FileNotFoundError))
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -913,13 +913,13 @@ async def test_remote_compile_bundle_build_error_fires_job_failed(
 ) -> None:
     """``BundleBuildError`` fails the job; the log closes with a bundle-failed notice."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _wire_remote_build(controller)
     bundle_error = BundleBuildError(
         "bundle subprocess failed", output="ERROR: syntax in kitchen.yaml"
     )
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", AsyncMock(side_effect=bundle_error))
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -935,17 +935,16 @@ async def test_remote_compile_stop_during_bundle_cancels_promptly(
 ) -> None:
     """A Stop click mid-bundle cancels the bundle task instead of waiting it out."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _wire_remote_build(controller)
     bundle_started = asyncio.Event()
 
     async def _hang_bundle(yaml_path: Any, *, on_output: Any = None) -> bytes:
         bundle_started.set()
         await asyncio.Event().wait()
-        raise AssertionError("unreachable")
 
     monkeypatch.setattr(bundle_phase, "build_yaml_bundle", _hang_bundle)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await asyncio.wait_for(bundle_started.wait(), timeout=2.0)
@@ -968,7 +967,7 @@ async def test_remote_compile_missing_source_pin_fires_job_failed(
 ) -> None:
     """A REMOTE job with empty ``source_pin_sha256`` fails before any wire work."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _wire_remote_build(controller)
     job = FirmwareJob(
         job_id="x",
@@ -991,12 +990,12 @@ async def test_remote_compile_no_remote_build_controller_fires_job_failed(
 ) -> None:
     """A REMOTE job dispatched before the remote-build controller is initialised fails cleanly."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     # No remote_build attached — production sets this in
     # ``DeviceBuilder.__init__`` but ``None`` is the typed
     # default the runner has to handle.
     controller._db.remote_build_offloader = None
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -1011,10 +1010,10 @@ async def test_remote_compile_submit_no_session_fires_job_failed(
 ) -> None:
     """``submit_job`` raising :class:`PeerLinkNoSessionError` surfaces in ``job.error``."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client(submit_error=PeerLinkNoSessionError("session not open"))
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     await remote_runner.run_remote_job(controller, job)
 
@@ -1042,10 +1041,10 @@ async def test_remote_compile_session_lost_mid_build_fires_job_failed(
     fails fast rather than wedging the firmware queue.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1090,10 +1089,10 @@ async def test_remote_compile_session_lost_raises_for_pool_retry(
 ) -> None:
     """A mid-build session loss raises for pool retry instead of finalising locally."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(
         remote_runner.run_remote_job(controller, job, retry_on_server_loss=True)
@@ -1125,10 +1124,10 @@ async def test_remote_compile_session_lost_synthetic_line_skips_leading_newline(
     "session closed" message.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1159,7 +1158,7 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
     spinning waiting for a frame.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     # First lookup (for submit) succeeds; second lookup (for
     # cancel) raises. Both flow through the same MagicMock so
     # the side_effect list-pattern covers the sequence.
@@ -1170,7 +1169,7 @@ async def test_remote_compile_cancel_translation_handles_missing_session(
         CommandError(ErrorCode.PRECONDITION_FAILED, "session not connected (mid-reconnect)"),
     ]
     controller._db.remote_build_offloader = remote_build
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(initial_client)
@@ -1188,10 +1187,10 @@ async def test_remote_compile_cancel_translation_handles_session_drop_on_send(
 ) -> None:
     """``cancel_job`` raising ``PeerLinkNoSessionError`` finalises CANCELLED locally."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client(cancel_error=PeerLinkNoSessionError("session gone"))
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1221,9 +1220,9 @@ async def test_remote_compile_runner_task_cancelled_finalises_as_cancelled(
     queue runner can unwind.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1260,9 +1259,9 @@ async def test_execute_job_routes_remote_source_through_remote_runner(
     method.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(controller._execute_job(job, controller.state.compile_lane))
     await _wait_until_dispatched(client)
@@ -1295,10 +1294,10 @@ async def test_submit_job_ack_echoes_caller_job_id(
     showing up as an unrelated runner-test failure.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    _capture_local_events(controller)
+    capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job(job_id="unique-echo-1234")
+    job = make_remote_job(job_id="unique-echo-1234")
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1330,9 +1329,9 @@ async def test_remote_compile_ignores_session_closed_for_other_pin(
     take each other's jobs down on every reconnect.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1379,10 +1378,10 @@ async def test_remote_compile_cancel_before_runner_registers_event_still_fires(
     newly-created event).
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     # Cancel landed BEFORE the runner registers its event —
     # ``_cancel_requested`` carries the flag, but no entry
@@ -1423,10 +1422,10 @@ async def test_firmware_cancel_handler_wakes_remote_runner_via_event(
     code path.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     # The WS cancel handler refuses non-existent jobs and a
     # missing lane slot is a hard error — wire both so
@@ -1471,9 +1470,9 @@ async def test_remote_compile_cancel_after_remote_build_torn_down_finalises_loca
     clean CANCELLED event.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     _, client = _wire_remote_build(controller)
-    job = _make_remote_job()
+    job = make_remote_job()
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
     await _wait_until_dispatched(client)
@@ -1502,7 +1501,7 @@ def _make_remote_install_job(*, job_id: str = "remote-1", port: str = "OTA") -> 
         job_type=JobType.INSTALL,
         port=port,
         source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
+        source_pin_sha256=REMOTE_PIN,
         source_label="desktop",
     )
 
@@ -1572,7 +1571,7 @@ async def test_remote_install_resets_progress_between_compile_and_upload(
     advance the gauge from 0.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     _wire_remote_build(controller, client=client)
@@ -1616,7 +1615,7 @@ async def test_remote_install_completes_after_local_upload_succeeds(
     as ``COMPLETED`` and fires the local terminal event.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     _wire_remote_build(controller, client=client)
@@ -1643,7 +1642,7 @@ async def test_remote_install_local_upload_failure_fires_job_failed(
 ) -> None:
     """A non-zero ``esphome upload`` exit lands as JOB_FAILED with exit-code in error."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     _wire_remote_build(controller, client=client)
@@ -1667,7 +1666,7 @@ async def test_remote_install_download_artifacts_failure_fires_job_failed(
 ) -> None:
     """``download_artifacts`` failing surfaces in ``job.error`` with the receiver's reason."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(
         side_effect=DownloadArtifactsError("build dir wiped", reason="build_dir_missing")
@@ -1692,7 +1691,7 @@ async def test_remote_install_materialise_failure_fires_job_failed(
 ) -> None:
     """Materialise failure (malformed tarball, missing member) lands as JOB_FAILED."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     _wire_remote_build(controller, client=client)
@@ -1720,7 +1719,7 @@ async def test_remote_install_materialise_oserror_fires_job_failed(
 ) -> None:
     """An OSError from materialise (disk full / permissions) lands as JOB_FAILED."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
     monkeypatch.setattr(
@@ -1745,7 +1744,7 @@ async def test_fetch_and_run_local_upload_pre_spawn_cancel_finalises_locally(
 ) -> None:
     """Cancel landing after ``_fetch_and_materialise`` returns but before the spawn."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     job = _make_remote_install_job()
     controller.state.cancel_requested.add(job.job_id)
@@ -1777,7 +1776,7 @@ async def test_remote_install_cancel_during_local_upload_finalises_as_cancelled(
     FAILED branch the non-zero exit would normally trigger.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     _wire_remote_build(controller, client=client)
@@ -1850,7 +1849,7 @@ async def test_run_upload_subprocess_cancel_landing_between_pre_check_and_spawn_
     the flag and fires ``_terminate_job_process``.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     job = _make_remote_install_job()
@@ -1899,7 +1898,7 @@ async def test_fetch_and_materialise_cancel_post_staging_finalises_locally(
     ``False`` so the caller skips the spawn.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     job = _make_remote_install_job()
     controller.state.cancel_requested.add(job.job_id)
@@ -1932,7 +1931,7 @@ async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
     silently breaking the UPLOAD path.
     """
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     client.download_artifacts = AsyncMock(return_value=_make_packed_artifacts())
     _wire_remote_build(controller, client=client)
@@ -1943,7 +1942,7 @@ async def test_remote_upload_runs_the_same_local_flash_chain_as_install(
         job_type=JobType.UPLOAD,
         port="192.168.1.50",
         source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
+        source_pin_sha256=REMOTE_PIN,
     )
 
     runner = asyncio.create_task(remote_runner.run_remote_job(controller, job))
@@ -1962,7 +1961,7 @@ def _make_reset_job(*, job_id: str = "reset-1") -> FirmwareJob:
         configuration="",
         job_type=JobType.RESET_BUILD_ENV,
         source=JobSource.REMOTE,
-        source_pin_sha256=_PIN,
+        source_pin_sha256=REMOTE_PIN,
         source_label="desktop",
     )
 
@@ -1984,7 +1983,7 @@ async def test_remote_reset_dispatches_frame_and_finalises_on_completed(
 ) -> None:
     """A REMOTE reset sends one bundle-less frame, streams output, finalises COMPLETED."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
     job = _make_reset_job()
@@ -2013,7 +2012,7 @@ async def test_remote_reset_busy_reject_fails_with_retry_message(
 ) -> None:
     """A ``busy`` reject finalises FAILED with the retry-when-idle message."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client(accepted=False, reason="busy")
     _wire_remote_build(controller, client=client)
     job = _make_reset_job()
@@ -2032,7 +2031,7 @@ async def test_remote_reset_duplicate_request_fires_job_failed(
 ) -> None:
     """``reset_build_env`` refusing a duplicate ``job_id`` surfaces in ``job.error``."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client(
         submit_error=DuplicateRequestError("reset_build_env: request already registered")
     )
@@ -2051,7 +2050,7 @@ async def test_remote_reset_session_lost_mid_reset_fires_job_failed(
 ) -> None:
     """A peer-link close mid-reset fails the mirror; the receiver's wipe continues."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
     job = _make_reset_job()
@@ -2072,7 +2071,7 @@ async def test_remote_reset_cancel_round_trip(
 ) -> None:
     """A local Stop sends ``cancel_job``; the receiver's ``cancelled`` finalises the mirror."""
     controller = firmware_controller_factory(with_terminate=True)
-    captured = _capture_local_events(controller)
+    captured = capture_local_events(controller)
     client = _make_client()
     _wire_remote_build(controller, client=client)
     job = _make_reset_job()

--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -71,8 +71,11 @@ async def test_build_yaml_bundle_streams_output_to_callback(
 
     chunks: list[str] = []
     await build_yaml_bundle(yaml_path, on_output=chunks.append)
-    assert "INFO Reading configuration...\n" in chunks
-    assert "INFO Bundling 3 files\n" in chunks
+    # Windows children emit \r\n; the terminator is preserved either way.
+    assert all(chunk.endswith("\n") for chunk in chunks)
+    stripped = [chunk.rstrip("\r\n") for chunk in chunks]
+    assert "INFO Reading configuration..." in stripped
+    assert "INFO Bundling 3 files" in stripped
 
 
 async def test_build_yaml_bundle_missing_yaml_raises_file_not_found(
@@ -98,7 +101,7 @@ async def test_build_yaml_bundle_subprocess_failure_raises_bundle_build_error(
     with pytest.raises(BundleBuildError, match="exited 1") as exc_info:
         await build_yaml_bundle(yaml_path, on_output=chunks.append)
     assert "INVALID_YAML" in exc_info.value.output
-    assert "INVALID_YAML: unexpected token\n" in chunks
+    assert "INVALID_YAML: unexpected token" in [chunk.rstrip("\r\n") for chunk in chunks]
 
 
 async def test_build_yaml_bundle_captures_stderr(
@@ -160,4 +163,4 @@ async def test_build_yaml_bundle_timeout_raises_bundle_build_error(
     with pytest.raises(BundleBuildError, match="timed out") as exc_info:
         await build_yaml_bundle(yaml_path, on_output=chunks.append)
     assert "EARLY DIAGNOSTIC" in exc_info.value.output
-    assert "EARLY DIAGNOSTIC\n" in chunks
+    assert "EARLY DIAGNOSTIC" in [chunk.rstrip("\r\n") for chunk in chunks]

--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -98,7 +98,7 @@ async def test_build_yaml_bundle_missing_yaml_raises_file_not_found(
 async def test_build_yaml_bundle_subprocess_failure_raises_bundle_build_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Non-zero exit raises :class:`BundleBuildError` carrying the output tail."""
+    """Non-zero exit raises :class:`BundleBuildError` carrying the captured output."""
     yaml_path = _write_yaml(tmp_path)
     _install_fake_esphome(
         monkeypatch,
@@ -106,11 +106,9 @@ async def test_build_yaml_bundle_subprocess_failure_raises_bundle_build_error(
         "print('INVALID_YAML: unexpected token')\nsys.exit(1)\n",
     )
 
-    chunks: list[str] = []
     with pytest.raises(BundleBuildError, match="exited 1") as exc_info:
-        await build_yaml_bundle(yaml_path, on_output=chunks.append)
+        await build_yaml_bundle(yaml_path)
     assert "INVALID_YAML" in exc_info.value.output
-    assert "INVALID_YAML: unexpected token" in [chunk.rstrip("\r\n") for chunk in chunks]
 
 
 async def test_build_yaml_bundle_captures_stderr(
@@ -193,8 +191,6 @@ async def test_build_yaml_bundle_timeout_raises_bundle_build_error(
     )
     monkeypatch.setattr(config_bundle, "_BUNDLE_BUILD_TIMEOUT_SECONDS", 0.5)
 
-    chunks: list[str] = []
     with pytest.raises(BundleBuildError, match="timed out") as exc_info:
-        await build_yaml_bundle(yaml_path, on_output=chunks.append)
+        await build_yaml_bundle(yaml_path)
     assert "EARLY DIAGNOSTIC" in exc_info.value.output
-    assert "EARLY DIAGNOSTIC" in [chunk.rstrip("\r\n") for chunk in chunks]

--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -1,20 +1,17 @@
 """
 Unit tests for :mod:`helpers.config_bundle`.
 
-The bundle helper spawns ``esphome bundle <yaml> -o <tarball>``
-through :func:`helpers.subprocess.run_subprocess_capture`. Tests
-monkeypatch :func:`run_subprocess_capture` on the
-:mod:`config_bundle` namespace with a fake that materialises the
-expected bundle bytes at the output path, so the helper's
-plumbing (temp-file lifecycle, error mapping, missing-yaml
-pre-check) is exercised without invoking real ESPHome.
+The bundle helper spawns ``esphome bundle <yaml> -o <tarball>`` and
+streams its output. Tests monkeypatch ``_find_esphome_cmd`` to a tiny
+``sys.executable`` script standing in for esphome, so the helper's
+plumbing (streaming, temp-file lifecycle, error mapping, timeout,
+missing-yaml pre-check) is exercised against a real subprocess.
 """
 
 from __future__ import annotations
 
-import asyncio
+import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -23,63 +20,59 @@ from esphome_device_builder.helpers.config_bundle import (
     BundleBuildError,
     build_yaml_bundle,
 )
-from esphome_device_builder.helpers.subprocess import CapturedSubprocess
+
+_SCRIPT_PRELUDE = "import sys, time\nout = sys.argv[sys.argv.index('-o') + 1]\n"
 
 
-def _install_fake_subprocess(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    returncode: int = 0,
-    stdout: bytes = b"",
-    output_bytes: bytes | None = None,
-    timed_out: bool = False,
-) -> list[tuple[Any, ...]]:
-    """Patch ``run_subprocess_capture`` with a fake; return captured arg tuples.
+def _install_fake_esphome(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, body: str) -> Path:
+    """Point ``_find_esphome_cmd`` at a stand-in script; return the reserved output path."""
+    script = tmp_path / "fake_esphome.py"
+    script.write_text(_SCRIPT_PRELUDE + body, encoding="utf-8")
+    monkeypatch.setattr(config_bundle, "_find_esphome_cmd", lambda: [sys.executable, str(script)])
+    output_path = tmp_path / "bundle-out.tar.gz"
+    monkeypatch.setattr(config_bundle, "_allocate_temp_bundle_path", lambda: output_path)
+    return output_path
 
-    On a non-timed-out success-path call, the fake materialises
-    *output_bytes* at the output path the helper passed via
-    ``-o`` so the read-back step finds real bytes.
-    """
-    captured: list[tuple[Any, ...]] = []
 
-    async def _fake(*args: Any, **_kwargs: Any) -> CapturedSubprocess:
-        captured.append(args)
-        if not timed_out and output_bytes is not None and "-o" in args:
-            try:
-                output_path = Path(args[args.index("-o") + 1])
-            except IndexError:  # pragma: no cover — defensive
-                output_path = None
-            else:
-                # ``write_bytes`` is a blocking syscall; the
-                # production helper materialises bytes via the
-                # real esphome subprocess (no event-loop block),
-                # so the fake has to mirror that by deferring
-                # the write to a worker thread. blockbuster on
-                # Linux CI catches direct ``write_bytes`` on the
-                # loop.
-                await asyncio.to_thread(output_path.write_bytes, output_bytes)
-        return CapturedSubprocess(returncode=returncode, stdout=stdout, timed_out=timed_out)
-
-    monkeypatch.setattr(config_bundle, "run_subprocess_capture", _fake)
-    return captured
+def _write_yaml(tmp_path: Path) -> Path:
+    yaml_path = tmp_path / "kitchen.yaml"
+    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
+    return yaml_path
 
 
 async def test_build_yaml_bundle_returns_subprocess_output(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Happy path: subprocess exits 0 and the temp-file bytes are returned."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    expected = b"GZIPPED-TAR-BYTES"
-    captured = _install_fake_subprocess(monkeypatch, output_bytes=expected)
+    yaml_path = _write_yaml(tmp_path)
+    _install_fake_esphome(
+        monkeypatch,
+        tmp_path,
+        "assert sys.argv[1] == 'bundle'\n"
+        f"assert sys.argv[2] == {str(yaml_path)!r}\n"
+        "open(out, 'wb').write(b'GZIPPED-TAR-BYTES')\n",
+    )
 
-    result = await build_yaml_bundle(yaml_path)
-    assert result == expected
-    # CLI was invoked with the ``bundle`` subcommand + yaml + -o.
-    args = captured[0]
-    assert "bundle" in args
-    assert str(yaml_path) in args
-    assert "-o" in args
+    assert await build_yaml_bundle(yaml_path) == b"GZIPPED-TAR-BYTES"
+
+
+async def test_build_yaml_bundle_streams_output_to_callback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``on_output`` receives each subprocess chunk with its terminator."""
+    yaml_path = _write_yaml(tmp_path)
+    _install_fake_esphome(
+        monkeypatch,
+        tmp_path,
+        "print('INFO Reading configuration...')\n"
+        "print('INFO Bundling 3 files')\n"
+        "open(out, 'wb').write(b'bytes')\n",
+    )
+
+    chunks: list[str] = []
+    await build_yaml_bundle(yaml_path, on_output=chunks.append)
+    assert "INFO Reading configuration...\n" in chunks
+    assert "INFO Bundling 3 files\n" in chunks
 
 
 async def test_build_yaml_bundle_missing_yaml_raises_file_not_found(
@@ -93,32 +86,50 @@ async def test_build_yaml_bundle_missing_yaml_raises_file_not_found(
 async def test_build_yaml_bundle_subprocess_failure_raises_bundle_build_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Non-zero exit raises :class:`BundleBuildError` with the captured output."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text("invalid yaml content", encoding="utf-8")
-    _install_fake_subprocess(
+    """Non-zero exit raises :class:`BundleBuildError` carrying the output tail."""
+    yaml_path = _write_yaml(tmp_path)
+    _install_fake_esphome(
         monkeypatch,
-        returncode=1,
-        stdout=b"INVALID_YAML: unexpected token\n",
+        tmp_path,
+        "print('INVALID_YAML: unexpected token')\nsys.exit(1)\n",
+    )
+
+    chunks: list[str] = []
+    with pytest.raises(BundleBuildError, match="exited 1") as exc_info:
+        await build_yaml_bundle(yaml_path, on_output=chunks.append)
+    assert "INVALID_YAML" in exc_info.value.output
+    assert "INVALID_YAML: unexpected token\n" in chunks
+
+
+async def test_build_yaml_bundle_captures_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stderr merges into the streamed output so validator errors surface."""
+    yaml_path = _write_yaml(tmp_path)
+    _install_fake_esphome(
+        monkeypatch,
+        tmp_path,
+        "print('ERROR bad platform', file=sys.stderr)\nsys.exit(2)\n",
     )
 
     with pytest.raises(BundleBuildError) as exc_info:
         await build_yaml_bundle(yaml_path)
-    assert "INVALID_YAML" in exc_info.value.output
+    assert "ERROR bad platform" in exc_info.value.output
 
 
 async def test_build_yaml_bundle_cleans_temp_file_on_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The temp output file is unlinked even when the subprocess fails."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    captured = _install_fake_subprocess(monkeypatch, returncode=1, stdout=b"err")
+    yaml_path = _write_yaml(tmp_path)
+    output_path = _install_fake_esphome(
+        monkeypatch,
+        tmp_path,
+        "open(out, 'wb').write(b'partial')\nsys.exit(1)\n",
+    )
 
     with pytest.raises(BundleBuildError):
         await build_yaml_bundle(yaml_path)
-
-    output_path = Path(captured[0][captured[0].index("-o") + 1])
     assert not output_path.exists()
 
 
@@ -126,22 +137,27 @@ async def test_build_yaml_bundle_cleans_temp_file_on_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The temp output file is unlinked after a successful read."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    captured = _install_fake_subprocess(monkeypatch, output_bytes=b"bytes")
+    yaml_path = _write_yaml(tmp_path)
+    output_path = _install_fake_esphome(monkeypatch, tmp_path, "open(out, 'wb').write(b'bytes')\n")
 
     await build_yaml_bundle(yaml_path)
-    output_path = Path(captured[0][captured[0].index("-o") + 1])
     assert not output_path.exists()
 
 
 async def test_build_yaml_bundle_timeout_raises_bundle_build_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A timed-out subprocess raises :class:`BundleBuildError` with 'timed out'."""
-    yaml_path = tmp_path / "kitchen.yaml"
-    yaml_path.write_text("esphome:\n  name: kitchen\n", encoding="utf-8")
-    _install_fake_subprocess(monkeypatch, timed_out=True)
+    """A timed-out subprocess raises with the pre-timeout output preserved."""
+    yaml_path = _write_yaml(tmp_path)
+    _install_fake_esphome(
+        monkeypatch,
+        tmp_path,
+        "print('EARLY DIAGNOSTIC', flush=True)\ntime.sleep(30)\n",
+    )
+    monkeypatch.setattr(config_bundle, "_BUNDLE_BUILD_TIMEOUT_SECONDS", 0.5)
 
-    with pytest.raises(BundleBuildError, match="timed out"):
-        await build_yaml_bundle(yaml_path)
+    chunks: list[str] = []
+    with pytest.raises(BundleBuildError, match="timed out") as exc_info:
+        await build_yaml_bundle(yaml_path, on_output=chunks.append)
+    assert "EARLY DIAGNOSTIC" in exc_info.value.output
+    assert "EARLY DIAGNOSTIC\n" in chunks

--- a/tests/test_config_bundle.py
+++ b/tests/test_config_bundle.py
@@ -10,6 +10,7 @@ missing-yaml pre-check) is exercised against a real subprocess.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
@@ -24,13 +25,20 @@ from esphome_device_builder.helpers.config_bundle import (
 _SCRIPT_PRELUDE = "import sys, time\nout = sys.argv[sys.argv.index('-o') + 1]\n"
 
 
-def _install_fake_esphome(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, body: str) -> Path:
+def _install_fake_esphome(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    body: str,
+    *,
+    patch_output_path: bool = True,
+) -> Path:
     """Point ``_find_esphome_cmd`` at a stand-in script; return the reserved output path."""
     script = tmp_path / "fake_esphome.py"
     script.write_text(_SCRIPT_PRELUDE + body, encoding="utf-8")
     monkeypatch.setattr(config_bundle, "_find_esphome_cmd", lambda: [sys.executable, str(script)])
     output_path = tmp_path / "bundle-out.tar.gz"
-    monkeypatch.setattr(config_bundle, "_allocate_temp_bundle_path", lambda: output_path)
+    if patch_output_path:
+        monkeypatch.setattr(config_bundle, "_allocate_temp_bundle_path", lambda: output_path)
     return output_path
 
 
@@ -51,6 +59,7 @@ async def test_build_yaml_bundle_returns_subprocess_output(
         "assert sys.argv[1] == 'bundle'\n"
         f"assert sys.argv[2] == {str(yaml_path)!r}\n"
         "open(out, 'wb').write(b'GZIPPED-TAR-BYTES')\n",
+        patch_output_path=False,
     )
 
     assert await build_yaml_bundle(yaml_path) == b"GZIPPED-TAR-BYTES"
@@ -145,6 +154,31 @@ async def test_build_yaml_bundle_cleans_temp_file_on_success(
 
     await build_yaml_bundle(yaml_path)
     assert not output_path.exists()
+
+
+async def test_build_yaml_bundle_cancel_kills_subprocess(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancelling the build kills the bundle subprocess and propagates the cancel."""
+    yaml_path = _write_yaml(tmp_path)
+    _install_fake_esphome(
+        monkeypatch,
+        tmp_path,
+        "print('started', flush=True)\ntime.sleep(30)\n",
+    )
+
+    chunks: list[str] = []
+    task = asyncio.get_running_loop().create_task(
+        build_yaml_bundle(yaml_path, on_output=chunks.append)
+    )
+    while not chunks:
+        await asyncio.sleep(0.01)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    assert task.cancelled()
+    # Let the child watcher reap the SIGKILL'd process before the
+    # test loop closes, or its transport __del__ warns at teardown.
+    await asyncio.sleep(0.1)
 
 
 async def test_build_yaml_bundle_timeout_raises_bundle_build_error(

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 import esphome_device_builder
 from esphome_device_builder.helpers import subprocess as subprocess_helper
 
@@ -108,6 +110,40 @@ async def test_run_subprocess_capture_timeout_returns_partial_output() -> None:
     )
     assert result.timed_out is True
     assert b"EARLY" in result.stdout
+
+
+async def test_run_subprocess_capture_on_line_streams_and_stdout_empty() -> None:
+    """``on_line`` receives each chunk; the result's stdout stays empty."""
+    lines: list[str] = []
+    result = await subprocess_helper.run_subprocess_capture(
+        sys.executable,
+        "-c",
+        "print('a'); print('b')",
+        timeout=10,
+        on_line=lines.append,
+    )
+    assert result.returncode == 0
+    assert result.stdout == b""
+    assert [line.rstrip("\r\n") for line in lines] == ["a", "b"]
+
+
+async def test_run_subprocess_capture_on_line_exception_kills_child() -> None:
+    """An exception escaping *on_line* propagates and the child is killed."""
+
+    def _boom(line: str) -> None:
+        raise RuntimeError("listener boom")
+
+    with pytest.raises(RuntimeError, match="listener boom"):
+        await subprocess_helper.run_subprocess_capture(
+            sys.executable,
+            "-c",
+            "import time; print('hello', flush=True); time.sleep(30)",
+            timeout=30,
+            on_line=_boom,
+        )
+    # Let the child watcher reap the SIGKILL'd process before the
+    # test loop closes, or its transport __del__ warns at teardown.
+    await asyncio.sleep(0.1)
 
 
 async def test_run_subprocess_capture_timeout_with_stdin_pending() -> None:

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -110,6 +110,51 @@ async def test_run_subprocess_capture_timeout_returns_partial_output() -> None:
     assert b"EARLY" in result.stdout
 
 
+async def test_run_subprocess_capture_timeout_with_stdin_pending() -> None:
+    """Timeout with a stdin writer in flight still returns cleanly."""
+    result = await subprocess_helper.run_subprocess_capture(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(30)",
+        timeout=0.5,
+        stdin_data=b"unread",
+    )
+    assert result.timed_out is True
+
+
+async def test_run_subprocess_capture_cancel_kills_child() -> None:
+    """Cancelling the awaiting task kills the child and propagates the cancel."""
+    task = asyncio.get_running_loop().create_task(
+        subprocess_helper.run_subprocess_capture(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(30)",
+            timeout=60,
+            stdin_data=b"unread",
+        )
+    )
+    await asyncio.sleep(0.3)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    assert task.cancelled()
+    # Let the child watcher reap the SIGKILL'd process before the
+    # test loop closes, or its transport __del__ warns at teardown.
+    await asyncio.sleep(0.1)
+
+
+async def test_run_subprocess_capture_tolerates_child_ignoring_stdin() -> None:
+    """A child exiting without draining a large stdin doesn't raise."""
+    result = await subprocess_helper.run_subprocess_capture(
+        sys.executable,
+        "-c",
+        "pass",
+        timeout=10,
+        stdin_data=b"x" * (8 * 1024 * 1024),
+    )
+    assert result.timed_out is False
+    assert result.returncode == 0
+
+
 def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
     """Guard against regressions: no callsite should bypass the helper.
 

--- a/tests/test_subprocess_helper.py
+++ b/tests/test_subprocess_helper.py
@@ -98,6 +98,18 @@ async def test_run_subprocess_capture_merges_stderr_by_default() -> None:
     assert b"out" in result.stdout
 
 
+async def test_run_subprocess_capture_timeout_returns_partial_output() -> None:
+    """A timed-out child's pre-timeout stdout survives as the diagnostic."""
+    result = await subprocess_helper.run_subprocess_capture(
+        sys.executable,
+        "-c",
+        "import time; print('EARLY', flush=True); time.sleep(30)",
+        timeout=0.5,
+    )
+    assert result.timed_out is True
+    assert b"EARLY" in result.stdout
+
+
 def test_no_call_site_uses_asyncio_create_subprocess_exec_directly() -> None:
     """Guard against regressions: no callsite should bypass the helper.
 


### PR DESCRIPTION
# What does this implement/fix?

Remote builds start with an `esphome bundle` subprocess that ran silently; the job log stayed empty, a Stop click waited it out, and on timeout the captured output was thrown away, leaving only `bundle failed: esphome bundle timed out after 60s`. A slow validating config legitimately exceeds 60s, so those users could never start a remote build at all.

The bundle phase now streams the subprocess output into the job log live, framed by notices; `*** building configuration bundle for remote build ***`, a `still building bundle (Ns elapsed)` heartbeat every 30s for configs whose validation prints nothing, and `*** bundle ready (N KiB); sending to build server ***` on success. Failures close the log with the cause and keep the output tail on the error. The timeout is raised to 300s since the wait is no longer blind, and Stop now cancels the bundle subprocess immediately instead of waiting for it. `run_subprocess_capture` also keeps its partial output on timeout, so the env provisioner and importable probe get their diagnostics too.

**Related issue or feature (if applicable):**

- https://github.com/orgs/esphome/discussions/3781

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [x] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
