### PR TITLE
Point web.esphome.io reporters at the frontend issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,8 @@
 # escape hatch so reporters always pick one of the curated paths
 # below — most of which redirect them to a more appropriate venue
 # (esphome core repo, org-wide discussions, the project backlog,
-# Discord) before they end up filing here. The two real templates
+# the frontend repo for web.esphome.io, Discord) before they end up
+# filing here. The two real templates
 # (``bug_report.yml`` for dashboard bugs, ``device_status.yml`` for
 # online/offline/sync/detection reports) are reserved for actual issues.
 
@@ -31,6 +32,13 @@ contact_links:
       The dashboard is still in active development. Before filing,
       please check the project board — your idea or issue may
       already be on the roadmap or assigned to an upcoming release.
+
+  - name: 🌐 web.esphome.io issues (browser flashing, provisioning, logs)
+    url: https://github.com/esphome/device-builder-frontend/issues/new?template=web_bug_report.yml
+    about: |
+      Problems with the web.esphome.io site — flashing, Wi-Fi
+      provisioning, or log viewing from the browser — are filed
+      on the frontend repo.
 
   - name: 💬 Discord — Device Builder feedback channel
     url: https://discord.gg/Rf2jWGVjaK


### PR DESCRIPTION
# What does this implement/fix?

web.esphome.io now deploys from the frontend repo, and esphome/device-builder-frontend#1328 adds an issue form there with fields that fit a browser only report. Users habitually file everything on this tracker, so this adds a chooser card routing web.esphome.io problems (browser flashing, Wi-Fi provisioning, log viewing) to that form, and folds the new venue into the header comment's inventory.

**Related issue or feature (if applicable):**

- companion to esphome/device-builder-frontend#1328; reported on Discord, web.esphome.io reports had no fitting template

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

- [ ] No frontend change needed
- [x] Companion frontend PR: esphome/device-builder-frontend#1328

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
