### PR TITLE
Trim the ordering comment to its invariant

### DIFF
--- a/esphome_device_builder/controllers/automations/controller.py
+++ b/esphome_device_builder/controllers/automations/controller.py
@@ -314,9 +314,8 @@ def _scope_from_yaml(text: str) -> _ScopedYaml:
 
     if isinstance(data.get("script"), list):
         scripts = _scope_scripts(data["script"])
-    # Iterate in document order: ``devices`` ships to the frontend in this
-    # order, and a ``set()`` here reshuffled it every restart (hash
-    # randomization), so the by-target picker's groups moved around.
+    # ``devices`` ships to the frontend in this order; keep document-order
+    # iteration (a ``set()`` wrap hash-shuffles it per process).
     for domain in data:
         section = data.get(domain)
         if isinstance(section, list):

--- a/tests/test_automations_controller.py
+++ b/tests/test_automations_controller.py
@@ -292,7 +292,7 @@ async def test_get_available_lists_configured_component_instances(tmp_path: Path
 
 
 async def test_get_available_devices_follow_document_order(tmp_path: Path) -> None:
-    """``devices`` ships in YAML document order, stable across restarts (#2213)."""
+    """``devices`` ships in YAML document order, stable across restarts."""
     config = tmp_path / "device.yaml"
     config.write_text(
         "esphome:\n  name: d\n"


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #2216, which merged while the Copilot style feedback was still in flight; the fix commit landed on the closed branch. Condenses the document-order comment to its invariant and drops the issue reference from the test docstring, per the comment rules in CLAUDE.md.

**Related issue or feature (if applicable):**

- fixes <link to issue>

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [x] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
