### PR TITLE
Adopt the uv-managed Python composite for every CI job but CodSpeed

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -59,16 +59,13 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python
+    - name: Set up uv and Python 3.13
       if: inputs.initial-release != 'true'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      # Resolves through the caller's workspace checkout — both call
+      # sites check the repo out at the workspace root.
+      uses: ./.github/actions/setup-uv-python
       with:
         python-version: "3.13"
-
-    - name: Install Python dependencies
-      if: inputs.initial-release != 'true'
-      shell: bash
-      run: pip install --no-cache-dir PyGithub PyYAML
 
     - name: Generate release notes
       id: generate
@@ -83,7 +80,9 @@ runs:
         COMMITISH: ${{ inputs.commitish }}
         FRONTEND_REPO: ${{ inputs.frontend-repo }}
         FRONTEND_DEP_NAME: ${{ inputs.frontend-dep-name }}
-      run: python "${{ github.action_path }}/generate_notes.py"
+      # ``--no-project`` keeps uv from syncing the workspace's own
+      # pyproject; the two deps ride an ephemeral cached env.
+      run: uv run --no-project --with PyGithub --with PyYAML python "${{ github.action_path }}/generate_notes.py"
 
     - name: Emit initial-release placeholder
       id: initial

--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -17,11 +17,10 @@ description: |
   fires), re-add the explicit step gated on
   ``runner.os != 'Windows'`` to dodge the same race.
 
-  Built for the 3.14 CI matrix where the tail-call interpreter
-  measurably shortens the suite; jobs that need stock CPython
-  (notably the CodSpeed benchmarks, where mimalloc + tail-call
-  dispatch would shift callgrind instruction counts) should stay
-  on ``actions/setup-python``.
+  The default Python setup for every job; jobs that need stock
+  CPython (notably the CodSpeed benchmarks, where mimalloc +
+  tail-call dispatch would shift callgrind instruction counts)
+  should stay on ``actions/setup-python``.
 
 inputs:
   python-version:
@@ -38,7 +37,7 @@ runs:
   steps:
     - name: Set up uv
       id: uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: true

--- a/.github/workflows/check-board-images.yml
+++ b/.github/workflows/check-board-images.yml
@@ -34,18 +34,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - name: Set up uv and Python 3.13
+        uses: ./.github/actions/setup-uv-python
         with:
           python-version: "3.13"
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install package (test extra for jsonschema)
-        run: uv pip install --system -e '.[test]'
+      - name: Create venv + install package (test extra for jsonschema)
+        run: |
+          uv venv
+          uv pip install -e '.[test]'
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Check board image URLs
         run: python script/validate_definitions.py --check-images

--- a/.github/workflows/real-compile-tests.yml
+++ b/.github/workflows/real-compile-tests.yml
@@ -48,18 +48,16 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - name: Set up uv and Python 3.13
+        uses: ./.github/actions/setup-uv-python
         with:
           python-version: "3.13"
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install package + test deps
-        run: uv pip install --system -e '.[esphome,test]'
+      - name: Create venv + install package + test deps
+        run: |
+          uv venv
+          uv pip install -e '.[esphome,test]'
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Cache PlatformIO core + per-platform toolchains
         # ``~/.platformio`` holds PIO's wheel cache, downloaded

--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -157,22 +157,21 @@ jobs:
           cp -a pr/esphome_device_builder/definitions/components \
             base/esphome_device_builder/definitions/components
 
-      - name: Set up Python
+      - name: Set up uv and Python 3.13
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        # Path goes through the trusted base checkout — the workspace
+        # root holds no repo, and pr/ is never executed.
+        uses: ./base/.github/actions/setup-uv-python
         with:
           python-version: "3.13"
 
-      - name: Set up uv
-        if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install package (base constraints)
+      - name: Create venv + install package (base constraints)
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
         working-directory: base
-        run: uv pip install --system -c esphome-constraints.txt -e '.[esphome,test]'
+        run: |
+          uv venv
+          uv pip install -c esphome-constraints.txt -e '.[esphome,test]'
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Validate manifests
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,18 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - name: Set up uv and Python ${{ env.PYTHON_VERSION }}
+        uses: ./.github/actions/setup-uv-python
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install build tooling
-        run: pip install build tomli tomli-w
+      - name: Create venv + install build tooling
+        # The venv bin dir goes on PATH so the ``shell: python`` stamp
+        # step and ``python -m build`` below resolve to it.
+        run: |
+          uv venv
+          uv pip install build tomli tomli-w
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Stamp pyproject.toml with the release version
         # ``pyproject.toml`` ships with a ``0.0.0`` placeholder.

--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -52,23 +52,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - name: Set up uv and Python 3.13
+        uses: ./.github/actions/setup-uv-python
         with:
           python-version: "3.13"
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install package (with esphome extra)
+      - name: Create venv + install package (with esphome extra)
         # ``[esphome]`` pulls in the esphome package so the narrow
         # introspection in sync_components (multi_conf,
         # platform_defaults, supported_platforms, type refinement)
