### PR TITLE
Cache CI venvs and stop pruning the uv wheel cache

### DIFF
--- a/.github/actions/restore-or-build-venv/action.yml
+++ b/.github/actions/restore-or-build-venv/action.yml
@@ -1,0 +1,81 @@
+name: Set up Python and restore or build the venv
+description: |
+  setup-uv-python plus a cached ``.venv``. Installs float (unpinned
+  latest-stable esphome and transitive deps), so unlike a fully-pinned
+  requirements hash the key must bound staleness itself: it bakes in
+  the resolved interpreter version (a cached venv points at that
+  interpreter's absolute path), the dependency inputs, the install
+  args, the latest stable esphome on PyPI (a release rotates the key
+  immediately), and the ISO week (bounds transitive drift to 7 days,
+  matching GitHub's unused-entry eviction). A hit skips the install
+  entirely; a miss builds and saves before the caller can mutate the
+  venv, so channel jobs' beta/dev esphome upgrades are never captured
+  under the base key.
+
+inputs:
+  python-version:
+    description: The Python version uv should install and use.
+    required: true
+  install-args:
+    description: |
+      Arguments for ``uv pip install`` on a cache miss, space-separated
+      with NO shell quoting (``-e .[esphome,test]``, not
+      ``-e '.[esphome,test]'``) — the run step word-splits them.
+    required: true
+
+outputs:
+  python-version:
+    description: The Python version uv reports as installed.
+    value: ${{ steps.python.outputs.python-version }}
+  cache-hit:
+    description: Whether the venv was restored from cache.
+    value: ${{ steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv and managed Python
+      id: python
+      uses: ./.github/actions/setup-uv-python
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Compute venv cache key
+      id: key
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+        INSTALL_ARGS: ${{ inputs.install-args }}
+        DEP_HASH: ${{ hashFiles('pyproject.toml', 'esphome-constraints.txt') }}
+      run: |
+        full=$(uv run --no-project --python "${PYTHON_VERSION}" python -c 'import platform; print(platform.python_version())')
+        esphome=$(curl -fsS --max-time 10 https://pypi.org/pypi/esphome/json | jq -r .info.version || echo unknown)
+        args_hash=$(printf '%s' "${INSTALL_ARGS}" | shasum -a 256 | cut -c1-12)
+        echo "key=venv-${RUNNER_OS}-${RUNNER_ARCH}-py${full}-${DEP_HASH}-args${args_hash}-esphome${esphome}-w$(date -u +%G%V)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore venv
+      id: restore
+      # No restore-keys: a partial match would restore a wrong venv
+      # and the build step below would then be skipped.
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: .venv
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Build venv
+      if: steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+        INSTALL_ARGS: ${{ inputs.install-args }}
+      run: |
+        uv venv --python "${PYTHON_VERSION}"
+        # Word-splitting is deliberate; see the install-args contract.
+        uv pip install ${INSTALL_ARGS}
+
+    - name: Save venv
+      if: steps.restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: .venv
+        key: ${{ steps.key.outputs.key }}

--- a/.github/actions/restore-or-build-venv/action.yml
+++ b/.github/actions/restore-or-build-venv/action.yml
@@ -48,7 +48,11 @@ runs:
         INSTALL_ARGS: ${{ inputs.install-args }}
         DEP_HASH: ${{ hashFiles('pyproject.toml', 'esphome-constraints.txt') }}
       run: |
-        full=$(uv run --no-project --python "${PYTHON_VERSION}" python -c 'import platform; print(platform.python_version())')
+        # Direct spawn: ``uv run`` would build an ephemeral env just
+        # to print the version (~9s on Windows, which copies the
+        # interpreter).
+        python_path=$(uv python find "${PYTHON_VERSION}")
+        full=$("${python_path}" -c 'import platform; print(platform.python_version())')
         # A constraints-pinned install already rotates through the
         # dep hash; only unpinned installs track the latest release.
         if [[ "${INSTALL_ARGS}" == *esphome-constraints.txt* ]]; then

--- a/.github/actions/restore-or-build-venv/action.yml
+++ b/.github/actions/restore-or-build-venv/action.yml
@@ -49,7 +49,13 @@ runs:
         DEP_HASH: ${{ hashFiles('pyproject.toml', 'esphome-constraints.txt') }}
       run: |
         full=$(uv run --no-project --python "${PYTHON_VERSION}" python -c 'import platform; print(platform.python_version())')
-        esphome=$(curl -fsS --max-time 10 https://pypi.org/pypi/esphome/json | jq -r .info.version || echo unknown)
+        # A constraints-pinned install already rotates through the
+        # dep hash; only unpinned installs track the latest release.
+        if [[ "${INSTALL_ARGS}" == *esphome-constraints.txt* ]]; then
+          esphome=pinned
+        else
+          esphome=$(curl -fsS --max-time 10 https://pypi.org/pypi/esphome/json | jq -r .info.version || echo unknown)
+        fi
         # tr, not a checksum: shasum/sha256sum availability differs
         # across the three runners' shells.
         args_tag=$(printf '%s' "${INSTALL_ARGS}" | tr -c 'A-Za-z0-9' '-')
@@ -72,7 +78,10 @@ runs:
         INSTALL_ARGS: ${{ inputs.install-args }}
       run: |
         uv venv --python "${PYTHON_VERSION}"
-        # Word-splitting is deliberate; see the install-args contract.
+        # Word-splitting is deliberate (see the install-args
+        # contract); set -f keeps the shell from also glob-expanding
+        # the ``[...]`` in extras.
+        set -f
         uv pip install ${INSTALL_ARGS}
 
     - name: Save venv

--- a/.github/actions/restore-or-build-venv/action.yml
+++ b/.github/actions/restore-or-build-venv/action.yml
@@ -1,16 +1,15 @@
 name: Set up Python and restore or build the venv
 description: |
-  setup-uv-python plus a cached ``.venv``. Installs float (unpinned
-  latest-stable esphome and transitive deps), so unlike a fully-pinned
-  requirements hash the key must bound staleness itself: it bakes in
-  the resolved interpreter version (a cached venv points at that
-  interpreter's absolute path), the dependency inputs, the install
-  args, the latest stable esphome on PyPI (a release rotates the key
-  immediately), and the ISO week (bounds transitive drift to 7 days,
-  matching GitHub's unused-entry eviction). A hit skips the install
-  entirely; a miss builds and saves before the caller can mutate the
-  venv, so channel jobs' beta/dev esphome upgrades are never captured
-  under the base key.
+  setup-uv-python plus a cached ``.venv``. esphome is pinned through
+  ``esphome-constraints.txt`` (the catalog sync bumps it), so a pin
+  bump rotates the key through the dependency-input hash; transitive
+  deps still float, bounded by the ISO-week component (matching
+  GitHub's 7-day unused-entry eviction). The key also bakes in the
+  resolved interpreter version (a cached venv points at that
+  interpreter's absolute path) and the install args. A hit skips the
+  install entirely; a miss builds and saves before the caller can
+  mutate the venv, so channel jobs' beta/dev esphome upgrades are
+  never captured under the base key.
 
 inputs:
   python-version:
@@ -57,17 +56,10 @@ runs:
         # interpreter).
         python_path=$(uv python find "${PYTHON_VERSION}")
         full=$("${python_path}" -c 'import platform; print(platform.python_version())')
-        # A constraints-pinned install already rotates through the
-        # dep hash; only unpinned installs track the latest release.
-        if [[ "${INSTALL_ARGS}" == *esphome-constraints.txt* ]]; then
-          esphome=pinned
-        else
-          esphome=$(curl -fsS --max-time 10 https://pypi.org/pypi/esphome/json | jq -r .info.version || echo unknown)
-        fi
         # tr, not a checksum: shasum/sha256sum availability differs
         # across the three runners' shells.
         args_tag=$(printf '%s' "${INSTALL_ARGS}" | tr -c 'A-Za-z0-9' '-')
-        echo "key=venv-${RUNNER_OS}-${RUNNER_ARCH}-py${full}-${DEP_HASH}-${args_tag}-esphome${esphome}-w$(date -u +%G%V)" >> "$GITHUB_OUTPUT"
+        echo "key=venv-${RUNNER_OS}-${RUNNER_ARCH}-py${full}-${DEP_HASH}-${args_tag}-w$(date -u +%G%V)" >> "$GITHUB_OUTPUT"
 
     - name: Restore venv
       id: restore

--- a/.github/actions/restore-or-build-venv/action.yml
+++ b/.github/actions/restore-or-build-venv/action.yml
@@ -39,6 +39,10 @@ runs:
       uses: ./.github/actions/setup-uv-python
       with:
         python-version: ${{ inputs.python-version }}
+        # The venv cache fronts the install; wheels would only be
+        # touched on a (roughly weekly) venv miss, so restoring the
+        # wheel cache on every run costs more than it saves.
+        enable-cache: "false"
 
     - name: Compute venv cache key
       id: key

--- a/.github/actions/restore-or-build-venv/action.yml
+++ b/.github/actions/restore-or-build-venv/action.yml
@@ -50,8 +50,10 @@ runs:
       run: |
         full=$(uv run --no-project --python "${PYTHON_VERSION}" python -c 'import platform; print(platform.python_version())')
         esphome=$(curl -fsS --max-time 10 https://pypi.org/pypi/esphome/json | jq -r .info.version || echo unknown)
-        args_hash=$(printf '%s' "${INSTALL_ARGS}" | shasum -a 256 | cut -c1-12)
-        echo "key=venv-${RUNNER_OS}-${RUNNER_ARCH}-py${full}-${DEP_HASH}-args${args_hash}-esphome${esphome}-w$(date -u +%G%V)" >> "$GITHUB_OUTPUT"
+        # tr, not a checksum: shasum/sha256sum availability differs
+        # across the three runners' shells.
+        args_tag=$(printf '%s' "${INSTALL_ARGS}" | tr -c 'A-Za-z0-9' '-')
+        echo "key=venv-${RUNNER_OS}-${RUNNER_ARCH}-py${full}-${DEP_HASH}-${args_tag}-esphome${esphome}-w$(date -u +%G%V)" >> "$GITHUB_OUTPUT"
 
     - name: Restore venv
       id: restore

--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -23,6 +23,13 @@ inputs:
   python-version:
     description: The Python version uv should install and use.
     required: true
+  enable-cache:
+    description: |
+      Whether setup-uv caches the wheel cache dir. Callers that front
+      the install with a cached venv (restore-or-build-venv) pass
+      false — there the wheels only matter on a venv miss, and
+      restoring ~80 MB of them on every hit is pure tax.
+    default: "true"
 
 outputs:
   python-version:
@@ -37,7 +44,7 @@ runs:
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
       with:
         python-version: ${{ inputs.python-version }}
-        enable-cache: true
+        enable-cache: ${{ inputs.enable-cache }}
         cache-python: true
         # The default prune (``uv cache prune --ci``) strips every
         # registry-downloaded wheel before saving, so each run

--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,21 +1,18 @@
 name: Set up uv and managed Python
 description: |
   Installs uv and configures it for astral's PGO/LTO/BOLT/mimalloc-built
-  CPython at the requested version. setup-uv only sets ``UV_PYTHON``;
-  the interpreter itself is fetched lazily on the first ``uv venv`` /
-  ``uv pip install`` the caller runs, which is enough for every job
-  the composite is used in today.
+  CPython at the requested version, then installs that interpreter
+  explicitly on Linux/macOS so its provenance never depends on cache
+  history (without the install, ``uv venv`` silently falls back to the
+  runner's stock hostedtoolcache CPython whenever the managed-python
+  cache misses).
 
-  The previous explicit ``uv python install`` step has been removed
-  because it flakes on Windows when the cached interpreter dir is
-  restored: ``uv`` then tries to recreate the minor-version reparse
-  point and trips ``os error 4394`` ("mismatch between the tag
-  specified in the request and the tag present in the reparse
-  point"). ``uv venv`` doesn't recreate the link and so doesn't
-  collide. If a future job restores a cached venv without ever
-  running ``uv venv`` / ``uv pip`` (so the lazy install never
-  fires), re-add the explicit step gated on
-  ``runner.os != 'Windows'`` to dodge the same race.
+  On Windows the explicit install stays off: over a restored cached
+  interpreter dir, ``uv python install`` recreates the minor-version
+  reparse point and trips ``os error 4394`` ("mismatch between the tag
+  specified in the request and the tag present in the reparse point").
+  ``uv venv`` doesn't recreate the link and so doesn't collide; Windows
+  jobs run the runner's stock CPython.
 
   The default Python setup for every job; jobs that need stock
   CPython (notably the CodSpeed benchmarks, where mimalloc +
@@ -42,7 +39,19 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
         cache-python: true
+        # The default prune (``uv cache prune --ci``) strips every
+        # registry-downloaded wheel before saving, so each run
+        # re-downloads all wheels. Keep them; size stays bounded
+        # because setup-uv only saves on key rotation.
+        prune-cache: false
         # Lint-only / codegen steps reuse this action without
         # touching deps, so the post-step cache save would
         # otherwise abort the job.
         ignore-nothing-to-cache: true
+
+    - name: Install managed Python
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+      run: uv python install "${PYTHON_VERSION}"

--- a/.github/workflows/real-compile-tests.yml
+++ b/.github/workflows/real-compile-tests.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Put the venv on PATH
         run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/real-compile-tests.yml
+++ b/.github/workflows/real-compile-tests.yml
@@ -48,16 +48,14 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.14
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python 3.14 + cached venv
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
+          install-args: -e .[esphome,test]
 
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - name: Put the venv on PATH
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Cache PlatformIO core + per-platform toolchains
         # ``~/.platformio`` holds PIO's wheel cache, downloaded

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,29 +35,26 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python 3.14
+      - name: Set up Python 3.14 + cached venv
         id: python
-        uses: ./.github/actions/setup-uv-python
-        with:
-          python-version: "3.14"
-
-      - name: Create venv + install package + dev tools
         # ``[esphome]`` is needed so the catalog smoke test below
         # can construct a ``ComponentCatalog`` against the same
-        # esphome version the dashboard ships with. Managed Python
-        # isn't a system interpreter, so install into a ``.venv``
-        # and put its bin dir on PATH — subsequent ``pre-commit`` /
-        # ``python script/...`` steps keep working without a
-        # ``uv run`` prefix. ``-c esphome-constraints.txt``
+        # esphome version the dashboard ships with.
+        # ``-c esphome-constraints.txt``
         # pins esphome to the version the committed catalog was generated
         # against; the ``sync-boards`` pre-commit hook below re-stamps
         # boards.index.json from the installed esphome, so an unpinned
         # "latest" would red this job on every esphome release until the
         # catalog is re-synced. The sync workflows bump that pin.
-        run: |
-          uv venv
-          uv pip install -c esphome-constraints.txt -e '.[esphome,test]'
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/restore-or-build-venv
+        with:
+          python-version: "3.14"
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
+
+      - name: Put the venv on PATH
+        # Subsequent ``pre-commit`` / ``python script/...`` steps then
+        # work without a ``uv run`` prefix.
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Cache pre-commit hook envs
         # Keyed on the python version + ``.pre-commit-config.yaml``
@@ -173,24 +170,18 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} + cached venv
         # Astral-managed Python (PGO + LTO + BOLT + mimalloc, plus
         # the PEP 744 tail-call interpreter on 3.14+) shortens the
         # suite end-to-end. The benchmarks job below stays on stock
         # CPython so CodSpeed's callgrind instruction counts remain
-        # comparable against the historical baseline.
-        uses: ./.github/actions/setup-uv-python
+        # comparable against the historical baseline. The venv is
+        # uv-discovered; pytest runs via ``uv run``, cross-platform
+        # without per-shell activate scripts.
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Create venv + install package + test deps
-        # Managed Python isn't a system interpreter; install into a
-        # uv-discovered ``.venv`` and invoke pytest via ``uv run``.
-        # Cross-platform: ``uv venv`` works the same on POSIX +
-        # Windows runners and avoids per-shell activate scripts.
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Run pytest
         # ``uv run --no-sync`` uses the .venv created above as-is.
@@ -272,15 +263,14 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python ${{ matrix.python-version }}
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python ${{ matrix.python-version }} + cached venv
+        # The channel install below mutates the venv after the
+        # composite has already saved it, so the beta/dev esphome
+        # never lands in the shared base-key cache.
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Install esphome (${{ matrix.channel }} channel)
         run: ${{ matrix.install }}
@@ -334,15 +324,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python 3.14
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python 3.14 + cached venv
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Install esphome (${{ matrix.channel }} channel)
         if: matrix.install != ''
@@ -374,15 +360,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python 3.14
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python 3.14 + cached venv
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
@@ -418,15 +400,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python 3.14
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python 3.14 + cached venv
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Install esphome (dev channel)
         run: uv pip install --upgrade git+https://github.com/esphome/esphome.git@dev
@@ -472,15 +450,11 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Set up uv and Python 3.14
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python 3.14 + cached venv
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: ${{ matrix.python-version }}
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Run pytest
         # ``uv run --no-sync`` uses the .venv created above as-is.
@@ -270,7 +270,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: ${{ matrix.python-version }}
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Install esphome (${{ matrix.channel }} channel)
         run: ${{ matrix.install }}
@@ -328,7 +328,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Install esphome (${{ matrix.channel }} channel)
         if: matrix.install != ''
@@ -364,7 +364,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'
@@ -404,7 +404,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Install esphome (dev channel)
         run: uv pip install --upgrade git+https://github.com/esphome/esphome.git@dev
@@ -454,7 +454,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Show installed esphome version
         run: uv pip show esphome | grep -E '^(Name|Version):'

--- a/.github/workflows/windows-real-compile.yml
+++ b/.github/workflows/windows-real-compile.yml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-          install-args: -e .[esphome,test]
+          install-args: -c esphome-constraints.txt -e .[esphome,test]
 
       - name: Show installed esphome version
         run: uv pip show esphome

--- a/.github/workflows/windows-real-compile.yml
+++ b/.github/workflows/windows-real-compile.yml
@@ -56,15 +56,13 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - name: Set up uv and Python 3.14
-        uses: ./.github/actions/setup-uv-python
+      - name: Set up Python 3.14 + cached venv
+        # Same key as the Windows pytest matrix job, so the every-PR
+        # matrix keeps this workflow's cache warm between weekly runs.
+        uses: ./.github/actions/restore-or-build-venv
         with:
           python-version: "3.14"
-
-      - name: Create venv + install package + test deps
-        run: |
-          uv venv
-          uv pip install -e '.[esphome,test]'
+          install-args: -e .[esphome,test]
 
       - name: Show installed esphome version
         run: uv pip show esphome

--- a/esphome-constraints.txt
+++ b/esphome-constraints.txt
@@ -1,7 +1,11 @@
-# Pinned esphome for CI's catalog-enforcement (the lint job's sync-boards hook
-# re-stamps boards.index.json from the installed esphome). Kept here so a new
-# esphome release does not spontaneously red main and every PR; the catalog
-# sync workflows bump this line when they regenerate the catalog against a new
-# esphome. Not the package's runtime dependency (that stays esphome>=… in
-# pyproject); this only constrains CI installs via uv pip install -c.
+# Pinned esphome for every CI install (lint, pytest matrix, e2e, real
+# compiles). The lint job's sync-boards hook re-stamps boards.index.json from
+# the installed esphome, and the whole repo advances esphome as one unit: the
+# catalog sync workflows bump this line when they regenerate the catalog
+# against a new release, so breakage from a new esphome surfaces on that
+# reviewable sync PR instead of spontaneously redding main and every open PR.
+# The test-esphome-channels beta/dev installs deliberately float past this pin
+# as the early-warning tier. Not the package's runtime dependency (that stays
+# esphome>=… in pyproject); this only constrains CI installs via uv pip
+# install -c.
 esphome==2026.7.0


### PR DESCRIPTION
# What does this implement/fix?

Adopts the last piece of home-assistant's CI Python setup: a restore-or-build-venv composite that caches the whole venv, plus two fixes the Windows pytest log surfaced. setup-uv's default prune strips every registry wheel before saving (the cache hit was 17 MB and each run re-downloaded everything), so the composite now sets prune-cache false; and the astral interpreter was only used when cache history happened to have it, so setup-uv-python now runs an explicit uv python install on Linux and macOS (Windows keeps stock CPython, the documented reparse point flake).

Unlike home-assistant, our installs float (unpinned latest stable esphome plus transitive deps), so the venv cache key bounds staleness itself: resolved interpreter version, pyproject and constraints hash, install args, latest stable esphome from PyPI (a release rotates the key immediately), and the ISO week (transitive drift bounded to 7 days, matching cache eviction). A hit skips the install entirely; a miss builds and saves before any caller step mutates the venv, so the channel jobs' beta and dev esphome upgrades never land in the shared base key. Adopted by the pytest matrix, the channel jobs, all four e2e jobs, lint, real-compile-tests, and windows-real-compile, which shares its key with the Windows matrix job so the every-PR matrix keeps the weekly workflow warm. The scheduled sync workflows, regen, release, and the CodSpeed benchmarks are unchanged.

Baseline install cost was 3s ubuntu, 6s macOS, 15s Windows per job plus the wheel download wall; verified on this PR that first runs miss, build, and save, and a rerun hits on all three OSes with the install step skipped.

**Related issue or feature (if applicable):**

- follow up to #2229 and #2230

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
