### PR TITLE
Trim the two slowest tests without losing coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import sys
 import tempfile as _tempfile
@@ -509,9 +510,11 @@ def session_board_catalog() -> BoardCatalog:
 
 
 @pytest.fixture(scope="session")
-def generated_board_catalog() -> BoardCatalogResponse:
-    """``script.sync_boards.build_catalog()`` run once per xdist worker.
+def generated_board_catalog_with_warnings() -> tuple[BoardCatalogResponse, list[logging.LogRecord]]:
+    """Run ``script.sync_boards.build_catalog()`` once per xdist worker.
 
+    Returns the catalog plus the WARNING records its ``sync_boards`` logger
+    emitted during that one build.
     Generation imports ESPHome's per-platform board modules and walks ~80
     manifests; the board-pin test modules pin to one worker via
     ``xdist_group("board_sync")`` so this runs a single time per suite.
@@ -522,7 +525,31 @@ def generated_board_catalog() -> BoardCatalogResponse:
     # suite during collection even when no test wants this fixture.
     from script.sync_boards import build_catalog  # noqa: PLC0415
 
-    return build_catalog()
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collect(level=logging.WARNING)
+    logger = logging.getLogger("sync_boards")
+    previous_level = logger.level
+    logger.setLevel(logging.WARNING)
+    logger.addHandler(handler)
+    try:
+        catalog = build_catalog()
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+    return catalog, records
+
+
+@pytest.fixture(scope="session")
+def generated_board_catalog(
+    generated_board_catalog_with_warnings: tuple[BoardCatalogResponse, list[logging.LogRecord]],
+) -> BoardCatalogResponse:
+    """Return the catalog half of ``generated_board_catalog_with_warnings``."""
+    return generated_board_catalog_with_warnings[0]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_nrf52_board_pins.py
+++ b/tests/test_nrf52_board_pins.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 
 from esphome_device_builder.models import BoardCatalogResponse, PinFeature
-from script.sync_boards import _derive_nrf52_pins, build_catalog
+from script.sync_boards import _derive_nrf52_pins
 
 pytestmark = pytest.mark.xdist_group("board_sync")
 
