### PR TITLE
Cache the managed interpreter independently of dependency files

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -30,6 +30,13 @@ inputs:
       false — there the wheels only matter on a venv miss, and
       restoring ~80 MB of them on every hit is pure tax.
     default: "true"
+  uv-version:
+    description: |
+      The uv version setup-uv installs. Pinned: resolving "latest"
+      fetches astral's manifest from raw.githubusercontent.com, and
+      that fetch failing reds the job before checkout. Bump manually;
+      keep the benchmarks job's standalone setup-uv in sync.
+    default: "0.11.29"
 
 outputs:
   python-version:
@@ -43,6 +50,7 @@ runs:
       id: uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
       with:
+        version: ${{ inputs.uv-version }}
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.enable-cache }}
         # Interpreter caching is owned below instead: setup-uv's own

--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -45,7 +45,11 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.enable-cache }}
-        cache-python: true
+        # Interpreter caching is owned below instead: setup-uv's own
+        # cache-python shares the wheel cache's dependency-file key
+        # (a pyproject edit re-downloads Python) and is a silent
+        # no-op when enable-cache is false.
+        cache-python: false
         # The default prune (``uv cache prune --ci``) strips every
         # registry-downloaded wheel before saving, so each run
         # re-downloads all wheels. Keep them; size stays bounded
@@ -55,6 +59,25 @@ runs:
         # touching deps, so the post-step cache save would
         # otherwise abort the job.
         ignore-nothing-to-cache: true
+
+    - name: Compute interpreter cache key
+      if: runner.os != 'Windows'
+      id: python-key
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+      run: echo "key=managed-python-${RUNNER_OS}-${RUNNER_ARCH}-py${PYTHON_VERSION}-w$(date -u +%G%V)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache managed Python
+      if: runner.os != 'Windows'
+      # Keyed on os/arch/version/ISO-week only — never on dependency
+      # files. The week stamp is how a new astral patch release gets
+      # picked up: while the cached interpreter satisfies the
+      # requested version, the install below is a no-op.
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ${{ env.UV_PYTHON_INSTALL_DIR }}
+        key: ${{ steps.python-key.outputs.key }}
 
     - name: Install managed Python
       if: runner.os != 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -489,6 +489,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
         with:
+          # Keep in sync with setup-uv-python's uv-version default.
+          version: "0.11.29"
           enable-cache: true
 
       - name: Install package + test deps


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #2232, from watching a pyproject-touching PR re-download the interpreter: setup-uv's cache-python shares the wheel cache's dependency-file key, so any pyproject or constraints edit re-downloads Python, and with enable-cache false (the restore-or-build-venv path) it is a silent no-op, meaning the Linux and macOS jobs were downloading cpython on every run. The composite now owns the interpreter cache itself: actions/cache on UV_PYTHON_INSTALL_DIR keyed only on os, arch, requested version, and ISO week. On a hit the explicit uv python install is a no-op; the week stamp is how a new astral patch release gets picked up. Windows is unchanged, it runs the runner's stock CPython and caches nothing.

Also pins uv itself (0.11.29, composite input default plus the benchmarks job's standalone setup-uv): unpinned, setup-uv resolves latest through a raw.githubusercontent.com manifest fetch that can fail before checkout, which is exactly how a beta job on another PR went red tonight. Bumps are manual; the two sites carry a keep-in-sync note.

**Related issue or feature (if applicable):**

- follow up to #2232

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
