### PR TITLE
Run CI utility jobs on Python 3.14

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -59,13 +59,13 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up uv and Python 3.13
+    - name: Set up uv and Python 3.14
       if: inputs.initial-release != 'true'
       # Resolves through the caller's workspace checkout — both call
       # sites check the repo out at the workspace root.
       uses: ./.github/actions/setup-uv-python
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Generate release notes
       id: generate

--- a/.github/workflows/check-board-images.yml
+++ b/.github/workflows/check-board-images.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         uses: ./.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package (test extra for jsonschema)
         run: |

--- a/.github/workflows/real-compile-tests.yml
+++ b/.github/workflows/real-compile-tests.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         uses: ./.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package + test deps
         run: |

--- a/.github/workflows/regen-board-catalog.yml
+++ b/.github/workflows/regen-board-catalog.yml
@@ -157,13 +157,13 @@ jobs:
           cp -a pr/esphome_device_builder/definitions/components \
             base/esphome_device_builder/definitions/components
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'
         # Path goes through the trusted base checkout — the workspace
         # root holds no repo, and pr/ is never executed.
         uses: ./base/.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package (base constraints)
         if: steps.inspect.outputs.skip != 'true' && steps.loop.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
         default: false
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 permissions:
   contents: read

--- a/.github/workflows/sync-component-catalog.yml
+++ b/.github/workflows/sync-component-catalog.yml
@@ -52,10 +52,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         uses: ./.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package (with esphome extra)
         # ``[esphome]`` pulls in the esphome package so the narrow

--- a/.github/workflows/sync-device-catalog.yml
+++ b/.github/workflows/sync-device-catalog.yml
@@ -47,10 +47,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         uses: ./.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package (with esphome extra)
         # ``sync_boards.py`` introspects ESPHome's per-platform board

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         id: python
         uses: ./.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package + dev tools
         # ``[esphome]`` is needed so the catalog smoke test below
@@ -506,6 +506,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
+        # Stock CPython, held at 3.13: a version bump resets every
+        # CodSpeed baseline at once, so it moves deliberately and alone.
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.13"

--- a/.github/workflows/windows-real-compile.yml
+++ b/.github/workflows/windows-real-compile.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.13
+      - name: Set up uv and Python 3.14
         uses: ./.github/actions/setup-uv-python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Create venv + install package + test deps
         run: |


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #2229: bumps every remaining CI 3.13 pin to 3.14, matching the test matrix and e2e jobs that moved long ago. Covers the lint job, both catalog syncs, regen-board-catalog, real-compile-tests, check-board-images, windows-real-compile, the release build, and the generate-release-notes composite; on the 3.14 astral build these also pick up the tail-call interpreter. The pinned esphome (2026.7.0) declares support up to <3.15, and the e2e jobs already compile real firmware on 3.14 including native ESP-IDF and LibreTiny.

The one deliberate holdout is the CodSpeed benchmarks job, still stock CPython 3.13; bumping it resets every callgrind baseline at once, so it should move alone, and the step now carries a comment saying so. Both real-compile workflows trigger on their own file, so this PR exercises the Linux round-trip compile and all three Windows MAX_PATH suites on 3.14 directly.

**Related issue or feature (if applicable):**

- follow up to #2229

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