-        # can run. ``--system`` installs into the setup-python
-        # interpreter, matching the rest of CI.
-        run: uv pip install --system -e '.[esphome]'
+        # can run. The venv bin dir goes on PATH so the bare
+        # ``python script/...`` steps below resolve to it.
+        run: |
+          uv venv
+          uv pip install -e '.[esphome]'
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Resolve schema version
         id: version
@@ -116,7 +114,7 @@ jobs:
         # its wheel), introspecting a beta schema with a stale esphome
         # would regress the catalog. Better a red nightly that retries
         # than a degraded catalog proposed for merge.
-        run: uv pip install --system --prerelease=allow "esphome==${{ steps.version.outputs.version }}"
+        run: uv pip install --prerelease=allow "esphome==${{ steps.version.outputs.version }}"
 
       - name: Run sync_components
         run: python script/sync_components.py --version "${{ steps.version.outputs.version }}"

--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -47,17 +47,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - name: Set up uv and Python 3.13
+        uses: ./.github/actions/setup-uv-python
         with:
           python-version: "3.13"
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install package (with esphome extra)
+      - name: Create venv + install package (with esphome extra)
         # ``sync_boards.py`` introspects ESPHome's per-platform board
         # modules to regenerate board pins, so the esphome extra is
         # required; ``test`` carries jsonschema for validate_definitions.
@@ -67,7 +62,10 @@ jobs:
         # newer prerelease here would commit a stamp the Test job's pinned
         # lint can't match. The catalog advances to a new esphome as one
         # unit when the component sync bumps the pin on release.
-        run: uv pip install --system -c esphome-constraints.txt -e '.[esphome,test]'
+        run: |
+          uv venv
+          uv pip install -c esphome-constraints.txt -e '.[esphome,test]'
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run sync_esphome_devices
         run: python script/sync_esphome_devices.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,36 +35,29 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      - name: Set up uv and Python 3.13
+        id: python
+        uses: ./.github/actions/setup-uv-python
         with:
           python-version: "3.13"
 
-      - name: Set up uv
-        # uv replaces pip for the install step (an order of
-        # magnitude faster on cold boots, with its own wheel cache).
-        # ``actions/setup-python`` provides the interpreter — its
-        # Python isn't marked externally-managed, so ``uv pip
-        # install --system`` works on macos / windows runners that
-        # would otherwise refuse a brew-shipped Python under PEP 668.
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install package + dev tools
+      - name: Create venv + install package + dev tools
         # ``[esphome]`` is needed so the catalog smoke test below
         # can construct a ``ComponentCatalog`` against the same
-        # esphome version the dashboard ships with. ``--system``
-        # installs into the runner's Python instead of a venv —
-        # matches the existing pip-based CI shape so subsequent
-        # ``pre-commit`` / ``python script/...`` steps keep working
-        # without a ``uv run`` prefix. ``-c esphome-constraints.txt``
+        # esphome version the dashboard ships with. Managed Python
+        # isn't a system interpreter, so install into a ``.venv``
+        # and put its bin dir on PATH — subsequent ``pre-commit`` /
+        # ``python script/...`` steps keep working without a
+        # ``uv run`` prefix. ``-c esphome-constraints.txt``
         # pins esphome to the version the committed catalog was generated
         # against; the ``sync-boards`` pre-commit hook below re-stamps
         # boards.index.json from the installed esphome, so an unpinned
         # "latest" would red this job on every esphome release until the
         # catalog is re-synced. The sync workflows bump that pin.
-        run: uv pip install --system -c esphome-constraints.txt -e '.[esphome,test]'
+        run: |
+          uv venv
+          uv pip install -c esphome-constraints.txt -e '.[esphome,test]'
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Cache pre-commit hook envs
         # Keyed on the python version + ``.pre-commit-config.yaml``
@@ -76,7 +69,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit|py${{ steps.python.outputs.python-version }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit (ruff lint + format, codespell, yaml/json checks)
         # On a cache hit the per-hook envs (ruff, codespell, …) are


### PR DESCRIPTION
# What does this implement/fix?

Finishes the migration to uv managed Python in CI, the same shape home-assistant core uses. The lint job, the release build, the release notes generator, and the five auxiliary workflows still installed the interpreter with actions/setup-python and layered a standalone setup-uv on top; they now all go through the existing setup-uv-python composite (setup-uv with cache-python, astral's PGO/LTO/BOLT build) that the test matrix and e2e jobs already use. Managed Python is not a system interpreter, so each converted job creates a venv and puts its bin dir on PATH; every later bare python, pre-commit, pytest, and shell:python step resolves through it unchanged. The pre-commit cache is re-keyed on the composite's reported version since env.pythonLocation came from setup-python.

This drops one action and its post steps per job, removes the dependence on the runner tool cache (a fresh 3.13.x patch before the image update costs setup-python a 10-25s download), and runs the scripts on the faster astral interpreter. The CodSpeed benchmarks job intentionally stays on actions/setup-python so callgrind instruction counts remain comparable. The composite's setup-uv pin is bumped to the v8.3.2 SHA the deleted standalone call sites were already on.

Verified on this PR's CI plus a check-board-images dispatch from the branch; the two catalog sync workflows and regen-board-catalog are the same pattern reviewed by eye, and the release path gets exercised at the next release.

**Related issue or feature (if applicable):**

- follow up to #2226

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
