### PR TITLE
Keep get_available devices in YAML document order

### DIFF
--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -314,7 +314,10 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
 
     if isinstance(data.get("script"), list):
         scripts = _scope_scripts(data["script"])
-    for domain in set(data.keys()):
+    # Iterate in document order: ``devices`` ships to the frontend in this
+    # order, and a ``set()`` here reshuffled it every restart (hash
+    # randomization), so the by-target picker's groups moved around.
+    for domain in data:
         section = data.get(domain)
         if isinstance(section, list):
             domains.update(_qualified_domains(domain, section))

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -291,6 +291,41 @@ async def test_get_available_lists_configured_component_instances(tmp_path: Path
     assert devices[("switch.gpio", "relay_one")]["is_entity_container"] is False
 
 
+async def test_get_available_devices_follow_document_order(tmp_path: Path) -> None:
+    """``devices`` ships in YAML document order, stable across restarts (#2213)."""
+    config = tmp_path / "device.yaml"
+    config.write_text(
+        "esphome:\n  name: d\n"
+        "wifi:\n  ssid: home\n"
+        "logger:\n  baud_rate: 115200\n"
+        "button:\n"
+        "  - platform: template\n"
+        "    id: testbutton\n"
+        "switch:\n"
+        "  - platform: gpio\n"
+        "    id: relay\n"
+        "    pin: GPIO5\n"
+        "binary_sensor:\n"
+        "  - platform: gpio\n"
+        "    id: door\n"
+        "    pin: GPIO4\n"
+        "text_sensor:\n"
+        "  - platform: template\n"
+        "    id: status_text\n",
+        encoding="utf-8",
+    )
+    controller = _make_controller(tmp_path)
+    result = await controller.get_available(configuration="device.yaml")
+    assert [d["id"] for d in result["devices"]] == [
+        "wifi",
+        "logger",
+        "testbutton",
+        "relay",
+        "door",
+        "status_text",
+    ]
+
+
 async def test_get_available_flags_explicit_ids(tmp_path: Path) -> None:
     """``has_explicit_id`` is true only for a declared ``id:``, never a synthesized one."""
     config = tmp_path / "device.yaml"


### PR DESCRIPTION
# What does this implement/fix?

`_scope_from_yaml` iterated `set(data.keys())`, so the `devices` list in `automations/get_available` reshuffled on every backend restart (hash randomization); the by-target picker's groups moved around across sessions. Iterate the mapping directly instead: dict keys are already unique, so the set wrap added nothing, and the wire order now matches the YAML document order, which is also the most intuitive presentation.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/device-builder/issues/2213

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