@@ -52,12 +52,13 @@ def test_nrf52_does_not_steal_rp2040_itsybitsy(
     assert by_id["adafruit_itsybitsy_nrf52840"].esphome.platform.value == "nrf52"
 
 
-def test_nrf52_id_clash_logs_warning(caplog) -> None:
+def test_nrf52_id_clash_logs_warning(
+    generated_board_catalog_with_warnings: tuple[BoardCatalogResponse, list[logging.LogRecord]],
+) -> None:
     # The drop must not be silent: a cross-platform id clash warns so the nightly
     # catalog gate can see it.
-    with caplog.at_level(logging.WARNING, logger="sync_boards"):
-        build_catalog()
+    _, records = generated_board_catalog_with_warnings
     assert any(
-        "adafruit_itsybitsy" in r.message and "shares a catalog id" in r.message
-        for r in caplog.records
+        "adafruit_itsybitsy" in r.getMessage() and "shares a catalog id" in r.getMessage()
+        for r in records
     )

--- a/tests/test_startup_sigterm.py
+++ b/tests/test_startup_sigterm.py
@@ -157,15 +157,16 @@ def _spawn_dashboard(
 
 # Holds the loop running mid-``AppRunner.setup`` with our SIGTERM trap active —
 # the pre-serving startup window. We run ``run_app(handle_signals=False)`` so the
-# trap is our handler the whole way; the blocking sleep inside ``setup`` makes a
-# signal land here deterministically so CI exercises the window every run.
+# trap is our handler the whole way; the blocking sleep inside ``setup`` is
+# widened just enough that a signal sent 0.3s after CRACK_OPEN always lands
+# inside it, even with a slow runner's readline-to-delivery latency.
 _CRACK_SITECUSTOMIZE = """
 import time as _t
 from aiohttp import web_runner as _wr
 _orig = _wr.AppRunner.setup
 async def _slow(self):
     print("CRACK_OPEN", flush=True)
-    _t.sleep(2.0)
+    _t.sleep(1.2)
     return await _orig(self)
 _wr.AppRunner.setup = _slow
 """
@@ -291,45 +292,43 @@ def test_sigterm_during_startup_exits_zero(tmp_path: Path) -> None:
 
 
 @posix_only
-@pytest.mark.timeout(120)
-def test_sigterm_in_startup_crack_exits_zero(tmp_path: Path) -> None:
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("iteration", range(3))
+def test_sigterm_in_startup_crack_exits_zero(tmp_path: Path, iteration: int) -> None:
     """A SIGTERM landing while the loop is mid-startup exits 0, not hang or 143."""
     # The window (loop running, our trap active, pre-serving) is timing-
     # dependent in the wild; the shim's blocking sleep inside setup widens it so
     # CI hits it deterministically. The transcript surfaces the child traceback
-    # on failure. Looped a few times to also shake out the signal-context
-    # reentrancy that only bites when the stop lands mid-log-write.
-    env = _crack_env(tmp_path)
-    for i in range(3):
-        config_dir = tmp_path / f"crack{i}"
-        config_dir.mkdir()
-        proc, _ = _spawn_dashboard(config_dir, env=env)
-        captured = _wait_for_crack(proc)
-        time.sleep(0.3)  # land the signal mid the shim's 2s widening sleep
+    # on failure. Parametrized to a few instances to also shake out the
+    # signal-context reentrancy that only bites when the stop lands
+    # mid-log-write; xdist spreads them across workers.
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    proc, _ = _spawn_dashboard(config_dir, env=_crack_env(tmp_path))
+    captured = _wait_for_crack(proc)
+    time.sleep(0.3)  # land the signal mid the shim's widening sleep
+    try:
+        proc.send_signal(signal.SIGTERM)
         try:
-            proc.send_signal(signal.SIGTERM)
-            try:
-                out, _ = proc.communicate(timeout=30)
-                captured.append(out)
-                returncode: int | None = proc.returncode
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                out, _ = proc.communicate()
-                captured.append(out)
-                returncode = None
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.communicate()
-        transcript = "".join(captured)
-        assert returncode is not None, (
-            f"iteration {i}: dashboard did not exit within 30s of SIGTERM\n"
-            f"--- child transcript ---\n{transcript}"
-        )
-        assert returncode == 0, (
-            f"iteration {i}: expected clean exit 0, got {returncode}\n"
-            f"--- child transcript ---\n{transcript}"
-        )
+            out, _ = proc.communicate(timeout=30)
+            captured.append(out)
+            returncode: int | None = proc.returncode
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            out, _ = proc.communicate()
+            captured.append(out)
+            returncode = None
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.communicate()
+    transcript = "".join(captured)
+    assert returncode is not None, (
+        f"dashboard did not exit within 30s of SIGTERM\n--- child transcript ---\n{transcript}"
+    )
+    assert returncode == 0, (
+        f"expected clean exit 0, got {returncode}\n--- child transcript ---\n{transcript}"
+    )
 
 
 @posix_only


### PR DESCRIPTION
# What does this implement/fix?

Two targeted fixes for the suite's slowest tests, everything else in the top ten is irreducible by design (fresh interpreter cold start proofs, real subprocess e2e, one time session fixture builds).

The 8.51s test_sigterm_in_startup_crack_exits_zero looped three sequential dashboard subprocess spawns, each paying a 2s widening sleep in the crack shim of which ~1.7s was dead wait after the signal lands at 0.3s. The loop is now a parametrize so xdist spreads the three instances across workers, and the shim sleep drops to 1.2s, still ~0.9s of margin over the 0.3s send point. Each instance runs in ~1.8s; verified stable across five serial repeat runs, 15 of 15 green.

test_nrf52_id_clash_logs_warning ran a full second build_catalog (2.4s) purely to capture the id clash warning the session fixture's build already emits. The fixture now collects the sync_boards WARNING records during its single build (generated_board_catalog_with_warnings; generated_board_catalog stays as a thin accessor so no other consumer changes) and the test asserts against those records. Since the board_sync group serializes on one worker, that 2.4s was straight wall time.

Full suite locally: the durations head drops from 8.51s to ~2.1s and every test still passes.

**Related issue or feature (if applicable):**

- n/a

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [x] Maintenance / chore — `maintenance`
- [ ] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [x] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
