### PR TITLE
Enable ccache for the native ESP-IDF e2e job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -419,9 +419,7 @@ jobs:
         # installed IDF version is pinned by ``esphome@dev`` (reinstalled
         # each run), not by the test file -- so use a rolling ``run_id`` key
         # that saves a fresh cache every run (picking up dev IDF bumps) and
-        # ``restore-keys`` to warm from the most recent prior cache. The
-        # ccache dir lives under the same prefix, so compile objects ride
-        # this cache across runs too.
+        # ``restore-keys`` to warm from the most recent prior cache.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/esphome-idf
@@ -429,10 +427,23 @@ jobs:
           restore-keys: |
             e2e-espidf-${{ runner.os }}-
 
+      - name: Cache ccache objects
+        # Same rolling shape as the toolchain cache above: restored from
+        # the newest prior entry on every run, saved fresh each run, so
+        # repeat compiles hit across runs. Small (~0.1-0.3 GB) next to
+        # the toolchain entry.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.cache/esphome-ccache
+          key: e2e-espidf-ccache-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            e2e-espidf-ccache-${{ runner.os }}-
+
       - name: Install ccache
         # esphome's native-IDF build enables ccache whenever the binary is
-        # on PATH (``espidf/framework.py``'s ``_ccache_env``), storing the
-        # cache under the IDF tools path -- inside the prefix cached above.
+        # on PATH (``espidf/framework.py``'s ``_ccache_env``) and respects
+        # a pre-set CCACHE_DIR, so the run step below points it at the
+        # dedicated cached dir instead of the default inside the prefix.
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends ccache
@@ -445,15 +456,14 @@ jobs:
         timeout-minutes: 25
         env:
           ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
-        run: uv run --no-sync pytest -q tests/e2e/slow/esp32 --durations=10 --timeout=900 --no-cov
+        # CCACHE_DIR is set in the shell, not step env: ccache does not
+        # expanduser a ``~`` (only ESPHOME_ESP_IDF_PREFIX gets that
+        # treatment, from esphome itself).
+        run: CCACHE_DIR="$HOME/.cache/esphome-ccache" uv run --no-sync pytest -q tests/e2e/slow/esp32 --durations=10 --timeout=900 --no-cov
 
       - name: Print ccache statistics
-        # esphome stores the cache under the IDF tools path; expand the
-        # leading ~ so ccache reads the dir the build used.
         if: always()
-        env:
-          ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
-        run: CCACHE_DIR="${ESPHOME_ESP_IDF_PREFIX/#\~/$HOME}/ccache" ccache -s
+        run: CCACHE_DIR="$HOME/.cache/esphome-ccache" ccache -s
 
   e2e-boards:
     name: E2E board create validation (esphome stable)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -419,13 +419,23 @@ jobs:
         # installed IDF version is pinned by ``esphome@dev`` (reinstalled
         # each run), not by the test file -- so use a rolling ``run_id`` key
         # that saves a fresh cache every run (picking up dev IDF bumps) and
-        # ``restore-keys`` to warm from the most recent prior cache.
+        # ``restore-keys`` to warm from the most recent prior cache. The
+        # ccache dir lives under the same prefix, so compile objects ride
+        # this cache across runs too.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/.cache/esphome-idf
           key: e2e-espidf-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
             e2e-espidf-${{ runner.os }}-
+
+      - name: Install ccache
+        # esphome's native-IDF build enables ccache whenever the binary is
+        # on PATH (``espidf/framework.py``'s ``_ccache_env``), storing the
+        # cache under the IDF tools path -- inside the prefix cached above.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ccache
 
       - name: Run native ESP-IDF e2e
         # A cold native-IDF compile installs the IDF toolchain then runs
@@ -436,6 +446,14 @@ jobs:
         env:
           ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
         run: uv run --no-sync pytest -q tests/e2e/slow/esp32 --durations=10 --timeout=900 --no-cov
+
+      - name: Print ccache statistics
+        # esphome stores the cache under the IDF tools path; expand the
+        # leading ~ so ccache reads the dir the build used.
+        if: always()
+        env:
+          ESPHOME_ESP_IDF_PREFIX: ~/.cache/esphome-idf
+        run: CCACHE_DIR="${ESPHOME_ESP_IDF_PREFIX/#\~/$HOME}/ccache" ccache -s
 
   e2e-boards:
     name: E2E board create validation (esphome stable)


### PR DESCRIPTION
# What does this implement/fix?

Speeds up the E2E native ESP-IDF job with ccache, the device-builder side of what esphome/esphome#17722, #17728, and #17735 do for host and platformio builds. Those PRs target other toolchains; for native IDF the support already landed on esphome dev: espidf/framework.py enables ccache whenever the binary is on PATH, with CCACHE_BASEDIR rewriting the per-run build paths so repeat compiles hit across runs, and it stores the cache under the IDF tools path.

That tools path lives inside ESPHOME_ESP_IDF_PREFIX, which this job already persists with a rolling run_id cache key, so the objects ride the existing toolchain cache with no new cache entry. The only missing ingredient was the ccache binary (not preinstalled on ubuntu runners, so esphome silently disabled itself); the job now apt installs it and prints ccache -s after the run, mirroring esphome's own CI, so hit rates are visible in the log. First run after merge seeds the cache; runs after that should skip most of the ninja compile.

**Related issue or feature (if applicable):**

- companion to esphome/esphome#17735

## Types of changes

<!--
Tick exactly one box. CI (.github/workflows/pr-labels.yaml) blocks
the PR until a matching label is applied; release-drafter uses the
same label to slot this change into the next release notes.
-->

- [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
- [ ] New feature (non-breaking change which adds functionality) — `new-feature`
- [ ] Enhancement to an existing feature — `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
- [ ] Refactor (no behaviour change) — `refactor`
- [ ] Documentation only — `docs`
- [ ] Maintenance / chore — `maintenance`
- [x] CI / workflow change — `ci`
- [ ] Dependencies bump — `dependencies`

## Frontend coordination

<!--
The frontend ships prebuilt inside our wheel
(esphome/device-builder-frontend). Flag anything that
needs a coordinated change there — new ConfigEntryType values,
new WS commands or events, model shape changes, etc. Link the
companion frontend PR if there is one.
-->

- [x] No frontend change needed
- [ ] Companion frontend PR: esphome/device-builder-frontend#<number>

## Checklist

- [x] The code change is tested and works locally.
- [x] Pre-commit hooks pass (`ruff`, `codespell`, yaml/json/python checks).
- [ ] Tests have been added or updated under `tests/` where applicable.
- [x] `components.index.json` / `definitions/components/*.json` have **not** been hand-edited (regenerate via `script/sync_components.py` if a sync is needed).
- [ ] Architecture-level changes are reflected in `docs/ARCHITECTURE.md` and/or `docs/API.md`.
